### PR TITLE
Add chat channel header menu

### DIFF
--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -59,4 +59,11 @@ public class StringUtils {
 
         return message.substring(0, maxChar - 3) + "...";
     }
+
+    public static boolean containsIgnoreCase(String string, String searchString) {
+        if (string == null || searchString == null) {
+            return false;
+        }
+        return string.toLowerCase().contains(searchString.toLowerCase());
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/components/controls/BisqRadioButton.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/BisqRadioButton.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.controls;
+
+import bisq.desktop.common.utils.TooltipUtil;
+import com.jfoenix.controls.JFXRadioButton;
+import javafx.scene.control.Skin;
+
+public class BisqRadioButton extends JFXRadioButton {
+
+    public BisqRadioButton() {
+        super();
+    }
+
+    public BisqRadioButton(String text) {
+        super(text);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new AutoTooltipRadioButtonSkin(this);
+    }
+
+    private class AutoTooltipRadioButtonSkin extends JFXRadioButtonSkinBisqStyle {
+        public AutoTooltipRadioButtonSkin(JFXRadioButton radioButton) {
+            super(radioButton);
+        }
+
+        @Override
+        protected void layoutChildren(double x, double y, double w, double h) {
+            super.layoutChildren(x, y, w, h);
+            TooltipUtil.showTooltipIfTruncated(this, getSkinnable());
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/components/controls/JFXRadioButtonSkinBisqStyle.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/JFXRadioButtonSkinBisqStyle.java
@@ -1,0 +1,281 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.controls;
+
+import com.jfoenix.controls.JFXRadioButton;
+import com.jfoenix.controls.JFXRippler;
+import com.jfoenix.transitions.JFXAnimationTimer;
+import com.jfoenix.transitions.JFXKeyFrame;
+import com.jfoenix.transitions.JFXKeyValue;
+import javafx.animation.Interpolator;
+import javafx.geometry.HPos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.skin.RadioButtonSkin;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.StrokeType;
+import javafx.scene.text.Text;
+import javafx.util.Duration;
+
+/**
+ * Code copied and adapted from com.jfoenix.skins.JFXRadioButtonSkin
+ */
+
+public class JFXRadioButtonSkinBisqStyle extends RadioButtonSkin {
+    private final JFXRippler rippler;
+    private double padding = 12;
+
+    private Circle radio, dot;
+    private final StackPane container;
+
+    private JFXAnimationTimer timer;
+
+    public JFXRadioButtonSkinBisqStyle(JFXRadioButton control) {
+        super(control);
+
+        final double radioRadius = 7;
+        radio = new Circle(radioRadius);
+        radio.getStyleClass().setAll("radio");
+        radio.setStrokeWidth(1);
+        radio.setStrokeType(StrokeType.INSIDE);
+        radio.setFill(Color.TRANSPARENT);
+        radio.setSmooth(true);
+
+        dot = new Circle(radioRadius);
+        dot.getStyleClass().setAll("dot");
+        dot.fillProperty().bind(control.selectedColorProperty());
+        dot.setScaleX(0);
+        dot.setScaleY(0);
+        dot.setSmooth(true);
+
+        container = new StackPane(radio, dot);
+        container.getStyleClass().add("radio-container");
+
+        rippler = new JFXRippler(container, JFXRippler.RipplerMask.CIRCLE) {
+            @Override
+            protected double computeRippleRadius() {
+                double width = ripplerPane.getWidth();
+                double width2 = width * width;
+                return Math.min(Math.sqrt(width2 + width2), RIPPLE_MAX_RADIUS) * 1.1 + 5;
+            }
+
+            @Override
+            protected void setOverLayBounds(Rectangle overlay) {
+                overlay.setWidth(ripplerPane.getWidth());
+                overlay.setHeight(ripplerPane.getHeight());
+            }
+
+            protected void initControlListeners() {
+                // if the control got resized the overlay rect must be rest
+                control.layoutBoundsProperty().addListener(observable -> resetRippler());
+                if (getChildren().contains(control)) {
+                    control.boundsInParentProperty().addListener(observable -> resetRippler());
+                }
+                control.addEventHandler(MouseEvent.MOUSE_PRESSED,
+                        (event) -> createRipple(event.getX() + padding, event.getY() + padding));
+                // create fade out transition for the ripple
+                control.addEventHandler(MouseEvent.MOUSE_RELEASED, e -> releaseRipple());
+            }
+
+            @Override
+            protected Node getMask() {
+                double radius = ripplerPane.getWidth() / 2;
+                return new Circle(radius, radius, radius);
+            }
+
+            @Override
+            protected void positionControl(Node control) {
+
+            }
+        };
+
+        updateChildren();
+
+        // show focused state
+        control.focusedProperty().addListener((o, oldVal, newVal) -> {
+            if (!control.disableVisualFocusProperty().get()) {
+                if (newVal) {
+                    if (!getSkinnable().isPressed()) {
+                        rippler.setOverlayVisible(true);
+                    }
+                } else {
+                    rippler.setOverlayVisible(false);
+                }
+            }
+        });
+
+        control.pressedProperty().addListener((o, oldVal, newVal) -> rippler.setOverlayVisible(false));
+
+        timer = new JFXAnimationTimer(
+                new JFXKeyFrame(Duration.millis(200),
+                        JFXKeyValue.builder()
+                                .setTarget(dot.scaleXProperty())
+                                .setEndValueSupplier(() -> getSkinnable().isSelected() ? 0.55 : 0)
+                                .setInterpolator(Interpolator.EASE_BOTH)
+                                .build(),
+                        JFXKeyValue.builder()
+                                .setTarget(dot.scaleYProperty())
+                                .setEndValueSupplier(() -> getSkinnable().isSelected() ? 0.55 : 0)
+                                .setInterpolator(Interpolator.EASE_BOTH)
+                                .build(),
+                        JFXKeyValue.builder()
+                                .setTarget(radio.strokeProperty())
+                                .setEndValueSupplier(() -> getSkinnable().isSelected() ? ((JFXRadioButton) getSkinnable()).getSelectedColor() : ((JFXRadioButton) getSkinnable()).getUnSelectedColor())
+                                .setInterpolator(Interpolator.EASE_BOTH)
+                                .build()
+                ));
+
+
+        registerChangeListener(control.selectedColorProperty(), obs -> updateColors());
+        registerChangeListener(control.unSelectedColorProperty(), obs -> updateColors());
+        registerChangeListener(control.selectedProperty(), obs -> {
+            boolean isSelected = getSkinnable().isSelected();
+            Color unSelectedColor = ((JFXRadioButton) getSkinnable()).getUnSelectedColor();
+            Color selectedColor = ((JFXRadioButton) getSkinnable()).getSelectedColor();
+            rippler.setRipplerFill(isSelected ? selectedColor : unSelectedColor);
+            if (((JFXRadioButton) getSkinnable()).isDisableAnimation()) {
+                // apply end values
+                timer.applyEndValues();
+            } else {
+                // play selection animation
+                timer.reverseAndContinue();
+            }
+        });
+
+        updateColors();
+        timer.applyEndValues();
+    }
+
+    @Override
+    protected void updateChildren() {
+        super.updateChildren();
+        if (radio != null) {
+            removeRadio();
+            getChildren().addAll(container, rippler);
+        }
+    }
+
+    @Override
+    protected void layoutChildren(final double x, final double y, final double w, final double h) {
+        final RadioButton radioButton = getSkinnable();
+        final double contWidth = snapSizeX(container.prefWidth(-1));
+        final double contHeight = snapSizeY(container.prefHeight(-1));
+        final double computeWidth = Math.max(radioButton.prefWidth(-1), radioButton.minWidth(-1));
+        final double width = snapSizeX(contWidth);
+        final double height = snapSizeY(contHeight);
+
+        final double labelWidth = Math.min(computeWidth - contWidth, w - width);
+        final double labelHeight = Math.min(radioButton.prefHeight(labelWidth), h);
+        final double maxHeight = Math.max(contHeight, labelHeight);
+        final double xOffset = computeXOffset(w, labelWidth + contWidth, radioButton.getAlignment().getHpos()) + x;
+
+        final double yOffset = computeYOffset(h, maxHeight, radioButton.getAlignment().getVpos()) + x + 5;
+
+        layoutLabelInArea(xOffset + contWidth + padding / 3, yOffset, labelWidth, maxHeight, radioButton.getAlignment());
+        ((Text) getChildren().get((getChildren().get(0) instanceof Text) ? 0 : 1)).
+                textProperty().set(getSkinnable().textProperty().get());
+
+        container.resize(width, height);
+        positionInArea(container,
+                xOffset,
+                yOffset,
+                contWidth,
+                maxHeight,
+                0,
+                radioButton.getAlignment().getHpos(),
+                radioButton.getAlignment().getVpos());
+
+        final double ripplerWidth = width + 2 * padding;
+        final double ripplerHeight = height + 2 * padding;
+        rippler.resizeRelocate((width / 2 + xOffset) - ripplerWidth / 2,
+                (height / 2 + yOffset) + 2 - ripplerHeight / 2,
+                ripplerWidth, ripplerHeight);
+    }
+
+    private void removeRadio() {
+        // TODO: replace with removeIf
+        for (int i = 0; i < getChildren().size(); i++) {
+            if ("radio".equals(getChildren().get(i).getStyleClass().get(0))) {
+                getChildren().remove(i);
+            }
+        }
+    }
+
+    private void updateColors() {
+        boolean isSelected = getSkinnable().isSelected();
+        Color unSelectedColor = ((JFXRadioButton) getSkinnable()).getUnSelectedColor();
+        Color selectedColor = ((JFXRadioButton) getSkinnable()).getSelectedColor();
+        rippler.setRipplerFill(isSelected ? selectedColor : unSelectedColor);
+        radio.setStroke(isSelected ? selectedColor : unSelectedColor);
+    }
+
+    @Override
+    protected double computeMinWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
+        return super.computeMinWidth(height,
+                topInset,
+                rightInset,
+                bottomInset,
+                leftInset) + snapSize(radio.minWidth(-1)) + padding / 3;
+    }
+
+    @Override
+    protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
+        return super.computePrefWidth(height,
+                topInset,
+                rightInset,
+                bottomInset,
+                leftInset) + snapSizeX(radio.prefWidth(-1)) + padding / 3;
+    }
+
+    private static double computeXOffset(double width, double contentWidth, HPos hpos) {
+        switch (hpos) {
+            case LEFT:
+                return 0;
+            case CENTER:
+                return (width - contentWidth) / 2;
+            case RIGHT:
+                return width - contentWidth;
+        }
+        return 0;
+    }
+
+    private static double computeYOffset(double height, double contentHeight, VPos vpos) {
+        switch (vpos) {
+            case TOP:
+                return 0;
+            case CENTER:
+                return (height - contentHeight) / 2;
+            case BOTTOM:
+                return height - contentHeight;
+            default:
+                return 0;
+        }
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        timer.dispose();
+        timer = null;
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/components/table/FilterBox.java
+++ b/desktop/src/main/java/bisq/desktop/components/table/FilterBox.java
@@ -15,10 +15,9 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.primary.main.content.social.chat;
+package bisq.desktop.components.table;
 
 import bisq.desktop.components.controls.BisqInputTextField;
-import bisq.desktop.components.table.FilteredListItem;
 import bisq.i18n.Res;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.transformation.FilteredList;
@@ -56,7 +55,7 @@ public class FilterBox {
         public void onViewDetached() {
         }
 
-        public void onSearch(String filterString) {
+        private void onSearch(String filterString) {
             model.filteredList.setPredicate(item -> item.match(filterString));
         }
     }

--- a/desktop/src/main/java/bisq/desktop/components/table/FilteredListItem.java
+++ b/desktop/src/main/java/bisq/desktop/components/table/FilteredListItem.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.table;
+
+public interface FilteredListItem {
+    boolean match(String filterString);
+}

--- a/desktop/src/main/java/bisq/desktop/overlay/Notification.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/Notification.java
@@ -66,7 +66,7 @@ public class Notification extends Overlay<Notification> {
         super.display();
 
         if (autoClose && autoCloseTimer == null) {
-            autoCloseTimer = UIScheduler.run(this::doClose).after(1000);
+            autoCloseTimer = UIScheduler.run(this::doClose).after(5000);
         }
 
         stage.addEventHandler(MouseEvent.MOUSE_PRESSED, (event) -> doClose());

--- a/desktop/src/main/java/bisq/desktop/primary/PrimaryStageView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/PrimaryStageView.java
@@ -73,7 +73,8 @@ public class PrimaryStageView extends View<AnchorPane, PrimaryStageModel, Primar
     }
 
     private boolean configCss() {
-        return scene.getStylesheets().setAll(requireNonNull(getClass().getResource("/bisq.css")).toExternalForm(),
+        return scene.getStylesheets().setAll(
+                requireNonNull(getClass().getResource("/bisq.css")).toExternalForm(),
                 requireNonNull(getClass().getResource("/bisq2.css")).toExternalForm(),
                 requireNonNull(getClass().getResource("/images.css")).toExternalForm(),
                 requireNonNull(getClass().getResource("/theme-dark.css")).toExternalForm());

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatController.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatController.java
@@ -73,14 +73,15 @@ public class ChatController implements Controller {
     public void onViewAttached() {
         chatService.addDummyChannels();
 
-        selectedChannelPin = chatService.getPersistableStore().getSelectedChannel().addObserver(selected -> {
-            log.error("selected " + selected);
+        selectedChannelPin = chatService.getPersistableStore().getSelectedChannel().addObserver(channel -> {
             if (chatMessagesPin != null) {
                 chatMessagesPin.unbind();
             }
-            chatMessagesPin = FxBindings.<ChatMessage, ChatMessageListItem>bind(model.chatMessages)
+            chatMessagesPin = FxBindings.<ChatMessage, ChatMessageListItem>bind(model.getChatMessages())
                     .map(ChatMessageListItem::new)
-                    .to(selected.getChatMessages());
+                    .to(channel.getChatMessages());
+
+            model.getSelectedChannelAsString().set(channel.getChannelName());
         });
     }
 
@@ -148,7 +149,16 @@ public class ChatController implements Controller {
     }
 
     public void onToggleSettings() {
-        boolean sideBarVisible = !model.getSideBarVisible().get();
-        model.getSideBarVisible().set(sideBarVisible);
+        boolean visible = !model.getSideBarVisible().get();
+        model.getSideBarVisible().set(visible);
+    }
+
+    public void onToggleFilterBox() {
+        boolean visible = !model.getFilterBoxVisible().get();
+        model.getFilterBoxVisible().set(visible);
+    }
+
+    public void onShowNotifications() {
+        
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatMessageListItem.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatMessageListItem.java
@@ -17,6 +17,8 @@
 
 package bisq.desktop.primary.main.content.social.chat;
 
+import bisq.common.util.StringUtils;
+import bisq.desktop.components.table.FilteredListItem;
 import bisq.presentation.formatters.TimeFormatter;
 import bisq.social.chat.ChatMessage;
 import lombok.EqualsAndHashCode;
@@ -26,7 +28,7 @@ import java.util.Date;
 
 @Getter
 @EqualsAndHashCode
-class ChatMessageListItem implements Comparable<ChatMessageListItem> {
+class ChatMessageListItem implements Comparable<ChatMessageListItem>, FilteredListItem {
     private final ChatMessage chatMessage;
     private final String message;
     private final String senderUserName;
@@ -36,12 +38,21 @@ class ChatMessageListItem implements Comparable<ChatMessageListItem> {
         this.chatMessage = chatMessage;
         message = chatMessage.getText();
         senderUserName = chatMessage.getSenderUserName();
-       
+
         date = TimeFormatter.formatTime(new Date(chatMessage.getDate()));
     }
 
     @Override
     public int compareTo(ChatMessageListItem o) {
         return new Date(chatMessage.getDate()).compareTo(new Date(o.getChatMessage().getDate()));
+    }
+
+    @Override
+    public boolean match(String filterString) {
+        return filterString == null ||
+                filterString.isEmpty() ||
+                StringUtils.containsIgnoreCase(message, filterString) ||
+                StringUtils.containsIgnoreCase(senderUserName, filterString) ||
+                StringUtils.containsIgnoreCase(date, filterString);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatMessageListItem.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatMessageListItem.java
@@ -23,9 +23,10 @@ import bisq.presentation.formatters.TimeFormatter;
 import bisq.social.chat.ChatMessage;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Date;
-
+@Slf4j
 @Getter
 @EqualsAndHashCode
 class ChatMessageListItem implements Comparable<ChatMessageListItem>, FilteredListItem {
@@ -38,6 +39,8 @@ class ChatMessageListItem implements Comparable<ChatMessageListItem>, FilteredLi
         this.chatMessage = chatMessage;
         message = chatMessage.getText();
         senderUserName = chatMessage.getSenderUserName();
+        log.error(senderUserName);
+                
 
         date = TimeFormatter.formatTime(new Date(chatMessage.getDate()));
     }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatModel.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatModel.java
@@ -26,6 +26,7 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -43,11 +44,13 @@ public class ChatModel implements Model {
 
 
     private final BooleanProperty sideBarVisible = new SimpleBooleanProperty();
+    private final BooleanProperty filterBoxVisible = new SimpleBooleanProperty();
     private final double defaultLeftDividerPosition = 0.3;
-    public final ObservableList<ChatMessageListItem> chatMessages = FXCollections.observableArrayList();
-    public final SortedList<ChatMessageListItem> sortedChatMessages = new SortedList<>(chatMessages);
+    private final ObservableList<ChatMessageListItem> chatMessages = FXCollections.observableArrayList();
+    private final SortedList<ChatMessageListItem> sortedChatMessages = new SortedList<>(chatMessages);
+    private final FilteredList<ChatMessageListItem> filteredChatMessages = new FilteredList<>(sortedChatMessages);
 
-    public ChatModel( ) {
+    public ChatModel() {
     }
 /*
     void addChatMessage(Channel channel, ChatMessage chatMessage) {

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatModel.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatModel.java
@@ -20,10 +20,8 @@ package bisq.desktop.primary.main.content.social.chat;
 import bisq.desktop.common.view.Model;
 import bisq.network.p2p.services.confidential.ConfidentialMessageService;
 import bisq.network.p2p.services.data.broadcast.BroadcastResult;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import bisq.social.chat.Channel;
+import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -37,13 +35,12 @@ import java.util.Map;
 @Slf4j
 @Getter
 public class ChatModel implements Model {
-
     private final Map<String, StringProperty> chatMessagesByChannelId = new HashMap<>();
     private final StringProperty selectedChatMessages = new SimpleStringProperty("");
     private final StringProperty selectedChannelAsString = new SimpleStringProperty("");
-
-
-    private final BooleanProperty sideBarVisible = new SimpleBooleanProperty();
+    private final ObjectProperty<Channel> selectedChannel = new SimpleObjectProperty<>();
+    private final BooleanProperty infoVisible = new SimpleBooleanProperty();
+    private final BooleanProperty notificationsVisible = new SimpleBooleanProperty();
     private final BooleanProperty filterBoxVisible = new SimpleBooleanProperty();
     private final double defaultLeftDividerPosition = 0.3;
     private final ObservableList<ChatMessageListItem> chatMessages = FXCollections.observableArrayList();

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatView.java
@@ -20,7 +20,9 @@ package bisq.desktop.primary.main.content.social.chat;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.BisqInputTextField;
 import bisq.desktop.components.controls.BisqLabel;
+import bisq.desktop.components.table.FilterBox;
 import bisq.desktop.layout.Layout;
+import bisq.desktop.primary.main.content.social.chat.components.UserProfileComboBox;
 import bisq.i18n.Res;
 import de.jensd.fx.fontawesome.AwesomeDude;
 import de.jensd.fx.fontawesome.AwesomeIcon;
@@ -39,18 +41,24 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
     private final ListView<ChatMessageListItem> messagesListView;
     private final BisqInputTextField inputField;
     private final BisqLabel selectedChannelLabel;
-    private final Button searchButton, notificationsButton, settingButton;
-    private final VBox sideBar;
+    private final Button searchButton, notificationsButton, infoButton;
     private final ComboBox<UserProfileComboBox.ListItem> userProfileComboBox;
     private final VBox left;
     private final FilterBox filterBox;
     private final BisqInputTextField filterBoxRoot;
+    private final Pane notificationsSettings;
+    private final Pane channelInfo;
 
     public ChatView(ChatModel model, ChatController controller,
                     ComboBox<UserProfileComboBox.ListItem> userProfileComboBox,
                     Pane publicChannelSelection,
-                    Pane privateChannelSelection) {
+                    Pane privateChannelSelection,
+                    Pane notificationsSettings,
+                    Pane channelInfo) {
         super(new SplitPane(), model, controller);
+        
+        this.notificationsSettings = notificationsSettings;
+        this.channelInfo = channelInfo;
         this.userProfileComboBox = userProfileComboBox;
         root.getStyleClass().add("hide-focus");
 
@@ -63,23 +71,23 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
         selectedChannelLabel.getStyleClass().add("headline-label");
         filterBox = new FilterBox(model.getFilteredChatMessages());
         filterBoxRoot = filterBox.getRoot();
-        HBox.setHgrow(filterBoxRoot,Priority.ALWAYS);
-        HBox.setMargin(filterBoxRoot,new Insets(0,0,0,10));
+        HBox.setHgrow(filterBoxRoot, Priority.ALWAYS);
+        HBox.setMargin(filterBoxRoot, new Insets(0, 0, 0, 10));
         searchButton = AwesomeDude.createIconButton(AwesomeIcon.SEARCH);
         notificationsButton = AwesomeDude.createIconButton(AwesomeIcon.BELL);
-        settingButton = AwesomeDude.createIconButton(AwesomeIcon.GEAR);
-        HBox centerToolbar = Layout.hBoxWith(selectedChannelLabel, filterBoxRoot, searchButton, notificationsButton, settingButton);
+        infoButton = AwesomeDude.createIconButton(AwesomeIcon.INFO_SIGN);
+        HBox centerToolbar = Layout.hBoxWith(selectedChannelLabel, filterBoxRoot, searchButton, notificationsButton, infoButton);
 
         messagesListView = new ListView<>();
         messagesListView.setFocusTraversable(false);
         VBox.setVgrow(messagesListView, Priority.ALWAYS);
         inputField = new BisqInputTextField();
         inputField.setPromptText(Res.get("social.chat.input.prompt"));
-        sideBar = new VBox(); //todo for settings/info like in Element
-        sideBar.setMinWidth(200);
 
         VBox messagesAndInput = Layout.vBoxWith(messagesListView, inputField);
-        HBox messagesListAndSideBar = Layout.hBoxWith(messagesAndInput, sideBar);
+        channelInfo.setMinWidth(200);
+        channelInfo.setMaxWidth(600);
+        HBox messagesListAndSideBar = Layout.hBoxWith(messagesAndInput, notificationsSettings, channelInfo);
         HBox.setHgrow(messagesAndInput, Priority.ALWAYS);
         VBox.setVgrow(messagesListAndSideBar, Priority.ALWAYS);
         VBox center = Layout.vBoxWith(centerToolbar, messagesListAndSideBar);
@@ -124,12 +132,14 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
         userProfileComboBox.prefWidthProperty().bind(left.widthProperty());
         selectedChannelLabel.textProperty().bind(model.getSelectedChannelAsString());
         filterBoxRoot.visibleProperty().bind(model.getFilterBoxVisible());
-        sideBar.visibleProperty().bind(model.getSideBarVisible());
-        sideBar.managedProperty().bind(model.getSideBarVisible());
+        notificationsSettings.visibleProperty().bind(model.getNotificationsVisible());
+        notificationsSettings.managedProperty().bind(model.getNotificationsVisible());
+        channelInfo.visibleProperty().bind(model.getInfoVisible());
+        channelInfo.managedProperty().bind(model.getInfoVisible());
 
         searchButton.setOnAction(e -> controller.onToggleFilterBox());
-        notificationsButton.setOnAction(e -> controller.onShowNotifications());
-        settingButton.setOnAction(e -> controller.onToggleSettings());
+        notificationsButton.setOnAction(e -> controller.onToggleNotifications());
+        infoButton.setOnAction(e -> controller.onToggleInfo());
 
         inputField.setOnAction(e -> {
             controller.onSendMessage(inputField.getText());
@@ -143,12 +153,14 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
         userProfileComboBox.prefWidthProperty().unbind();
         selectedChannelLabel.textProperty().unbind();
         filterBoxRoot.visibleProperty().unbind();
-        sideBar.visibleProperty().unbind();
-        sideBar.managedProperty().unbind();
+        notificationsSettings.visibleProperty().unbind();
+        notificationsSettings.managedProperty().unbind();
+        channelInfo.visibleProperty().unbind();
+        channelInfo.managedProperty().unbind();
 
         searchButton.setOnAction(null);
         notificationsButton.setOnAction(null);
-        settingButton.setOnAction(null);
+        infoButton.setOnAction(null);
         inputField.setOnAction(null);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatView.java
@@ -26,6 +26,7 @@ import bisq.desktop.primary.main.content.social.chat.components.UserProfileCombo
 import bisq.i18n.Res;
 import de.jensd.fx.fontawesome.AwesomeDude;
 import de.jensd.fx.fontawesome.AwesomeIcon;
+import javafx.collections.ListChangeListener;
 import javafx.geometry.Insets;
 import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
@@ -48,6 +49,7 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
     private final BisqInputTextField filterBoxRoot;
     private final Pane notificationsSettings;
     private final Pane channelInfo;
+    private final ListChangeListener<ChatMessageListItem> messagesListener;
 
     public ChatView(ChatModel model, ChatController controller,
                     ComboBox<UserProfileComboBox.ListItem> userProfileComboBox,
@@ -56,10 +58,11 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
                     Pane notificationsSettings,
                     Pane channelInfo) {
         super(new SplitPane(), model, controller);
-        
+
         this.notificationsSettings = notificationsSettings;
         this.channelInfo = channelInfo;
         this.userProfileComboBox = userProfileComboBox;
+        
         root.getStyleClass().add("hide-focus");
 
         userProfileComboBox.setPadding(new Insets(10, 10, 10, 10));
@@ -79,8 +82,10 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
         HBox centerToolbar = Layout.hBoxWith(selectedChannelLabel, filterBoxRoot, searchButton, notificationsButton, infoButton);
 
         messagesListView = new ListView<>();
+        messagesListView.setCellFactory(getCellFactory());
         messagesListView.setFocusTraversable(false);
         VBox.setVgrow(messagesListView, Priority.ALWAYS);
+        
         inputField = new BisqInputTextField();
         inputField.setPromptText(Res.get("social.chat.input.prompt"));
 
@@ -92,10 +97,54 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
         VBox.setVgrow(messagesListAndSideBar, Priority.ALWAYS);
         VBox center = Layout.vBoxWith(centerToolbar, messagesListAndSideBar);
         center.setPadding(new Insets(10, 10, 10, 10));
-        this.root.setDividerPosition(0, model.getDefaultLeftDividerPosition());
-        this.root.getItems().addAll(left, center);
+        root.setDividerPosition(0, model.getDefaultLeftDividerPosition());
+        root.getItems().addAll(left, center);
 
-        messagesListView.setCellFactory(new Callback<>() {
+        messagesListener = c -> messagesListView.scrollTo(model.getFilteredChatMessages().size() - 1);
+    }
+
+    @Override
+    public void onViewAttached() {
+        userProfileComboBox.prefWidthProperty().bind(left.widthProperty());
+        selectedChannelLabel.textProperty().bind(model.getSelectedChannelAsString());
+        filterBoxRoot.visibleProperty().bind(model.getFilterBoxVisible());
+        notificationsSettings.visibleProperty().bind(model.getNotificationsVisible());
+        notificationsSettings.managedProperty().bind(model.getNotificationsVisible());
+        channelInfo.visibleProperty().bind(model.getInfoVisible());
+        channelInfo.managedProperty().bind(model.getInfoVisible());
+
+        searchButton.setOnAction(e -> controller.onToggleFilterBox());
+        notificationsButton.setOnAction(e -> controller.onToggleNotifications());
+        infoButton.setOnAction(e -> controller.onToggleInfo());
+
+        inputField.setOnAction(e -> {
+            controller.onSendMessage(inputField.getText());
+            inputField.clear();
+        });
+
+        model.getFilteredChatMessages().addListener(messagesListener);
+
+        messagesListView.setItems(model.getFilteredChatMessages());
+    }
+
+    @Override
+    protected void onViewDetached() {
+        userProfileComboBox.prefWidthProperty().unbind();
+        selectedChannelLabel.textProperty().unbind();
+        filterBoxRoot.visibleProperty().unbind();
+        notificationsSettings.visibleProperty().unbind();
+        notificationsSettings.managedProperty().unbind();
+        channelInfo.visibleProperty().unbind();
+        channelInfo.managedProperty().unbind();
+
+        searchButton.setOnAction(null);
+        notificationsButton.setOnAction(null);
+        infoButton.setOnAction(null);
+        inputField.setOnAction(null);
+        model.getFilteredChatMessages().removeListener(messagesListener);
+    }
+    private Callback<ListView<ChatMessageListItem>, ListCell<ChatMessageListItem>> getCellFactory() {
+        return new Callback<>() {
             @Override
             public ListCell<ChatMessageListItem> call(ListView<ChatMessageListItem> list) {
                 return new ListCell<>() {
@@ -124,43 +173,6 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
                     }
                 };
             }
-        });
-    }
-
-    @Override
-    public void onViewAttached() {
-        userProfileComboBox.prefWidthProperty().bind(left.widthProperty());
-        selectedChannelLabel.textProperty().bind(model.getSelectedChannelAsString());
-        filterBoxRoot.visibleProperty().bind(model.getFilterBoxVisible());
-        notificationsSettings.visibleProperty().bind(model.getNotificationsVisible());
-        notificationsSettings.managedProperty().bind(model.getNotificationsVisible());
-        channelInfo.visibleProperty().bind(model.getInfoVisible());
-        channelInfo.managedProperty().bind(model.getInfoVisible());
-
-        searchButton.setOnAction(e -> controller.onToggleFilterBox());
-        notificationsButton.setOnAction(e -> controller.onToggleNotifications());
-        infoButton.setOnAction(e -> controller.onToggleInfo());
-
-        inputField.setOnAction(e -> {
-            controller.onSendMessage(inputField.getText());
-            inputField.clear();
-        });
-        messagesListView.setItems(model.getFilteredChatMessages());
-    }
-
-    @Override
-    protected void onViewDetached() {
-        userProfileComboBox.prefWidthProperty().unbind();
-        selectedChannelLabel.textProperty().unbind();
-        filterBoxRoot.visibleProperty().unbind();
-        notificationsSettings.visibleProperty().unbind();
-        notificationsSettings.managedProperty().unbind();
-        channelInfo.visibleProperty().unbind();
-        channelInfo.managedProperty().unbind();
-
-        searchButton.setOnAction(null);
-        notificationsButton.setOnAction(null);
-        infoButton.setOnAction(null);
-        inputField.setOnAction(null);
+        };
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/FilterBox.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/FilterBox.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.primary.main.content.social.chat;
+
+import bisq.desktop.components.controls.BisqInputTextField;
+import bisq.desktop.components.table.FilteredListItem;
+import bisq.i18n.Res;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.transformation.FilteredList;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class FilterBox {
+    private final Controller controller;
+
+    public FilterBox(FilteredList<? extends FilteredListItem> filteredList) {
+        controller = new Controller(filteredList);
+    }
+
+    public BisqInputTextField getRoot() {
+        return controller.view.getRoot();
+    }
+
+    private static class Controller implements bisq.desktop.common.view.Controller {
+        private final Model model;
+        @Getter
+        private final View view;
+
+        private Controller(FilteredList<? extends FilteredListItem> filteredList) {
+            model = new Model(filteredList);
+            view = new View(model, this);
+        }
+
+        @Override
+        public void onViewAttached() {
+        }
+
+        @Override
+        public void onViewDetached() {
+        }
+
+        public void onSearch(String filterString) {
+            model.filteredList.setPredicate(item -> item.match(filterString));
+        }
+    }
+
+    private static class Model implements bisq.desktop.common.view.Model {
+        final FilteredList<? extends FilteredListItem> filteredList;
+
+        private Model(FilteredList<? extends FilteredListItem> filteredList) {
+            this.filteredList = filteredList;
+        }
+    }
+
+
+    @Slf4j
+    public static class View extends bisq.desktop.common.view.View<BisqInputTextField, Model, Controller> {
+        private final ChangeListener<String> listener;
+
+        private View(Model model, Controller controller) {
+            super(new BisqInputTextField(), model, controller);
+
+            root.setPromptText(Res.get("search"));
+            root.setMinWidth(100);
+
+            listener = (observable, oldValue, newValue) -> controller.onSearch(root.getText());
+        }
+
+        @Override
+        public void onViewAttached() {
+            root.textProperty().addListener(listener);
+            root.setOnAction(e -> controller.onSearch(root.getText()));
+        }
+
+        @Override
+        protected void onViewDetached() {
+            root.textProperty().removeListener(listener);
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/PublicChannelSelection.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/PublicChannelSelection.java
@@ -78,6 +78,10 @@ public class PublicChannelSelection {
             channelsPin = FxBindings.<PublicChannel, ListItem>bind(model.channels)
                     .map(ListItem::new)
                     .to(chatService.getPersistableStore().getPublicChannels());
+
+            if (!model.channels.isEmpty()) {
+                chatService.selectChannel(model.channels.get(0).channel);
+            }
         }
 
         @Override

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChannelInfo.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChannelInfo.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.primary.main.content.social.chat.components;
+
+import bisq.desktop.components.controls.BisqLabel;
+import bisq.i18n.Res;
+import bisq.social.chat.Channel;
+import bisq.social.chat.PublicChannel;
+import bisq.social.user.ChatUser;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.util.Callback;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ChannelInfo {
+    private final Controller controller;
+
+    public ChannelInfo() {
+        controller = new Controller();
+    }
+
+    public Pane getRoot() {
+        return controller.view.getRoot();
+    }
+
+    public void setChannel(Channel channel) {
+        controller.model.setChannel(channel);
+    }
+
+    private static class Controller implements bisq.desktop.common.view.Controller {
+        private final Model model;
+        @Getter
+        private final View view;
+
+        private Controller() {
+            model = new Model();
+            view = new View(model, this);
+        }
+
+        @Override
+        public void onViewAttached() {
+        }
+
+        @Override
+        public void onViewDetached() {
+        }
+    }
+
+    private static class Model implements bisq.desktop.common.view.Model {
+        private ObjectProperty<Channel> channel = new SimpleObjectProperty<>();
+        private String channelName;
+        private Optional<String> description = Optional.empty();
+        private final ObservableList<ChatUserDisplay> moderators = FXCollections.observableArrayList();
+        private Optional<ChatUserDisplay> adminProfile = Optional.empty();
+        private final ObservableList<ChatUserDisplay> members = FXCollections.observableArrayList();
+
+        private Model() {
+        }
+
+        private void setChannel(Channel channel) {
+            channelName = channel.getChannelName();
+            members.setAll(channel.getChatMessages().stream()
+                    .map(chatMessage -> new ChatUserDisplay(new ChatUser(chatMessage.getSenderNetworkId())))
+                    .sorted()
+                    .collect(Collectors.toList()));
+            if (channel instanceof PublicChannel publicChannel) {
+                description = Optional.of(publicChannel.getDescription());
+                adminProfile = Optional.of(new ChatUserDisplay(publicChannel.getChannelAdmin()));
+                moderators.setAll(publicChannel.getChannelModerators().stream()
+                        .map(ChatUserDisplay::new)
+                        .sorted()
+                        .collect(Collectors.toList()));
+
+            } else {
+                description = Optional.empty();
+                adminProfile = Optional.empty();
+                moderators.clear();
+            }
+
+            this.channel.set(channel);
+        }
+    }
+
+    @Slf4j
+    public static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
+
+        private final ChangeListener<Channel> channelChangeListener;
+
+        private View(Model model, Controller controller) {
+            super(new VBox(), model, controller);
+
+            root.setSpacing(5);
+
+            channelChangeListener = (observable, oldValue, newValue) -> update();
+            update();
+        }
+
+        private void update() {
+            if (model.channel.get() == null) {
+                return;
+            }
+
+            root.getChildren().clear();
+
+            BisqLabel channelName = new BisqLabel(model.channelName);
+            channelName.getStyleClass().add("channel-settings-headline");
+            root.getChildren().add(channelName);
+
+            model.description.ifPresent(description -> root.getChildren().add(new BisqLabel(description)));
+
+            model.adminProfile.ifPresent(adminProfile -> {
+                BisqLabel adminHeadLine = new BisqLabel(Res.get("social.channel.settings.admin"));
+                adminHeadLine.setPadding(new Insets(20, 0, -10, 0));
+                adminHeadLine.getStyleClass().add("accent-headline");
+                root.getChildren().addAll(adminHeadLine, adminProfile.getRoot());
+            });
+
+            if (!model.moderators.isEmpty()) {
+                BisqLabel moderatorsHeadLine = new BisqLabel(Res.get("social.channel.settings.moderators"));
+                moderatorsHeadLine.setPadding(new Insets(20, 0, -10, 0));
+                moderatorsHeadLine.getStyleClass().add("accent-headline");
+                root.getChildren().add(moderatorsHeadLine);
+                root.getChildren().addAll(model.moderators.stream()
+                        .map(ChatUserDisplay::getRoot)
+                        .collect(Collectors.toList()));
+            }
+
+            ListView<ChatUserDisplay> members = new ListView<>();
+            members.setFocusTraversable(false);
+            VBox.setVgrow(members, Priority.ALWAYS);
+            members.setCellFactory(new Callback<>() {
+                @Override
+                public ListCell<ChatUserDisplay> call(ListView<ChatUserDisplay> list) {
+                    return new ListCell<>() {
+                        BisqLabel label = new BisqLabel();
+
+                        @Override
+                        public void updateItem(final ChatUserDisplay item, boolean empty) {
+                            super.updateItem(item, empty);
+                            if (item != null && !empty) {
+                                setGraphic(item.getRoot());
+                            } else {
+                                setGraphic(null);
+                            }
+                        }
+                    };
+                }
+            });
+            members.setItems(model.members);
+
+            BisqLabel membersHeadLine = new BisqLabel(Res.get("social.channel.settings.members"));
+            membersHeadLine.setPadding(new Insets(20, 0, 0, 0));
+            membersHeadLine.getStyleClass().add("accent-headline");
+            root.getChildren().addAll(membersHeadLine, members);
+        }
+
+        @Override
+        public void onViewAttached() {
+            model.channel.addListener(channelChangeListener);
+        }
+
+        @Override
+        protected void onViewDetached() {
+            model.channel.removeListener(channelChangeListener);
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChannelInfo.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChannelInfo.java
@@ -20,6 +20,7 @@ package bisq.desktop.primary.main.content.social.chat.components;
 import bisq.desktop.components.controls.BisqLabel;
 import bisq.i18n.Res;
 import bisq.social.chat.Channel;
+import bisq.social.chat.ChatMessage;
 import bisq.social.chat.PublicChannel;
 import bisq.social.user.ChatUser;
 import javafx.beans.property.ObjectProperty;
@@ -89,7 +90,9 @@ public class ChannelInfo {
         private void setChannel(Channel channel) {
             channelName = channel.getChannelName();
             members.setAll(channel.getChatMessages().stream()
-                    .map(chatMessage -> new ChatUserDisplay(new ChatUser(chatMessage.getSenderNetworkId())))
+                    .map(ChatMessage::getSenderNetworkId)
+                    .distinct()
+                    .map(senderNetworkId -> new ChatUserDisplay(new ChatUser(senderNetworkId)))
                     .sorted()
                     .collect(Collectors.toList()));
             if (channel instanceof PublicChannel publicChannel) {
@@ -161,8 +164,6 @@ public class ChannelInfo {
                 @Override
                 public ListCell<ChatUserDisplay> call(ListView<ChatUserDisplay> list) {
                     return new ListCell<>() {
-                        BisqLabel label = new BisqLabel();
-
                         @Override
                         public void updateItem(final ChatUserDisplay item, boolean empty) {
                             super.updateItem(item, empty);

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChatUserDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChatUserDisplay.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.primary.main.content.social.chat.components;
+
+import bisq.common.data.ByteArray;
+import bisq.desktop.components.controls.BisqLabel;
+import bisq.desktop.components.robohash.RoboHash;
+import bisq.i18n.Res;
+import bisq.social.user.ChatUser;
+import javafx.beans.property.*;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.Subscription;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ChatUserDisplay implements Comparable<ChatUserDisplay> {
+    private final Controller controller;
+
+    public ChatUserDisplay(ChatUser chatUser) {
+        controller = new Controller(chatUser);
+    }
+
+    public Pane getRoot() {
+        return controller.view.getRoot();
+    }
+
+    @Override
+    public int compareTo(ChatUserDisplay o) {
+        return controller.model.chatUser.userName().compareTo(o.controller.model.chatUser.userName());
+    }
+
+    private static class Controller implements bisq.desktop.common.view.Controller {
+        private final Model model;
+        @Getter
+        private final View view;
+
+
+        private Controller(ChatUser chatUser) {
+
+            model = new Model(chatUser);
+            view = new View(model, this);
+        }
+
+        @Override
+        public void onViewAttached() {
+            ChatUser chatUser = model.chatUser;
+            if (chatUser == null) {
+                return;
+            }
+
+            model.id.set(chatUser.id());
+            model.userName.set(chatUser.userName());
+            model.roboHashNode.set(RoboHash.getImage(new ByteArray(chatUser.pubKeyHash()), false));
+            String entitledRoles = chatUser.entitlements().stream().map(e -> Res.get(e.entitlementType().name())).collect(Collectors.joining(", "));
+            model.entitlements.set(Res.get("social.createUserProfile.entitledRoles", entitledRoles));
+            model.entitlementsVisible.set(!chatUser.entitlements().isEmpty());
+        }
+
+        @Override
+        public void onViewDetached() {
+        }
+    }
+
+    private static class Model implements bisq.desktop.common.view.Model {
+        private final ChatUser chatUser;
+        ObjectProperty<Image> roboHashNode = new SimpleObjectProperty<>();
+        StringProperty userName = new SimpleStringProperty();
+        StringProperty id = new SimpleStringProperty();
+        BooleanProperty entitlementsVisible = new SimpleBooleanProperty();
+        StringProperty entitlements = new SimpleStringProperty();
+
+        private Model(ChatUser chatUser) {
+            this.chatUser = chatUser;
+        }
+    }
+
+    @Slf4j
+    public static class View extends bisq.desktop.common.view.View<HBox, Model, Controller> {
+        private final ImageView roboIconImageView;
+        private final BisqLabel userName, id, entitlements;
+        private Subscription roboHashNodeSubscription;
+
+        private View(Model model, Controller controller) {
+            super(new HBox(), model, controller);
+            root.setSpacing(10);
+            root.setAlignment(Pos.CENTER_LEFT);
+
+            userName = new BisqLabel();
+            userName.setPadding(new Insets(4, 0, 0, 0));
+
+            roboIconImageView = new ImageView();
+            roboIconImageView.setFitWidth(30);
+            roboIconImageView.setFitHeight(30);
+
+            root.getChildren().addAll(roboIconImageView, userName);
+
+            // todo add tooltip overlay for id and entitlements
+            id = new BisqLabel();
+            id.getStyleClass().add("offer-label-small");
+            id.setPadding(new Insets(-5, 0, 0, 0));
+
+            entitlements = new BisqLabel();
+            entitlements.getStyleClass().add("offer-label-small");
+            entitlements.setPadding(new Insets(-5, 0, 0, 0));
+        }
+
+        @Override
+        public void onViewAttached() {
+            userName.textProperty().bind(model.userName);
+            id.textProperty().bind(model.id);
+            entitlements.textProperty().bind(model.entitlements);
+            entitlements.visibleProperty().bind(model.entitlementsVisible);
+            entitlements.managedProperty().bind(model.entitlementsVisible);
+
+            roboHashNodeSubscription = EasyBind.subscribe(model.roboHashNode, roboIcon -> {
+                if (roboIcon != null) {
+                    roboIconImageView.setImage(roboIcon);
+                }
+            });
+        }
+
+        @Override
+        protected void onViewDetached() {
+            userName.textProperty().unbindBidirectional(model.userName);
+            id.textProperty().unbind();
+            entitlements.textProperty().unbind();
+            entitlements.visibleProperty().unbind();
+            entitlements.managedProperty().unbind();
+            roboHashNodeSubscription.unsubscribe();
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/NotificationsSettings.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/NotificationsSettings.java
@@ -1,0 +1,160 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.primary.main.content.social.chat.components;
+
+import bisq.desktop.components.controls.BisqLabel;
+import bisq.desktop.components.controls.BisqRadioButton;
+import bisq.i18n.Res;
+import bisq.social.chat.Channel;
+import bisq.social.chat.NotificationSetting;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.geometry.Insets;
+import javafx.scene.control.Toggle;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NotificationsSettings {
+
+    private final Controller controller;
+
+    public NotificationsSettings() {
+        controller = new Controller();
+    }
+
+    public void setChannel(Channel channel) {
+        controller.model.setChannel(channel);
+    }
+
+    public ReadOnlyObjectProperty<NotificationSetting> getNotificationSetting() {
+        return controller.model.notificationSetting;
+    }
+
+    public Pane getRoot() {
+        return controller.view.getRoot();
+    }
+
+    private static class Controller implements bisq.desktop.common.view.Controller {
+        private final Model model;
+        @Getter
+        private final View view;
+
+        private Controller() {
+            model = new Model();
+            view = new View(model, this);
+        }
+
+        @Override
+        public void onViewAttached() {
+        }
+
+        @Override
+        public void onViewDetached() {
+        }
+
+        public void onSelected(NotificationSetting notificationSetting) {
+            model.notificationSetting.set(notificationSetting);
+        }
+    }
+
+    private static class Model implements bisq.desktop.common.view.Model {
+        private ObjectProperty<Channel> channel = new SimpleObjectProperty<>();
+        public ObjectProperty<NotificationSetting> notificationSetting = new SimpleObjectProperty<>(NotificationSetting.ALL);
+
+        private Model() {
+        }
+
+        private void setChannel(Channel channel) {
+            this.notificationSetting.set(channel.getNotificationSetting().get());
+
+            this.channel.set(channel);
+        }
+    }
+
+    @Slf4j
+    public static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
+        private final ToggleGroup toggleGroup = new ToggleGroup();
+        ;
+        private final ChangeListener<Toggle> toggleListener;
+        private final BisqRadioButton all, mention, none;
+
+        private final ChangeListener<Channel> channelChangeListener;
+
+        private View(Model model, Controller controller) {
+            super(new VBox(), model, controller);
+
+            root.setSpacing(5);
+            
+            BisqLabel headline = new BisqLabel(Res.get("social.channel.notifications"));
+            headline.getStyleClass().add("channel-settings-headline");
+            headline.setPadding(new Insets(0, 40, 0, 0));
+
+            all = new BisqRadioButton(Res.get("social.channel.notifications.all"));
+            mention = new BisqRadioButton(Res.get("social.channel.notifications.mention"));
+            none = new BisqRadioButton(Res.get("social.channel.notifications.never"));
+
+            all.setToggleGroup(toggleGroup);
+            mention.setToggleGroup(toggleGroup);
+            none.setToggleGroup(toggleGroup);
+
+            all.setUserData(NotificationSetting.ALL);
+            mention.setUserData(NotificationSetting.MENTION);
+            none.setUserData(NotificationSetting.NEVER);
+
+            root.getChildren().addAll(headline, all, mention, none);
+
+            toggleListener = (observable, oldValue, newValue) -> controller.onSelected((NotificationSetting) newValue.getUserData());
+            channelChangeListener = (observable, oldValue, newValue) -> update();
+
+            update();
+        }
+
+        private void update() {
+            switch (model.notificationSetting.get()) {
+                case ALL -> {
+                    toggleGroup.selectToggle(all);
+                }
+                case MENTION -> {
+                    toggleGroup.selectToggle(mention);
+                }
+                case NEVER -> {
+                    toggleGroup.selectToggle(none);
+                }
+            }
+        }
+
+
+        @Override
+        public void onViewAttached() {
+            model.channel.addListener(channelChangeListener);
+            toggleGroup.selectedToggleProperty().addListener(toggleListener);
+        }
+
+        @Override
+        protected void onViewDetached() {
+            model.channel.removeListener(channelChangeListener);
+            toggleGroup.selectedToggleProperty().removeListener(toggleListener);
+        }
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/NotificationsSettings.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/NotificationsSettings.java
@@ -80,7 +80,7 @@ public class NotificationsSettings {
 
     private static class Model implements bisq.desktop.common.view.Model {
         private ObjectProperty<Channel> channel = new SimpleObjectProperty<>();
-        public ObjectProperty<NotificationSetting> notificationSetting = new SimpleObjectProperty<>(NotificationSetting.ALL);
+        public ObjectProperty<NotificationSetting> notificationSetting = new SimpleObjectProperty<>(NotificationSetting.MENTION);
 
         private Model() {
         }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/PrivateChannelSelection.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/PrivateChannelSelection.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.primary.main.content.social.chat;
+package bisq.desktop.primary.main.content.social.chat.components;
 
 import bisq.common.observable.Pin;
 import bisq.desktop.common.observable.FxBindings;

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/PublicChannelSelection.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/PublicChannelSelection.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.primary.main.content.social.chat;
+package bisq.desktop.primary.main.content.social.chat.components;
 
 import bisq.common.observable.Pin;
 import bisq.desktop.common.observable.FxBindings;

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/UserProfileComboBox.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/UserProfileComboBox.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.primary.main.content.social.chat;
+package bisq.desktop.primary.main.content.social.chat.components;
 
 import bisq.common.observable.Pin;
 import bisq.desktop.common.observable.FxBindings;

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/UserProfileComboBox.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/UserProfileComboBox.java
@@ -156,7 +156,7 @@ public class UserProfileComboBox {
         private ListItem(UserProfile userProfile) {
             this.userProfile = userProfile;
             userName = userProfile.identity().domainId();
-            roboHashNode = RoboHash.getImage(userProfile.identity().pubKeyHash(), false);
+            roboHashNode = RoboHash.getImage(userProfile.identity().pubKeyHashAsByteArray(), false);
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/components/UserProfileDisplay.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/components/UserProfileDisplay.java
@@ -72,7 +72,7 @@ public class UserProfileDisplay {
                         String entitledRoles = userProfile.entitlements().stream().map(e -> Res.get(e.entitlementType().name())).collect(Collectors.joining(", "));
                         model.entitlements.set(Res.get("social.createUserProfile.entitledRoles", entitledRoles));
                         model.entitlementsVisible.set(!userProfile.entitlements().isEmpty());
-                        model.roboHashNode.set(RoboHash.getImage(userProfile.identity().pubKeyHash(), false));
+                        model.roboHashNode.set(RoboHash.getImage(userProfile.identity().pubKeyHashAsByteArray(), false));
                     });
         }
 

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/profile/components/CreateUserProfile.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/profile/components/CreateUserProfile.java
@@ -110,7 +110,7 @@ public class CreateUserProfile {
                             new HashSet<>(entitlementSelection.getVerifiedEntitlements()))
                     .thenAccept(userProfile -> {
                         UIThread.run(() -> {
-                            checkArgument(userProfile.identity().pubKeyHash().equals(new ByteArray(DigestUtil.hash(model.tempKeyPair.getPublic().getEncoded()))));
+                            checkArgument(userProfile.identity().pubKeyHashAsByteArray().equals(new ByteArray(DigestUtil.hash(model.tempKeyPair.getPublic().getEncoded()))));
                             checkArgument(userProfile.identity().domainId().equals(useName));
                             reset();
                             model.feedback.set(Res.get("social.createUserProfile.success", useName));

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/profile/components/UserProfileSelection.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/profile/components/UserProfileSelection.java
@@ -51,6 +51,7 @@ public class UserProfileSelection {
     public Pane getRoot() {
         return controller.view.getRoot();
     }
+
     public ReadOnlyObjectProperty<UserProfile> getSelectedUserProfile() {
         return controller.model.selectedUserProfile;
     }

--- a/desktop/src/main/resources/bisq2.css
+++ b/desktop/src/main/resources/bisq2.css
@@ -23,6 +23,15 @@ New css for bisq2.
     -fx-fill: -bs-rd-nav-selected;
 }
 
+.accent-headline {
+    -fx-font-size: 1.1em;
+    -fx-text-fill: -bs-color-green-5;
+}
+
+.channel-settings-headline {
+    -fx-font-size: 1.692em;
+    -fx-text-fill: -bs-color-green-5;
+}
 
 /*
 .jfx-badge .badge-pane {

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -135,6 +135,15 @@ social.createUserProfile.mediator.info=Requirement: Bonded DAO role as mediator
 social.channelAdmin.headline=Channel administration
 social.channelAdmin.addChannel=Add channel
 
+social.channel.settings.admin=Channel admin
+social.channel.settings.moderators=Channel moderators
+social.channel.settings.members=Members
+
+social.channel.notifications=Notifications
+social.channel.notifications.all=All
+social.channel.notifications.mention=When mentioned
+social.channel.notifications.never=Never
+
 social.userName=User name
 validation.invalid=Invalid input
 ######################################################

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -143,6 +143,7 @@ social.channel.notifications=Notifications
 social.channel.notifications.all=All
 social.channel.notifications.mention=When mentioned
 social.channel.notifications.never=Never
+social.notification.getMentioned={0} mentioned you\n{1}
 
 social.userName=User name
 validation.invalid=Invalid input

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -78,6 +78,7 @@ buy=buy
 sell=sell
 spend=spend
 receive=receive
+search=Search
 direction.label.buy=BUY {0}
 direction.label.sell=SELL {0}
 # Table

--- a/identity/src/main/java/bisq/identity/Identity.java
+++ b/identity/src/main/java/bisq/identity/Identity.java
@@ -42,10 +42,14 @@ public record Identity(String domainId, NetworkId networkId, KeyPair keyPair) im
 
     // Use hash of public key as ID
     public String id() {
-        return Hex.encode(pubKeyHash().getBytes());
+        return Hex.encode(pubKeyHash());
     }
 
-    public ByteArray pubKeyHash() {
-        return new ByteArray(DigestUtil.hash(keyPair.getPublic().getEncoded()));
+    public byte[] pubKeyHash() {
+        return DigestUtil.hash(keyPair.getPublic().getEncoded());
+    }
+
+    public ByteArray pubKeyHashAsByteArray() {
+        return new ByteArray(pubKeyHash());
     }
 }

--- a/social/src/main/java/bisq/social/chat/Channel.java
+++ b/social/src/main/java/bisq/social/chat/Channel.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
 public abstract class Channel implements Serializable {
     protected final String id;
     protected final ObservableSet<ChatMessage> chatMessages = new ObservableSet<>();
-    protected final Observable<NotificationSetting> notificationSetting = new Observable<>(NotificationSetting.ALL);
+    protected final Observable<NotificationSetting> notificationSetting = new Observable<>(NotificationSetting.MENTION);
 
     public Channel(String id) {
         this.id = id;

--- a/social/src/main/java/bisq/social/chat/ChatMessage.java
+++ b/social/src/main/java/bisq/social/chat/ChatMessage.java
@@ -20,6 +20,8 @@ package bisq.social.chat;
 import bisq.network.NetworkId;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.security.DigestUtil;
+import bisq.social.user.UserNameGenerator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -32,20 +34,23 @@ import java.util.concurrent.TimeUnit;
 public class ChatMessage implements MailboxMessage {
     private final String channelId;
     private final String text;
-    private final String senderUserName;
+    private final String senderUserName; 
     private final NetworkId senderNetworkId;
     private final long date;
     private final ChannelType channelType;
     private final MetaData metaData;
 
+    //todo remove senderUserName
     public ChatMessage(String channelId, String text, String senderUserName, NetworkId senderNetworkId,
                        long date, ChannelType channelType) {
         this.channelId = channelId;
         this.text = text;
-        this.senderUserName = senderUserName;
         this.senderNetworkId = senderNetworkId;
         this.date = date;
         this.channelType = channelType;
+
+        byte[] senderPubKeyHash = DigestUtil.hash(senderNetworkId.getPubKey().publicKey().getEncoded());
+        this.senderUserName = UserNameGenerator.fromHash(senderPubKeyHash);
         metaData = new MetaData(TimeUnit.DAYS.toMillis(10), 100000, getClass().getSimpleName());
     }
 

--- a/social/src/main/java/bisq/social/chat/NotificationSetting.java
+++ b/social/src/main/java/bisq/social/chat/NotificationSetting.java
@@ -17,25 +17,10 @@
 
 package bisq.social.chat;
 
-import bisq.common.observable.Observable;
-import bisq.common.observable.ObservableSet;
-import lombok.Getter;
-
 import java.io.Serializable;
 
-@Getter
-public abstract class Channel implements Serializable {
-    protected final String id;
-    protected final ObservableSet<ChatMessage> chatMessages = new ObservableSet<>();
-    protected final Observable<NotificationSetting> notificationSetting = new Observable<>(NotificationSetting.ALL);
-
-    public Channel(String id) {
-        this.id = id;
-    }
-
-    public void addChatMessage(ChatMessage chatMessage) {
-        chatMessages.add(chatMessage);
-    }
-
-    public abstract String getChannelName();
+public enum NotificationSetting implements Serializable {
+    ALL,
+    MENTION,
+    NEVER
 }

--- a/social/src/main/java/bisq/social/chat/PublicChannel.java
+++ b/social/src/main/java/bisq/social/chat/PublicChannel.java
@@ -22,7 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-// TODO not used yet. Will require more work on the chatUser and chatIdentity management. 
+import java.util.Set;
+
 @Getter
 @ToString
 @EqualsAndHashCode(callSuper = true)
@@ -30,12 +31,18 @@ public class PublicChannel extends Channel {
     private final String channelName;
     private final String description;
     private final ChatUser channelAdmin;
+    private final Set<ChatUser> channelModerators;
 
-    public PublicChannel(String id, String channelName, String description, ChatUser channelAdmin ) {
+    public PublicChannel(String id,
+                         String channelName,
+                         String description,
+                         ChatUser channelAdmin,
+                         Set<ChatUser> channelModerators) {
         super(id);
 
         this.channelName = channelName;
         this.description = description;
         this.channelAdmin = channelAdmin;
+        this.channelModerators = channelModerators;
     }
 }

--- a/social/src/main/java/bisq/social/user/ChatUser.java
+++ b/social/src/main/java/bisq/social/user/ChatUser.java
@@ -33,7 +33,15 @@ public record ChatUser(NetworkId networkId, Set<Entitlement> entitlements) imple
         this(networkId, new HashSet<>());
     }
 
+    public byte[] pubKeyHash() {
+        return DigestUtil.hash(networkId.getPubKey().publicKey().getEncoded());
+    }
+
     public String id() {
-        return Hex.encode(DigestUtil.hash(networkId.getPubKey().publicKey().getEncoded()));
+        return Hex.encode(pubKeyHash());
+    }
+
+    public String userName() {
+        return UserNameGenerator.fromHash(pubKeyHash());
     }
 }

--- a/social/src/main/java/bisq/social/user/profile/UserProfile.java
+++ b/social/src/main/java/bisq/social/user/profile/UserProfile.java
@@ -17,8 +17,10 @@
 
 package bisq.social.user.profile;
 
+import bisq.common.encoding.Hex;
 import bisq.identity.Identity;
 import bisq.social.user.Entitlement;
+import bisq.social.user.UserNameGenerator;
 
 import java.io.Serializable;
 import java.util.Set;
@@ -29,5 +31,17 @@ import java.util.Set;
 public record UserProfile(Identity identity, Set<Entitlement> entitlements) implements Serializable {
     public boolean hasEntitlementType(Entitlement.Type type) {
         return entitlements.stream().anyMatch(e -> e.entitlementType() == type);
+    }
+
+    public byte[] pubKeyHash() {
+        return identity.pubKeyHash();
+    }
+
+    public String id() {
+        return Hex.encode(pubKeyHash());
+    }
+
+    public String userName() {
+        return UserNameGenerator.fromHash(pubKeyHash());
     }
 }


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq2/issues/132, https://github.com/bisq-network/bisq2/issues/133, https://github.com/bisq-network/bisq2/issues/130, https://github.com/bisq-network/bisq2/issues/131

Some parts are not fully implemented and require either other work to get finished (e.g. private channels) or are conceptually still a bit open (notifications handling, trade related filters).

Regarding notifications:
It might be too annoying to get a notification at each message if user has selected ALL. We could instead highlight the notification icon and queue up the notification in the sidebar.

Regarding trade related filters:
We could use the keyword tags (buy, sell, BTC, SEPA, Zelle,...) as OR filter items. Once the work for the tags is done we can look into that further.