### PR TITLE
BisqTextField: Set Label Float by default

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/containers/BisqGridPane.java
+++ b/desktop/src/main/java/bisq/desktop/components/containers/BisqGridPane.java
@@ -90,7 +90,6 @@ public class BisqGridPane extends GridPane {
 
     public BisqTextField addTextField(String labelText, String textFieldText) {
         BisqTextField textField = new BisqTextField(textFieldText);
-        textField.setLabelFloat(true);
         textField.setPromptText(labelText);
         GridPane.setRowIndex(textField, getRowCount());
         GridPane.setColumnIndex(textField, 0);

--- a/desktop/src/main/java/bisq/desktop/components/controls/BisqTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/BisqTextField.java
@@ -7,10 +7,12 @@ public class BisqTextField extends JFXTextField {
 
     public BisqTextField(String value) {
         super(value);
+        setLabelFloat(true);
     }
 
     public BisqTextField() {
         super();
+        setLabelFloat(true);
     }
 
     @Override


### PR DESCRIPTION
After setting a prompt text, most of our text fields call setLabelFloat(true). Setting label float to true by default could reduce boilerplate code. Ideally, I would like to call setLabelFloat(true) when setPromptText() is called, but sadly the method is final.