### PR TITLE
I2P - Autodetect External I2P Router

### DIFF
--- a/application/src/main/resources/default.conf
+++ b/application/src/main/resources/default.conf
@@ -117,7 +117,6 @@ application {
                 outboundKBytesPerSecond = 512
                 bandwidthSharePercentage = 50
                 embeddedRouter = true
-                bandwidth = -1
                 extendedI2pLogging = false
             }
         }

--- a/application/src/main/resources/network.conf
+++ b/application/src/main/resources/network.conf
@@ -98,7 +98,6 @@ application {
                 outboundKBytesPerSecond = 512
                 bandwidthSharePercentage = 50
                 embeddedRouter = true
-                bandwidth = -1
                 extendedI2pLogging = false
             }
         }

--- a/i2p/src/main/java/bisq/i2p/I2pClient.java
+++ b/i2p/src/main/java/bisq/i2p/I2pClient.java
@@ -18,7 +18,6 @@
 package bisq.i2p;
 
 import bisq.common.util.FileUtils;
-import bisq.common.util.NetworkUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.i2p.I2PAppContext;
 import net.i2p.I2PException;
@@ -28,9 +27,6 @@ import net.i2p.client.streaming.I2PSocketOptions;
 import net.i2p.data.DataFormatException;
 import net.i2p.data.Destination;
 import net.i2p.data.PrivateKeyFile;
-import net.i2p.router.CommSystemFacade;
-import net.i2p.router.Router;
-import net.i2p.router.RouterContext;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -75,7 +71,7 @@ public class I2pClient {
     private I2pClient(String dirPath, String host, int port, long socketTimeout, boolean isEmbeddedRouter) {
         this.embeddedRouter = isEmbeddedRouter;
         if(isEmbeddedRouter) {
-            this.i2pRouter = I2pEmbeddedRouter.getInitialzedI2pEmbeddedRouter();
+            this.i2pRouter = I2pEmbeddedRouter.getInitializedI2pEmbeddedRouter();
         }
 
         this.socketTimeout = socketTimeout;
@@ -83,10 +79,6 @@ public class I2pClient {
         log.info("I2P client created with dirPath={}; host={}; port={}; socketTimeout={}", dirPath, host, port,
                 socketTimeout);
         configureI2pLogging();
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            Thread.currentThread().setName("I2pClient.shutdownHook");
-            shutdown();
-        }));
     }
 
     /**

--- a/i2p/src/main/java/bisq/i2p/I2pEmbeddedRouter.java
+++ b/i2p/src/main/java/bisq/i2p/I2pEmbeddedRouter.java
@@ -2,13 +2,13 @@ package bisq.i2p;
 
 import bisq.common.timer.Scheduler;
 import bisq.i2p.util.I2PLogManager;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.i2p.client.streaming.I2PSocketManager;
 import net.i2p.client.streaming.I2PSocketManagerFactory;
 import net.i2p.router.CommSystemFacade;
 import net.i2p.router.Router;
 import net.i2p.router.RouterContext;
-import org.minidns.record.UNKNOWN;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
+@Getter
 public class I2pEmbeddedRouter {
 
     //TODO - Restart of embedded router not implemented yet
@@ -53,11 +54,11 @@ public class I2pEmbeddedRouter {
         return localRouter;
     }
 
-    public static boolean hasBeenInitialized(){
+    public static boolean isInitialized(){
         return initialized;
     }
 
-    public static I2pEmbeddedRouter getInitialzedI2pEmbeddedRouter() {
+    public static I2pEmbeddedRouter getInitializedI2pEmbeddedRouter() {
         return localRouter;
     }
 
@@ -84,15 +85,12 @@ public class I2pEmbeddedRouter {
                 .periodically(30, TimeUnit.SECONDS)
                 .name("I2pStatus");
 
-
     }
 
     @SuppressWarnings("SpellCheckingInspection")
-
     public I2PSocketManager getManager(File privKeyFile) throws IOException {
 
         I2PSocketManager manager;
-
         //Has the router been initialized?
         while(RouterContext.listContexts().size() < 1) {
             try {
@@ -149,48 +147,16 @@ public class I2pEmbeddedRouter {
         }
     }
 
-    public void reportRouterStatus() {
-        if(i2pRouterStatus == CommSystemFacade.Status.OK ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_DISABLED_IPV6_OK ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_FIREWALLED_IPV6_OK ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_SNAT_IPV6_OK ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_UNKNOWN_IPV6_OK ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_OK_IPV6_UNKNOWN ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_DISABLED_IPV6_FIREWALLED ||
-                i2pRouterStatus == CommSystemFacade.Status.REJECT_UNSOLICITED ||
-                i2pRouterStatus == CommSystemFacade.Status.IPV4_OK_IPV6_FIREWALLED) {
-            log.info("I2P Router status - {}", i2pRouterStatus.toStatusString());
-        }
-        else if(i2pRouterStatus == CommSystemFacade.Status.DIFFERENT ||
-                i2pRouterStatus == CommSystemFacade.Status.HOSED) {
-            log.warn("I2P Router status - {}", i2pRouterStatus.toStatusString());
-        }
-        else if(i2pRouterStatus == CommSystemFacade.Status.DISCONNECTED) {
-            log.warn("I2P Router status - {}", i2pRouterStatus.toStatusString());
-            //todo - create a restart() routine?
-        }
-        else {
-            log.warn("Not connected to I2P Network.");
-        }
-    }
-
     public static boolean isRouterRunning() {
         if(null == localRouter) {
             return false;
         }
-        return getInitialzedI2pEmbeddedRouter().isRouterInstanceRunning();
+        return localRouter.getRouter().isRunning();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////////
-
-    private boolean isRouterInstanceRunning() {
-        if(null == router) {
-            return false;
-        }
-        return router.isRunning();
-    }
 
     @SuppressWarnings("SpellCheckingInspection")
     private void startEmbeddedRouter(boolean extendedI2pLogging) throws IOException {
@@ -278,5 +244,30 @@ public class I2pEmbeddedRouter {
 
     private CommSystemFacade.Status getRouterStatus() {
         return routerContext.commSystem().getStatus();
+    }
+
+    private void reportRouterStatus() {
+        if(i2pRouterStatus == CommSystemFacade.Status.OK ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_DISABLED_IPV6_OK ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_FIREWALLED_IPV6_OK ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_SNAT_IPV6_OK ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_UNKNOWN_IPV6_OK ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_OK_IPV6_UNKNOWN ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_DISABLED_IPV6_FIREWALLED ||
+                i2pRouterStatus == CommSystemFacade.Status.REJECT_UNSOLICITED ||
+                i2pRouterStatus == CommSystemFacade.Status.IPV4_OK_IPV6_FIREWALLED) {
+            log.info("I2P Router status - {}", i2pRouterStatus.toStatusString());
+        }
+        else if(i2pRouterStatus == CommSystemFacade.Status.DIFFERENT ||
+                i2pRouterStatus == CommSystemFacade.Status.HOSED) {
+            log.warn("I2P Router status - {}", i2pRouterStatus.toStatusString());
+        }
+        else if(i2pRouterStatus == CommSystemFacade.Status.DISCONNECTED) {
+            log.warn("I2P Router status - {}", i2pRouterStatus.toStatusString());
+            //todo - create a restart() routine?
+        }
+        else {
+            log.warn("Not connected to I2P Network.");
+        }
     }
 }


### PR DESCRIPTION
This change checks if there's an I2P router running locally on port 7654, if there's one and the user is trying to run an embedded router, it will ignore the parameter for the embedded router and use the external router instead.

Developer: @c4talys7 