### PR TITLE
Add simple framework to start local seeds / clients

### DIFF
--- a/.screenrc-make
+++ b/.screenrc-make
@@ -1,0 +1,12 @@
+# This is a screen config used by the tests in Makefile in the same directory.
+
+# Change to previous / next tabs with F6 / F7
+bindkey -k k6 prev
+bindkey -k k7 next
+
+# Change default scrollback value for new windows
+defscrollback 10000
+
+# Bottom 2 lines: window title and list of windows as tabs
+caption always "%{= bb}%{+b w}%n %t %h %="
+hardstatus alwayslastline "%-Lw%{= BW}%50>%n%f* %t%{-}%+Lw%<"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+#
+# INTRODUCTION
+#
+# This makefile is designed to help Bisq contributors test the behavior of seeds and clients
+# under different network setups.
+#
+#
+# REQUIREMENTS
+#
+# `make`, `screen`
+#
+#
+# USAGE
+#
+# The tests will launch different seeds and clients using the gradle wrapper. Each
+# instance's console output will be tracked in a separate `screen` tab. F6/F7 navigates
+# to the previous/next `screen` tab. Ctrl+C kills the gradle process running in the current
+# `screen` tab and closes the tab.
+#
+# 1) Local clearnet scenario
+#
+# Launch 2 clearnet seeds and several (n) clearnet desktop clients with:
+#
+#     $ make start-local-clearnet n=4
+#
+# When not specified, n will default to 2, so this will start 2 seeds and 2 clients:
+#
+#     $ make start-local-clearnet
+#
+
+.start-local-clearnet-seeds:
+	# First screen command uses custom config, creates the session, and is detached
+	# All subsequent screen calls will create a new tab in the same session
+	# Seed 1
+	screen -c .screenrc-make -dmS localtests -t seed-1 ./gradlew --console=plain seed:run \
+		-Dbisq.application.appName=bisq2_seed1_test \
+		-Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8000 \
+		-Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR \
+		-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=127.0.0.1:8000 \
+		-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.1=127.0.0.1:8001
+	# Seed 2
+	screen -S localtests -X screen -t seed-2 ./gradlew --console=plain seed:run \
+		-Dbisq.application.appName=bisq2_seed2_test \
+		-Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8001 \
+		-Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR \
+		-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=127.0.0.1:8000 \
+		-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.1=127.0.0.1:8001
+
+# Set n to 2, if otherwise not set
+n ?= 2
+.start-clearnet-clients:
+	for i in $$(seq 1 $n); do \
+		screen -S localtests -X screen -t client-$$i ./gradlew --console=plain desktop:run \
+			-Dbisq.application.appName=bisq_$${i}_test \
+			-Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR \
+			-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=127.0.0.1:8000 \
+			-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.1=127.0.0.1:8001; \
+	done
+
+# Reattach to the screen session
+.reconnect-screen-session:
+	screen -r localtests
+
+
+start-local-clearnet: .start-local-clearnet-seeds .start-clearnet-clients .reconnect-screen-session
+

--- a/docs/sample-run-configs.md
+++ b/docs/sample-run-configs.md
@@ -103,15 +103,52 @@ Copy the `Alice_clear` run configuration, rename it to `Alice_i2p` and change:
 
 ### Command line: Gradle run configs
 
-Start a default desktop client with:
+Start a seed with:
 
 ```
+# Using default settings
+./gradlew seed:run
+```
+
+For example, to start two local seeds, `bisq2_seed1` and `bisq2_seed2`, reachable on all 3 networks:
+
+```
+# Seed 1
+./gradlew seed:run \
+    -Dbisq.application.appName=bisq2_seed1 \
+    -Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8000 \
+    -Dbisq.networkServiceConfig.defaultNodePortByTransportType.tor=1000 \
+    -Dbisq.networkServiceConfig.defaultNodePortByTransportType.i2p=5000 \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.0=TOR \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.1=I2P \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.2=CLEAR \
+    -Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=127.0.0.1:8000 \
+    -Dbisq.networkServiceConfig.seedAddressByTransportType.clear.1=127.0.0.1:8001
+
+# Seed 2
+./gradlew seed:run \
+    -Dbisq.application.appName=bisq2_seed2 \
+    -Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8001 \
+    -Dbisq.networkServiceConfig.defaultNodePortByTransportType.tor=1001 \
+    -Dbisq.networkServiceConfig.defaultNodePortByTransportType.i2p=5001 \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.0=TOR \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.1=I2P \
+    -Dbisq.networkServiceConfig.supportedTransportTypes.2=CLEAR \
+    -Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=127.0.0.1:8000 \
+    -Dbisq.networkServiceConfig.seedAddressByTransportType.clear.1=127.0.0.1:8001
+```
+
+Start a desktop client with:
+
+```
+# Using default settings
 ./gradlew desktop:run
 ```
 
-Start a customized desktop client with:
+To start a custom desktop client connecting only to I2P:
 
 ```
+# Local client on I2P only
 ./gradlew desktop:run \
     -Dbisq.application.appName=bisq_Alice_i2p \
     -Dbisq.networkServiceConfig.supportedTransportTypes.0=I2P \

--- a/seed/build.gradle
+++ b/seed/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java-library'
+    id 'application'
 }
 
 repositories {
@@ -11,6 +12,17 @@ apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
 apply from: '../buildSrc/lombok-dependencies.gradle'
+
+application {
+    project.mainClassName = 'bisq.seed.SeedMain'
+}
+
+run {
+    // Pass command-line properties to application
+    // Normally they'd only be applied to the gradle process, but we need them in the started application
+    // See https://stackoverflow.com/a/23689696
+    systemProperties System.getProperties()
+}
 
 dependencies {
     api platform(project(':platforms:common-platform'))


### PR DESCRIPTION
Combine make and screen to allow the launch of different combinations of seeds and clients. Include a scenario with two local seeds and n clients.

Depends on the `:seed:run` gradle task in #102.