### PR TITLE
Fix startup CSS warnings related to fonts

### DIFF
--- a/desktop/src/main/resources/bisq.css
+++ b/desktop/src/main/resources/bisq.css
@@ -1,28 +1,26 @@
 @font-face {
+    font-family: "IBM Plex Sans";
     src: url("/fonts/IBMPlexSans-Regular.ttf");
-    font-family: "IBM Plex Sans";
-    font-weight: normal;
 }
 
 @font-face {
+    font-family: "IBM Plex Sans Bold";
     src: url("/fonts/IBMPlexSans-Bold.ttf");
-    font-family: "IBM Plex Sans";
-    font-weight: bold;
 }
 
 @font-face {
-    src: url("/fonts/IBMPlexSans-Medium.ttf");
     font-family: "IBM Plex Sans Medium";
+    src: url("/fonts/IBMPlexSans-Medium.ttf");
 }
 
 @font-face {
-    src: url("/fonts/IBMPlexSans-Light.ttf");
     font-family: "IBM Plex Sans Light";
+    src: url("/fonts/IBMPlexSans-Light.ttf");
 }
 
 @font-face {
-    src: url("/fonts/IBMPlexMono-Regular.ttf");
     font-family: "IBM Plex Mono";
+    src: url("/fonts/IBMPlexMono-Regular.ttf");
 }
 
 .root {


### PR DESCRIPTION
One warning was fixed by having the `font-family` prop defined first in the `@font-face` blocks. A second warning was used by using the full font family name, and thus removing the font-weight.

The full font family name was found by opening the `tff` in IntelliJ. The font viewer showed the font name as the first line.