### PR TITLE
Extend PeerExchangeService with optimistic peer exchange

### DIFF
--- a/common/src/main/java/bisq/common/util/CompletableFutureUtils.java
+++ b/common/src/main/java/bisq/common/util/CompletableFutureUtils.java
@@ -48,12 +48,17 @@ public class CompletableFutureUtils {
         );
     }
 
-    public static <T> CompletableFuture<List<T>> anyOf(Collection<CompletableFuture<T>> collection) {
+    public static CompletableFuture<Boolean> anyOfBooleanMatchingFilterOrAll(boolean filter, Collection<CompletableFuture<Boolean>> collection) {
+        //noinspection unchecked
+        return anyOfBooleanMatchingFilterOrAll(filter, collection.toArray(new CompletableFuture[0]));
+    }
+
+    public static <T> CompletableFuture<T> anyOf(Collection<CompletableFuture<T>> collection) {
         //noinspection unchecked
         return anyOf(collection.toArray(new CompletableFuture[0]));
     }
 
-    public static <T> CompletableFuture<List<T>> anyOf(Stream<CompletableFuture<T>> collection) {
+    public static <T> CompletableFuture<T> anyOf(Stream<CompletableFuture<T>> collection) {
         return anyOf(collection.collect(Collectors.toList()));
     }
 
@@ -64,6 +69,44 @@ public class CompletableFutureUtils {
                         .filter(CompletableFuture::isDone)
                         .findAny()
                         .orElseThrow());
+    }
+
+    /**
+     * Completes on any one of the following conditions:
+     * <br/>
+     * a) ANY of the CompletableFutures completes with the given filter, or
+     * <br/>
+     * b) ALL CompletableFutures complete
+     * <br/><br/>
+     *
+     * Useful in situations such as
+     * <br/>
+     * "complete when any boolean future in the list completes with true, else complete when all complete with false"
+     *
+     * @param filter
+     * @param list
+     * @return
+     *
+     * @see "https://stackoverflow.com/a/58999999"
+     */
+    @SafeVarargs
+    public static CompletableFuture<Boolean> anyOfBooleanMatchingFilterOrAll(
+            boolean filter, CompletableFuture<Boolean>... list) {
+        CompletableFuture<Boolean> allWithFailFast = CompletableFuture
+                .allOf(list)
+                .thenApply(__ -> {
+                            Stream.of(list)
+                                    .map(CompletableFuture::join);
+                            return filter;
+                        }
+                );
+        Stream.of(list)
+                .forEach(f -> f.thenAccept(result -> {
+                    if (result == filter) {
+                        allWithFailFast.complete(result);
+                    }
+                }));
+        return allWithFailFast;
     }
 
     // CompletableFuture.applyToEither has some undesired error handling behavior (if first fail result fails).

--- a/common/src/test/java/bisq/common/util/CompletableFutureUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/CompletableFutureUtilsTest.java
@@ -1,0 +1,116 @@
+package bisq.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+public class CompletableFutureUtilsTest {
+
+    @Test
+    public void testAllOf() throws ExecutionException, InterruptedException {
+
+        CompletableFuture<Void> cfA = createCompletableFuture(1000, "A");
+        CompletableFuture<Void> cfB = createCompletableFuture(2000, "B");
+        CompletableFuture<Void> cfC = createCompletableFuture(3000, "C");
+
+        CompletableFutureUtils.allOf(cfA, cfB, cfC)
+                .thenApply(res -> {
+                    log.info("CompletableFutureUtils.allOf(A, B, C) completed");
+                    return null;
+                })
+                .get();
+    }
+
+    @Test
+    public void testAnyOf_allSucceed() throws ExecutionException, InterruptedException {
+
+        CompletableFuture<Void> cfA = createCompletableFuture(1000, "A");
+        CompletableFuture<Void> cfB = createCompletableFuture(2000, "B");
+        CompletableFuture<Void> cfC = createCompletableFuture(3000, "C");
+
+        // Completes as soon as the fastest future in the args
+        CompletableFutureUtils.anyOf(cfA, cfB, cfC)
+                .thenApply(res -> {
+                    log.info("CompletableFutureUtils.anyOf(A, B, C) completed");
+                    return null;
+                })
+                .get();
+    }
+
+    @Test
+    public void testAnyOfBoolean() throws ExecutionException, InterruptedException {
+
+        CompletableFuture<Boolean> cfA = createCompletableFutureBool(1000, "A", false);
+        CompletableFuture<Boolean> cfB = createCompletableFutureBool(2000, "B", true);
+        CompletableFuture<Boolean> cfC = createCompletableFutureBool(3000, "C", true);
+
+        // Completes as soon as the fastest future in the args
+        // Has the value returned by the first future that completes
+        CompletableFutureUtils.anyOf(cfA, cfB, cfC)
+                .thenApply(res -> {
+                    log.info("CompletableFutureUtils.anyOf(A, B, C) completed: {}", res);
+                    return res;
+                })
+                .get();
+    }
+
+    @Test
+    public void testAnyOfBoolean_filterVal() throws ExecutionException, InterruptedException {
+        boolean expectedValue = true;
+
+        // Completes when C completes (C = first future that completes with true)
+        CompletableFutureUtils.anyOfBooleanMatchingFilterOrAll(
+                    expectedValue,
+                    createCompletableFutureBool(1000, "A", false),
+                    createCompletableFutureBool(2000, "B", false),
+                    createCompletableFutureBool(3000, "C", true)
+                )
+                .thenApply(res -> {
+                    log.info("CompletableFutureUtils.anyOfBooleanFiltered(A, B, C) completed: {}", res);
+                    return res;
+                })
+                .get();
+
+        // Completes when B completes (B = first future that completes with true)
+        CompletableFutureUtils.anyOfBooleanMatchingFilterOrAll(
+                        expectedValue,
+                        createCompletableFutureBool(1000, "A", false),
+                        createCompletableFutureBool(2000, "B", true),
+                        createCompletableFutureBool(3000, "C", true)
+                )
+                .thenApply(res -> {
+                    log.info("CompletableFutureUtils.anyOfBooleanFiltered(A, B, C) completed: {}", res);
+                    return res;
+                })
+                .get();
+    }
+
+    private CompletableFuture<Boolean> createCompletableFutureBool(long sleepMs, String msg, boolean val) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                Thread.sleep(sleepMs);
+                log.info("{} (waited {} ms: {})", msg, sleepMs, val);
+                return val;
+            } catch (InterruptedException e) {
+                log.error("Interrupted: " + e.getMessage(), e);
+                return false;
+            }
+        });
+    }
+
+    private CompletableFuture<Void> createCompletableFuture(long sleepMs, String msg) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(sleepMs);
+                log.info("{} (waited {} ms)", msg, sleepMs);
+            } catch (InterruptedException e) {
+                log.error("Interrupted: " + e.getMessage(), e);
+            }
+//            return null;
+        });
+    }
+
+}


### PR DESCRIPTION
Extend the peer exchange logic with ability to complete future when first peer exchange succeeds (optimistic scenario). Alternatively, wait until all peer connections have been tried.