### PR TITLE
Distinguish between wallet not running and wrong rpc credentials

### DIFF
--- a/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindWallet.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindWallet.java
@@ -17,12 +17,13 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.*;
+import bisq.wallets.AddressType;
+import bisq.wallets.Wallet;
 import bisq.wallets.bitcoind.responses.ListTransactionsResponseEntry;
 import bisq.wallets.bitcoind.responses.ListUnspentResponseEntry;
-import bisq.wallets.bitcoind.rpc.*;
-import bisq.wallets.exceptions.InvalidRpcCredentialsException;
-import bisq.wallets.exceptions.RpcCallFailureException;
+import bisq.wallets.bitcoind.rpc.RpcClient;
+import bisq.wallets.bitcoind.rpc.RpcConfig;
+import bisq.wallets.bitcoind.rpc.WalletRpcConfig;
 import bisq.wallets.exceptions.WalletInitializationFailedException;
 import bisq.wallets.model.Transaction;
 import bisq.wallets.model.Utxo;
@@ -55,12 +56,8 @@ public class BitcoindWallet implements Wallet {
 
     @Override
     public void initialize(String walletPassphrase) {
-        try {
-            chainBackend.createOrLoadWallet(walletPath, walletPassphrase, false, false);
-            walletBackend.walletPassphrase(walletPassphrase, BitcoindWalletBackend.DEFAULT_WALLET_TIMEOUT);
-        } catch (RpcCallFailureException e) {
-            throw new InvalidRpcCredentialsException(e);
-        }
+        chainBackend.createOrLoadWallet(walletPath, walletPassphrase, false, false);
+        walletBackend.walletPassphrase(walletPassphrase, BitcoindWalletBackend.DEFAULT_WALLET_TIMEOUT);
     }
 
     @Override

--- a/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcClient.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcClient.java
@@ -19,9 +19,11 @@ package bisq.wallets.bitcoind.rpc;
 
 import bisq.common.encoding.Base64;
 import bisq.wallets.bitcoind.BitcoindRpcEndpoint;
+import bisq.wallets.exceptions.CannotConnectToWalletException;
 import bisq.wallets.exceptions.RpcCallFailureException;
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 
+import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +46,10 @@ public class RpcClient {
     public <T> T invoke(BitcoindRpcEndpoint rpcEndpoint, Object argument, Class<T> clazz) {
         try {
             return jsonRpcClient.invoke(rpcEndpoint.getMethodName(), argument, clazz);
-        } catch (Throwable t) {
+        } catch (ConnectException e) {
+            throw new CannotConnectToWalletException(e);
+        }
+        catch (Throwable t) {
             throw new RpcCallFailureException("RPC call to " + rpcEndpoint.getMethodName() + " failed.", t);
         }
     }

--- a/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcClient.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcClient.java
@@ -20,6 +20,7 @@ package bisq.wallets.bitcoind.rpc;
 import bisq.common.encoding.Base64;
 import bisq.wallets.bitcoind.BitcoindRpcEndpoint;
 import bisq.wallets.exceptions.CannotConnectToWalletException;
+import bisq.wallets.exceptions.InvalidRpcCredentialsException;
 import bisq.wallets.exceptions.RpcCallFailureException;
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 
@@ -50,6 +51,9 @@ public class RpcClient {
             throw new CannotConnectToWalletException(e);
         }
         catch (Throwable t) {
+            if (rpcAuthenticationFailed(t)) {
+                throw new InvalidRpcCredentialsException("Invalid RPC credentials", t);
+            }
             throw new RpcCallFailureException("RPC call to " + rpcEndpoint.getMethodName() + " failed.", t);
         }
     }
@@ -67,6 +71,10 @@ public class RpcClient {
             url += urlSuffix.get();
         }
         return new JsonRpcHttpClient(new URL(url), createAuthHeader(rpcConfig));
+    }
+
+    private boolean rpcAuthenticationFailed(Throwable t) {
+        return t.getCause().toString().contains("401");
     }
 
     private Map<String, String> createAuthHeader(RpcConfig rpcConfig) {

--- a/wallets/src/main/java/bisq/wallets/exceptions/CannotConnectToWalletException.java
+++ b/wallets/src/main/java/bisq/wallets/exceptions/CannotConnectToWalletException.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.exceptions;
+
+public class CannotConnectToWalletException extends RuntimeException {
+    public CannotConnectToWalletException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/wallets/src/main/java/bisq/wallets/exceptions/InvalidRpcCredentialsException.java
+++ b/wallets/src/main/java/bisq/wallets/exceptions/InvalidRpcCredentialsException.java
@@ -18,7 +18,7 @@
 package bisq.wallets.exceptions;
 
 public class InvalidRpcCredentialsException extends RuntimeException {
-    public InvalidRpcCredentialsException(Throwable cause) {
-        super(cause);
+    public InvalidRpcCredentialsException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindConnectionFailureTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindConnectionFailureTests.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.bitcoind;
+
+import bisq.wallets.bitcoind.rpc.RpcClient;
+import bisq.wallets.exceptions.CannotConnectToWalletException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.ConnectException;
+import java.net.MalformedURLException;
+
+public class BitcoindConnectionFailureTests {
+    @Test
+    void bitcoindNotRunningTest() throws MalformedURLException {
+        var rpcClient = new RpcClient(BitcoindRegtestSetup.RPC_CONFIG);
+        var minerChainBackend = new BitcoindChainBackend(rpcClient);
+
+        CannotConnectToWalletException exception = Assertions
+                .assertThrows(CannotConnectToWalletException.class, minerChainBackend::listWallets);
+
+        Assertions.assertTrue(exception.getCause() instanceof ConnectException);
+    }
+}


### PR DESCRIPTION
At the moment, it's not easy for the UI to check whether the wallet RPC call failed because the external wallet was not running or the credentials were wrong.