### PR TITLE
Cleanup wallets modules

### DIFF
--- a/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest/ApplicationRunTaskFactory.kt
+++ b/build-logic/regtest/src/main/kotlin/bisq/gradle/regtest/ApplicationRunTaskFactory.kt
@@ -29,9 +29,8 @@ object ApplicationRunTaskFactory {
         dataDir: Provider<Directory>,
         dependentTask: TaskProvider<out DefaultTask>?
     ) {
-        val desktopProject: Project = project.project("desktopapp")
         registerRunTaskToProject(
-            project = desktopProject,
+            project = project,
             taskName = taskName,
             descriptionText = description,
             cmdLineArgs = cmdLineArgs,

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'bisq.gradle.regtest.BisqRegtestPlugin'
 }
 
 group 'bisq'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,1 @@
-plugins {
-    id 'java'
-}
-
 group 'bisq'

--- a/desktopapp/build.gradle
+++ b/desktopapp/build.gradle
@@ -72,7 +72,6 @@ shadowDistZip.enabled = false
 shadowDistTar.enabled = false
 
 tasks.jpackage {
-    dependsOn rootProject.clean
     dependsOn tasks.clean // Ensure fresh buildDir for every jpackager binary build
     dependsOn tasks.jar, tasks.shadowJar
 

--- a/desktopapp/build.gradle
+++ b/desktopapp/build.gradle
@@ -2,6 +2,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     id 'bisq.java-library'
+    id 'bisq.gradle.regtest.BisqRegtestPlugin'
     id 'application'
     /* id 'distribution'*/ //todo as long we dont need a jar we leave that out, speeds up build
     alias(libs.plugins.openjfx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ google-gson-lib = { strictly = '2.9.0' }
 google-guava-lib = { strictly = '31.1-jre' }
 
 i2p-lib = { strictly = '1.7.0' }
-jackson-lib = { strictly = '2.13.2' }
+jackson-lib = { strictly = '2.13.3' }
 jeasy-easy-states-lib = { strictly = '2.0.0' }
 jeromq-lib = { strictly = '0.5.2' }
 jpackage-plugin = { strictly = '1.3.1' }

--- a/wallets/build.gradle
+++ b/wallets/build.gradle
@@ -1,8 +1,0 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.18'
-    }
-}

--- a/wallets/regtest/build.gradle
+++ b/wallets/regtest/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation "bisq:common"
-    implementation "bisq:persistence"
-
     implementation project(':core')
     implementation project(':bitcoind')
 

--- a/wallets/regtest/build.gradle
+++ b/wallets/regtest/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     implementation project(':core')
     implementation project(':bitcoind')
 
-    implementation libs.junit.jupiter
     implementation libs.google.guava
-    testImplementation libs.assertj.core
+
+    implementation libs.assertj.core
+    implementation libs.junit.jupiter
 }


### PR DESCRIPTION
- [Apply Gradle Regtest Plugin only to desktopapp](https://github.com/alvasw/bisq2/commit/0ba9443828b0af5d2da7c6d7e21fbcb4bbb633be)
- [Fix broken :wallets:regtest modules](https://github.com/alvasw/bisq2/commit/997802f0f51909eeb1f434d64d1eee39ed32d910)
- [wallets.regtest: Remove unused dependencies](https://github.com/alvasw/bisq2/commit/6b864874861eb5db8fbdfeafcd606cd66c676e63)
- [wallets: Use global protobuf configuration](https://github.com/alvasw/bisq2/commit/d1fc5293d3d3029cf70685076393ef6461f14099)
- [Update jackson-lib to 2.13.3](https://github.com/alvasw/bisq2/commit/1330d7cb56ec12547893a0d08fb3e45943ba43bf)
- [Remove java plugin from root build.gradle](https://github.com/alvasw/bisq2/commit/380560be6417f3f024fe1e55c1f9b26c84f75bb0)