### PR TITLE
Wallet Tests: Use random port for bitcoind regtest instance

### DIFF
--- a/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindProcess.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/BitcoindProcess.java
@@ -18,10 +18,12 @@
 package bisq.wallets.bitcoind;
 
 import bisq.common.util.FileUtils;
+import bisq.common.util.NetworkUtils;
 import bisq.wallets.NetworkType;
 import bisq.wallets.exceptions.RpcCallFailureException;
 import bisq.wallets.bitcoind.rpc.RpcClient;
 import bisq.wallets.bitcoind.rpc.RpcConfig;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -31,6 +33,7 @@ import java.util.Scanner;
 @Slf4j
 public class BitcoindProcess {
 
+    @Getter
     private final RpcConfig rpcConfig;
     private final Path dataDir;
 
@@ -71,9 +74,10 @@ public class BitcoindProcess {
                 "bitcoind",
                 networkArg,
                 "-datadir=" + dataDir.toAbsolutePath(),
+                "-bind=127.0.0.1:" + NetworkUtils.findFreeSystemPort(),
                 "-whitelist=127.0.0.1",
-                "-rpcbind",
-                "-rpcallowip=" + rpcConfig.hostname(),
+                "-rpcbind=127.0.0.1:" + rpcConfig.port(),
+                "-rpcallowip=127.0.0.1",
                 "-rpcuser=" + rpcConfig.user(),
                 "-rpcpassword=" + rpcConfig.password(),
                 "-fallbackfee=0.00000001",

--- a/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcClient.java
+++ b/wallets/src/main/java/bisq/wallets/bitcoind/rpc/RpcClient.java
@@ -65,7 +65,7 @@ public class RpcClient {
 
     private JsonRpcHttpClient createRpcClientWithUrlSuffix(RpcConfig rpcConfig, Optional<String> urlSuffix) throws MalformedURLException {
         String hostname = rpcConfig.hostname();
-        int port = rpcConfig.networkType().getRpcPort();
+        int port = rpcConfig.port();
         var url = "http://" + hostname + ":" + port;
         if (urlSuffix.isPresent()) {
             url += urlSuffix.get();

--- a/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
@@ -21,6 +21,7 @@ import bisq.wallets.AddressType;
 import bisq.wallets.bitcoind.psbt.PsbtOptions;
 import bisq.wallets.bitcoind.psbt.PsbtOutput;
 import bisq.wallets.bitcoind.responses.*;
+import bisq.wallets.bitcoind.rpc.RpcConfig;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
@@ -34,13 +35,14 @@ public class BitcoindPsbtMultiSigIntegrationTests extends SharedBitcoindInstance
     @Test
     public void psbtMultiSigTest() throws MalformedURLException {
         BitcoindRegtestSetup.mineInitialRegtestBlocks(minerChainBackend, minerWalletBackend);
+        RpcConfig rpcConfig = bitcoindProcess.getRpcConfig();
 
         var aliceBackend = BitcoindRegtestSetup
-                .createTestWalletBackend(minerChainBackend, tmpDirPath, "alice_wallet");
+                .createTestWalletBackend(rpcConfig, minerChainBackend, tmpDirPath, "alice_wallet");
         var bobBackend = BitcoindRegtestSetup
-                .createTestWalletBackend(minerChainBackend, tmpDirPath, "bob_wallet");
+                .createTestWalletBackend(rpcConfig, minerChainBackend, tmpDirPath, "bob_wallet");
         var charlieBackend = BitcoindRegtestSetup
-                .createTestWalletBackend(minerChainBackend, tmpDirPath, "charlie_wallet");
+                .createTestWalletBackend(rpcConfig, minerChainBackend, tmpDirPath, "charlie_wallet");
 
         String aliceAddress = aliceBackend.getNewAddress(AddressType.BECH32, "");
         String bobAddress = bobBackend.getNewAddress(AddressType.BECH32, "");

--- a/wallets/src/test/java/bisq/wallets/bitcoind/SharedBitcoindInstanceTests.java
+++ b/wallets/src/test/java/bisq/wallets/bitcoind/SharedBitcoindInstanceTests.java
@@ -19,6 +19,7 @@ package bisq.wallets.bitcoind;
 
 import bisq.common.util.FileUtils;
 import bisq.wallets.bitcoind.rpc.RpcClient;
+import bisq.wallets.bitcoind.rpc.RpcConfig;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
@@ -53,11 +54,13 @@ abstract class SharedBitcoindInstanceTests {
         walletFilePath = tmpDirPath.resolve("wallet");
         assertFalse(walletFilePath.toFile().exists());
 
-        rpcClient = new RpcClient(BitcoindRegtestSetup.RPC_CONFIG);
+        RpcConfig rpcConfig = bitcoindProcess.getRpcConfig();
+        rpcClient = new RpcClient(rpcConfig);
+
         minerChainBackend = new BitcoindChainBackend(rpcClient);
         minerChainBackend.createOrLoadWallet(walletFilePath, BitcoindRegtestSetup.WALLET_PASSPHRASE, false, false);
 
-        RpcClient walletRpcClient = BitcoindRegtestSetup.createWalletRpcClient(walletFilePath);
+        RpcClient walletRpcClient = BitcoindRegtestSetup.createWalletRpcClient(rpcConfig, walletFilePath);
         minerWalletBackend = new BitcoindWalletBackend(walletRpcClient);
         minerWalletBackend.walletPassphrase(BitcoindRegtestSetup.WALLET_PASSPHRASE, BitcoindWalletBackend.DEFAULT_WALLET_TIMEOUT);
     }


### PR DESCRIPTION
Get a free port and start the bitcoind regtest instances. Otherwise we could interfere with a running bitcoind regtest instance.