### PR TITLE
Store seeds in Sets to avoid duplicates

### DIFF
--- a/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/src/main/java/bisq/network/NetworkService.java
@@ -90,7 +90,7 @@ public class NetworkService implements PersistenceClient<NetworkIdStore> {
                                 ServiceNode.Config serviceNodeConfig,
                                 Map<Transport.Type, PeerGroupService.Config> peerGroupServiceConfigByTransport,
                                 Map<Transport.Type, Integer> defaultNodePortByTransportType,
-                                Map<Transport.Type, List<Address>> seedAddressesByTransport,
+                                Map<Transport.Type, Set<Address>> seedAddressesByTransport,
                                 Optional<String> socks5ProxyAddress) {
     }
 

--- a/network/src/main/java/bisq/network/NetworkServiceConfigFactory.java
+++ b/network/src/main/java/bisq/network/NetworkServiceConfigFactory.java
@@ -57,7 +57,7 @@ public class NetworkServiceConfigFactory {
 
         Config seedConfig = typesafeConfig.getConfig("seedAddressByTransportType");
         // Only read seed addresses for explicitly supported address types
-        Map<Transport.Type, List<Address>> seedAddressesByTransport = supportedTransportTypes.stream()
+        Map<Transport.Type, Set<Address>> seedAddressesByTransport = supportedTransportTypes.stream()
                 .collect(toMap(
                         supportedTransportType -> supportedTransportType,
                         supportedTransportType -> getSeedAddresses(supportedTransportType, seedConfig)));
@@ -105,29 +105,29 @@ public class NetworkServiceConfigFactory {
                 Optional.empty());
     }
 
-    public static List<Address> getSeedAddresses(Transport.Type transportType, Config config) {
+    public static Set<Address> getSeedAddresses(Transport.Type transportType, Config config) {
         switch (transportType) {
             case TOR -> {
                 return ConfigUtil.getStringList(config, "tor").stream()
                         .map(Address::new)
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toSet());
             }
             case I2P -> {
                 return ConfigUtil.getStringList(config, "i2p").stream()
                         .map(Address::new)
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toSet());
             }
             case CLEAR -> {
                 return ConfigUtil.getStringList(config, "clear").stream()
                         .map(Address::new)
-                        .collect(Collectors.toList());
+                        .collect(Collectors.toSet());
             }
             default -> {
                /* List<Address> seedAddresses = new ArrayList<>();
                 for (int i = 0; i < 3; i++) {
                     seedAddresses.add(Address.localHost(8000 + i));
                 }*/
-                return new ArrayList<>();
+                return new HashSet<>();
             }
         }
     }

--- a/network/src/main/java/bisq/network/p2p/ServiceNode.java
+++ b/network/src/main/java/bisq/network/p2p/ServiceNode.java
@@ -112,7 +112,7 @@ public class ServiceNode {
                        Optional<DataService> dataService,
                        KeyPairService keyPairService,
                        PersistenceService persistenceService,
-                       List<Address> seedNodeAddresses) {
+                       Set<Address> seedNodeAddresses) {
         BanList banList = new BanList();
         nodesById = new NodesById(banList, nodeConfig);
         defaultNode = nodesById.getDefaultNode();

--- a/network/src/main/java/bisq/network/p2p/ServiceNodesByTransport.java
+++ b/network/src/main/java/bisq/network/p2p/ServiceNodesByTransport.java
@@ -62,7 +62,7 @@ public class ServiceNodesByTransport {
                                    Set<Transport.Type> supportedTransportTypes,
                                    ServiceNode.Config serviceNodeConfig,
                                    Map<Transport.Type, PeerGroupService.Config> peerGroupServiceConfigByTransport,
-                                   Map<Transport.Type, List<Address>> seedAddressesByTransport,
+                                   Map<Transport.Type, Set<Address>> seedAddressesByTransport,
                                    Optional<DataService> dataService,
                                    KeyPairService keyPairService,
                                    PersistenceService persistenceService) {
@@ -74,7 +74,7 @@ public class ServiceNodesByTransport {
                     new UnrestrictedAuthorizationService(),
                     transportConfig,
                     (int) socketTimeout);
-            List<Address> seedAddresses = seedAddressesByTransport.get(transportType);
+            Set<Address> seedAddresses = seedAddressesByTransport.get(transportType);
             checkNotNull(seedAddresses, "Seed nodes must be setup for %s", transportType);
             PeerGroupService.Config peerGroupServiceConfig = peerGroupServiceConfigByTransport.get(transportType);
             ServiceNode serviceNode = new ServiceNode(serviceNodeConfig,

--- a/network/src/main/java/bisq/network/p2p/services/peergroup/PeerGroup.java
+++ b/network/src/main/java/bisq/network/p2p/services/peergroup/PeerGroup.java
@@ -64,13 +64,13 @@ public class PeerGroup {
     private final Node node;
     private final Config config;
     @Getter
-    private final List<Address> seedNodeAddresses;
+    private final Set<Address> seedNodeAddresses;
     private final BanList banList;
     private final PeerGroupStore peerGroupStore;
     @Getter
     private final Set<Peer> reportedPeers = new CopyOnWriteArraySet<>();
 
-    public PeerGroup(Node node, Config config, List<Address> seedNodeAddresses, BanList banList, PeerGroupStore peerGroupStore) {
+    public PeerGroup(Node node, Config config, Set<Address> seedNodeAddresses, BanList banList, PeerGroupStore peerGroupStore) {
         this.node = node;
         this.config = config;
         this.seedNodeAddresses = seedNodeAddresses;

--- a/network/src/main/java/bisq/network/p2p/services/peergroup/PeerGroupService.java
+++ b/network/src/main/java/bisq/network/p2p/services/peergroup/PeerGroupService.java
@@ -104,7 +104,7 @@ public class PeerGroupService implements PersistenceClient<PeerGroupStore>, Pers
         }
     }
 
-    public PeerGroupService(PersistenceService persistenceService, Node node, BanList banList, Config config, List<Address> seedNodeAddresses) {
+    public PeerGroupService(PersistenceService persistenceService, Node node, BanList banList, Config config, Set<Address> seedNodeAddresses) {
         this.node = node;
         this.banList = banList;
         this.config = config;

--- a/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeService.java
+++ b/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeService.java
@@ -78,7 +78,7 @@ public class PeerExchangeService implements Node.Listener {
         return doPeerExchange(peerExchangeStrategy.getAddressesForFurtherPeerExchange());
     }
 
-    private CompletableFuture<Void> doPeerExchange(List<Address> candidates) {
+    private CompletableFuture<Void> doPeerExchange(Set<Address> candidates) {
         if (candidates.isEmpty() || isStopped) {
             return CompletableFuture.completedFuture(null);
         }

--- a/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeStrategy.java
+++ b/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeStrategy.java
@@ -72,8 +72,8 @@ public class PeerExchangeStrategy {
         this.peerGroupStore = peerGroupStore;
     }
 
-    List<Address> getAddressesForInitialPeerExchange() {
-        List<Address> candidates = getCandidates(getPriorityListForInitialPeerExchange());
+    Set<Address> getAddressesForInitialPeerExchange() {
+        Set<Address> candidates = getCandidates(getPriorityListForInitialPeerExchange());
         if (candidates.isEmpty()) {
             // It can be that we don't have peers anymore which we have not already connected in the past.
             // We reset the usedAddresses and try again. It is likely that some peers have different peers to 
@@ -88,8 +88,8 @@ public class PeerExchangeStrategy {
 
     // After bootstrap, we might want to add more connections and use the peer exchange protocol for that.
     // We do not want to use seed nodes or already existing connections in that case.
-    List<Address> getAddressesForFurtherPeerExchange() {
-        List<Address> candidates = getCandidates(getPriorityListForFurtherPeerExchange());
+    Set<Address> getAddressesForFurtherPeerExchange() {
+        Set<Address> candidates = getCandidates(getPriorityListForFurtherPeerExchange());
         if (candidates.isEmpty()) {
             // It can be that we don't have peers anymore which we have not already connected in the past.
             // We reset the usedAddresses and try again. It is likely that some peers have different peers to 
@@ -165,9 +165,9 @@ public class PeerExchangeStrategy {
                 isDateValid(peer);
     }
 
-    private List<Address> getPriorityListForInitialPeerExchange() {
-        List<Address> seeds = getSeeds();
-        List<Address> priorityList = new ArrayList<>(seeds);
+    private Set<Address> getPriorityListForInitialPeerExchange() {
+        Set<Address> seeds = getSeeds();
+        Set<Address> priorityList = new HashSet<>(seeds);
         Set<Address> reported = getReported();
         priorityList.addAll(reported);
         priorityList.addAll(getPersisted());
@@ -180,18 +180,18 @@ public class PeerExchangeStrategy {
         return priorityList;
     }
 
-    private List<Address> getPriorityListForFurtherPeerExchange() {
-        List<Address> priorityList = new ArrayList<>(getReported());
+    private Set<Address> getPriorityListForFurtherPeerExchange() {
+        Set<Address> priorityList = new HashSet<>(getReported());
         priorityList.addAll(getPersisted());
         return priorityList;
     }
 
-    private List<Address> getSeeds() {
+    private Set<Address> getSeeds() {
         return getShuffled(peerGroup.getSeedNodeAddresses()).stream()
                 .filter(peerGroup::notMyself)
                 .filter(this::isNotUsed)
                 .limit(config.getNumSeeNodesAtBoostrap())
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     private Set<Address> getReported() {
@@ -226,11 +226,10 @@ public class PeerExchangeStrategy {
                 .collect(Collectors.toSet());
     }
 
-    private List<Address> getCandidates(List<Address> priorityList) {
+    private Set<Address> getCandidates(Set<Address> priorityList) {
         return priorityList.stream()
-                .distinct()
                 .limit(getLimit())
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     private int getLimit() {

--- a/network/src/test/java/bisq/network/p2p/services/data/MultiNodesSetup.java
+++ b/network/src/test/java/bisq/network/p2p/services/data/MultiNodesSetup.java
@@ -66,7 +66,7 @@ public class MultiNodesSetup {
     @Getter
     private final Map<Address, NetworkService> networkServicesByAddress = new ConcurrentHashMap<>();
     private final Map<Address, String> logHistoryByAddress = new ConcurrentHashMap<>();
-    private final Map<Transport.Type, List<Address>> seedAddressesByTransport;
+    private final Map<Transport.Type, Set<Address>> seedAddressesByTransport;
 
 
     public MultiNodesSetup(NetworkService.Config networkServiceConfig, Set<Transport.Type> supportedTransportTypes,
@@ -164,9 +164,9 @@ public class MultiNodesSetup {
                                                         int numSeeds,
                                                         Set<Transport.Type> supportedTransportTypes) {
 
-        Map<Transport.Type, List<Address>> seeds = networkServiceConfig.seedAddressesByTransport().entrySet().stream()
+        Map<Transport.Type, Set<Address>> seeds = networkServiceConfig.seedAddressesByTransport().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
-                        e -> e.getValue().stream().limit(numSeeds).collect(Collectors.toList())));
+                        e -> e.getValue().stream().limit(numSeeds).collect(Collectors.toSet())));
         return new NetworkService.Config(networkServiceConfig.baseDir(),
                 networkServiceConfig.transportConfig(),
                 supportedTransportTypes,

--- a/network/src/test/java/bisq/network/p2p/services/peergroup/exchange/BasePeerExchangeServiceTest.java
+++ b/network/src/test/java/bisq/network/p2p/services/peergroup/exchange/BasePeerExchangeServiceTest.java
@@ -26,7 +26,9 @@ import bisq.network.p2p.services.peergroup.PeerGroupStore;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +43,7 @@ public abstract class BasePeerExchangeServiceTest extends BaseNetworkTest {
         int numNodes = 2;
         PeerGroupStore peerGroupStore = new PeerGroupStore();
         BanList banList = new BanList();
-        List<Address> seedNodeAddresses = new ArrayList<>();
+        Set<Address> seedNodeAddresses = new HashSet<>();
         for (int i = 0; i < numSeeds; i++) {
             int port = 1000 + i;
             Address address = Address.localHost(port);


### PR DESCRIPTION
In some tests, there were multiple connections to the same seed. Eliminate duplicates by storing and passing seeds in hashsets.