### PR TITLE
Seed service: add support for seed arguments

### DIFF
--- a/application/src/main/resources/Seed.conf
+++ b/application/src/main/resources/Seed.conf
@@ -7,8 +7,8 @@ bisq {
     }
   
     networkServiceConfig = {
-        // supportedTransportTypes = ["CLEAR", "TOR", "I2P"]
-        supportedTransportTypes = ["TOR"]
+        supportedTransportTypes = ["CLEAR", "TOR", "I2P"]
+        // supportedTransportTypes = ["TOR"]
         
         serviceNodeConfig {
             p2pServiceNodeConfig="PEER_GROUP,DATA,CONFIDENTIAL,MONITOR"

--- a/seed/service-scripts/README.md
+++ b/seed/service-scripts/README.md
@@ -17,14 +17,9 @@ If this is seed 1, ensure the content of that file now reads:
 ```
 JAVA_OPTS="
 -Dbisq.application.appName=bisq2_seed1
--Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR
 -Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8000
--Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=159.65.117.67:8001
--Dbisq.networkServiceConfig.supportedTransportTypes.1=TOR
 -Dbisq.networkServiceConfig.defaultNodePortByTransportType.tor=1000
--Dbisq.networkServiceConfig.supportedTransportTypes.2=I2P
 -Dbisq.networkServiceConfig.defaultNodePortByTransportType.i2p=5000
--Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.1=0~EXMqCbYcdPHvb7nl-Y3eHxSUbaFhwQLycOtA0c45mhrieMaEbRVSRxaUEtjhgk8nVBpKYiDn4Za6X82aPokSFqURJx09bfKTExTklI~1u~0PJk6Wt3~Jpg4TLCYxql0WEphbEs5oEIR1d4myIm4ng3Iz9TM3dZUBMf4B~oRUiMGRxO-U7Vwxb3Qh1J0ZiqvQZmKzk9~ShEpk-FDR1-j0hlICQ2~RHNM7z4CdWReZLiyY8UboOxkakSIYasVEL2xs2Vgt7t4o078X5AcVtEJu6H31WXvUZSffFrt1BXZNTIoYs1FCCuhS1jMLh8N96eR3AqZ43Nr4Ljp78iqbLdikeVhb53Nzr0rDSYcfh57d2YVitjhfz2ant~6~SGSPxdJRdmsmDkTn5VAZwJhHGM5nh2BQbEwuEeeoufw6s7FNEoWMcv86h6ODmKTO0xyk8oMBT81zjdT8Xg5UkaHMSqJ0DnGcrVN4RQ6kOEbT5wtshVjpHgwWiJvOyEcj8XLJLqAAAA:5001
 "
 ```
 
@@ -33,14 +28,9 @@ If this is seed 2, set the file content to:
 ```
 JAVA_OPTS="
 -Dbisq.application.appName=bisq2_seed2
--Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR
 -Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8001
--Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=167.71.33.219:8000
--Dbisq.networkServiceConfig.supportedTransportTypes.1=TOR
 -Dbisq.networkServiceConfig.defaultNodePortByTransportType.tor=1001
--Dbisq.networkServiceConfig.supportedTransportTypes.2=I2P
 -Dbisq.networkServiceConfig.defaultNodePortByTransportType.i2p=5001
--Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.0=kglZCQYj~nyK3YlXCD5FjxOY2ggH8yosII0rqc7oqFhFfjKWy-89WYw-~mtTUqzCaN6LGd17XzheKG44XJnKrM-WvP732V8lbJcoMBIKeeHPlcfwpsTNbMJyWeXIlJByYNlw1HPVRMpBtzfJ9IznyQdwQWDkzA72pLreqpzJrgIoVYzP9OTXVLdROXnTP9RdmnzZ0h1B8XhQM-8LjHB7cE9o9VT9IXIFScICM8VZ8I1sp02rn26McTM~~XO5Zs1Df3IMV0eqteAe6TvH~Rc-6Hh3YhPrjEcv-YvV6RUlsoj605mmSO0Sj5oeacH3Cec73BlNJEGfQkmbTrXVNLqt2S4smqmkAhMq~sdCJCRKP8CFeBk6r-qVREucTeW3AmwXuGS~-8s7pAm99SlpTSepp75a2WNTIsWw~rWiHlM6faTJrkjcO5wJM7~G0tdYgVGk4zrt4VJ02AakUdh8wG1Y5sAX-daTUum~0YTk-fIAVBJSEiNc93XgZkwuTcc4J2BqAAAA:5000
 "
 ```
 

--- a/seed/service-scripts/README.md
+++ b/seed/service-scripts/README.md
@@ -1,10 +1,71 @@
 ## Install seed service
 
+### Part 1: Install service
+
 ```
 ./seed-debian-install.sh
 ```
 
 Creates a user `bisq` and installs the service under that username.
+
+### Part 2: Configure service
+
+Edit the file `/etc/default/bisq2-seed.env` to set the seed arguments.
+
+If this is seed 1, ensure the content of that file now reads:
+
+```
+JAVA_OPTS="
+-Dbisq.application.appName=bisq2_seed1
+-Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR
+-Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8000
+-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=159.65.117.67:8001
+-Dbisq.networkServiceConfig.supportedTransportTypes.1=TOR
+-Dbisq.networkServiceConfig.defaultNodePortByTransportType.tor=1000
+-Dbisq.networkServiceConfig.supportedTransportTypes.2=I2P
+-Dbisq.networkServiceConfig.defaultNodePortByTransportType.i2p=5000
+-Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.1=0~EXMqCbYcdPHvb7nl-Y3eHxSUbaFhwQLycOtA0c45mhrieMaEbRVSRxaUEtjhgk8nVBpKYiDn4Za6X82aPokSFqURJx09bfKTExTklI~1u~0PJk6Wt3~Jpg4TLCYxql0WEphbEs5oEIR1d4myIm4ng3Iz9TM3dZUBMf4B~oRUiMGRxO-U7Vwxb3Qh1J0ZiqvQZmKzk9~ShEpk-FDR1-j0hlICQ2~RHNM7z4CdWReZLiyY8UboOxkakSIYasVEL2xs2Vgt7t4o078X5AcVtEJu6H31WXvUZSffFrt1BXZNTIoYs1FCCuhS1jMLh8N96eR3AqZ43Nr4Ljp78iqbLdikeVhb53Nzr0rDSYcfh57d2YVitjhfz2ant~6~SGSPxdJRdmsmDkTn5VAZwJhHGM5nh2BQbEwuEeeoufw6s7FNEoWMcv86h6ODmKTO0xyk8oMBT81zjdT8Xg5UkaHMSqJ0DnGcrVN4RQ6kOEbT5wtshVjpHgwWiJvOyEcj8XLJLqAAAA:5001
+"
+```
+
+If this is seed 2, set the file content to:
+
+```
+JAVA_OPTS="
+-Dbisq.application.appName=bisq2_seed2
+-Dbisq.networkServiceConfig.supportedTransportTypes.0=CLEAR
+-Dbisq.networkServiceConfig.defaultNodePortByTransportType.clear=8001
+-Dbisq.networkServiceConfig.seedAddressByTransportType.clear.0=167.71.33.219:8000
+-Dbisq.networkServiceConfig.supportedTransportTypes.1=TOR
+-Dbisq.networkServiceConfig.defaultNodePortByTransportType.tor=1001
+-Dbisq.networkServiceConfig.supportedTransportTypes.2=I2P
+-Dbisq.networkServiceConfig.defaultNodePortByTransportType.i2p=5001
+-Dbisq.networkServiceConfig.seedAddressByTransportType.i2p.0=kglZCQYj~nyK3YlXCD5FjxOY2ggH8yosII0rqc7oqFhFfjKWy-89WYw-~mtTUqzCaN6LGd17XzheKG44XJnKrM-WvP732V8lbJcoMBIKeeHPlcfwpsTNbMJyWeXIlJByYNlw1HPVRMpBtzfJ9IznyQdwQWDkzA72pLreqpzJrgIoVYzP9OTXVLdROXnTP9RdmnzZ0h1B8XhQM-8LjHB7cE9o9VT9IXIFScICM8VZ8I1sp02rn26McTM~~XO5Zs1Df3IMV0eqteAe6TvH~Rc-6Hh3YhPrjEcv-YvV6RUlsoj605mmSO0Sj5oeacH3Cec73BlNJEGfQkmbTrXVNLqt2S4smqmkAhMq~sdCJCRKP8CFeBk6r-qVREucTeW3AmwXuGS~-8s7pAm99SlpTSepp75a2WNTIsWw~rWiHlM6faTJrkjcO5wJM7~G0tdYgVGk4zrt4VJ02AakUdh8wG1Y5sAX-daTUum~0YTk-fIAVBJSEiNc93XgZkwuTcc4J2BqAAAA:5000
+"
+```
+
+These settings reflect those in
+- `application/src/main/resources/Seed.conf` > `seedAddressByTransportType`
+- `application/src/main/resources/Bisq.conf` > `seedAddressByTransportType`
+
+### Part 3: Finalize install
+
+After the contents of `/etc/default/bisq2-seed.env` have been set, we can start the service:
+
+```
+# Reload systemd daemon configuration
+sudo systemctl daemon-reload
+
+# Enable bisq2-seed service
+sudo systemctl enable bisq2-seed
+
+# Start service
+sudo systemctl start bisq2-seed
+
+# Check service log output
+sudo journalctl --no-pager --unit bisq2-seed
+```
+
 
 ## Build seed based on latest version
 

--- a/seed/service-scripts/bisq2-seed.env
+++ b/seed/service-scripts/bisq2-seed.env
@@ -1,0 +1,1 @@
+JAVA_OPTS=""

--- a/seed/service-scripts/bisq2-seed.service
+++ b/seed/service-scripts/bisq2-seed.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 SyslogIdentifier=bisq2-seed
+EnvironmentFile=/etc/default/bisq2-seed.env
 ExecStart=/bisq/bisq2/seed/build/install/seed/bin/seed
 ExecStop=/bin/kill -TERM ${MAINPID}
 Restart=on-failure

--- a/seed/service-scripts/seed-debian-install.sh
+++ b/seed/service-scripts/seed-debian-install.sh
@@ -23,20 +23,9 @@ update-clean-install-seed
 
 echo "[*] Installing bisq2-seed systemd service"
 sudo -H -i -u "${ROOT_USER}" install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 "${BISQ_HOME}/${BISQ_REPO_NAME}/seed/service-scripts/bisq2-seed.service" "${SYSTEMD_SERVICE_HOME}"
+sudo -H -i -u "${ROOT_USER}" install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 "${BISQ_HOME}/${BISQ_REPO_NAME}/seed/service-scripts/bisq2-seed.env" "${SYSTEMD_ENV_HOME}"
 
-echo "[*] Reloading systemd daemon configuration"
-sudo -H -i -u "${ROOT_USER}" systemctl daemon-reload
-
-echo "[*] Enabling bisq2-seed service"
-sudo -H -i -u "${ROOT_USER}" systemctl enable bisq2-seed
-
-echo "[*] Starting bisq2-seed service"
-sudo -H -i -u "${ROOT_USER}" systemctl start bisq2-seed
-sleep 5
-sudo -H -i -u "${ROOT_USER}" journalctl --no-pager --unit bisq2-seed
-
-echo '[*] Done'
-echo "[*] Start with: sudo systemctl start bisq2-seed"
-echo "[*] Stop with:  sudo systemctl stop bisq2-seed"
+echo '[*] Part 1 of service installation done'
+echo "[*] To finalize installation, see README.md for part 2 and 3"
 
 exit 0


### PR DESCRIPTION
Add support for arguments such as appName or the default ports on which the seed will listen.