### PR TITLE
desktop/desktopapp: Target Java 17

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -3,8 +3,12 @@ plugins {
     alias(libs.plugins.openjfx)
 }
 
+compileJava {
+    options.release = 17
+}
+
 javafx {
-    version = '11.0.2'
+    version = '17.0.1'
     modules = [ 'javafx.controls' ]
 }
 

--- a/desktopapp/build.gradle
+++ b/desktopapp/build.gradle
@@ -10,6 +10,10 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
+compileJava {
+    options.release = 17
+}
+
 application {
     project.mainClassName = 'bisq.desktopapp.Main'
     applicationDefaultJvmArgs = []
@@ -37,7 +41,7 @@ tasks.named('jar') {
 }
 
 javafx {
-    version = '11.0.2'
+    version = '17.0.1'
     modules = [ 'javafx.controls' ]
 }
 


### PR DESCRIPTION
JPackage cannot sign the DMG image on Mac because the JavaFX 11 Mac dylib libraries are not signed. It's less work to target Java 17 (and JavaFx 17) instead of adapting the build process to sign the dylib libraries before creating and signing the DMG image.