### PR TITLE
ElectrumGetInfoRpcCall: Check for serverHeight

### DIFF
--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/rpc/calls/ElectrumGetInfoRpcCall.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/rpc/calls/ElectrumGetInfoRpcCall.java
@@ -32,7 +32,7 @@ public class ElectrumGetInfoRpcCall extends DaemonRpcCall<Void, ElectrumGetInfoR
 
     @Override
     public boolean isResponseValid(ElectrumGetInfoResponse response) {
-        return response.getBlockchainHeight() >= 0;
+        return response.getServerHeight() >= 0;
     }
 
     @Override


### PR DESCRIPTION
The blockchainHeight is '-1' when Electrum is initializing.