### PR TITLE
Refactor public discussion channel id

### DIFF
--- a/desktop/src/main/java/bisq/desktop/primary/main/content/social/components/ChannelSelection.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/social/components/ChannelSelection.java
@@ -8,6 +8,8 @@ import bisq.desktop.components.robohash.RoboHash;
 import bisq.social.chat.ChatService;
 import bisq.social.chat.channels.Channel;
 import bisq.social.chat.channels.PrivateChannel;
+import bisq.social.chat.channels.PublicChannel;
+import bisq.social.chat.channels.PublicDiscussionChannel;
 import bisq.social.user.ChatUser;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ObjectProperty;
@@ -156,7 +158,7 @@ public abstract class ChannelSelection {
                             label.setText(StringUtils.truncate(userName, 20));
                             label.setTooltip(new Tooltip(peer.getTooltipString()));
                         } else {
-                            label.setText(item.getId());
+                            label.setText(item.getDisplayString());
                         }
                         hBox.getChildren().add(label);
                         setGraphic(hBox);

--- a/social/src/main/java/bisq/social/chat/ChatService.java
+++ b/social/src/main/java/bisq/social/chat/ChatService.java
@@ -543,7 +543,7 @@ public class ChatService implements PersistenceClient<ChatStore>, MessageListene
         Identity channelAdminIdentity = identityService.getOrCreateIdentity(IdentityService.DEFAULT).join();
         ChatUser channelAdmin = new ChatUser("Admin", channelAdminIdentity.networkId());
 
-        PublicDiscussionChannel defaultDiscussionChannel = new PublicDiscussionChannel("Discussions Bisq",
+        PublicDiscussionChannel defaultDiscussionChannel = new PublicDiscussionChannel(StringUtils.createUid(),
                 "Discussions Bisq",
                 "Channel for discussions about Bisq",
                 channelAdmin,
@@ -551,31 +551,31 @@ public class ChatService implements PersistenceClient<ChatStore>, MessageListene
         );
         selectDiscussionChannel(defaultDiscussionChannel);
         persistableStore.getPublicDiscussionChannels().add(defaultDiscussionChannel);
-        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel("Discussions Bitcoin",
+        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel(StringUtils.createUid(),
                 "Discussions Bitcoin",
                 "Channel for discussions about Bitcoin",
                 channelAdmin,
                 new HashSet<>()
         ));
-        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel("Discussions Monero",
+        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel(StringUtils.createUid(),
                 "Discussions Monero",
                 "Channel for discussions about Monero",
                 channelAdmin,
                 new HashSet<>()
         ));
-        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel("Price",
+        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel(StringUtils.createUid(),
                 "Price",
                 "Channel for discussions about market price",
                 channelAdmin,
                 new HashSet<>()
         ));
-        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel("Economy",
+        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel(StringUtils.createUid(),
                 "Economy",
                 "Channel for discussions about economy",
                 channelAdmin,
                 new HashSet<>()
         ));
-        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel("Off-topic",
+        persistableStore.getPublicDiscussionChannels().add(new PublicDiscussionChannel(StringUtils.createUid(),
                 "Off-topic",
                 "Channel for anything else",
                 channelAdmin,

--- a/social/src/main/java/bisq/social/chat/channels/PublicDiscussionChannel.java
+++ b/social/src/main/java/bisq/social/chat/channels/PublicDiscussionChannel.java
@@ -111,4 +111,9 @@ public class PublicDiscussionChannel extends Channel<PublicDiscussionChatMessage
     public void removeChatMessages(Collection<PublicDiscussionChatMessage> removeMessages) {
         chatMessages.removeAll(removeMessages);
     }
+
+    @Override
+    public String getDisplayString() {
+        return channelName;
+    }
 }


### PR DESCRIPTION
- use UUID for `PublicDiscussionChannel -> id` during creation of default channels
- display `PublicDiscussionChannel -> channelName` instead of `PublicDiscussionChannel -> id`