### PR TITLE
Fix: Prompt text cutoff in BisqTextField

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/controls/BisqTextField.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/BisqTextField.java
@@ -1,6 +1,7 @@
 package bisq.desktop.components.controls;
 
 import com.jfoenix.controls.JFXTextField;
+import javafx.geometry.Insets;
 import javafx.scene.control.Skin;
 
 public class BisqTextField extends JFXTextField {
@@ -8,11 +9,13 @@ public class BisqTextField extends JFXTextField {
     public BisqTextField(String value) {
         super(value);
         setLabelFloat(true);
+        createEnoughSpaceForPromptText();
     }
 
     public BisqTextField() {
         super();
         setLabelFloat(true);
+        createEnoughSpaceForPromptText();
     }
 
     @Override
@@ -28,5 +31,9 @@ public class BisqTextField extends JFXTextField {
     public void show() {
         setVisible(true);
         setManaged(true);
+    }
+
+    private void createEnoughSpaceForPromptText() {
+        setPadding(new Insets(20, 0, 0, 0));
     }
 }


### PR DESCRIPTION
When the user enters text into a text field, the prompt text floats
above the text field. There is no padding by default which takes this
into account. This results in the prompt text clashing with the control
above.