### PR TITLE
Make RpcCallFailureException a RuntimeException

### DIFF
--- a/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindChainBackend.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindChainBackend.java
@@ -3,7 +3,6 @@ package bisq.wallets.bitcoind;
 import bisq.wallets.bitcoind.responses.CreateOrLoadWalletResponse;
 import bisq.wallets.bitcoind.responses.FinalizePsbtResponse;
 import bisq.wallets.bitcoind.responses.UnloadWalletResponse;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import bisq.wallets.bitcoind.rpc.RpcClient;
 
 import java.nio.file.Path;
@@ -18,7 +17,7 @@ public class BitcoindChainBackend {
         this.rpcClient = rpcClient;
     }
 
-    public void createOrLoadWallet(Path walletPath, String passphrase, boolean isWatchOnly, boolean createBlankWallet) throws RpcCallFailureException {
+    public void createOrLoadWallet(Path walletPath, String passphrase, boolean isWatchOnly, boolean createBlankWallet) {
         if (!doesWalletExist(walletPath)) {
             createWallet(walletPath, passphrase, isWatchOnly, createBlankWallet);
         } else {
@@ -26,7 +25,7 @@ public class BitcoindChainBackend {
         }
     }
 
-    public FinalizePsbtResponse finalizePsbt(String psbt) throws RpcCallFailureException {
+    public FinalizePsbtResponse finalizePsbt(String psbt) {
         return rpcClient.invoke(
                 BitcoindRpcEndpoint.FINALIZE_PSBT,
                 new Object[]{psbt},
@@ -34,7 +33,7 @@ public class BitcoindChainBackend {
         );
     }
 
-    public List<String> generateToAddress(int numberOfBlocksToMine, String addressOfMiner) throws RpcCallFailureException {
+    public List<String> generateToAddress(int numberOfBlocksToMine, String addressOfMiner) {
         return Arrays.asList(
                 rpcClient.invoke(
                         BitcoindRpcEndpoint.GENERATE_TO_ADDRESS,
@@ -44,7 +43,7 @@ public class BitcoindChainBackend {
         );
     }
 
-    public String sendRawTransaction(String hexString) throws RpcCallFailureException {
+    public String sendRawTransaction(String hexString) {
         return rpcClient.invoke(
                 BitcoindRpcEndpoint.SEND_RAW_TRANSACTION,
                 new Object[]{hexString},
@@ -52,7 +51,7 @@ public class BitcoindChainBackend {
         );
     }
 
-    public boolean stop() throws RpcCallFailureException {
+    public boolean stop() {
         String result = rpcClient.invoke(
                 BitcoindRpcEndpoint.STOP,
                 new Object[0],
@@ -61,7 +60,7 @@ public class BitcoindChainBackend {
         return result.equals("Bitcoin Core stopping");
     }
 
-    public void unloadWallet(Path walletPath) throws RpcCallFailureException {
+    public void unloadWallet(Path walletPath) {
         String absoluteWalletPath = walletPath.toAbsolutePath().toString();
         UnloadWalletResponse response = rpcClient.invoke(
                 BitcoindRpcEndpoint.UNLOAD_WALLET,
@@ -75,7 +74,7 @@ public class BitcoindChainBackend {
         return walletPath.toFile().exists();
     }
 
-    private void createWallet(Path walletPath, String passphrase, boolean isWatchOnly, boolean createBlankWallet) throws RpcCallFailureException {
+    private void createWallet(Path walletPath, String passphrase, boolean isWatchOnly, boolean createBlankWallet) {
         String absoluteWalletPath = walletPath.toAbsolutePath().toString();
         CreateOrLoadWalletResponse response = rpcClient.invoke(
                 BitcoindRpcEndpoint.CREATE_WALLET,
@@ -90,7 +89,7 @@ public class BitcoindChainBackend {
         response.validate(absoluteWalletPath);
     }
 
-    private void loadWallet(Path walletPath) throws RpcCallFailureException {
+    private void loadWallet(Path walletPath) {
         String absoluteWalletPath = walletPath.toAbsolutePath().toString();
         CreateOrLoadWalletResponse response = rpcClient.invoke(
                 BitcoindRpcEndpoint.LOAD_WALLET,

--- a/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindWalletBackend.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindWalletBackend.java
@@ -5,7 +5,6 @@ import bisq.wallets.bitcoind.psbt.PsbtInput;
 import bisq.wallets.bitcoind.psbt.PsbtOptions;
 import bisq.wallets.bitcoind.psbt.PsbtOutput;
 import bisq.wallets.bitcoind.responses.*;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import bisq.wallets.bitcoind.rpc.RpcClient;
 
 import java.util.Arrays;
@@ -21,7 +20,7 @@ public class BitcoindWalletBackend {
         this.walletRpcClient = walletRpcClient;
     }
 
-    public AddMultisigAddressResponse addMultisigAddress(int nRequired, List<String> keys) throws RpcCallFailureException {
+    public AddMultisigAddressResponse addMultisigAddress(int nRequired, List<String> keys) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.ADD_MULTISIG_ADDRESS,
                 new Object[]{nRequired, keys},
@@ -29,7 +28,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public GetAddressInfoResponse getAddressInfo(String address) throws RpcCallFailureException {
+    public GetAddressInfoResponse getAddressInfo(String address) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.GET_ADDRESS_INFO,
                 new Object[]{address},
@@ -37,7 +36,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public double getBalance() throws RpcCallFailureException {
+    public double getBalance() {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.GET_BALANCE,
                 new Object[0],
@@ -45,7 +44,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public String getNewAddress(AddressType addressType, String label) throws RpcCallFailureException {
+    public String getNewAddress(AddressType addressType, String label) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.GET_NEW_ADDRESS,
                 new Object[]{label, addressType.getName()},
@@ -53,7 +52,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public void importAddress(String address, String label) throws RpcCallFailureException {
+    public void importAddress(String address, String label) {
         walletRpcClient.invoke(
                 BitcoindRpcEndpoint.IMPORT_ADDRESS,
                 new Object[]{address, label},
@@ -61,7 +60,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public List<ListTransactionsResponseEntry> listTransactions(int count) throws RpcCallFailureException {
+    public List<ListTransactionsResponseEntry> listTransactions(int count) {
         return Arrays.asList(
                 walletRpcClient.invoke(
                         BitcoindRpcEndpoint.LIST_TRANSACTIONS,
@@ -71,7 +70,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public List<ListUnspentResponseEntry> listUnspent() throws RpcCallFailureException {
+    public List<ListUnspentResponseEntry> listUnspent() {
         return Arrays.asList(
                 walletRpcClient.invoke(
                         BitcoindRpcEndpoint.LIST_UNSPENT,
@@ -81,7 +80,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public String sendToAddress(String address, double amount) throws RpcCallFailureException {
+    public String sendToAddress(String address, double amount) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.SEND_TO_ADDRESS,
                 new Object[]{address, amount},
@@ -89,7 +88,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public String signMessage(String address, String message) throws RpcCallFailureException {
+    public String signMessage(String address, String message) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.SIGN_MESSAGE,
                 new Object[]{address, message},
@@ -97,7 +96,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public boolean verifyMessage(String address, String signature, String message) throws RpcCallFailureException {
+    public boolean verifyMessage(String address, String signature, String message) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.VERIFY_MESSAGE,
                 new Object[]{address, signature, message},
@@ -108,7 +107,7 @@ public class BitcoindWalletBackend {
     public WalletCreateFundedPsbtResponse walletCreateFundedPsbt(List<PsbtInput> inputs,
                                                                  PsbtOutput psbtOutput,
                                                                  int lockTime,
-                                                                 PsbtOptions psbtOptions) throws RpcCallFailureException {
+                                                                 PsbtOptions psbtOptions) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.WALLET_CREATE_FUNDED_PSBT,
                 new Object[]{
@@ -121,7 +120,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public void walletPassphrase(String passphrase, long timeout) throws RpcCallFailureException {
+    public void walletPassphrase(String passphrase, long timeout) {
         walletRpcClient.invoke(
                 BitcoindRpcEndpoint.WALLET_PASSPHRASE,
                 new Object[]{
@@ -132,7 +131,7 @@ public class BitcoindWalletBackend {
         );
     }
 
-    public WalletProcessPsbtResponse walletProcessPsbt(String psbt) throws RpcCallFailureException {
+    public WalletProcessPsbtResponse walletProcessPsbt(String psbt) {
         return walletRpcClient.invoke(
                 BitcoindRpcEndpoint.WALLET_PROCESS_PSBT,
                 new Object[]{psbt},

--- a/wallets/src/main/java/bisq/wallets/bitcoind/responses/CreateOrLoadWalletResponse.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/responses/CreateOrLoadWalletResponse.java
@@ -13,7 +13,7 @@ public class CreateOrLoadWalletResponse extends BitcoindWalletResponse {
     public CreateOrLoadWalletResponse() {
     }
 
-    public void validate(String walletDirPath) throws RpcCallFailureException {
+    public void validate(String walletDirPath) {
         if (!isSuccess(walletDirPath)) {
             throw new RpcCallFailureException(warning);
         }

--- a/wallets/src/main/java/bisq/wallets/bitcoind/responses/UnloadWalletResponse.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/responses/UnloadWalletResponse.java
@@ -4,7 +4,7 @@ import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 
 public class UnloadWalletResponse extends BitcoindWalletResponse {
 
-    public void validate() throws RpcCallFailureException {
+    public void validate() {
         if (!isSuccess()) {
             throw new RpcCallFailureException(warning);
         }

--- a/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcCallFailureException.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcCallFailureException.java
@@ -1,6 +1,6 @@
 package bisq.wallets.bitcoind.rpc;
 
-public class RpcCallFailureException extends Exception {
+public class RpcCallFailureException extends RuntimeException {
     public RpcCallFailureException(String message) {
         super(message);
     }

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
@@ -4,7 +4,6 @@ import bisq.wallets.AddressType;
 import bisq.wallets.bitcoind.psbt.PsbtOptions;
 import bisq.wallets.bitcoind.psbt.PsbtOutput;
 import bisq.wallets.bitcoind.responses.*;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
@@ -16,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BitcoindPsbtMultiSigIntegrationTests extends SharedBitcoindInstanceTests {
 
     @Test
-    public void psbtMultiSigTest() throws MalformedURLException, RpcCallFailureException {
+    public void psbtMultiSigTest() throws MalformedURLException {
         BitcoindRegtestSetup.mineInitialRegtestBlocks(minerChainBackend, minerWalletBackend);
 
         var aliceBackend = BitcoindRegtestSetup

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindReceiveAddrIntegrationTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindReceiveAddrIntegrationTests.java
@@ -1,7 +1,6 @@
 package bisq.wallets.bitcoind;
 
 import bisq.wallets.AddressType;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,19 +8,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BitcoindReceiveAddrIntegrationTests extends SharedBitcoindInstanceTests {
 
     @Test
-    void getNewLegacyAddress() throws RpcCallFailureException {
+    void getNewLegacyAddress() {
         String address = minerWalletBackend.getNewAddress(AddressType.LEGACY, "");
         assertTrue(address.startsWith("m") || address.startsWith("n"), address);
     }
 
     @Test
-    void getNewP2ShSegwitAddress() throws RpcCallFailureException {
+    void getNewP2ShSegwitAddress() {
         String address = minerWalletBackend.getNewAddress(AddressType.P2SH_SEGWIT, "");
         assertTrue(address.startsWith("2"), address);
     }
 
     @Test
-    void getNewBech32Address() throws RpcCallFailureException {
+    void getNewBech32Address() {
         String address = minerWalletBackend.getNewAddress(AddressType.BECH32, "");
         assertTrue(address.startsWith("bcr"), address);
     }

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindRegtestSetup.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindRegtestSetup.java
@@ -4,7 +4,6 @@ import bisq.common.util.FileUtils;
 import bisq.wallets.AddressType;
 import bisq.wallets.NetworkType;
 import bisq.wallets.bitcoind.responses.ListUnspentResponseEntry;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import bisq.wallets.bitcoind.rpc.RpcClient;
 import bisq.wallets.bitcoind.rpc.RpcConfig;
 
@@ -37,7 +36,7 @@ public class BitcoindRegtestSetup {
 
     public static BitcoindWalletBackend createTestWalletBackend(BitcoindChainBackend chainBackend,
                                                                 Path tmpDirPath,
-                                                                String walletName) throws MalformedURLException, RpcCallFailureException {
+                                                                String walletName) throws MalformedURLException {
         Path receiverWalletPath = tmpDirPath.resolve(walletName);
         RpcClient receiverWalletRpc = createWalletRpcClient(receiverWalletPath);
 
@@ -61,12 +60,12 @@ public class BitcoindRegtestSetup {
                 .findFirst();
     }
 
-    public static void mineInitialRegtestBlocks(BitcoindChainBackend minerChainBackend, BitcoindWalletBackend minerBackend) throws RpcCallFailureException {
+    public static void mineInitialRegtestBlocks(BitcoindChainBackend minerChainBackend, BitcoindWalletBackend minerBackend) {
         String address = minerBackend.getNewAddress(AddressType.BECH32, "");
         minerChainBackend.generateToAddress(101, address);
     }
 
-    public static void mineOneBlock(BitcoindChainBackend minerChainBackend, BitcoindWalletBackend minerBackend) throws RpcCallFailureException {
+    public static void mineOneBlock(BitcoindChainBackend minerChainBackend, BitcoindWalletBackend minerBackend) {
         String minerAddress = minerBackend.getNewAddress(AddressType.BECH32, "");
         minerChainBackend.generateToAddress(1, minerAddress);
     }
@@ -74,7 +73,7 @@ public class BitcoindRegtestSetup {
     public static String sendBtcAndMineOneBlock(BitcoindChainBackend minerChainBackend,
                                                 BitcoindWalletBackend minerWalletBackend,
                                                 BitcoindWalletBackend receiverBackend,
-                                                double amount) throws RpcCallFailureException {
+                                                double amount) {
         String receiverAddress = receiverBackend.getNewAddress(AddressType.BECH32, "");
         minerWalletBackend.sendToAddress(receiverAddress, amount);
 

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindSendIntegrationTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindSendIntegrationTests.java
@@ -4,7 +4,6 @@ import bisq.common.util.FileUtils;
 import bisq.wallets.AddressType;
 import bisq.wallets.bitcoind.responses.ListTransactionsResponseEntry;
 import bisq.wallets.bitcoind.responses.ListUnspentResponseEntry;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import bisq.wallets.bitcoind.rpc.RpcClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +27,7 @@ public class BitcoindSendIntegrationTests {
     private BitcoindWalletBackend walletBackend;
 
     @BeforeEach
-    public void setUp() throws IOException, RpcCallFailureException {
+    public void setUp() throws IOException {
         bitcoindProcess = BitcoindRegtestSetup.createAndStartBitcoind();
         tmpDirPath = FileUtils.createTempDir();
 
@@ -44,20 +43,20 @@ public class BitcoindSendIntegrationTests {
     }
 
     @AfterEach
-    public void cleanUp() throws RpcCallFailureException {
+    public void cleanUp() {
         chainBackend.unloadWallet(walletFilePath);
         bitcoindProcess.stopAndWaitUntilStopped();
     }
 
     @Test
-    public void mineInitialRegtestBlocks() throws RpcCallFailureException {
+    public void mineInitialRegtestBlocks() {
         String address = walletBackend.getNewAddress(AddressType.BECH32, "");
         chainBackend.generateToAddress(101, address);
         assertEquals(50, walletBackend.getBalance());
     }
 
     @Test
-    public void sendOneBtcToAddress() throws MalformedURLException, RpcCallFailureException {
+    public void sendOneBtcToAddress() throws MalformedURLException {
         mineInitialRegtestBlocks();
         var receiverBackend = BitcoindRegtestSetup
                 .createTestWalletBackend(chainBackend, tmpDirPath, "receiver_wallet");
@@ -73,7 +72,7 @@ public class BitcoindSendIntegrationTests {
     }
 
     @Test
-    public void sendBtcAndListTxs() throws MalformedURLException, RpcCallFailureException {
+    public void sendBtcAndListTxs() throws MalformedURLException {
         mineInitialRegtestBlocks();
         var receiverBackend = BitcoindRegtestSetup
                 .createTestWalletBackend(chainBackend, tmpDirPath, "receiver_wallet");
@@ -122,7 +121,7 @@ public class BitcoindSendIntegrationTests {
     }
 
     @Test
-    public void listUnspent() throws MalformedURLException, RpcCallFailureException {
+    public void listUnspent() throws MalformedURLException {
         mineInitialRegtestBlocks();
         BitcoindWalletBackend receiverBackend = BitcoindRegtestSetup
                 .createTestWalletBackend(chainBackend, tmpDirPath, "receiver_wallet");

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindSigningIntegrationTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindSigningIntegrationTests.java
@@ -1,7 +1,6 @@
 package bisq.wallets.bitcoind;
 
 import bisq.wallets.AddressType;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,7 +9,7 @@ public class BitcoindSigningIntegrationTests extends SharedBitcoindInstanceTests
     private static final String MESSAGE = "my message";
 
     @Test
-    public void signAndVerifyMessage() throws RpcCallFailureException {
+    public void signAndVerifyMessage() {
         String address = minerWalletBackend.getNewAddress(AddressType.LEGACY, "");
         String signature = minerWalletBackend.signMessage(address, MESSAGE);
         boolean isValid = minerWalletBackend.verifyMessage(address, signature, MESSAGE);

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindWalletCreationIntegrationTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindWalletCreationIntegrationTests.java
@@ -1,6 +1,5 @@
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,13 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BitcoindWalletCreationIntegrationTests extends SharedBitcoindInstanceTests {
     @Test
-    public void createFreshWallet() throws RpcCallFailureException {
+    public void createFreshWallet() {
         assertTrue(walletFilePath.toFile().exists());
         assertEquals(0, minerWalletBackend.getBalance());
     }
 
     @Test
-    public void loadWalletIfExisting() throws RpcCallFailureException {
+    public void loadWalletIfExisting() {
         assertTrue(walletFilePath.toFile().exists());
 
         minerChainBackend.unloadWallet(walletFilePath);

--- a/wallets/src/test/java/bisq/wallets/bitcoind/SharedBitcoindInstanceTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/SharedBitcoindInstanceTests.java
@@ -1,7 +1,6 @@
 package bisq.wallets.bitcoind;
 
 import bisq.common.util.FileUtils;
-import bisq.wallets.bitcoind.rpc.RpcCallFailureException;
 import bisq.wallets.bitcoind.rpc.RpcClient;
 import org.junit.jupiter.api.*;
 
@@ -32,7 +31,7 @@ abstract class SharedBitcoindInstanceTests {
     }
 
     @BeforeEach
-    public void setUp() throws IOException, RpcCallFailureException {
+    public void setUp() throws IOException {
         tmpDirPath = FileUtils.createTempDir();
         walletFilePath = tmpDirPath.resolve("wallet");
         assertFalse(walletFilePath.toFile().exists());
@@ -47,7 +46,7 @@ abstract class SharedBitcoindInstanceTests {
     }
 
     @AfterEach
-    public void cleanUp() throws RpcCallFailureException {
+    public void cleanUp() {
         minerChainBackend.unloadWallet(walletFilePath);
     }
 }


### PR DESCRIPTION
The RpcClient will be called later in CompletableFutures. A checked
exception forces us to explicitly handle the exception in the
WalletService, making the code more complex. A RuntimeException can be
handled by the caller using CompletableFuture.handle(...) or a related
method. This allows the WalletService consumer to decide how to respond
to a failed call. Furthermore, the WalletService is not smart enough to
handle the exception because it doesn't know the context in which it
was triggered.

Fixes #72