### PR TITLE
Bitcoind: Add descriptor field to responses

### DIFF
--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindGetAddressInfoResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindGetAddressInfoResponse.java
@@ -17,6 +17,7 @@
 
 package bisq.wallets.bitcoind.rpc.responses;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -28,7 +29,11 @@ public class BitcoindGetAddressInfoResponse {
     private boolean ismine;
     private boolean iswatchonly;
     private boolean solvable;
+
     private String desc;
+    @JsonProperty("parent_desc")
+    private String parentDesc;
+
     private boolean isscript;
     private boolean ischange;
     private boolean iswitness;

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindScriptPubKey.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindScriptPubKey.java
@@ -24,6 +24,7 @@ import lombok.Setter;
 @Setter
 public class BitcoindScriptPubKey {
     private String asm;
+    private String desc;
     private String hex;
     private int reqSigs;
     private String type;


### PR DESCRIPTION
Bitcoin Core 23 enforces descriptors in all RPC calls.