### PR TITLE
Update font configuration

### DIFF
--- a/desktop/src/main/resources/bisq.css
+++ b/desktop/src/main/resources/bisq.css
@@ -1,24 +1,32 @@
 @font-face {
     src: url("/fonts/IBMPlexSans-Regular.ttf");
+    font-family: "IBM Plex Sans";
+    font-weight: normal;
 }
 
 @font-face {
     src: url("/fonts/IBMPlexSans-Bold.ttf");
+    font-family: "IBM Plex Sans";
+    font-weight: bold;
 }
 
 @font-face {
     src: url("/fonts/IBMPlexSans-Medium.ttf");
+    font-family: "IBM Plex Sans Medium";
 }
 
 @font-face {
     src: url("/fonts/IBMPlexSans-Light.ttf");
+    font-family: "IBM Plex Sans Light";
 }
 
 @font-face {
     src: url("/fonts/IBMPlexMono-Regular.ttf");
+    font-family: "IBM Plex Mono";
 }
 
 .root {
+    -fx-font-family: "IBM Plex Sans";
     -fx-font-size: 13;
 
 


### PR DESCRIPTION
Refers to: https://github.com/bisq-network/bisq2/pull/296#discussion_r865683868

I went a bit deeper into font configuration and I realized that [System Regular](https://github.com/openjdk/jfx/blob/14b23bcf69a321c44b09e584b30f39e1fa3e6948/modules/javafx.graphics/src/main/java/javafx/scene/text/Font.java#L85) font was used by default in application instead of `IBM Plex Sans`. Adding:
```
.root {
    -fx-font-family: "IBM Plex Sans";
    ...
 }   
```
fixed it.

I also extended `@font-face` declaration about `font-family`. It doesn't have any impact on UI but could be helpful for developers. I retrieved family names this way:
```
fc-scan IBMPlexSans-Medium.ttf
fc-scan IBMPlexSans-Bold.ttf
fc-scan IBMPlexSans-Regular.ttf
fc-scan IBMPlexSans-Light.ttf
fc-scan IBMPlexMono-Regular.ttf
```

UI:
1) Before
![before-font-setup](https://user-images.githubusercontent.com/84982606/167126081-c461da90-b240-4451-b53a-022a248836f6.png)

2) After
![after-font-setup](https://user-images.githubusercontent.com/84982606/167126101-2cca08ba-deb3-4e64-b8d9-56d3f30b9282.png)

