### PR TITLE
Electrum RPC support follow up

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,9 @@ fontawesomefx-materialdesignfont-lib = { strictly = '2.0.26-9.1.2' }
 fxmisc-easybind-lib = { strictly = '1.0.3' }
 fxmisc-richtextfx-lib = { strictly = '0.10.9' }
 
+glassfish-jersey-lib = { strictly = '3.0.4' }
+glassfish-jaxb-runtime-lib = { strictly = '3.0.2' }
+
 google-gson-lib = { strictly = '2.9.0' }
 google-guava-lib = { strictly = '31.1-jre' }
 
@@ -47,6 +50,7 @@ shadow-plugin = { strictly = '7.1.2' }
 slf4j-lib = { strictly = '1.7.36' }
 spring-boot-starter-web-lib = { strictly = '2.5.6' }
 springfox-lib = { strictly = '3.0.0' }
+swagger-jaxrs2-jakarta-lib = { strictly = '2.2.0' }
 tukaani-lib = { strictly = '1.9' }
 typesafe-config-lib = { strictly = '1.4.2' }
 
@@ -81,6 +85,11 @@ fontawesomefx-materialdesignfont = { module = 'de.jensd:fontawesomefx-materialde
 fxmisc-easybind = { module = 'org.fxmisc.easybind:easybind', version.ref = 'fxmisc-easybind-lib' }
 fxmisc-richtextfx = { module = 'org.fxmisc.richtext:richtextfx', version.ref = 'fxmisc-richtextfx-lib' }
 
+glassfish-jersey-jdk-http = { module = 'org.glassfish.jersey.containers:jersey-container-jdk-http', version.ref = 'glassfish-jersey-lib' }
+glassfish-jersey-json-jackson = { module = 'org.glassfish.jersey.media:jersey-media-json-jackson', version.ref = 'glassfish-jersey-lib' }
+glassfish-jersey-inject-hk2 = { module = 'org.glassfish.jersey.inject:jersey-hk2', version.ref = 'glassfish-jersey-lib' }
+glassfish-jaxb-runtime = { module = 'org.glassfish.jaxb:jaxb-runtime', version.ref = 'glassfish-jaxb-runtime-lib' }
+
 google-gson = { module = 'com.google.code.gson:gson', version.ref = 'google-gson-lib' }
 google-guava = { module = 'com.google.guava:guava', version.ref = 'google-guava-lib' }
 
@@ -111,8 +120,8 @@ springfox-boot-starter = { module = 'io.springfox:springfox-boot-starter', versi
 springfox-swagger2 = { module = 'io.springfox:springfox-swagger2', version.ref = 'springfox-lib' }
 springfox-swagger-ui = { module = 'io.springfox:springfox-swagger-ui', version.ref = 'springfox-lib' }
 
+swagger-jaxrs2-jakarta = { module = 'io.swagger.core.v3:swagger-jaxrs2-jakarta', version.ref = 'swagger-jaxrs2-jakarta-lib' }
 tukaani = { module = 'org.tukaani:xz', version.ref = 'tukaani-lib' }
-
 typesafe-config = { module = 'com.typesafe:config', version.ref = 'typesafe-config-lib' }
 
 # Defines groups of libs that are commonly used together
@@ -121,6 +130,7 @@ typesafe-config = { module = 'com.typesafe:config', version.ref = 'typesafe-conf
 bisq-tor-binaries = ['bisq-tor-binary-geoip', 'bisq-tor-binary-macos', 'bisq-tor-binary-linux32', 'bisq-tor-binary-linux64', 'bisq-tor-binary-windows']
 fontawesomefx = ['fontawesomefx', 'fontawesomefx-commons', 'fontawesomefx-materialdesignfont']
 fxmisc-libs = ['fxmisc-easybind', 'fxmisc-richtextfx']
+glassfish-jersey = ['glassfish-jersey-jdk-http', 'glassfish-jersey-json-jackson', 'glassfish-jersey-inject-hk2', 'glassfish-jaxb-runtime']
 i2p = ['i2p-core', 'i2p-router', 'i2p-streaming']
 jackson = ['jackson-core', 'jackson-annotations', 'jackson-databind']
 springfox-libs = ['springfox-boot-starter', 'springfox-swagger2', 'springfox-swagger-ui']

--- a/restApi/build.gradle
+++ b/restApi/build.gradle
@@ -15,11 +15,6 @@ run {
     systemProperties System.getProperties()
 }
 
-ext {
-    swaggerVersion = '2.2.0'
-    jerseyVersion = '3.0.4'
-}
-
 repositories {
     mavenCentral()
 }
@@ -42,13 +37,10 @@ dependencies {
     implementation project(':presentation')
     implementation project(':application')
 
-    implementation libs.google.guava
+    implementation libs.bundles.glassfish.jersey
     implementation libs.bundles.jackson
 
-    implementation("org.glassfish.jersey.containers:jersey-container-jdk-http:$jerseyVersion")
-    implementation("org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion")
-    implementation("org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion")
-    implementation("org.glassfish.jaxb:jaxb-runtime:3.0.2")
-    implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:$swaggerVersion")
+    implementation libs.google.guava
+    implementation libs.swagger.jaxrs2.jakarta
 }
 

--- a/wallets/electrum/build.gradle
+++ b/wallets/electrum/build.gradle
@@ -3,21 +3,13 @@ plugins {
     id 'bisq.protobuf'
 }
 
-ext {
-    swaggerVersion = '2.2.0'
-    jerseyVersion = '3.0.4'
-}
-
 dependencies {
     implementation("bisq:persistence")
     implementation project(':core')
-    implementation libs.jackson.databind
 
-    implementation("org.glassfish.jersey.containers:jersey-container-jdk-http:$jerseyVersion")
-    implementation("org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion")
-    implementation("org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion")
-    implementation("org.glassfish.jaxb:jaxb-runtime:3.0.2")
-    implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:$swaggerVersion")
+    implementation libs.jackson.databind
+    implementation libs.bundles.glassfish.jersey
+    implementation libs.swagger.jaxrs2.jakarta
 
     testImplementation project(':bitcoind')
     testImplementation project(':regtest')

--- a/wallets/electrum/build.gradle
+++ b/wallets/electrum/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
     implementation libs.jackson.databind
     implementation libs.bundles.glassfish.jersey
-    implementation libs.swagger.jaxrs2.jakarta
 
     testImplementation project(':bitcoind')
     testImplementation project(':regtest')

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyApi.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyApi.java
@@ -17,34 +17,36 @@
 
 package bisq.wallets.electrum.notifications;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.MediaType;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import static bisq.wallets.electrum.notifications.ElectrumNotifyApi.ENDPOINT_NAME;
+
 @Slf4j
-@Path("/electrum-notify")
+@Path("/" + ENDPOINT_NAME)
 public class ElectrumNotifyApi {
 
     public static final String ENDPOINT_NAME = "electrum-notify";
-
-    public interface Listener {
-        void onAddressStatusChanged(String address, String status);
-    }
-
     private static final List<Listener> listeners = new CopyOnWriteArrayList<>();
 
+    public interface Listener {
+
+        void onAddressStatusChanged(String address, String status);
+
+    }
+
     @POST
-    @Consumes("application/json")
-    public Response notifyEndpoint(@Parameter(required = true) ElectrumNotifyRequest request) {
+    @Consumes(MediaType.APPLICATION_JSON)
+    public String notifyEndpoint(ElectrumNotifyRequest request) {
         log.info(request.toString());
         listeners.forEach(listener -> listener.onAddressStatusChanged(request.getAddress(), request.getStatus()));
-        return Response.ok().entity("SUCCESS").build();
+        return "SUCCESS";
     }
 
     public static void registerListener(Listener listener) {

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyApi.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyApi.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 @Slf4j
@@ -36,22 +37,22 @@ public class ElectrumNotifyApi {
         void onAddressStatusChanged(String address, String status);
     }
 
-    private static final CopyOnWriteArrayList<Listener> sListeners = new CopyOnWriteArrayList<>();
+    private static final List<Listener> listeners = new CopyOnWriteArrayList<>();
 
     @POST
     @Consumes("application/json")
     public Response notifyEndpoint(@Parameter(required = true) ElectrumNotifyRequest request) {
         log.info(request.toString());
-        sListeners.forEach(listener -> listener.onAddressStatusChanged(request.getAddress(), request.getStatus()));
+        listeners.forEach(listener -> listener.onAddressStatusChanged(request.getAddress(), request.getStatus()));
         return Response.ok().entity("SUCCESS").build();
     }
 
     public static void registerListener(Listener listener) {
-        sListeners.add(listener);
+        listeners.add(listener);
     }
 
     public static void removeListener(Listener listener) {
-        sListeners.remove(listener);
+        listeners.remove(listener);
     }
 
 }

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyRequest.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyRequest.java
@@ -17,32 +17,17 @@
 
 package bisq.wallets.electrum.notifications;
 
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
+@Getter
 @Setter
-@XmlRootElement
+@ToString
 public class ElectrumNotifyRequest {
-
+    @JsonProperty
     private String address;
+    @JsonProperty
     private String status;
-
-    @XmlElement(name = "address")
-    public String getAddress() {
-        return address;
-    }
-
-    @XmlElement(name = "status")
-    public String getStatus() {
-        return status;
-    }
-
-    @Override
-    public String toString() {
-        return "ElectrumNotifyRequest{" +
-                "address='" + address + '\'' +
-                ", status='" + status + '\'' +
-                '}';
-    }
 }

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyWebServer.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/notifications/ElectrumNotifyWebServer.java
@@ -17,7 +17,6 @@
 
 package bisq.wallets.electrum.notifications;
 
-import bisq.wallets.electrum.notifications.ElectrumNotifyApi;
 import com.sun.net.httpserver.HttpServer;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.jdkhttp.JdkHttpServerFactory;


### PR DESCRIPTION
- [ElectrumNotifyApi: Change to List<> base type and rename field](https://github.com/bisq-network/bisq2/commit/ac70ec36912c1739d0081b694d1023b935879376)
- [ElectrumNotifyRequest: Switch from XML to JsonProperty](https://github.com/bisq-network/bisq2/commit/fc4f9006e8d87276af1ee166183761d0b45a95dc)
- [Gradle: Move glassfish and swagger dependencies to version catalog](https://github.com/bisq-network/bisq2/commit/1aecacb3aa70ac395253281ec572531a361859d5)