### PR TITLE
ApplicationOptions: Get Default Locale From LocaleRepository

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationOptions.java
+++ b/application/src/main/java/bisq/application/ApplicationOptions.java
@@ -17,6 +17,7 @@
 
 package bisq.application;
 
+import bisq.common.locale.LocaleRepository;
 import bisq.common.options.PropertiesReader;
 
 import java.util.Locale;
@@ -28,7 +29,7 @@ public record ApplicationOptions(String baseDir, String appName) {
     public Locale getLocale() {
         Properties properties = PropertiesReader.getProperties("bisq.properties");
         if (properties == null) {
-            return Locale.getDefault();
+            return LocaleRepository.getDefaultLocale();
         }
         String language = properties.getProperty("language");
         String country = properties.getProperty("country");


### PR DESCRIPTION
On some systems the country is not defined.
LocaleRepository.getDefaultLocale() calls Locale.getDefault() first and
handles the special cases afterwards. We should rely on it instead of
calling Locale.getDefault() directly.