### PR TITLE
Fix race condition in elementsd unconfirmed txs

### DIFF
--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/responses/ElementsdIssuance.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/responses/ElementsdIssuance.java
@@ -17,19 +17,21 @@
 
 package bisq.wallets.elementsd.rpc.responses;
 
-import bisq.wallets.bitcoind.rpc.responses.AbstractVin;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
-
 @Getter
 @Setter
-public class ElementsdVin extends AbstractVin {
-    @JsonProperty("is_pegin")
-    private boolean isPegin;
-    @JsonProperty("pegin_witness")
-    private List<String> peginWitnesses;
-    private ElementsdIssuance issuance;
+public class ElementsdIssuance {
+    private String assetBlindingNonce;
+    private String assetEntropy;
+    @JsonProperty("isreissuance")
+    private boolean isReissuance;
+    private String token;
+    private String asset;
+    @JsonProperty("assetamount")
+    private double assetAmount;
+    @JsonProperty("tokenamountcommitment")
+    private String tokenAmountCommitment;
 }

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/responses/ElementsdVin.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/responses/ElementsdVin.java
@@ -22,9 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class ElementsdVin extends AbstractVin {
     @JsonProperty("is_pegin")
     private boolean isPegin;
+    @JsonProperty("pegin_witness")
+    private List<String> peginWitnesses;
 }

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdConnectionFailureIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdConnectionFailureIntegrationTests.java
@@ -17,6 +17,7 @@
 
 package bisq.wallets.elementsd;
 
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.ElementsdWallet;
 import bisq.wallets.regtest.AbstractRegtestSetup;
 import bisq.wallets.regtest.ConnectionFailureIntegrationTests;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdLiquidAssetsIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdLiquidAssetsIntegrationTests.java
@@ -18,6 +18,7 @@
 package bisq.wallets.elementsd;
 
 import bisq.wallets.core.model.AddressType;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.responses.ElementsdIssueAssetResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdLiquidAssetsIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdLiquidAssetsIntegrationTests.java
@@ -44,7 +44,7 @@ public class ElementsdLiquidAssetsIntegrationTests extends SharedElementsdInstan
     }
 
     @Test
-    public void sendOneLiquidAssetToAddress() throws MalformedURLException {
+    public void sendOneLiquidAssetToAddress() throws MalformedURLException, InterruptedException {
         ElementsdIssueAssetResponse issueAssetResponse = elementsdMinerWallet.issueAsset(
                 Optional.of(ElementsdRegtestSetup.WALLET_PASSPHRASE), 2, 1
         );

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdPeginBtcIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdPeginBtcIntegrationTests.java
@@ -17,6 +17,7 @@
 
 package bisq.wallets.elementsd;
 
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.responses.ElementsdGetPeginAddressResponse;
 import org.junit.jupiter.api.Test;
 

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSendAndListTxsIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSendAndListTxsIntegrationTests.java
@@ -18,6 +18,7 @@
 package bisq.wallets.elementsd;
 
 import bisq.wallets.core.model.AddressType;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.responses.ElementsdListTransactionsResponseEntry;
 import org.junit.jupiter.api.Test;
 

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSendIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSendIntegrationTests.java
@@ -18,6 +18,7 @@
 package bisq.wallets.elementsd;
 
 import bisq.wallets.core.model.AddressType;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSendUnconfirmedTxIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSendUnconfirmedTxIntegrationTests.java
@@ -18,6 +18,7 @@
 package bisq.wallets.elementsd;
 
 import bisq.wallets.core.model.AddressType;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSigningIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdSigningIntegrationTests.java
@@ -18,6 +18,7 @@
 package bisq.wallets.elementsd;
 
 import bisq.wallets.core.model.AddressType;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdStartupIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdStartupIntegrationTests.java
@@ -17,6 +17,7 @@
 
 package bisq.wallets.elementsd;
 
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.ElementsdWallet;
 import bisq.wallets.regtest.AbstractRegtestSetup;
 import bisq.wallets.regtest.WalletStartupTests;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/SharedElementsdInstanceTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/SharedElementsdInstanceTests.java
@@ -18,6 +18,7 @@
 package bisq.wallets.elementsd;
 
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.ElementsdDaemon;
 import bisq.wallets.elementsd.rpc.ElementsdWallet;
 import bisq.wallets.elementsd.rpc.responses.ElementsdGetPeginAddressResponse;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestProcess.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestProcess.java
@@ -15,13 +15,14 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.wallets.elementsd;
+package bisq.wallets.elementsd.regtest;
 
 import bisq.common.util.NetworkUtils;
 import bisq.wallets.core.RpcConfig;
 import bisq.wallets.core.exceptions.RpcCallFailureException;
 import bisq.wallets.core.rpc.DaemonRpcClient;
 import bisq.wallets.core.rpc.RpcClientFactory;
+import bisq.wallets.elementsd.ElementsdConfig;
 import bisq.wallets.elementsd.rpc.ElementsdDaemon;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestProcess;
 import bisq.wallets.regtest.process.ProcessConfig;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestSetup.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestSetup.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.wallets.elementsd;
+package bisq.wallets.elementsd.regtest;
 
 import bisq.common.util.NetworkUtils;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindGetZmqNotificationsResponse;
@@ -27,6 +27,7 @@ import bisq.wallets.core.model.AddressType;
 import bisq.wallets.core.rpc.DaemonRpcClient;
 import bisq.wallets.core.rpc.RpcClientFactory;
 import bisq.wallets.core.rpc.WalletRpcClient;
+import bisq.wallets.elementsd.ElementsdConfig;
 import bisq.wallets.elementsd.rpc.ElementsdDaemon;
 import bisq.wallets.elementsd.rpc.ElementsdRawTxProcessor;
 import bisq.wallets.elementsd.rpc.ElementsdWallet;

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/zmq/ElementsdZeroMqBlockHashIntegrationIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/zmq/ElementsdZeroMqBlockHashIntegrationIntegrationTests.java
@@ -17,12 +17,8 @@
 
 package bisq.wallets.elementsd.zmq;
 
-import bisq.wallets.bitcoind.rpc.responses.BitcoindGetZmqNotificationsResponse;
-import bisq.wallets.bitcoind.zmq.ZmqConnection;
 import bisq.wallets.bitcoind.zmq.ZmqListeners;
-import bisq.wallets.bitcoind.zmq.ZmqTopicProcessors;
 import bisq.wallets.elementsd.SharedElementsdInstanceTests;
-import bisq.wallets.elementsd.rpc.ElementsdRawTxProcessor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 public class ElementsdZeroMqBlockHashIntegrationIntegrationTests extends SharedElementsdInstanceTests {
@@ -41,7 +36,7 @@ public class ElementsdZeroMqBlockHashIntegrationIntegrationTests extends SharedE
 
     @Test
     void blockHashNotification() throws InterruptedException {
-        ZmqListeners zmqListeners = elementsdRegtestSetup.getZmqListeners();
+        ZmqListeners zmqListeners = elementsdRegtestSetup.getZmqMinerListeners();
         zmqListeners.registerNewBlockMinedListener((blockHash) -> {
             log.info("Notification: New block with hash " + blockHash);
             if (minedBlockHashes.contains(blockHash)) {

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/zmq/ElementsdZeroMqRawTxIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/zmq/ElementsdZeroMqRawTxIntegrationTests.java
@@ -18,7 +18,7 @@
 package bisq.wallets.elementsd.zmq;
 
 import bisq.wallets.core.model.AddressType;
-import bisq.wallets.elementsd.ElementsdRegtestSetup;
+import bisq.wallets.elementsd.regtest.ElementsdRegtestSetup;
 import bisq.wallets.elementsd.rpc.ElementsdWallet;
 import bisq.wallets.elementsd.rpc.responses.ElementsdGetAddressInfoResponse;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- [ElementsdVin: Add missing peginWitnesses field](https://github.com/bisq-network/bisq2/commit/c51e24b2e5f3355b92cd5bf7f39fa6eb1065a8e8)
- [Elements: Make regtest block mining blocking](https://github.com/bisq-network/bisq2/commit/9863931530b2b6208d6f26aa1a4a43880857fd34)
- [Elements: Move regtest classes to its own package](https://github.com/bisq-network/bisq2/commit/5b3a7ab446c2d470a5343822f868f98dba620f7c)
- [ElementsSendUnconfirmedTest: Wait until tx broadcasted](https://github.com/bisq-network/bisq2/commit/ed096fce7a6b02cda2db9ba5916747b2e470a8aa)
- [ElementsdVin: Add issuance field](https://github.com/bisq-network/bisq2/commit/28073fa1cee12ddb297224d12c8f45467b02df41)