### PR TITLE
Bitcoind: Support watch-only wallets for multisig

### DIFF
--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
@@ -39,8 +39,16 @@ public class BitcoindDaemon {
     }
 
     public void createOrLoadWallet(Path walletPath, Optional<String> passphrase) {
+        createOrLoadWallet(walletPath, passphrase, false, false);
+    }
+
+    public void createOrLoadWatchOnlyWallet(Path walletPath) {
+        createOrLoadWallet(walletPath, Optional.empty(), true, true);
+    }
+
+    private void createOrLoadWallet(Path walletPath, Optional<String> passphrase, boolean disablePrivateKeys, boolean blank) {
         if (!doesWalletExist(walletPath)) {
-            createWallet(walletPath, passphrase.orElse(""));
+            createWallet(walletPath, passphrase.orElse(""), disablePrivateKeys, blank);
         } else {
             List<String> loadedWallets = listWallets();
             if (!loadedWallets.contains(walletPath.toString())) {
@@ -131,9 +139,11 @@ public class BitcoindDaemon {
         return walletPath.toFile().exists();
     }
 
-    private void createWallet(Path walletPath, String passphrase) {
+    private void createWallet(Path walletPath, String passphrase, boolean disablePrivateKeys, boolean blank) {
         var request = BitcoindCreateWalletRpcCall.Request.builder()
                 .walletName(walletPath.toAbsolutePath().toString())
+                .disablePrivateKeys(disablePrivateKeys)
+                .blank(blank)
                 .passphrase(passphrase)
                 .build();
 

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindCreateWalletRpcCall.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindCreateWalletRpcCall.java
@@ -31,7 +31,14 @@ public class BitcoindCreateWalletRpcCall
     public static class Request {
         @JsonProperty("wallet_name")
         private String walletName;
+
+        @JsonProperty("disable_private_keys")
+        private Boolean disablePrivateKeys;
+        private Boolean blank;
+
         private String passphrase;
+        @JsonProperty("avoid_reuse")
+        private Boolean avoidReuse;
         private final boolean descriptors = true;
     }
 
@@ -46,7 +53,7 @@ public class BitcoindCreateWalletRpcCall
 
     @Override
     public boolean isResponseValid(BitcoindCreateOrLoadWalletResponse response) {
-        return response.getName().equals(request.walletName) && !response.hasWarning();
+        return response.getName().equals(request.walletName);
     }
 
     @Override


### PR DESCRIPTION
In Bitcoin Core 23+ we need to create separate watch-only wallets to perform multisig operations.