### PR TITLE
Electrum: Watch log files for "ready" signal

### DIFF
--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/CannotCreateElectrumLogFileDirectoryException.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/CannotCreateElectrumLogFileDirectoryException.java
@@ -15,10 +15,10 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.wallets.process;
+package bisq.wallets.electrum;
 
-public interface BisqProcess {
-    void start() throws InterruptedException;
-
-    void shutdown();
+public class CannotCreateElectrumLogFileDirectoryException extends RuntimeException {
+    public CannotCreateElectrumLogFileDirectoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/FileCreationWatcher.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/FileCreationWatcher.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.electrum;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class FileCreationWatcher {
+    private final Path directoryToWatch;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public FileCreationWatcher(Path directoryToWatch) {
+        this.directoryToWatch = directoryToWatch;
+    }
+
+    public Future<Path> waitUntilNewFileCreated() {
+        return executor.submit(this::waitForNewFile);
+    }
+
+    private Path waitForNewFile() throws IOException, InterruptedException {
+        try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
+            directoryToWatch.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+
+            WatchKey watchKey = watchService.poll(1, TimeUnit.MINUTES);
+            for (WatchEvent<?> event : watchKey.pollEvents()) {
+                WatchEvent.Kind<?> kind = event.kind();
+
+                if (kind == StandardWatchEventKinds.OVERFLOW) {
+                    continue;
+                }
+
+                @SuppressWarnings("unchecked")
+                WatchEvent<Path> castedWatchEvent = (WatchEvent<Path>) event;
+                Path filename = castedWatchEvent.context();
+                return directoryToWatch.resolve(filename);
+            }
+        }
+
+        throw new IllegalStateException("FileCreationWatcher terminated prematurely.");
+    }
+}

--- a/wallets/electrum/src/test/java/bisq/wallets/electrum/regtest/electrumx/ElectrumXServerRegtestProcess.java
+++ b/wallets/electrum/src/test/java/bisq/wallets/electrum/regtest/electrumx/ElectrumXServerRegtestProcess.java
@@ -20,6 +20,8 @@ package bisq.wallets.electrum.regtest.electrumx;
 import bisq.wallets.core.RpcConfig;
 import bisq.wallets.process.DaemonProcess;
 import bisq.wallets.process.ProcessConfig;
+import bisq.wallets.process.scanner.InputStreamScanner;
+import bisq.wallets.process.scanner.LogScanner;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
@@ -67,6 +69,14 @@ public class ElectrumXServerRegtestProcess extends DaemonProcess {
     @Override
     public void invokeStopRpcCall() {
         electrumXRpc.stop();
+    }
+
+    @Override
+    protected LogScanner getLogScanner() {
+        return new InputStreamScanner(
+                getIsSuccessfulStartUpLogLines(),
+                process.getInputStream()
+        );
     }
 
     @Override

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestSetup.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestSetup.java
@@ -39,7 +39,6 @@ import bisq.wallets.regtest.process.MultiProcessCoordinator;
 import lombok.Getter;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -80,7 +79,7 @@ public class ElementsdRegtestSetup extends AbstractRegtestSetup<MultiProcessCoor
     }
 
     @Override
-    public void start() throws IOException, InterruptedException {
+    public void start() throws InterruptedException {
         super.start();
         minerWallet = createNewWallet("miner_wallet");
 
@@ -125,12 +124,12 @@ public class ElementsdRegtestSetup extends AbstractRegtestSetup<MultiProcessCoor
         return txId;
     }
 
-    public ElementsdWallet createNewWallet(String walletName) throws MalformedURLException {
+    public ElementsdWallet createNewWallet(String walletName) {
         Path receiverWalletPath = tmpDirPath.resolve(walletName);
         return createNewWallet(receiverWalletPath);
     }
 
-    public ElementsdWallet createNewWallet(Path walletPath) throws MalformedURLException {
+    public ElementsdWallet createNewWallet(Path walletPath) {
         if (loadedWalletPaths.contains(walletPath)) {
             throw new IllegalStateException("Cannot create wallet '" + walletPath.toAbsolutePath() +
                     "'. It exists already.");
@@ -168,12 +167,12 @@ public class ElementsdRegtestSetup extends AbstractRegtestSetup<MultiProcessCoor
         return new ElementsdRegtestProcess(elementsdConfig, elementsdDataDir);
     }
 
-    private ElementsdDaemon createDaemon() throws MalformedURLException {
+    private ElementsdDaemon createDaemon() {
         DaemonRpcClient rpcClient = RpcClientFactory.createDaemonRpcClient(elementsdConfig.elementsdRpcConfig());
         return new ElementsdDaemon(rpcClient);
     }
 
-    private ElementsdWallet newWallet(Path walletPath) throws MalformedURLException {
+    private ElementsdWallet newWallet(Path walletPath) {
         RpcConfig walletRpcConfig = elementsdConfig.elementsdRpcConfig();
         WalletRpcClient rpcClient = RpcClientFactory.createWalletRpcClient(walletRpcConfig, walletPath);
         return new ElementsdWallet(rpcClient);

--- a/wallets/process/src/main/java/bisq/wallets/process/CannotStartProcessException.java
+++ b/wallets/process/src/main/java/bisq/wallets/process/CannotStartProcessException.java
@@ -17,8 +17,8 @@
 
 package bisq.wallets.process;
 
-public interface BisqProcess {
-    void start() throws InterruptedException;
-
-    void shutdown();
+public class CannotStartProcessException extends RuntimeException {
+    public CannotStartProcessException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/wallets/process/src/main/java/bisq/wallets/process/scanner/FileScanner.java
+++ b/wallets/process/src/main/java/bisq/wallets/process/scanner/FileScanner.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.process.scanner;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+public class FileScanner extends LogScanner {
+
+    private final Future<Path> logFilePath;
+
+    public FileScanner(Set<String> linesToMatch, Future<Path> logFilePath) {
+        super(linesToMatch);
+        this.logFilePath = logFilePath;
+    }
+
+    @Override
+    public boolean waitUntilLogContainsLines() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        while (true) {
+            Path logFilePath = this.logFilePath.get(1, TimeUnit.MINUTES);
+            try (Scanner scanner = new Scanner(logFilePath)) {
+                boolean foundAllLines = waitUntilScannerContainsLines(scanner);
+                if (foundAllLines) {
+                    return true;
+                }
+            }
+        }
+    }
+}

--- a/wallets/process/src/main/java/bisq/wallets/process/scanner/InputStreamScanner.java
+++ b/wallets/process/src/main/java/bisq/wallets/process/scanner/InputStreamScanner.java
@@ -15,10 +15,28 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.wallets.process;
+package bisq.wallets.process.scanner;
 
-public interface BisqProcess {
-    void start() throws InterruptedException;
+import lombok.extern.slf4j.Slf4j;
 
-    void shutdown();
+import java.io.InputStream;
+import java.util.Scanner;
+import java.util.Set;
+
+@Slf4j
+public class InputStreamScanner extends LogScanner {
+
+    private final InputStream inputStream;
+
+    public InputStreamScanner(Set<String> linesToMatch, InputStream inputStream) {
+        super(linesToMatch);
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public boolean waitUntilLogContainsLines() {
+        try (Scanner scanner = new Scanner(inputStream)) {
+            return waitUntilScannerContainsLines(scanner);
+        }
+    }
 }

--- a/wallets/process/src/main/java/bisq/wallets/process/scanner/LogScanner.java
+++ b/wallets/process/src/main/java/bisq/wallets/process/scanner/LogScanner.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.process.scanner;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public abstract class LogScanner {
+
+    private final Set<String> linesToMatch;
+    private final Set<String> matchedLines = new HashSet<>();
+
+    public LogScanner(Set<String> linesToMatch) {
+        this.linesToMatch = linesToMatch;
+    }
+
+    public abstract boolean waitUntilLogContainsLines() throws IOException, ExecutionException, InterruptedException, TimeoutException;
+
+    protected boolean waitUntilScannerContainsLines(Scanner scanner) {
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+
+            for (String lineToMatch : linesToMatch) {
+                if (line.contains(lineToMatch)) {
+                    matchedLines.add(lineToMatch);
+
+                    if (matchedLines.size() == linesToMatch.size()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/AbstractRegtestSetup.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/AbstractRegtestSetup.java
@@ -35,9 +35,9 @@ public abstract class AbstractRegtestSetup<T extends BisqProcess> implements Bis
         this.tmpDirPath = FileUtils.createTempDir();
     }
 
-    protected abstract T createProcess() throws IOException;
+    protected abstract T createProcess();
 
-    public void start() throws IOException, InterruptedException {
+    public void start() throws InterruptedException {
         daemonProcess = createProcess();
         daemonProcess.start();
     }

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestBlockMiner.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestBlockMiner.java
@@ -48,7 +48,7 @@ public class BitcoindRegtestBlockMiner implements BisqProcess {
     }
 
     @Override
-    public void start() throws IOException, InterruptedException {
+    public void start() throws InterruptedException {
         zmqListeners.registerNewBlockMinedListener(newBlockMinedListener);
     }
 

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestProcess.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestProcess.java
@@ -25,6 +25,8 @@ import bisq.wallets.core.rpc.DaemonRpcClient;
 import bisq.wallets.core.rpc.RpcClientFactory;
 import bisq.wallets.process.DaemonProcess;
 import bisq.wallets.process.ProcessConfig;
+import bisq.wallets.process.scanner.InputStreamScanner;
+import bisq.wallets.process.scanner.LogScanner;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -69,6 +71,14 @@ public class BitcoindRegtestProcess extends DaemonProcess {
                         "-txindex=1"))
                 .environmentVars(Collections.emptyMap())
                 .build();
+    }
+
+    @Override
+    protected LogScanner getLogScanner() {
+        return new InputStreamScanner(
+                getIsSuccessfulStartUpLogLines(),
+                process.getInputStream()
+        );
     }
 
     @Override

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/RemoteBitcoind.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/RemoteBitcoind.java
@@ -32,7 +32,6 @@ import bisq.wallets.process.BisqProcess;
 import lombok.Getter;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -69,7 +68,7 @@ public class RemoteBitcoind implements BisqProcess {
     }
 
     @Override
-    public void start() throws InterruptedException, IOException {
+    public void start() throws InterruptedException {
         blockMiner.start();
         initializeZmqListeners();
         initializeWallet(minerWallet);

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/process/MultiProcessCoordinator.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/process/MultiProcessCoordinator.java
@@ -21,7 +21,6 @@ import bisq.wallets.core.exceptions.WalletStartupFailedException;
 import bisq.wallets.process.BisqProcess;
 import com.google.common.collect.Lists;
 
-import java.io.IOException;
 import java.util.List;
 
 public class MultiProcessCoordinator implements BisqProcess {
@@ -36,7 +35,7 @@ public class MultiProcessCoordinator implements BisqProcess {
         daemonProcesses.forEach(bisqProcess -> {
             try {
                 bisqProcess.start();
-            } catch (InterruptedException | IOException e) {
+            } catch (InterruptedException e) {
                 throw new WalletStartupFailedException("Cannot start process.", e);
             }
         });


### PR DESCRIPTION
We wait until the Electrum daemon is ready to accept RPC calls by waiting until the Electrum process outputs a ready signal in its process output. However, this only happens on Mac and Windows. This change parses the log file for the "ready" signal.