### PR TITLE
Add support for gradle args when starting desktop client

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you want to use more seed nodes repeat it and fill in more but 1-2 is usually
 
 ### Example Run Configurations
 
-See [here](docs/intellij-idea-sample-run-configs.md)
+See [here](docs/sample-run-configs.md)
 
 
 ## Contributing

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -19,6 +19,13 @@ application {
                                  '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED']
 }
 
+run {
+    // Pass command-line properties to application
+    // Normally they'd only be applied to the gradle process, but we need them in the started application
+    // See https://stackoverflow.com/a/23689696
+    systemProperties System.getProperties()
+}
+
 distributions {
     main {
         distributionBaseName = 'jfx-dist'

--- a/docs/sample-run-configs.md
+++ b/docs/sample-run-configs.md
@@ -1,4 +1,4 @@
-### IntellJ IDEA Sample Run Configs
+### IntelliJ IDEA: Application Run Configs
 
 Here are a few IntelliJ IDEA run configurations for running two seeds and different desktop nodes.
 
@@ -91,4 +91,30 @@ Copy the `Alice_clear` run configuration, rename it to `Alice_i2p` and change:
 -Dbisq.networkServiceConfig.supportedTransportTypes.0=I2P 
 -Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.0=<i2p destination of seed 1>:5000 
 -Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.1=<i2p destination of seed 2>:5001
+```
+
+### IntelliJ IDEA: Gradle run configs
+
+* Create a new IntelliJ IDEA run config of type Gradle
+* Choose a config name (e.g. `[gradle] Alice I2P`)
+* Choose Gradle Project as `bisq2:desktop`
+* Add VM options as necessary, in the format `-Dprop=value` (e.g. `-Dbisq.application.appName=bisq_Alice_i2p`)
+
+
+### Command line: Gradle run configs
+
+Start a default desktop client with:
+
+```
+./gradlew desktop:run
+```
+
+Start a customized desktop client with:
+
+```
+./gradlew desktop:run \
+    -Dbisq.application.appName=bisq_Alice_i2p \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.0=I2P \
+    -Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.0=<i2p destination of seed 1>:5000 \
+    -Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.1=<i2p destination of seed 2>:5001
 ```


### PR DESCRIPTION
Make sure to propagate system properties to the started desktop application. Add documentation indicating how to do this.