### PR TITLE
Bitcoind: Only lock wallet if it's encrypted

### DIFF
--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindWallet.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindWallet.java
@@ -162,7 +162,9 @@ public class BitcoindWallet {
         var rpcCall = new BitcoindSendToAddressRpcCall(request);
         String txId = rpcClient.invokeAndValidate(rpcCall);
 
-        walletLock();
+        if (passphrase.isPresent()) {
+            walletLock();
+        }
         return txId;
     }
 
@@ -176,7 +178,9 @@ public class BitcoindWallet {
         var rpcCall = new BitcoindSignMessageRpcCall(request);
         String signature = rpcClient.invokeAndValidate(rpcCall);
 
-        walletLock();
+        if (walletPasshrase.isPresent()) {
+            walletLock();
+        }
         return signature;
     }
 


### PR DESCRIPTION
The walletlock RPC call fails if the wallet is not encrypted.