### PR TITLE
Fix clearnet outbound connections

### DIFF
--- a/network/src/main/java/bisq/network/p2p/node/Node.java
+++ b/network/src/main/java/bisq/network/p2p/node/Node.java
@@ -311,8 +311,13 @@ public class Node implements Connection.Handler {
             connectionHandshakes.remove(connectionHandshake.getId());
             log.debug("Outbound handshake completed: Initiated by {} to {}", myCapability.address(), address);
             log.debug("Create new outbound connection to {}", address);
-            checkArgument(address.equals(result.capability().address()),
-                    "Peers reported address must match address we used to connect");
+            if (! address.isClearNetAddress()) {
+                // For clearnet this check doesn't make sense because:
+                // - the peer binds to 127.0.0.1, therefore reports 127.0.0.1 in the handshake
+                // - we use the peer's public IP to connect to him
+                checkArgument(address.equals(result.capability().address()),
+                        "Peers reported address must match address we used to connect");
+            }
 
             // As time passed we check again if connection is still not available
             if (outboundConnectionsByAddress.containsKey(address)) {

--- a/network/src/main/java/bisq/network/p2p/node/OutboundConnection.java
+++ b/network/src/main/java/bisq/network/p2p/node/OutboundConnection.java
@@ -46,4 +46,13 @@ public class OutboundConnection extends Connection {
     public boolean isPeerAddressVerified() {
         return true;
     }
+
+    /**
+     * @return Peer address used when connecting to the peer, NOT the address reported by the peer. This matters when
+     * connecting to a clearnet seed, because the reported seed address will always be 127.0.0.1.
+     */
+    @Override
+    public Address getPeerAddress() {
+        return address;
+    }
 }


### PR DESCRIPTION
Can be tested with


> ./gradlew :desktopapp:run -Dadd-opens=java.base/java.lang.reflect=ALL-UNNAMED -Dbisq.application.appName=bisq_Bob2_cloud2 -Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR -Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=167.71.33.219:8000 -Dbisq.networkServiceConfig.seedAddressByTransportType.clear.1=159.65.117.67:8001


This will restrict connections to clearnet and try to connect to both seeds.

Note that without this PR, the same command will fail with

```
ERROR [NetworkService.network-IO-pool] b.n.p.n.Node:
                java.lang.IllegalArgumentException: Peers reported address must match address we used to connect java.lang.IllegalArgumentException: Peers reported address must match address we used to connect
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
        at bisq.network.p2p.node.Node.createOutboundConnection(Node.java:314)
        at bisq.network.p2p.node.Node.lambda$createOutboundConnection$3(Node.java:268)
        at java.base/java.util.Optional.map(Optional.java:260)
        at bisq.network.p2p.node.Node.createOutboundConnection(Node.java:268)
        at bisq.network.p2p.node.Node.getConnection(Node.java:258)
        at bisq.network.p2p.node.Node.getConnection(Node.java:248)
        at bisq.network.p2p.services.peergroup.exchange.PeerExchangeService.doPeerExchange(PeerExchangeService.java:129)
        at bisq.network.p2p.services.peergroup.exchange.PeerExchangeService.lambda$doPeerExchangeAsync$3(PeerExchangeService.java:123)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

With this PR:
- desktop clients can connect to clearnet seeds
- seeds can connect to other clearnet seeds

without any local code modifications on the destination.

One issue was that the validation check in `Node` failed all such outbound connections.

A second issue was that, even when that was done, the Connections view was listing the active connection as being to peer "127.0.0.1" (the address reported by the seed). Outbound connections now correctly show the actual IP of the destination.

FYI: This branch is currently running on both seeds (seeds only reachable via clearnet), to allow testing this PR.