### PR TITLE
Update BouncyCastle to v1.67

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@
 # when multiple versions are attempted to be brought in as transitive dependencies of other requirements.
 [versions]
 annotations-lib =       { strictly = '23.0.0' }
+bouncycastle-lib =      { strictly = '1.67' } # Oldest version without known CVEs
 google-gson-lib =       { strictly = '2.9.0' }
 google-guava-lib =      { strictly = '31.1-jre' }
 i2p-lib =               { strictly = '1.7.0' }
@@ -24,6 +25,7 @@ typesafe-config-lib =   { strictly = '1.4.2' }
 # in a build.gradle ('implementation libs.protobuf.java')
 [libraries]
 annotations =       { module = 'org.jetbrains:annotations',         version.ref = 'annotations-lib' }
+bouncycastle =      { module = 'org.bouncycastle:bcprov-jdk15on',   version.ref = 'bouncycastle-lib' }
 google-gson =       { module = 'com.google.code.gson:gson',         version.ref = 'google-gson-lib' }
 google-guava =      { module = 'com.google.guava:guava',            version.ref = 'google-guava-lib' }
 i2p-streaming =     { module = 'net.i2p.client:streaming',          version.ref = 'i2p-lib' }

--- a/security/build.gradle
+++ b/security/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-    implementation 'org.bouncycastle:bcprov-jdk16:1.46'
+    implementation libs.bouncycastle
 }
 test {
     useJUnitPlatform()

--- a/security/src/main/java/bisq/security/KeyGeneration.java
+++ b/security/src/main/java/bisq/security/KeyGeneration.java
@@ -17,10 +17,10 @@
 
 package bisq.security;
 
+import org.bouncycastle.jcajce.provider.asymmetric.util.EC5Util;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.ECPointUtil;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.jce.provider.asymmetric.ec.EC5Util;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.math.ec.ECCurve;
 


### PR DESCRIPTION
Update and consolidate the BC version in the version catalog.

Relates to https://github.com/bisq-network/bisq2/issues/178

This version also exposes a Java Module, so can be used in modularizing the other bisq 2 apps.