### PR TITLE
Fix bug in network domain not handling mailbox data

### DIFF
--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatMessageListItem.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatMessageListItem.java
@@ -41,24 +41,24 @@ import java.util.Optional;
 class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessageListItem<T>>, FilteredListItem {
     private final T chatMessage;
     private final String message;
-    private final String senderUserName;
+    private final String authorUserName;
     private final String time;
     private final String date;
     private final String chatUserId;
     private final ByteArray pubKeyHashAsByteArray;
     private final Optional<QuotedMessage> quotedMessage;
-    private final ChatUser chatUser;
+    private final ChatUser author;
 
     public ChatMessageListItem(T chatMessage) {
         this.chatMessage = chatMessage;
         String editPostFix = chatMessage.isWasEdited() ? " " + Res.get("social.message.wasEdited") : "";
         message = chatMessage.getText() + editPostFix;
         quotedMessage = chatMessage.getQuotedMessage();
-        chatUser = chatMessage.getChatUser();
-        senderUserName = chatUser.getUserName();
+        author = chatMessage.getAuthor();
+        authorUserName = author.getUserName();
         time = TimeFormatter.formatTime(new Date(chatMessage.getDate()));
         date = DateFormatter.formatDateTime(new Date(chatMessage.getDate()));
-        byte[] pubKeyHash = DigestUtil.hash(chatUser.getNetworkId().getPubKey().publicKey().getEncoded());
+        byte[] pubKeyHash = DigestUtil.hash(author.getNetworkId().getPubKey().publicKey().getEncoded());
         pubKeyHashAsByteArray = new ByteArray(pubKeyHash);
         chatUserId = Hex.encode(pubKeyHash);
     }
@@ -73,7 +73,7 @@ class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessa
         return filterString == null ||
                 filterString.isEmpty() ||
                 StringUtils.containsIgnoreCase(message, filterString) ||
-                StringUtils.containsIgnoreCase(senderUserName, filterString) ||
+                StringUtils.containsIgnoreCase(authorUserName, filterString) ||
                 StringUtils.containsIgnoreCase(date, filterString);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatModel.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatModel.java
@@ -80,9 +80,7 @@ public class ChatModel implements Model {
         log.error("Send message resulted in an error: channelId={}, error={}", channelId, throwable.toString());  //todo
     }
 
-     boolean isMyMessage(ChatMessage chatMessage) {
-         String chatId = chatMessage.getChatUser().getId();
-         return userProfileService.getPersistableStore().getUserProfiles().stream()
-                .anyMatch(userprofile -> userprofile.chatUser().getId().equals(chatId));
+    boolean isMyMessage(ChatMessage chatMessage) {
+        return chatService.isMyMessage(chatMessage);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/ChatView.java
@@ -323,10 +323,10 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
                             dateTooltip.setShowDelay(Duration.millis(100));
                             Tooltip.install(time, dateTooltip);
 
-                            userName.setText(item.getSenderUserName());
-                            userName.setOnMouseClicked(e -> controller.onUserNameClicked(item.getSenderUserName()));
+                            userName.setText(item.getAuthorUserName());
+                            userName.setOnMouseClicked(e -> controller.onUserNameClicked(item.getAuthorUserName()));
 
-                            chatUserIcon.setChatUser(item.getChatUser(), model.getUserProfileService());
+                            chatUserIcon.setChatUser(item.getAuthor(), model.getUserProfileService());
                             chatUserIcon.setCursor(Cursor.HAND);
                             chatUserIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(item.getChatMessage()));
                             hBox.setOnMouseEntered(e -> {
@@ -345,7 +345,7 @@ public class ChatView extends View<SplitPane, ChatModel, ChatController> {
                             emojiButton2.setOnAction(e -> controller.onAddEmoji((String) emojiButton2.getUserData()));
                             openEmojiSelectorButton.setOnAction(e -> controller.onOpenEmojiSelector(chatMessage));
                             replyButton.setOnAction(e -> controller.onReply(chatMessage));
-                            pmButton.setOnAction(e -> controller.addPrivateChannel(chatMessage));
+                            pmButton.setOnAction(e -> controller.onOpenPrivateChannel(chatMessage));
                             editButton.setOnAction(e -> onEditMessage(item));
                             deleteButton.setOnAction(e -> controller.onDeleteMessage(chatMessage));
                             moreOptionsButton.setOnAction(e -> controller.onOpenMoreOptions(chatMessage));

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChannelInfo.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/ChannelInfo.java
@@ -110,7 +110,7 @@ public class ChannelInfo {
             channelName = channel.getChannelName();
             Set<String> ignoredChatUserIds = new HashSet<>(chatService.getPersistableStore().getIgnoredChatUserIds());
             members.setAll(channel.getChatMessages().stream()
-                    .map(ChatMessage::getChatUser)
+                    .map(ChatMessage::getAuthor)
                     .distinct()
                     .map((chatUser -> new ChatUserOverview(chatUser, ignoredChatUserIds.contains(chatUser.getId()))))
                     .sorted()

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/QuotedMessageBlock.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/chat/components/QuotedMessageBlock.java
@@ -67,7 +67,7 @@ public class QuotedMessageBlock {
 
     public Optional<QuotedMessage> getQuotedMessage() {
         String text = controller.model.quotedMessage.get();
-        ChatUser chatUser = controller.model.chatUser;
+        ChatUser chatUser = controller.model.author;
         if (text == null || text.isEmpty() || chatUser == null) {
             return Optional.empty();
         }
@@ -86,10 +86,10 @@ public class QuotedMessageBlock {
         }
 
         private void reply(ChatMessage chatMessage) {
-            ChatUser chatUser = chatMessage.getChatUser();
-            model.chatUser = chatUser;
-            model.userName.set(chatUser.getUserName());
-            model.roboHashNode.set(RoboHash.getImage(new ByteArray(chatUser.getPubKeyHash()), false));
+            ChatUser author = chatMessage.getAuthor();
+            model.author = author;
+            model.userName.set(author.getUserName());
+            model.roboHashNode.set(RoboHash.getImage(new ByteArray(author.getPubKeyHash()), false));
             model.quotedMessage.set(chatMessage.getText());
             model.visible.set(true);
         }
@@ -113,7 +113,7 @@ public class QuotedMessageBlock {
         private final StringProperty quotedMessage = new SimpleStringProperty("");
         private final ObjectProperty<Image> roboHashNode = new SimpleObjectProperty<>();
         private final StringProperty userName = new SimpleStringProperty();
-        private ChatUser chatUser;
+        private ChatUser author;
 
         private Model() {
         }

--- a/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessage.java
+++ b/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessage.java
@@ -24,17 +24,19 @@ import bisq.security.ConfidentialData;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @ToString
 @EqualsAndHashCode
 @Getter
 public class ConfidentialMessage implements NetworkMessage, DistributedData {
     private final ConfidentialData confidentialData;
-    private final String keyId;
+    private final String receiverKeyId;
 
-    public ConfidentialMessage(ConfidentialData confidentialData, String keyId) {
+    public ConfidentialMessage(ConfidentialData confidentialData, String receiverKeyId) {
         this.confidentialData = confidentialData;
-        this.keyId = keyId;
+        this.receiverKeyId = receiverKeyId;
     }
 
     @Override
@@ -42,13 +44,13 @@ public class ConfidentialMessage implements NetworkMessage, DistributedData {
         return getNetworkMessageBuilder().setConfidentialMessage(
                 bisq.network.protobuf.ConfidentialMessage.newBuilder()
                         .setConfidentialData(confidentialData.toProto())
-                        .setKeyId(keyId)
+                        .setReceiverKeyId(receiverKeyId)
         ).build();
     }
 
     public static ConfidentialMessage fromProto(bisq.network.protobuf.ConfidentialMessage proto) {
         return new ConfidentialMessage(ConfidentialData.fromProto(proto.getConfidentialData()),
-                proto.getKeyId());
+                proto.getReceiverKeyId());
     }
 
     @Override
@@ -60,6 +62,6 @@ public class ConfidentialMessage implements NetworkMessage, DistributedData {
 
     @Override
     public boolean isDataInvalid() {
-        return confidentialData == null || keyId == null;
+        return confidentialData == null || receiverKeyId == null;
     }
 }

--- a/network/src/main/java/bisq/network/p2p/services/data/DataService.java
+++ b/network/src/main/java/bisq/network/p2p/services/data/DataService.java
@@ -319,6 +319,8 @@ public class DataService implements DataNetworkService.Listener {
                         // async calls
                         if (storageData instanceof AuthenticatedData authenticatedData) {
                             listeners.forEach(listener -> listener.onAuthenticatedDataAdded(authenticatedData));
+                        } else if (storageData instanceof MailboxData mailboxData) {
+                            listeners.forEach(listener -> listener.onMailboxDataAdded(mailboxData));
                         } else if (storageData instanceof AppendOnlyData appendOnlyData) {
                             listeners.forEach(listener -> listener.onAppendOnlyDataAdded(appendOnlyData));
                         }

--- a/network/src/main/proto/network.proto
+++ b/network/src/main/proto/network.proto
@@ -100,7 +100,7 @@ message Pong {
 
 message ConfidentialMessage {
   security.ConfidentialData confidentialData = 1;
-  string keyId = 2;
+  string receiverKeyId = 2;
 }
 
 message InventoryRequest {

--- a/social/src/main/java/bisq/social/chat/ChatMessage.java
+++ b/social/src/main/java/bisq/social/chat/ChatMessage.java
@@ -23,16 +23,17 @@ import bisq.social.user.ChatUser;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
-
+@Slf4j
 @Getter
 @ToString
 @EqualsAndHashCode
 public abstract class ChatMessage {
     protected final String channelId;
     protected final String text;
-    protected ChatUser chatUser;
+    protected ChatUser author;
     protected final Optional<QuotedMessage> quotedMessage;
     protected final long date;
     protected final ChannelType channelType;
@@ -40,7 +41,7 @@ public abstract class ChatMessage {
     protected final MetaData metaData;
 
     protected ChatMessage(String channelId,
-                          ChatUser chatUser,
+                          ChatUser author,
                           String text,
                           Optional<QuotedMessage> quotedMessage,
                           long date,
@@ -48,7 +49,7 @@ public abstract class ChatMessage {
                           boolean wasEdited,
                           MetaData metaData) {
         this.channelId = channelId;
-        this.chatUser = chatUser;
+        this.author = author;
         this.text = text;
         this.quotedMessage = quotedMessage;
         this.date = date;
@@ -60,7 +61,7 @@ public abstract class ChatMessage {
     bisq.social.protobuf.ChatMessage.Builder getChatMessageBuilder() {
         bisq.social.protobuf.ChatMessage.Builder builder = bisq.social.protobuf.ChatMessage.newBuilder()
                 .setChannelId(channelId)
-                .setChatUser(chatUser.toProto())
+                .setAuthor(author.toProto())
                 .setText(text)
                 .setDate(date)
                 .setChannelType(channelType.toProto())

--- a/social/src/main/java/bisq/social/chat/PrivateChannel.java
+++ b/social/src/main/java/bisq/social/chat/PrivateChannel.java
@@ -36,14 +36,13 @@ public class PrivateChannel extends Channel<PrivateChatMessage> {
 
     public PrivateChannel(String id, ChatUser peer, UserProfile myProfile) {
         this(id, peer, myProfile, NotificationSetting.ALL, new HashSet<>());
-
     }
 
-    public PrivateChannel(String id,
-                          ChatUser peer,
-                          UserProfile myProfile,
-                          NotificationSetting notificationSetting,
-                          Set<PrivateChatMessage> chatMessages) {
+    private PrivateChannel(String id,
+                           ChatUser peer,
+                           UserProfile myProfile,
+                           NotificationSetting notificationSetting,
+                           Set<PrivateChatMessage> chatMessages) {
         super(id, notificationSetting, chatMessages);
         this.peer = peer;
         this.myProfile = myProfile;

--- a/social/src/main/java/bisq/social/chat/PrivateChatMessage.java
+++ b/social/src/main/java/bisq/social/chat/PrivateChatMessage.java
@@ -92,7 +92,7 @@ public class PrivateChatMessage extends ChatMessage implements MailboxMessage {
                 Optional.empty();
         return new PrivateChatMessage(
                 baseProto.getChannelId(),
-                ChatUser.fromProto(baseProto.getChatUser()),
+                ChatUser.fromProto(baseProto.getAuthor()),
                 baseProto.getText(),
                 quotedMessage,
                 baseProto.getDate(),

--- a/social/src/main/java/bisq/social/chat/PublicChatMessage.java
+++ b/social/src/main/java/bisq/social/chat/PublicChatMessage.java
@@ -81,7 +81,7 @@ public class PublicChatMessage extends ChatMessage implements DistributedData {
                 Optional.empty();
         return new PublicChatMessage(
                 baseProto.getChannelId(),
-                ChatUser.fromProto(baseProto.getChatUser()),
+                ChatUser.fromProto(baseProto.getAuthor()),
                 baseProto.getText(),
                 quotedMessage,
                 baseProto.getDate(),

--- a/social/src/main/java/bisq/social/user/ChatUser.java
+++ b/social/src/main/java/bisq/social/user/ChatUser.java
@@ -50,14 +50,14 @@ public class ChatUser implements Proto {
     private final Set<Entitlement> entitlements;
     private transient final DerivedData derivedData;
 
+    public ChatUser(NetworkId networkId) {
+        this(networkId, new HashSet<>());
+    }
+
     public ChatUser(NetworkId networkId, Set<Entitlement> entitlements) {
         this.networkId = networkId;
         this.entitlements = entitlements;
         derivedData = getDerivedData(networkId.getPubKey().publicKey().getEncoded());
-    }
-
-    public ChatUser(NetworkId networkId) {
-        this(networkId, new HashSet<>());
     }
 
     public bisq.social.protobuf.ChatUser toProto() {

--- a/social/src/main/proto/social.proto
+++ b/social/src/main/proto/social.proto
@@ -83,7 +83,7 @@ message PublicChatMessage {
 message ChatMessage {
   string channelId = 1;
   string text = 2;
-  ChatUser chatUser = 3;
+  ChatUser author = 3;
   QuotedMessage quotedMessage = 4;
   uint64 date = 5;
   ChannelType channelType = 6;


### PR DESCRIPTION
Return false if keyId not found at processConfidentialMessage

Rename keyId to receiverKeyId in ConfidentialMessage
Rename chatUser to author in ChatMessage
Use peer for chatUser to make role more explicit in private message case
Add check at onMessage to ignore own messages