### PR TITLE
Set Java 11 as Compilation Target

### DIFF
--- a/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.java-conventions.gradle
@@ -9,8 +9,13 @@ repositories {
 
 java {
     toolchain {
+        // We use the Java 17 toolchain to use jpackage to create the binaries.
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+compileJava {
+    options.release = 11
 }
 
 dependencies {

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 javafx {
-    version = '17.0.1'
-    modules = ['javafx.base', 'javafx.controls', 'javafx.graphics']
+    version = '11.0.2'
+    modules = [ 'javafx.controls' ]
 }
 
 dependencies {

--- a/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
+++ b/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
@@ -77,7 +77,6 @@ public class ImageUtil {
         canvas.setWidth(width);
         canvas.setHeight(height);
         GraphicsContext graphicsContext2D = canvas.getGraphicsContext2D();
-        graphicsContext2D.setImageSmoothing(true);
 
         double radius = Math.min(height, width) / 2d;
         double x = width / 2d;

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMentionPopupMenu.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMentionPopupMenu.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class ChatMentionPopupMenu<T> extends BisqPopup {
     @Setter
@@ -62,7 +63,7 @@ public class ChatMentionPopupMenu<T> extends BisqPopup {
                     });
                     return button;
                 })
-                .toList();
+                .collect(Collectors.toList());
 
         ((VBox) contentNode).getChildren().setAll(buttons);
     }

--- a/desktopapp/build.gradle
+++ b/desktopapp/build.gradle
@@ -37,8 +37,8 @@ tasks.named('jar') {
 }
 
 javafx {
-    version = '17.0.1'
-    modules = ['javafx.base', 'javafx.controls', 'javafx.graphics']
+    version = '11.0.2'
+    modules = [ 'javafx.controls' ]
 }
 
 dependencies {

--- a/oracle/src/main/java/bisq/oracle/marketprice/MarketPriceService.java
+++ b/oracle/src/main/java/bisq/oracle/marketprice/MarketPriceService.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -223,11 +224,11 @@ public class MarketPriceService {
             candidates.addAll(providers.stream()
                     .filter(provider -> networkService.getSupportedTransportTypes().contains(Transport.Type.CLEAR))
                     .filter(provider -> Transport.Type.CLEAR == provider.transportType)
-                    .toList());
+                    .collect(Collectors.toList()));
             if (candidates.isEmpty()) {
                 candidates.addAll(providers.stream()
                         .filter(provider -> networkService.getSupportedTransportTypes().contains(provider.transportType))
-                        .toList());
+                        .collect(Collectors.toList()));
             }
         }
         if (candidates.isEmpty()) {


### PR DESCRIPTION
We do still use the Java 17 toolchain because we need jpackage to create the binaries. Since version 9, the Java compiler can be configured to produce bytecode for an older Java version while making sure the code does not use any APIs from a more recent version.

See https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation

Other changes:
- [Java 11: Replace Stream.toList() by Stream.collect(Collectors.toList())](https://github.com/bisq-network/bisq2/commit/5fa89b54daec1aa91ded5699789129bfcd4da21c)
- [JavaFX 11: Remove GraphicsContext2D.setImageSmoothing(...)](https://github.com/bisq-network/bisq2/commit/6617a1219e5a59969e19c2eb316794066e782bd4)