### PR TITLE
Fix typesafe ConfigException when using only tor or only i2p seeds

### DIFF
--- a/network/src/main/java/bisq/network/NetworkServiceConfigFactory.java
+++ b/network/src/main/java/bisq/network/NetworkServiceConfigFactory.java
@@ -31,6 +31,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toMap;
+
 /**
  * Parses the program arguments which are relevant for that domain and stores it in the options field.
  */
@@ -54,11 +56,11 @@ public class NetworkServiceConfigFactory {
                 ServiceNode.Service.MONITOR));
 
         Config seedConfig = typesafeConfig.getConfig("seedAddressByTransportType");
-        Map<Transport.Type, List<Address>> seedAddressesByTransport = Map.of(
-                Transport.Type.TOR, getSeedAddresses(Transport.Type.TOR, seedConfig),
-                Transport.Type.I2P, getSeedAddresses(Transport.Type.I2P, seedConfig),
-                Transport.Type.CLEAR, getSeedAddresses(Transport.Type.CLEAR, seedConfig)
-        );
+        // Only read seed addresses for explicitly supported address types
+        Map<Transport.Type, List<Address>> seedAddressesByTransport = supportedTransportTypes.stream()
+                .collect(toMap(
+                        supportedTransportType -> supportedTransportType,
+                        supportedTransportType -> getSeedAddresses(supportedTransportType, seedConfig)));
 
         PeerGroup.Config peerGroupConfig = PeerGroup.Config.from(typesafeConfig.getConfig("peerGroupConfig"));
         PeerExchangeStrategy.Config peerExchangeStrategyConfig = PeerExchangeStrategy.Config.from(typesafeConfig.getConfig("peerExchangeStrategyConfig"));


### PR DESCRIPTION
The config initializaiton now only tries to read seed addresses for the transport types explicitly supported with the supportedTransportTypes config.