### PR TITLE
Gradle: Regtest Task Configuration Avoidance (lazy init)

### DIFF
--- a/buildSrc/src/main/kotlin/bisq/gradle/ApplicationRunTaskFactory.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/ApplicationRunTaskFactory.kt
@@ -1,4 +1,4 @@
-package bisq.gradle.tasks
+package bisq.gradle
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project

--- a/buildSrc/src/main/kotlin/bisq/gradle/BisqPlugin.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/BisqPlugin.kt
@@ -1,32 +1,38 @@
 package bisq.gradle
 
+import bisq.gradle.bitcoind.BitcoindRegtestConfig
 import bisq.gradle.bitcoind.BitcoindRegtestTasks
+import bisq.gradle.elementsd.ElementsRegtestConfig
 import bisq.gradle.elementsd.ElementsdRegtestTasks
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import java.io.File
 
 
 class BisqPlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        val regtestRootDataDir = project.buildDir.resolve("regtest")
-        regtestRootDataDir.mkdirs()
-
-        registerBitcoindRegtestTasks(project, regtestRootDataDir)
-        registerElementsdRegtestTasks(project, regtestRootDataDir)
+    companion object {
+        const val REGTEST_ROOT_DIR = "regtest"
     }
 
-    private fun registerBitcoindRegtestTasks(project: Project, regtestRootDataDir: File) {
-        val bitcoindDataDir: File = regtestRootDataDir.resolve("bitcoind_regtest")
-        val bitcoindRegtestTasks = BitcoindRegtestTasks(project, bitcoindDataDir)
+    override fun apply(project: Project) {
+        registerBitcoindRegtestTasks(project)
+        registerElementsdRegtestTasks(project)
+    }
+
+    private fun registerBitcoindRegtestTasks(project: Project) {
+        val regtestConfig = BitcoindRegtestConfig(
+            project = project,
+            regtestDir = "$REGTEST_ROOT_DIR/bitcoind_regtest"
+        )
+        val bitcoindRegtestTasks = BitcoindRegtestTasks(project, regtestConfig)
         bitcoindRegtestTasks.registerTasks()
     }
 
-    private fun registerElementsdRegtestTasks(project: Project, regtestRootDataDir: File) {
-        val elementsdDataDir: File = regtestRootDataDir.resolve("elementsd_regtest")
-        val elementsdRegtestTasks = ElementsdRegtestTasks(project, elementsdDataDir)
+    private fun registerElementsdRegtestTasks(project: Project) {
+        val regtestConfig = ElementsRegtestConfig(
+            project = project,
+            regtestDir = "$REGTEST_ROOT_DIR/elementsd_regtest"
+        )
+        val elementsdRegtestTasks = ElementsdRegtestTasks(project, regtestConfig)
         elementsdRegtestTasks.registerTasks()
     }
-
-
 }

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindProcessTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindProcessTasks.kt
@@ -3,15 +3,16 @@ package bisq.gradle.bitcoind
 import bisq.gradle.bitcoind.tasks.BitcoindStopTask
 import bisq.gradle.bitcoind.tasks.StartBitcoinQtTask
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import java.io.File
 
 class BitcoindProcessTasks(
     project: Project,
-    private val bitcoindDataDir: File,
+    private val bitcoindDataDir: Provider<Directory>,
     private val taskNameSuffix: String = ""
 ) {
     private val tasks: TaskContainer = project.tasks
@@ -36,6 +37,6 @@ class BitcoindProcessTasks(
     private fun registerCleanTask(stopBitcoindTask: TaskProvider<BitcoindStopTask>): TaskProvider<Delete> =
         tasks.register<Delete>("cleanBitcoindRegtest$taskNameSuffix") {
             dependsOn(stopBitcoindTask)
-            delete = setOf(bitcoindDataDir.absolutePath)
+            delete = setOf(bitcoindDataDir)
         }
 }

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindProcessTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindProcessTasks.kt
@@ -1,7 +1,7 @@
 package bisq.gradle.bitcoind
 
-import bisq.gradle.tasks.bitcoind.BitcoindStopTask
-import bisq.gradle.tasks.bitcoind.StartBitcoinQtTask
+import bisq.gradle.bitcoind.tasks.BitcoindStopTask
+import bisq.gradle.bitcoind.tasks.StartBitcoinQtTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskContainer

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindRegtestConfig.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindRegtestConfig.kt
@@ -1,0 +1,25 @@
+package bisq.gradle.bitcoind
+
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+
+open class BitcoindRegtestConfig(
+    private val project: Project,
+    protected val regtestDir: String
+) {
+    val bitcoindDataDir: Provider<Directory>
+        get() = createDirProperty("$regtestDir/bitcoind")
+
+    val bisqDataDir: Provider<Directory>
+        get() = createDirProperty(bisqDataDirAsString)
+
+    protected val bisqDataDirAsString: String
+        get() = "$regtestDir/bisq"
+
+    val bitcoindWalletDir: Provider<Directory>
+        get() = createDirProperty("$bisqDataDirAsString/wallets/bitcoind")
+
+    protected fun createDirProperty(path: String): Provider<Directory> =
+        project.layout.buildDirectory.dir(path)
+}

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindRegtestTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindRegtestTasks.kt
@@ -1,7 +1,7 @@
 package bisq.gradle.bitcoind
 
-import bisq.gradle.tasks.ApplicationRunTaskFactory
-import bisq.gradle.tasks.bitcoind.StartBitcoinQtTask
+import bisq.gradle.ApplicationRunTaskFactory
+import bisq.gradle.bitcoind.tasks.StartBitcoinQtTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import java.io.File

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindRegtestTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindRegtestTasks.kt
@@ -4,17 +4,14 @@ import bisq.gradle.ApplicationRunTaskFactory
 import bisq.gradle.bitcoind.tasks.StartBitcoinQtTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
-import java.io.File
 
-class BitcoindRegtestTasks(private val project: Project, dataDir: File) {
-
-    private val bitcoindDataDir: File = dataDir.resolve("bitcoind")
-    private val bisqDataDir: File = dataDir.resolve("bisq")
+class BitcoindRegtestTasks(
+    private val project: Project,
+    private val regtestConfig: BitcoindRegtestConfig
+) {
 
     fun registerTasks() {
-        bisqDataDir.resolve("wallets").mkdirs()
-
-        val bitcoindProcessTasks = BitcoindProcessTasks(project, bitcoindDataDir)
+        val bitcoindProcessTasks = BitcoindProcessTasks(project, regtestConfig.bitcoindDataDir)
         bitcoindProcessTasks.registerTasks()
 
         val bitcoindWalletCreationTasks: BitcoindWalletCreationTasks =
@@ -24,7 +21,8 @@ class BitcoindRegtestTasks(private val project: Project, dataDir: File) {
             project = project,
             taskName = "runWithBitcoindRegtestWallet",
             description = "Run Bisq with Bitcoin Core Wallet (Regtest)",
-            cmdLineArgs = listOf("--regtest-bitcoind", "--data-dir=${bisqDataDir.absolutePath}"),
+            cmdLineArgs = listOf("--regtest-bitcoind"),
+            dataDir = regtestConfig.bisqDataDir,
             dependentTask = bitcoindWalletCreationTasks.mineInitialRegtestBlocksTask
         )
     }
@@ -34,7 +32,7 @@ class BitcoindRegtestTasks(private val project: Project, dataDir: File) {
     ): BitcoindWalletCreationTasks {
         val bitcoindWalletCreationTasks = BitcoindWalletCreationTasks(
             project = project,
-            bisqDataDir = bisqDataDir
+            regtestConfig = regtestConfig
         )
         bitcoindWalletCreationTasks.registerTasks(startBitcoinQtTask)
         return bitcoindWalletCreationTasks

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindWalletCreationTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindWalletCreationTasks.kt
@@ -1,8 +1,8 @@
 package bisq.gradle.bitcoind
 
-import bisq.gradle.tasks.bitcoind.BitcoindCreateOrLoadWalletTask
-import bisq.gradle.tasks.bitcoind.BitcoindMineToWallet
-import bisq.gradle.tasks.bitcoind.StartBitcoinQtTask
+import bisq.gradle.bitcoind.tasks.BitcoindCreateOrLoadWalletTask
+import bisq.gradle.bitcoind.tasks.BitcoindMineToWallet
+import bisq.gradle.bitcoind.tasks.StartBitcoinQtTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindWalletCreationTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/BitcoindWalletCreationTasks.kt
@@ -4,20 +4,20 @@ import bisq.gradle.bitcoind.tasks.BitcoindCreateOrLoadWalletTask
 import bisq.gradle.bitcoind.tasks.BitcoindMineToWallet
 import bisq.gradle.bitcoind.tasks.StartBitcoinQtTask
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import java.io.File
-
 
 class BitcoindWalletCreationTasks(
     project: Project,
-    bisqDataDir: File,
+    regtestConfig: BitcoindRegtestConfig,
     private val taskNameSuffix: String = ""
 ) {
 
     private val tasks: TaskContainer = project.tasks
-    val walletDirectory: File = bisqDataDir.resolve("wallets/bitcoind")
+    val walletDirProvider: Provider<Directory> = regtestConfig.bitcoindWalletDir
 
     private lateinit var createWalletTask: TaskProvider<BitcoindCreateOrLoadWalletTask>
     lateinit var mineInitialRegtestBlocksTask: TaskProvider<BitcoindMineToWallet>
@@ -31,7 +31,7 @@ class BitcoindWalletCreationTasks(
             TaskProvider<BitcoindCreateOrLoadWalletTask> =
         tasks.register<BitcoindCreateOrLoadWalletTask>("bitcoindCreateMinerWallet$taskNameSuffix") {
             dependsOn(startBitcoinQtTask)
-            walletDirectory.set(this@BitcoindWalletCreationTasks.walletDirectory)
+            walletDirectory.set(walletDirProvider)
         }
 
     private fun registerMineInitialRegtestBlocksTask(): TaskProvider<BitcoindMineToWallet> =
@@ -39,7 +39,7 @@ class BitcoindWalletCreationTasks(
             dependsOn(createWalletTask)
             onlyIf { getBlockCount() == 0 }
 
-            walletDirectory.set(this@BitcoindWalletCreationTasks.walletDirectory)
+            walletDirectory.set(walletDirProvider)
             numberOfBlocks.set(101)
         }
 

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindCreateOrLoadWalletTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindCreateOrLoadWalletTask.kt
@@ -1,13 +1,13 @@
-package bisq.gradle.tasks.elementsd
+package bisq.gradle.bitcoind.tasks
 
-import bisq.gradle.elementsd.ElementsdRpcClient
+import bisq.gradle.bitcoind.BitcoindRpcClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-abstract class ElementsdCreateOrLoadWalletTask : DefaultTask() {
+abstract class BitcoindCreateOrLoadWalletTask : DefaultTask() {
     @get:Input
     abstract val walletDirectory: DirectoryProperty
 
@@ -22,7 +22,7 @@ abstract class ElementsdCreateOrLoadWalletTask : DefaultTask() {
     }
 
     private fun createWallet(walletFile: File) {
-        ElementsdRpcClient.daemonRpcCall(
+        BitcoindRpcClient.daemonRpcCall(
             listOf(
                 "--named",
                 "createwallet",
@@ -33,7 +33,7 @@ abstract class ElementsdCreateOrLoadWalletTask : DefaultTask() {
     }
 
     private fun loadWallet(walletFile: File) {
-        ElementsdRpcClient.daemonRpcCall(
+        BitcoindRpcClient.daemonRpcCall(
             listOf(
                 "loadwallet",
                 walletFile.absolutePath,

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindCreateOrLoadWalletTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindCreateOrLoadWalletTask.kt
@@ -26,7 +26,6 @@ abstract class BitcoindCreateOrLoadWalletTask : DefaultTask() {
             listOf(
                 "--named",
                 "createwallet",
-
                 "wallet_name=${walletFile.absolutePath}",
             )
         )

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindMineToWallet.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindMineToWallet.kt
@@ -2,14 +2,14 @@ package bisq.gradle.bitcoind.tasks
 
 import bisq.gradle.bitcoind.BitcoindRpcClient
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 
 abstract class BitcoindMineToWallet : DefaultTask() {
     @get:Input
-    abstract val walletDirectory: Property<File>
+    abstract val walletDirectory: DirectoryProperty
 
     @get:Input
     abstract val numberOfBlocks: Property<Int>
@@ -21,7 +21,7 @@ abstract class BitcoindMineToWallet : DefaultTask() {
     @TaskAction
     fun mine() {
         BitcoindRpcClient.walletRpcCall(
-            walletPath = walletDirectory.get().absolutePath,
+            walletPath = walletDirectory.get().asFile.absolutePath,
             args = listOf(
                 "-generate", numberOfBlocks.get().toString()
             )

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindMineToWallet.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindMineToWallet.kt
@@ -1,4 +1,4 @@
-package bisq.gradle.tasks.bitcoind
+package bisq.gradle.bitcoind.tasks
 
 import bisq.gradle.bitcoind.BitcoindRpcClient
 import org.gradle.api.DefaultTask

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindStopTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/BitcoindStopTask.kt
@@ -1,19 +1,19 @@
-package bisq.gradle.tasks.elementsd
+package bisq.gradle.bitcoind.tasks
 
 import bisq.gradle.Network
-import bisq.gradle.elementsd.ElementsdRpcClient
+import bisq.gradle.bitcoind.BitcoindRpcClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 
-abstract class ElementsdStopTask : DefaultTask() {
+abstract class BitcoindStopTask : DefaultTask() {
     @get:Input
     abstract val port: Property<Int>
 
     init {
-        port.convention(StartElementsQtTask.DEFAULT_ELEMENTSD_RPC_PORT)
+        port.convention(StartBitcoinQtTask.DEFAULT_BITCOIND_RPC_PORT)
     }
 
     @TaskAction
@@ -22,7 +22,7 @@ abstract class ElementsdStopTask : DefaultTask() {
             throw StopExecutionException("bitcoind is not running.")
         }
 
-        ElementsdRpcClient.daemonRpcCall(
+        BitcoindRpcClient.daemonRpcCall(
             listOf("stop")
         )
     }

--- a/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/StartBitcoinQtTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/bitcoind/tasks/StartBitcoinQtTask.kt
@@ -1,4 +1,4 @@
-package bisq.gradle.tasks.bitcoind
+package bisq.gradle.bitcoind.tasks
 
 import bisq.gradle.Network
 import bisq.gradle.bitcoind.BitcoindRpcClient

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsRegtestConfig.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsRegtestConfig.kt
@@ -1,0 +1,14 @@
+package bisq.gradle.elementsd
+
+import bisq.gradle.bitcoind.BitcoindRegtestConfig
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+
+class ElementsRegtestConfig(project: Project, regtestDir: String) : BitcoindRegtestConfig(project, regtestDir) {
+    val elementsdDataDir: Provider<Directory>
+        get() = createDirProperty("$regtestDir/elementsd")
+
+    val elementsdWalletDir: Provider<Directory>
+        get() = createDirProperty("$bisqDataDirAsString/wallets/elementsd")
+}

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdProcessTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdProcessTasks.kt
@@ -1,9 +1,9 @@
 package bisq.gradle.elementsd
 
 import bisq.gradle.bitcoind.BitcoindProcessTasks
-import bisq.gradle.tasks.bitcoind.BitcoindMineToWallet
-import bisq.gradle.tasks.elementsd.ElementsdStopTask
-import bisq.gradle.tasks.elementsd.StartElementsQtTask
+import bisq.gradle.bitcoind.tasks.BitcoindMineToWallet
+import bisq.gradle.elementsd.tasks.ElementsdStopTask
+import bisq.gradle.elementsd.tasks.StartElementsQtTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskContainer

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdProcessTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdProcessTasks.kt
@@ -5,15 +5,16 @@ import bisq.gradle.bitcoind.tasks.BitcoindMineToWallet
 import bisq.gradle.elementsd.tasks.ElementsdStopTask
 import bisq.gradle.elementsd.tasks.StartElementsQtTask
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import java.io.File
 
 class ElementsdProcessTasks(
     project: Project,
-    private val elementsdDataDir: File
+    private val elementsdDataDir: Provider<Directory>
 ) {
 
     private val tasks: TaskContainer = project.tasks
@@ -46,6 +47,6 @@ class ElementsdProcessTasks(
     private fun registerCleanTask(): TaskProvider<Delete> =
         tasks.register<Delete>("cleanElementsdRegtest") {
             dependsOn(elementsdStopTask)
-            delete = setOf(elementsdDataDir.absolutePath)
+            delete = setOf(elementsdDataDir)
         }
 }

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdRegtestTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdRegtestTasks.kt
@@ -2,7 +2,7 @@ package bisq.gradle.elementsd
 
 import bisq.gradle.bitcoind.BitcoindProcessTasks
 import bisq.gradle.bitcoind.BitcoindWalletCreationTasks
-import bisq.gradle.tasks.ApplicationRunTaskFactory
+import bisq.gradle.ApplicationRunTaskFactory
 import org.gradle.api.Project
 import java.io.File
 

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdRegtestTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdRegtestTasks.kt
@@ -1,16 +1,11 @@
 package bisq.gradle.elementsd
 
+import bisq.gradle.ApplicationRunTaskFactory
 import bisq.gradle.bitcoind.BitcoindProcessTasks
 import bisq.gradle.bitcoind.BitcoindWalletCreationTasks
-import bisq.gradle.ApplicationRunTaskFactory
 import org.gradle.api.Project
-import java.io.File
 
-class ElementsdRegtestTasks(private val project: Project, dataDir: File) {
-
-    private val bitcoindDataDir: File = dataDir.resolve("bitcoind")
-    private val elementsdDataDir: File = dataDir.resolve("elementsd")
-    private val bisqDataDir: File = dataDir.resolve("bisq")
+class ElementsdRegtestTasks(private val project: Project, private val regtestConfig: ElementsRegtestConfig) {
 
     private lateinit var bitcoindProcessTasks: BitcoindProcessTasks
     private lateinit var bitcoindWalletCreationTasks: BitcoindWalletCreationTasks
@@ -18,8 +13,6 @@ class ElementsdRegtestTasks(private val project: Project, dataDir: File) {
     private lateinit var elementsdWalletCreationTasks: ElementsdWalletCreationTasks
 
     fun registerTasks() {
-        bisqDataDir.resolve("wallets").mkdirs()
-
         registerBitcoindTasks()
         registerElementsdTasks()
 
@@ -27,18 +20,23 @@ class ElementsdRegtestTasks(private val project: Project, dataDir: File) {
             project = project,
             taskName = "runWithElementsdRegtestWallet",
             description = "Run Bisq with Elements Core Wallet (Regtest)",
-            cmdLineArgs = listOf("--regtest-elementsd", "--data-dir=${bisqDataDir.absolutePath}"),
+            cmdLineArgs = listOf("--regtest-elementsd"),
+            dataDir = regtestConfig.bisqDataDir,
             dependentTask = elementsdWalletCreationTasks.peginTask
         )
     }
 
     private fun registerBitcoindTasks() {
-        bitcoindProcessTasks = BitcoindProcessTasks(project, bitcoindDataDir, taskNameSuffix = "ForElementsRegtest")
+        bitcoindProcessTasks = BitcoindProcessTasks(
+            project,
+            regtestConfig.bitcoindDataDir,
+            taskNameSuffix = "ForElementsRegtest"
+        )
         bitcoindProcessTasks.registerTasks()
 
         bitcoindWalletCreationTasks = BitcoindWalletCreationTasks(
             project = project,
-            bisqDataDir = bisqDataDir,
+            regtestConfig = regtestConfig,
             taskNameSuffix = "ForElementsRegtest"
         )
         bitcoindWalletCreationTasks.registerTasks(bitcoindProcessTasks.startBitcoinQtTask)
@@ -46,7 +44,7 @@ class ElementsdRegtestTasks(private val project: Project, dataDir: File) {
 
     private fun registerElementsdTasks() {
         val elementsdProcessTasks =
-            ElementsdProcessTasks(project, elementsdDataDir)
+            ElementsdProcessTasks(project, regtestConfig.elementsdDataDir)
         elementsdProcessTasks.registerTasks(
             bitcoindProcessTasks,
             bitcoindWalletCreationTasks.mineInitialRegtestBlocksTask
@@ -54,11 +52,11 @@ class ElementsdRegtestTasks(private val project: Project, dataDir: File) {
 
         elementsdWalletCreationTasks = ElementsdWalletCreationTasks(
             project = project,
-            bisqDataDir = bisqDataDir,
+            walletDirectory = regtestConfig.elementsdWalletDir
         )
         elementsdWalletCreationTasks.registerTasks(
             elementsdProcessTasks.elementsdStartTask,
-            bitcoindWalletCreationTasks.walletDirectory
+            bitcoindWalletCreationTasks.walletDirProvider
         )
     }
 }

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdWalletCreationTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdWalletCreationTasks.kt
@@ -4,40 +4,40 @@ import bisq.gradle.elementsd.tasks.ElementsdCreateOrLoadWalletTask
 import bisq.gradle.elementsd.tasks.ElementsdPeginTask
 import bisq.gradle.elementsd.tasks.StartElementsQtTask
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import java.io.File
 
 class ElementsdWalletCreationTasks(
     project: Project,
-    bisqDataDir: File
+    private val walletDirectory: Provider<Directory>
 ) {
 
     private val tasks: TaskContainer = project.tasks
-    private val walletDirectory: File = bisqDataDir.resolve("wallets/elementsd")
 
-    private lateinit var createWalletTask: TaskProvider<ElementsdCreateOrLoadWalletTask>
+    private lateinit var createOrLoadWalletTask: TaskProvider<ElementsdCreateOrLoadWalletTask>
     lateinit var peginTask: TaskProvider<ElementsdPeginTask>
 
     fun registerTasks(
         startElementsQtTask: TaskProvider<StartElementsQtTask>,
-        bitcoinWalletDirectory: File
+        bitcoinWalletDirectory: Provider<Directory>
     ) {
-        createWalletTask = registerCreatePeginWalletTask(startElementsQtTask)
+        createOrLoadWalletTask = registerCreateOrLoadWalletTask(startElementsQtTask)
         peginTask = registerPeginTask(bitcoinWalletDirectory)
     }
 
-    private fun registerCreatePeginWalletTask(startElementsQtTask: TaskProvider<StartElementsQtTask>):
+    private fun registerCreateOrLoadWalletTask(startElementsQtTask: TaskProvider<StartElementsQtTask>):
             TaskProvider<ElementsdCreateOrLoadWalletTask> =
         tasks.register<ElementsdCreateOrLoadWalletTask>("elementsdCreatePeginWallet") {
             dependsOn(startElementsQtTask)
             walletDirectory.set(this@ElementsdWalletCreationTasks.walletDirectory)
         }
 
-    private fun registerPeginTask(bitcoinWalletDirectory: File): TaskProvider<ElementsdPeginTask> =
+    private fun registerPeginTask(bitcoinWalletDirectory: Provider<Directory>): TaskProvider<ElementsdPeginTask> =
         tasks.register<ElementsdPeginTask>("elementsdRegtestPegin") {
-            dependsOn(createWalletTask)
+            dependsOn(createOrLoadWalletTask)
             onlyIf { getBlockCount() == 0 }
 
             bitcoindWalletDirectory.set(bitcoinWalletDirectory)

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdWalletCreationTasks.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/ElementsdWalletCreationTasks.kt
@@ -1,8 +1,8 @@
 package bisq.gradle.elementsd
 
-import bisq.gradle.tasks.elementsd.ElementsdCreateOrLoadWalletTask
-import bisq.gradle.tasks.elementsd.ElementsdPeginTask
-import bisq.gradle.tasks.elementsd.StartElementsQtTask
+import bisq.gradle.elementsd.tasks.ElementsdCreateOrLoadWalletTask
+import bisq.gradle.elementsd.tasks.ElementsdPeginTask
+import bisq.gradle.elementsd.tasks.StartElementsQtTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdCreateOrLoadWalletTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdCreateOrLoadWalletTask.kt
@@ -26,7 +26,6 @@ abstract class ElementsdCreateOrLoadWalletTask : DefaultTask() {
             listOf(
                 "--named",
                 "createwallet",
-
                 "wallet_name=${walletFile.absolutePath}",
             )
         )

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdCreateOrLoadWalletTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdCreateOrLoadWalletTask.kt
@@ -1,13 +1,13 @@
-package bisq.gradle.tasks.bitcoind
+package bisq.gradle.elementsd.tasks
 
-import bisq.gradle.bitcoind.BitcoindRpcClient
+import bisq.gradle.elementsd.ElementsdRpcClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-abstract class BitcoindCreateOrLoadWalletTask : DefaultTask() {
+abstract class ElementsdCreateOrLoadWalletTask : DefaultTask() {
     @get:Input
     abstract val walletDirectory: DirectoryProperty
 
@@ -22,7 +22,7 @@ abstract class BitcoindCreateOrLoadWalletTask : DefaultTask() {
     }
 
     private fun createWallet(walletFile: File) {
-        BitcoindRpcClient.daemonRpcCall(
+        ElementsdRpcClient.daemonRpcCall(
             listOf(
                 "--named",
                 "createwallet",
@@ -33,7 +33,7 @@ abstract class BitcoindCreateOrLoadWalletTask : DefaultTask() {
     }
 
     private fun loadWallet(walletFile: File) {
-        BitcoindRpcClient.daemonRpcCall(
+        ElementsdRpcClient.daemonRpcCall(
             listOf(
                 "loadwallet",
                 walletFile.absolutePath,

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdPeginTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdPeginTask.kt
@@ -1,4 +1,4 @@
-package bisq.gradle.tasks.elementsd
+package bisq.gradle.elementsd.tasks
 
 import bisq.gradle.bitcoind.BitcoindRpcClient
 import bisq.gradle.elementsd.ElementsdRpcClient

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdStopTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/ElementsdStopTask.kt
@@ -1,19 +1,19 @@
-package bisq.gradle.tasks.bitcoind
+package bisq.gradle.elementsd.tasks
 
 import bisq.gradle.Network
-import bisq.gradle.bitcoind.BitcoindRpcClient
+import bisq.gradle.elementsd.ElementsdRpcClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 
-abstract class BitcoindStopTask : DefaultTask() {
+abstract class ElementsdStopTask : DefaultTask() {
     @get:Input
     abstract val port: Property<Int>
 
     init {
-        port.convention(StartBitcoinQtTask.DEFAULT_BITCOIND_RPC_PORT)
+        port.convention(StartElementsQtTask.DEFAULT_ELEMENTSD_RPC_PORT)
     }
 
     @TaskAction
@@ -22,7 +22,7 @@ abstract class BitcoindStopTask : DefaultTask() {
             throw StopExecutionException("bitcoind is not running.")
         }
 
-        BitcoindRpcClient.daemonRpcCall(
+        ElementsdRpcClient.daemonRpcCall(
             listOf("stop")
         )
     }

--- a/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/StartElementsQtTask.kt
+++ b/buildSrc/src/main/kotlin/bisq/gradle/elementsd/tasks/StartElementsQtTask.kt
@@ -1,4 +1,4 @@
-package bisq.gradle.tasks.elementsd
+package bisq.gradle.elementsd.tasks
 
 import bisq.gradle.Network
 import bisq.gradle.elementsd.ElementsdRpcClient


### PR DESCRIPTION
At the moment, every Gradle run hits the disk to check for the regtest files and initializes these if they don't exist. This is bad for performance, and we shouldn't do it. This change lazily initializes all regtest tasks.
For more information, see: https://docs.gradle.org/current/userguide/task_configuration_avoidance.html