### PR TITLE
Let Bitcoin Core manage its wallet files

### DIFF
--- a/application/src/main/java/bisq/application/DefaultApplicationService.java
+++ b/application/src/main/java/bisq/application/DefaultApplicationService.java
@@ -82,8 +82,8 @@ public class DefaultApplicationService extends ApplicationService {
     public DefaultApplicationService(String[] args) {
         super("default", args);
 
-        bitcoinWalletService = new BitcoinWalletService(persistenceService, config.getBaseDir(), config.isBitcoindRegtest());
-        liquidWalletService = new LiquidWalletService(persistenceService, config.getBaseDir(), config.isElementsdRegtest());
+        bitcoinWalletService = new BitcoinWalletService(persistenceService, config.isBitcoindRegtest());
+        liquidWalletService = new LiquidWalletService(persistenceService, config.isElementsdRegtest());
 
         securityService = new SecurityService(persistenceService);
 

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/BitcoinWallet.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/BitcoinWallet.java
@@ -31,7 +31,6 @@ import bisq.wallets.core.model.Utxo;
 import lombok.Getter;
 
 import java.net.MalformedURLException;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,7 +44,7 @@ public class BitcoinWallet implements Wallet, ZmqWallet {
     @Getter
     private final ZmqConnection zmqConnection;
 
-    public BitcoinWallet(Path walletPath,
+    public BitcoinWallet(String walletName,
                          RpcConfig rpcConfig,
                          BitcoindDaemon daemon,
                          ObservableSet<String> receiveAddresses,
@@ -54,7 +53,7 @@ public class BitcoinWallet implements Wallet, ZmqWallet {
         this.zmqConnection = zmqConnection;
 
         try {
-            wallet = new BitcoindWallet(daemon, rpcConfig, walletPath);
+            wallet = new BitcoindWallet(daemon, rpcConfig, walletName);
         } catch (MalformedURLException e) {
             throw new WalletInitializationFailedException("Couldn't initialize BitcoinWalletService", e);
         }

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/BitcoinWalletService.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/BitcoinWalletService.java
@@ -23,8 +23,6 @@ import bisq.wallets.core.RpcConfig;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.Optional;
 
 @Slf4j
@@ -36,15 +34,14 @@ public class BitcoinWalletService extends AbstractBitcoindWalletService<BitcoinW
     private final Persistence<BitcoinWalletStore> persistence;
 
     public BitcoinWalletService(PersistenceService persistenceService,
-                                String baseDir,
                                 boolean isRegtest) {
-        super("BTC", getOptionalRegtestConfig(isRegtest, 18443), Path.of(baseDir + File.separator + "wallets"));
+        super("BTC", getOptionalRegtestConfig(isRegtest, 18443), "bisq_bitcoind_default_wallet");
         persistence = persistenceService.getOrCreatePersistence(this, persistableStore);
     }
 
     @Override
     protected BitcoinWallet createWallet(RpcConfig rpcConfig) {
-        return WalletFactory.createBitcoinWallet(rpcConfig, walletsDataDir, persistableStore);
+        return WalletFactory.createBitcoinWallet(rpcConfig, walletName, persistableStore);
     }
 
 

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/WalletFactory.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/WalletFactory.java
@@ -31,13 +31,11 @@ import java.util.List;
 public class WalletFactory {
 
     public static BitcoinWallet createBitcoinWallet(RpcConfig rpcConfig,
-                                                    Path walletsDataDir,
+                                                    String walletName,
                                                     BitcoinWalletStore bitcoinWalletStore) {
-        Path bitcoindDataDir = walletsDataDir.resolve("bitcoind"); // directory name for bitcoind wallet
-
         BitcoindDaemon daemon = createBitcoindDaemon(rpcConfig);
         ZmqConnection zmqConnection = initializeBitcoindZeroMq(daemon);
-        return new BitcoinWallet(bitcoindDataDir, rpcConfig, daemon, bitcoinWalletStore.getReceiveAddresses(), zmqConnection);
+        return new BitcoinWallet(walletName, rpcConfig, daemon, bitcoinWalletStore.getReceiveAddresses(), zmqConnection);
     }
 
     private static BitcoindDaemon createBitcoindDaemon(RpcConfig rpcConfig) {

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindWallet.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindWallet.java
@@ -28,7 +28,6 @@ import bisq.wallets.core.rpc.RpcClientFactory;
 import bisq.wallets.core.rpc.WalletRpcClient;
 
 import java.net.MalformedURLException;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,19 +40,19 @@ public class BitcoindWallet {
     private final BitcoindDaemon daemon;
     private final WalletRpcClient rpcClient;
 
-    public BitcoindWallet(BitcoindDaemon daemon, RpcConfig rpcConfig, Path walletPath) throws MalformedURLException {
+    public BitcoindWallet(BitcoindDaemon daemon, RpcConfig rpcConfig, String walletName) throws MalformedURLException {
         this.daemon = daemon;
-        this.rpcClient = RpcClientFactory.createWalletRpcClient(rpcConfig, walletPath);
+        this.rpcClient = RpcClientFactory.createWalletRpcClient(rpcConfig, walletName);
     }
 
     public void initialize(Optional<String> passphrase) {
-        Path walletPath = rpcClient.getWalletPath();
-        daemon.createOrLoadWallet(walletPath, passphrase);
+        String walletName = rpcClient.getWalletName();
+        daemon.createOrLoadWallet(walletName, passphrase);
     }
 
     public void shutdown() {
-        Path walletPath = rpcClient.getWalletPath();
-        daemon.unloadWallet(walletPath);
+        String walletName = rpcClient.getWalletName();
+        daemon.unloadWallet(walletName);
     }
 
     public BitcoindAddOrCreateMultiSigAddressResponse createMultiSig(int nRequired, List<String> keys) {

--- a/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameDocumentationIntegrationTests.java
+++ b/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameDocumentationIntegrationTests.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.bitcoind;
+
+import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
+import bisq.wallets.bitcoind.rpc.calls.BitcoindCreateWalletRpcCall;
+import bisq.wallets.core.RpcConfig;
+import bisq.wallets.core.rpc.DaemonRpcClient;
+import bisq.wallets.core.rpc.RpcClientFactory;
+import bisq.wallets.regtest.AbstractRegtestSetup;
+import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(BitcoindExtension.class)
+public class BitcoindCreateWalletNameDocumentationIntegrationTests {
+    private final Path dataDir;
+    private final DaemonRpcClient rpcClient;
+    private final BitcoindDaemon daemon;
+
+    public BitcoindCreateWalletNameDocumentationIntegrationTests(BitcoindRegtestSetup regtestSetup) {
+        this.dataDir = regtestSetup.getDataDir();
+        this.daemon = regtestSetup.getDaemon();
+        RpcConfig rpcConfig = regtestSetup.getRpcConfig();
+        this.rpcClient = RpcClientFactory.createDaemonRpcClient(rpcConfig);
+    }
+
+    @Test
+    @EnabledOnOs({OS.MAC, OS.LINUX})
+    void createWalletWithAbsolutePath(@TempDir Path walletPath) {
+        String walletName = walletPath.toAbsolutePath().toString();
+        var request = BitcoindCreateWalletRpcCall.Request.builder()
+                .walletName(walletName)
+                .passphrase(AbstractRegtestSetup.WALLET_PASSPHRASE)
+                .build();
+
+        var rpcCall = new BitcoindCreateWalletRpcCall(request);
+        rpcClient.invokeAndValidate(rpcCall);
+
+        File walletFile = walletPath.resolve("wallet.dat")
+                .toFile();
+        assertThat(walletFile).exists();
+
+        daemon.unloadWallet(walletName);
+    }
+
+    @Test
+    @EnabledOnOs({OS.MAC, OS.LINUX})
+    void createWalletWithRelativePath() throws IOException {
+        File bitcoindWalletsDir = dataDir.resolve("regtest")
+                .resolve("wallets")
+                .toFile();
+        Path newWalletDir = Files.createTempDirectory(bitcoindWalletsDir.toPath(), "bisq_");
+
+        String walletName = newWalletDir.getFileName() + "/b";
+        var request = BitcoindCreateWalletRpcCall.Request.builder()
+                .walletName(walletName)
+                .passphrase(AbstractRegtestSetup.WALLET_PASSPHRASE)
+                .build();
+
+        var rpcCall = new BitcoindCreateWalletRpcCall(request);
+        rpcClient.invokeAndValidate(rpcCall);
+
+        File expectedWalletFile = newWalletDir.resolve("b")
+                .resolve("wallet.dat")
+                .toFile();
+        assertThat(expectedWalletFile).exists();
+
+        daemon.unloadWallet(walletName);
+    }
+}

--- a/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameIntegrationTests.java
+++ b/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameIntegrationTests.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.bitcoind;
+
+import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
+import bisq.wallets.regtest.AbstractRegtestSetup;
+import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(BitcoindExtension.class)
+public class BitcoindCreateWalletNameIntegrationTests {
+    private final BitcoindDaemon daemon;
+
+    public BitcoindCreateWalletNameIntegrationTests(BitcoindRegtestSetup regtestSetup) {
+        this.daemon = regtestSetup.getDaemon();
+    }
+
+    @Test
+    void createWallet() {
+        String walletName = "My_awesome_wallet_creation";
+        daemon.createOrLoadWallet(walletName, Optional.of(AbstractRegtestSetup.WALLET_PASSPHRASE));
+
+        List<String> loadedWallets = daemon.listWallets();
+        assertThat(loadedWallets).contains(walletName);
+
+        daemon.unloadWallet(walletName);
+    }
+
+    @Test
+    void loadWallet() {
+        String walletName = "My_awesome_wallet_loading";
+        daemon.createOrLoadWallet(walletName, Optional.of(AbstractRegtestSetup.WALLET_PASSPHRASE));
+        daemon.unloadWallet(walletName);
+
+        daemon.createOrLoadWallet(walletName, Optional.of(AbstractRegtestSetup.WALLET_PASSPHRASE));
+
+        List<String> loadedWallets = daemon.listWallets();
+        assertThat(loadedWallets).contains(walletName);
+
+        daemon.unloadWallet(walletName);
+    }
+}

--- a/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
+++ b/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
@@ -17,7 +17,6 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.common.util.FileUtils;
 import bisq.wallets.bitcoind.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
@@ -30,9 +29,7 @@ import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -47,9 +44,8 @@ public class BitcoindPsbtMultiSigIntegrationTests {
     private final RpcConfig rpcConfig;
     private final BitcoindDaemon daemon;
     private final BitcoindWallet minerWallet;
-    private final Path watchOnlyWalletDataDir = FileUtils.createTempDir();
 
-    public BitcoindPsbtMultiSigIntegrationTests(BitcoindRegtestSetup regtestSetup) throws IOException {
+    public BitcoindPsbtMultiSigIntegrationTests(BitcoindRegtestSetup regtestSetup) {
         this.regtestSetup = regtestSetup;
         this.rpcConfig = regtestSetup.getRpcConfig();
         this.daemon = regtestSetup.getDaemon();
@@ -68,9 +64,9 @@ public class BitcoindPsbtMultiSigIntegrationTests {
         String bobXPub = getWalletXPub(bobWallet);
         String charlieXPub = getWalletXPub(charlieWallet);
 
-        BitcoindWallet aliceWatchOnlyWallet = createWatchOnlyDescriptorWallet(watchOnlyWalletDataDir, "alice");
-        BitcoindWallet bobWatchOnlyWallet = createWatchOnlyDescriptorWallet(watchOnlyWalletDataDir, "bob");
-        BitcoindWallet charlieWatchOnlyWallet = createWatchOnlyDescriptorWallet(watchOnlyWalletDataDir, "charlie");
+        BitcoindWallet aliceWatchOnlyWallet = createWatchOnlyDescriptorWallet("alice");
+        BitcoindWallet bobWatchOnlyWallet = createWatchOnlyDescriptorWallet("bob");
+        BitcoindWallet charlieWatchOnlyWallet = createWatchOnlyDescriptorWallet("charlie");
 
         String receiveDescriptor = "wsh(sortedmulti(2," +
                 aliceXPub + "/0/*," +
@@ -161,10 +157,10 @@ public class BitcoindPsbtMultiSigIntegrationTests {
         return xPub.split("]")[1].split("/")[0];
     }
 
-    private BitcoindWallet createWatchOnlyDescriptorWallet(Path tmpDir, String walletName) throws MalformedURLException {
-        Path walletPath = tmpDir.resolve(walletName + "_watch_only_descriptor_wallet");
-        daemon.createOrLoadWatchOnlyWallet(walletPath);
-        return new BitcoindWallet(daemon, rpcConfig, walletPath);
+    private BitcoindWallet createWatchOnlyDescriptorWallet(String walletPrefix) throws MalformedURLException {
+        String walletName = walletPrefix + "_watch_only_descriptor_wallet";
+        daemon.createOrLoadWatchOnlyWallet(walletName);
+        return new BitcoindWallet(daemon, rpcConfig, walletName);
     }
 
     private String appendChecksumToDescriptor(String descriptor) {

--- a/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindWalletCreationAndListIntegrationTests.java
+++ b/wallets/bitcoind/src/test/java/bisq/wallets/bitcoind/BitcoindWalletCreationAndListIntegrationTests.java
@@ -17,7 +17,6 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.common.util.FileUtils;
 import bisq.wallets.bitcoind.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
@@ -25,7 +24,6 @@ import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -36,10 +34,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(BitcoindExtension.class)
 public class BitcoindWalletCreationAndListIntegrationTests {
 
+    private final Path dataDir;
     private final BitcoindDaemon daemon;
     private final BitcoindWallet minerWallet;
 
     public BitcoindWalletCreationAndListIntegrationTests(BitcoindRegtestSetup regtestSetup) {
+        this.dataDir = regtestSetup.getDataDir();
         this.daemon = regtestSetup.getDaemon();
         this.minerWallet = regtestSetup.getMinerWallet();
     }
@@ -50,24 +50,28 @@ public class BitcoindWalletCreationAndListIntegrationTests {
     }
 
     @Test
-    public void loadWalletIfExisting() throws IOException {
-        Path tmpDir = FileUtils.createTempDir();
-        Path walletFilePath = tmpDir.resolve("wallet");
+    public void loadWalletIfExisting() {
+        String walletName = "wallet";
+
+        Path walletFilePath = dataDir.resolve("regtest")
+                .resolve("wallets")
+                .resolve(walletName)
+                .resolve("wallet.dat");
         assertThat(walletFilePath).doesNotExist();
 
         // Create Wallet
-        daemon.createOrLoadWallet(walletFilePath, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
+        daemon.createOrLoadWallet(walletName, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
         assertThat(walletFilePath).exists();
 
         // Unload and reload existing wallet
-        daemon.unloadWallet(walletFilePath);
-        daemon.createOrLoadWallet(walletFilePath, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
+        daemon.unloadWallet(walletName);
+        daemon.createOrLoadWallet(walletName, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
 
         assertThat(minerWallet.getBalance())
                 .isZero();
 
         // Cleanup, otherwise other tests don't start on a clean state.
-        daemon.unloadWallet(walletFilePath);
+        daemon.unloadWallet(walletName);
     }
 
     @Test

--- a/wallets/core/src/main/java/bisq/wallets/core/rpc/RpcClientFactory.java
+++ b/wallets/core/src/main/java/bisq/wallets/core/rpc/RpcClientFactory.java
@@ -24,7 +24,6 @@ import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -41,9 +40,9 @@ public class RpcClientFactory {
         }
     }
 
-    public static WalletRpcClient createWalletRpcClient(RpcConfig rpcConfig, Path walletPath) {
+    public static WalletRpcClient createWalletRpcClient(RpcConfig rpcConfig, String walletName) {
         try {
-            var urlSuffix = "/wallet/" + walletPath.toAbsolutePath();
+            var urlSuffix = "/wallet/" + walletName;
             return new WalletRpcClient(
                     createJsonRpcClientWithUrlSuffix(rpcConfig, Optional.of(urlSuffix))
             );

--- a/wallets/core/src/main/java/bisq/wallets/core/rpc/WalletRpcClient.java
+++ b/wallets/core/src/main/java/bisq/wallets/core/rpc/WalletRpcClient.java
@@ -22,7 +22,7 @@ import bisq.wallets.core.rpc.call.RpcCall;
 import bisq.wallets.core.rpc.call.WalletRpcCall;
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 
-import java.nio.file.Path;
+import java.util.Arrays;
 
 public class WalletRpcClient extends AbstractRpcClient {
 
@@ -50,12 +50,11 @@ public class WalletRpcClient extends AbstractRpcClient {
         }
     }
 
-    public Path getWalletPath() {
-        // URL looks like: http://127.0.0.1:45775/wallet//tmp/2035361932108224852/miner_wallet
-        String filePart = walletJsonRpcClient.getServiceUrl().getFile();
-        int startIndex = "/wallet/".length();
-        String walletPath = filePart.substring(startIndex);
-        return Path.of(walletPath);
+    public String getWalletName() {
+        // URL looks like: http://127.0.0.1:45775/wallet/miner_wallet
+        // fileUrl: "wallet/miner_wallet"
+        String fileUrl = walletJsonRpcClient.getServiceUrl().getFile();
+        String[] urlParts = fileUrl.split("/");
+        return urlParts[urlParts.length - 1];
     }
-
 }

--- a/wallets/electrum/src/test/java/bisq/wallets/electrum/regtest/electrum/WindowsElectrumRegtestSetup.java
+++ b/wallets/electrum/src/test/java/bisq/wallets/electrum/regtest/electrum/WindowsElectrumRegtestSetup.java
@@ -47,7 +47,7 @@ public class WindowsElectrumRegtestSetup extends ElectrumRegtestSetup {
     public WindowsElectrumRegtestSetup(boolean doCreateWallet) throws IOException {
         RpcConfig bitcoindRpcConfig = createBitcoindRpcConfigFromEnvironmentVars();
         Path tmpDirPath = FileUtils.createTempDir();
-        this.remoteBitcoind = new RemoteBitcoind(tmpDirPath, bitcoindRpcConfig, true);
+        this.remoteBitcoind = new RemoteBitcoind(bitcoindRpcConfig, true);
 
         RpcConfig electrumXRpcConfig = createElectrumXRpcConfigFromEnvironmentVars();
         this.electrumRegtest = new ElectrumRegtest(

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWallet.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWallet.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class LiquidWallet implements Wallet, ZmqWallet {
-    private final Path walletPath;
+    private final String walletName;
 
     private final ElementsdDaemon daemon;
     private final ElementsdWallet wallet;
@@ -44,12 +44,12 @@ public class LiquidWallet implements Wallet, ZmqWallet {
     @Getter
     private final ZmqConnection zmqConnection;
 
-    public LiquidWallet(Path walletPath,
+    public LiquidWallet(String walletName,
                         ElementsdDaemon daemon,
                         ElementsdWallet wallet,
                         LiquidWalletStore liquidWalletStore,
                         ZmqConnection zmqConnection) {
-        this.walletPath = walletPath;
+        this.walletName = walletName;
         this.daemon = daemon;
         this.wallet = wallet;
         this.liquidWalletStore = liquidWalletStore;
@@ -58,12 +58,12 @@ public class LiquidWallet implements Wallet, ZmqWallet {
 
     @Override
     public void initialize(Optional<String> walletPassphrase) {
-        daemon.createOrLoadWallet(walletPath, walletPassphrase);
+        daemon.createOrLoadWallet(walletName, walletPassphrase);
     }
 
     @Override
     public void shutdown() {
-        daemon.unloadWallet(walletPath);
+        daemon.unloadWallet(walletName);
     }
 
     @Override

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWalletService.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWalletService.java
@@ -24,8 +24,6 @@ import bisq.wallets.core.RpcConfig;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.Optional;
 
 @Slf4j
@@ -37,15 +35,14 @@ public class LiquidWalletService extends AbstractBitcoindWalletService<LiquidWal
     private final Persistence<LiquidWalletStore> persistence;
 
     public LiquidWalletService(PersistenceService persistenceService,
-                               String baseDir,
                                boolean isRegtest) {
-        super("L-BTC", getOptionalRegtestConfig(isRegtest, 7040), Path.of(baseDir + File.separator + "wallets"));
+        super("L-BTC", getOptionalRegtestConfig(isRegtest, 7040), "bisq_elements_default_wallet");
         persistence = persistenceService.getOrCreatePersistence(this, persistableStore);
     }
 
     @Override
     protected LiquidWallet createWallet(RpcConfig rpcConfig) {
-        return WalletFactory.createLiquidWallet(rpcConfig, walletsDataDir, persistableStore);
+        return WalletFactory.createLiquidWallet(rpcConfig, walletName, persistableStore);
     }
 
     @Override

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/WalletFactory.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/WalletFactory.java
@@ -26,21 +26,17 @@ import bisq.wallets.core.rpc.WalletRpcClient;
 import bisq.wallets.elementsd.rpc.ElementsdDaemon;
 import bisq.wallets.elementsd.rpc.ElementsdWallet;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public class WalletFactory {
 
     public static LiquidWallet createLiquidWallet(RpcConfig rpcConfig,
-                                                  Path walletsDataDir,
+                                                  String walletName,
                                                   LiquidWalletStore liquidWalletStore) {
-        Path walletDir = walletsDataDir.resolve("elementsd"); // directory name for bitcoind wallet
-
         ElementsdDaemon elementsdDaemon = createElementsdDaemon(rpcConfig);
-        ElementsdWallet elementsdWallet = createElementsdWallet(rpcConfig, walletDir);
+        ElementsdWallet elementsdWallet = createElementsdWallet(rpcConfig, walletName);
         ZmqConnection zmqConnection = initializeElementsdZeroMq(elementsdDaemon, elementsdWallet);
-
-        return new LiquidWallet(walletDir, elementsdDaemon, elementsdWallet, liquidWalletStore, zmqConnection);
+        return new LiquidWallet(walletName, elementsdDaemon, elementsdWallet, liquidWalletStore, zmqConnection);
     }
 
     private static ElementsdDaemon createElementsdDaemon(RpcConfig rpcConfig) {
@@ -48,8 +44,8 @@ public class WalletFactory {
         return new ElementsdDaemon(rpcClient);
     }
 
-    private static ElementsdWallet createElementsdWallet(RpcConfig rpcConfig, Path walletPath) {
-        WalletRpcClient rpcClient = RpcClientFactory.createWalletRpcClient(rpcConfig, walletPath);
+    private static ElementsdWallet createElementsdWallet(RpcConfig rpcConfig, String walletName) {
+        WalletRpcClient rpcClient = RpcClientFactory.createWalletRpcClient(rpcConfig, walletName);
         return new ElementsdWallet(rpcClient);
     }
 

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/ElementsdDaemon.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/ElementsdDaemon.java
@@ -38,8 +38,8 @@ public class ElementsdDaemon {
         bitcoindDaemon = new BitcoindDaemon(rpcClient);
     }
 
-    public void createOrLoadWallet(Path walletPath, Optional<String> passphrase) {
-        bitcoindDaemon.createOrLoadWallet(walletPath, passphrase);
+    public void createOrLoadWallet(String walletName, Optional<String> passphrase) {
+        bitcoindDaemon.createOrLoadWallet(walletName, passphrase);
     }
 
     public ElementsdDecodeRawTransactionResponse decodeRawTransaction(String txInHex) {
@@ -77,7 +77,7 @@ public class ElementsdDaemon {
         rpcClient.invokeAndValidate(rpcCall);
     }
 
-    public void unloadWallet(Path walletPath) {
-        bitcoindDaemon.unloadWallet(walletPath);
+    public void unloadWallet(String walletName) {
+        bitcoindDaemon.unloadWallet(walletName);
     }
 }

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdWalletCreationAndListIntegrationTests.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/ElementsdWalletCreationAndListIntegrationTests.java
@@ -17,13 +17,9 @@
 
 package bisq.wallets.elementsd;
 
-import bisq.common.util.FileUtils;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,13 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ElementsdWalletCreationAndListIntegrationTests extends SharedElementsdInstanceTests {
-    private Path walletFilePath;
-
-    @BeforeEach
-    void setUp() throws IOException {
-        Path tmpDir = FileUtils.createTempDir();
-        walletFilePath = tmpDir.resolve("wallet");
-    }
 
     @Test
     public void createFreshWallet() {
@@ -47,21 +36,20 @@ public class ElementsdWalletCreationAndListIntegrationTests extends SharedElemen
 
     @Test
     public void loadWalletIfExisting() {
-        assertThat(walletFilePath).doesNotExist();
+        String walletName = "My_new_shiny_wallet";
 
         // Create Wallet
-        elementsdDaemon.createOrLoadWallet(walletFilePath, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
-        assertThat(walletFilePath).exists();
+        elementsdDaemon.createOrLoadWallet(walletName, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
 
         // Unload and reload existing wallet
-        elementsdDaemon.unloadWallet(walletFilePath);
-        elementsdDaemon.createOrLoadWallet(walletFilePath, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
+        elementsdDaemon.unloadWallet(walletName);
+        elementsdDaemon.createOrLoadWallet(walletName, Optional.of(BitcoindRegtestSetup.WALLET_PASSPHRASE));
 
         assertThat(elementsdMinerWallet.getLBtcBalance())
                 .isZero();
 
         // Cleanup, otherwise other tests don't start on a clean state.
-        elementsdDaemon.unloadWallet(walletFilePath);
+        elementsdDaemon.unloadWallet(walletName);
     }
 
     @Test

--- a/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestSetup.java
+++ b/wallets/elementsd/src/test/java/bisq/wallets/elementsd/regtest/ElementsdRegtestSetup.java
@@ -54,7 +54,7 @@ public class ElementsdRegtestSetup extends AbstractRegtestSetup<MultiProcessCoor
 
     @Getter
     private final ElementsdDaemon daemon;
-    private final Set<Path> loadedWalletPaths;
+    private final Set<String> loadedWalletPaths;
 
     @Getter
     private ZmqListeners zmqMinerListeners;
@@ -125,20 +125,15 @@ public class ElementsdRegtestSetup extends AbstractRegtestSetup<MultiProcessCoor
     }
 
     public ElementsdWallet createNewWallet(String walletName) {
-        Path receiverWalletPath = tmpDirPath.resolve(walletName);
-        return createNewWallet(receiverWalletPath);
-    }
-
-    public ElementsdWallet createNewWallet(Path walletPath) {
-        if (loadedWalletPaths.contains(walletPath)) {
-            throw new IllegalStateException("Cannot create wallet '" + walletPath.toAbsolutePath() +
+        if (loadedWalletPaths.contains(walletName)) {
+            throw new IllegalStateException("Cannot create wallet '" + walletName +
                     "'. It exists already.");
         }
 
-        daemon.createOrLoadWallet(walletPath, Optional.of(WALLET_PASSPHRASE));
-        loadedWalletPaths.add(walletPath);
+        daemon.createOrLoadWallet(walletName, Optional.of(WALLET_PASSPHRASE));
+        loadedWalletPaths.add(walletName);
 
-        return newWallet(walletPath);
+        return newWallet(walletName);
     }
 
     public Optional<ElementsdListUnspentResponseEntry> filterUtxosByTxId(
@@ -172,9 +167,9 @@ public class ElementsdRegtestSetup extends AbstractRegtestSetup<MultiProcessCoor
         return new ElementsdDaemon(rpcClient);
     }
 
-    private ElementsdWallet newWallet(Path walletPath) {
+    private ElementsdWallet newWallet(String walletName) {
         RpcConfig walletRpcConfig = elementsdConfig.elementsdRpcConfig();
-        WalletRpcClient rpcClient = RpcClientFactory.createWalletRpcClient(walletRpcConfig, walletPath);
+        WalletRpcClient rpcClient = RpcClientFactory.createWalletRpcClient(walletRpcConfig, walletName);
         return new ElementsdWallet(rpcClient);
     }
 

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
@@ -52,7 +52,7 @@ public class BitcoindRegtestSetup
         super();
         rpcConfig = createRpcConfig();
         bitcoindProcess = createBitcoindProcess();
-        remoteBitcoind = new RemoteBitcoind(tmpDirPath, rpcConfig, doMineInitialRegtestBlocks);
+        remoteBitcoind = new RemoteBitcoind(rpcConfig, doMineInitialRegtestBlocks);
     }
 
     @Override
@@ -121,6 +121,10 @@ public class BitcoindRegtestSetup
                 rpcConfig,
                 bitcoindDataDir
         );
+    }
+
+    public Path getDataDir() {
+        return bitcoindProcess.getDataDir();
     }
 
     public BitcoindDaemon getDaemon() {


### PR DESCRIPTION
Currently, we store the Bitcoin Core wallet files in Bisq's data directory. The disadvantage of this approach is that we cannot run Bitcoin Core on another machine. This change lets Bitcoin Core fully manage all its wallet files.