### PR TITLE
Extend README.md with sample run configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ The desktop app also requires JVM args (the typesafe config lib we use does not 
 
 When you use I2P, you need to install I2P and start the router application. The web console opens automatically. There you  need to navigate to [Clients](http://127.0.0.1:7657/configclients) and start the `SAM application bridge`. It will take about 2 minutes to be ready.
 
+### Example Run Configurations
+
+Here are three IntelliJ IDEA run configurations for simulating a clearnet setup locally:
+
+| Run Config                  | MultiNodesMain                              | Bisq-clear-Alice       | Bisq-clear-Bob       |
+|:----------------------------|:--------------------------------------------|:-----------------------|:---------------------|
+| Classpath of module (Alt+O) | `bisq.tools.main`                           | `bisq.desktop.main`    | (same as Alice)      |
+| Main Class (Alt+C)          | `bisq.tools.network.monitor.MultiNodesMain` | `bisq.desktop.Main`    | (same as Alice)      |
+| Program Arguments (Alt+R)   | `--bootstrapAll=true --transports=CLEAR`    | `--appName=bisq_Alice` | `--appName=bisq_Bob` |
+
+
+
 ## Contributing
 
 Please get in touch on our [Matrix room](https://matrix.to/#/#bisq.v2.dev:bitcoin.kyoto). We can use help across many areas of development, UI/UX, etc!

--- a/README.md
+++ b/README.md
@@ -82,11 +82,27 @@ When you use I2P, you need to install I2P and start the router application. The 
 
 Here are three IntelliJ IDEA run configurations for simulating a clearnet setup locally:
 
-| Run Config                  | MultiNodesMain                              | Bisq-clear-Alice       | Bisq-clear-Bob       |
-|:----------------------------|:--------------------------------------------|:-----------------------|:---------------------|
-| Classpath of module (Alt+O) | `bisq.tools.main`                           | `bisq.desktop.main`    | (same as Alice)      |
-| Main Class (Alt+C)          | `bisq.tools.network.monitor.MultiNodesMain` | `bisq.desktop.Main`    | (same as Alice)      |
-| Program Arguments (Alt+R)   | `--bootstrapAll=true --transports=CLEAR`    | `--appName=bisq_Alice` | `--appName=bisq_Bob` |
+| Run Config                  | MultiNodesMain                              |
+|:----------------------------|:--------------------------------------------|
+| Classpath of module (Alt+O) | `bisq.tools.main`                           |
+| Main Class (Alt+C)          | `bisq.tools.network.monitor.MultiNodesMain` |
+| Program Arguments (Alt+R)   | `--bootstrapAll=true --transports=CLEAR`    |
+
+
+| Run Config                  | Bisq-clear-Alice                                                                                                  |
+|:----------------------------|:------------------------------------------------------------------------------------------------------------------|
+| Classpath of module (Alt+O) | `bisq.desktop.main`                                                                                               |
+| Main Class (Alt+C)          | `bisq.desktop.Main`                                                                                               |
+| Program Arguments (Alt+R)   | `--appName=bisq_Alice`                                                                                            |
+| VM Arguments (Alt+V)        | `--add-opens java.base/java.lang.reflect=ALL-UNNAMED -Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR` |
+
+
+| Run Config                  | Bisq-clear-Bob       |
+|:----------------------------|:---------------------|
+| Classpath of module (Alt+O) | (same as Alice)      |
+| Main Class (Alt+C)          | (same as Alice)      |
+| Program Arguments (Alt+R)   | `--appName=bisq_Bob` |
+| VM Arguments (Alt+V)        | (same as Alice)      |
 
 
 


### PR DESCRIPTION
Add a list of the run configs (and their params) needed to simulate the clearnet scenario locally.