### PR TITLE
Gradle: Create custom project type 'bisq.java-library'

### DIFF
--- a/account/build.gradle
+++ b/account/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -25,10 +19,6 @@ dependencies {
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -36,11 +30,6 @@ dependencies {
     implementation libs.protobuf.java
     implementation libs.google.guava
     implementation libs.typesafe.config
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlindsl)
     alias(libs.plugins.protobuf)
+    id 'groovy-gradle-plugin'
     id 'signing'
     id 'maven-publish'
 }

--- a/buildSrc/lombok-dependencies.gradle
+++ b/buildSrc/lombok-dependencies.gradle
@@ -1,6 +1,0 @@
-dependencies {
-    compileOnly libs.lombok
-    annotationProcessor libs.lombok
-    testCompileOnly libs.lombok
-    testAnnotationProcessor libs.lombok
-}

--- a/buildSrc/src/main/groovy/bisq.java-library.gradle
+++ b/buildSrc/src/main/groovy/bisq.java-library.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+    maven { url "https://jitpack.io" }
+}
+
+dependencies {
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+    testCompileOnly(libs.lombok)
+    testAnnotationProcessor(libs.lombok)
+}
+
+test {
+    useJUnitPlatform()
+    exclude '**/**Integration*'
+}

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,10 +1,6 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
@@ -18,9 +14,4 @@ dependencies {
     implementation 'io.grpc:grpc-core'
     implementation 'io.grpc:grpc-stub'
     implementation 'io.grpc:grpc-netty-shaded'
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,16 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -19,11 +14,6 @@ dependencies {
     implementation libs.google.guava
     implementation libs.typesafe.config
     implementation libs.annotations
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/contract/build.gradle
+++ b/contract/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -25,11 +19,6 @@ dependencies {
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.openjfx)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 javafx {
     version = '16'
@@ -49,8 +43,4 @@ dependencies {
     implementation "org.fxmisc.easybind:easybind:1.0.3"
     implementation 'org.fxmisc.richtext:richtextfx:0.10.9'
 
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/desktopapp/build.gradle
+++ b/desktopapp/build.gradle
@@ -1,13 +1,8 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     id 'application'
    /* id 'distribution'*/ //todo as long we dont need a jar we leave that out, speeds up build
     alias(libs.plugins.openjfx)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
@@ -47,7 +42,6 @@ javafx {
 
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -81,8 +75,4 @@ dependencies {
     implementation "org.fxmisc.easybind:easybind:1.0.3"
     implementation 'org.fxmisc.richtext:richtextfx:0.10.9'
 
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -1,16 +1,10 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
 
 dependencies {
@@ -54,9 +48,4 @@ protobuf {
         all()*.plugins { grpc {} }
     }
     generatedFilesBaseDir = "$projectDir/build/generated/source"
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/i18n/build.gradle
+++ b/i18n/build.gradle
@@ -1,25 +1,15 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/i2p/build.gradle
+++ b/i2p/build.gradle
@@ -1,15 +1,10 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
 
 dependencies {
@@ -27,9 +22,4 @@ dependencies {
     }
 
     implementation libs.bundles.i2p
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -25,10 +19,6 @@ dependencies {
     implementation libs.protobuf.java
     implementation libs.google.guava
     implementation libs.typesafe.config
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -1,16 +1,10 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
 apply from: '../buildSrc/gen-protos.gradle'
 
@@ -30,11 +24,6 @@ dependencies {
 
     implementation 'com.github.chimp1984:jsocks'
     implementation 'org.apache.httpcomponents:httpclient'
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/offer/build.gradle
+++ b/offer/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -30,11 +24,6 @@ dependencies {
     implementation libs.google.gson
     implementation libs.google.guava
     implementation 'com.github.chimp1984:jsocks'
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/oracle/build.gradle
+++ b/oracle/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -27,11 +21,6 @@ dependencies {
     implementation libs.google.gson
     implementation libs.google.guava
     implementation libs.typesafe.config
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/persistence/build.gradle
+++ b/persistence/build.gradle
@@ -1,16 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -19,11 +14,6 @@ dependencies {
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -1,16 +1,10 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
 
 dependencies {
@@ -24,9 +18,4 @@ dependencies {
     implementation project(':oracle')
 
     implementation libs.google.guava
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -32,10 +26,6 @@ dependencies {
     implementation libs.typesafe.config
 
     implementation("org.jeasy:easy-states:2.0.0")
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/satoshisquareapp/build.gradle
+++ b/satoshisquareapp/build.gradle
@@ -1,19 +1,13 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     id 'application'
    /* id 'distribution'*/  //todo as long we dont need a jar we leave that out, speeds up build
     alias(libs.plugins.openjfx)
 }
 
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
-}
-
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 application {
     project.mainClassName = 'bisq.satoshisquareapp.Main'
@@ -79,8 +73,4 @@ dependencies {
 
     implementation "org.fxmisc.easybind:easybind:1.0.3"
     implementation 'org.fxmisc.richtext:richtextfx:0.10.9'
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/security/build.gradle
+++ b/security/build.gradle
@@ -1,16 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -21,10 +16,6 @@ dependencies {
     implementation libs.protobuf.java
     implementation libs.google.guava
     implementation libs.bouncycastle
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/seed/build.gradle
+++ b/seed/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     id 'application'
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 application {
     project.mainClassName = 'bisq.seed.SeedMain'
@@ -31,8 +25,4 @@ dependencies {
 
     implementation libs.google.guava
     implementation libs.typesafe.config
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/settings/build.gradle
+++ b/settings/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -21,10 +15,6 @@ dependencies {
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/social/build.gradle
+++ b/social/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
 }
 
@@ -11,7 +11,6 @@ repositories {
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -31,11 +30,6 @@ dependencies {
     implementation libs.google.gson
     implementation libs.google.guava
     implementation libs.typesafe.config
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -27,10 +21,6 @@ dependencies {
 
     implementation libs.protobuf.java
     implementation libs.google.guava
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,13 +1,8 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     id 'application'
-     id 'distribution'
+    id 'distribution'
     alias(libs.plugins.openjfx)
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
@@ -47,7 +42,6 @@ javafx {
 
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -81,8 +75,4 @@ dependencies {
     implementation "org.fxmisc.easybind:easybind:1.0.3"
     implementation 'org.fxmisc.richtext:richtextfx:0.10.9'
 
-}
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/tor/build.gradle
+++ b/tor/build.gradle
@@ -1,16 +1,10 @@
 plugins {
-    id 'java-library'
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
+    id 'bisq.java-library'
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))
@@ -30,9 +24,4 @@ dependencies {
     implementation 'com.github.bisq-network.tor-binary:tor-binary-linux32:b9c6227'
     implementation 'com.github.bisq-network.tor-binary:tor-binary-linux64:b9c6227'
     implementation 'com.github.bisq-network.tor-binary:tor-binary-windows:b9c6227'
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }

--- a/wallets/build.gradle
+++ b/wallets/build.gradle
@@ -1,17 +1,11 @@
 plugins {
-    id 'java-library'
+    id 'bisq.java-library'
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
-    maven { url "https://jitpack.io" }
 }
 
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 ext {
     jsonrpc4jVersion = '1.6.0.bisq.2'
@@ -31,11 +25,6 @@ dependencies {
     implementation libs.google.guava
 
     testImplementation("org.assertj:assertj-core:3.22.0")
-}
-
-test {
-    useJUnitPlatform()
-    exclude '**/**Integration*'
 }
 
 ext {

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -1,10 +1,5 @@
 plugins {
-    id 'java-library'
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
+    id 'bisq.java-library'
 }
 
 version '0.0.1-SNAPSHOT'
@@ -12,7 +7,6 @@ version '0.0.1-SNAPSHOT'
 apply from: '../buildSrc/bisq-version.gradle'
 apply from: '../buildSrc/logging-dependencies.gradle'
 apply from: '../buildSrc/test-dependencies.gradle'
-apply from: '../buildSrc/lombok-dependencies.gradle'
 
 dependencies {
     api platform(project(':platforms:common-platform'))


### PR DESCRIPTION
The new custom project type 'bisq.java-library' applies the
'java-library' plugin, sets up the repositories, adds lombok, and sets
up the JUnit testing framework.