### PR TITLE
Gradle: Fix compiler mismatch bug (bug in Gradle)

### DIFF
--- a/build-logic/bisq-plugin/build.gradle
+++ b/build-logic/bisq-plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.5.31'
-    id 'org.gradle.kotlin.kotlin-dsl' version '2.1.7'
+    id 'org.gradle.kotlin.kotlin-dsl' version '2.3.3'
 }
 
 repositories {

--- a/build-logic/desktop-regtest/build.gradle
+++ b/build-logic/desktop-regtest/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.5.31'
-    id 'org.gradle.kotlin.kotlin-dsl' version '2.1.7'
+    id 'org.gradle.kotlin.kotlin-dsl' version '2.3.3'
 }
 
 repositories {

--- a/build-logic/electrum-binaries/build.gradle
+++ b/build-logic/electrum-binaries/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.5.31'
-    id 'org.gradle.kotlin.kotlin-dsl' version '2.1.7'
+    id 'org.gradle.kotlin.kotlin-dsl' version '2.3.3'
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a9a7b7baba105f6557c9dcf9c3c6e8f7e57e6b49889c5f1d133f015d0727e4be
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
+distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Currently, it's impossible to target any Java version other than 1.8
because it is hardcoded into Gradle. This bug has been fixed. The
compiler warning "'compileJava' task (current target is 17) and
'compileKotlin' task (current target is 1.8) jvm target compatibility
should be set to the same Java version." will disappear now.

Changes:
- Update to Gradle 7.5.1
- Update the kotlin-dsl plugin