### PR TITLE
Fix Gradle Run Task

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -14,6 +14,9 @@ apply from: '../buildSrc/bisq-version.gradle'
 
 application {
     project.mainClassName = 'bisq.desktop.Main'
+    applicationDefaultJvmArgs = ['--add-exports', 'javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED',
+                                 '--add-exports', 'javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED',
+                                 '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED']
 }
 
 distributions {

--- a/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
+++ b/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
@@ -30,7 +30,7 @@ public class ImageUtil {
 
     // Does not resolve the @2x automatically
     public static Image getImageByPath(String path) {
-        try (InputStream resourceAsStream = ImageView.class.getResourceAsStream(path)) {
+        try (InputStream resourceAsStream = ImageView.class.getClassLoader().getResourceAsStream(path)) {
             return new Image(Objects.requireNonNull(resourceAsStream));
         } catch (Exception e) {
             log.error("Loading image failed: path={}", path);
@@ -40,7 +40,7 @@ public class ImageUtil {
     }
 
     public static Image getImageByPath(String path, int width, int height) {
-        try (InputStream resourceAsStream = ImageView.class.getResourceAsStream(path)) {
+        try (InputStream resourceAsStream = ImageView.class.getClassLoader().getResourceAsStream(path)) {
             return new Image(Objects.requireNonNull(resourceAsStream), width, height, true, true);
         } catch (Exception e) {
             log.error("Loading image failed: path={}", path);
@@ -65,7 +65,7 @@ public class ImageUtil {
     public static Image composeImage(String[] paths, int width, int height) {
         WritableImage image = new WritableImage(width, height);
         for (String path : paths) {
-            Image part = getImageByPath("/images/robohash/" + path, width, height);
+            Image part = getImageByPath("images/robohash/" + path, width, height);
             PixelReader reader = part.getPixelReader();
             PixelWriter writer = image.getPixelWriter();
             for (int i = 0; i < width; i++) {

--- a/desktop/src/main/java/bisq/desktop/primary/PrimaryStageView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/PrimaryStageView.java
@@ -106,11 +106,11 @@ public class PrimaryStageView extends View<AnchorPane, PrimaryStageModel, Primar
     private Image getApplicationIconImage() {
         String iconPath;
         if (OsUtils.isOSX())
-            iconPath = ImageUtil.isRetina() ? "/images/window_icon@2x.png" : "/images/window_icon.png";
+            iconPath = ImageUtil.isRetina() ? "images/window_icon@2x.png" : "images/window_icon.png";
         else if (OsUtils.isWindows())
-            iconPath = "/images/task_bar_icon_windows.png";
+            iconPath = "images/task_bar_icon_windows.png";
         else
-            iconPath = "/images/task_bar_icon_linux.png";
+            iconPath = "images/task_bar_icon_linux.png";
 
         return ImageUtil.getImageByPath(iconPath);
     }


### PR DESCRIPTION
We cannot start the desktop app using Gradle. This change fixes this.

Changes:
- Add JVM arguments for jfoenix
- Load resources using `ClassLoader`