### PR TITLE
Windows: Switch to regular Electrum executable

### DIFF
--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/tasks/DownloadElectrumBinariesTask.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/tasks/DownloadElectrumBinariesTask.kt
@@ -22,7 +22,7 @@ abstract class DownloadElectrumBinariesTask : DefaultTask() {
         fun getBinaryNames(electrumVersion: String): Set<String> {
             return setOf(
                 "electrum-$electrumVersion.dmg",
-                "electrum-$electrumVersion-portable.exe",
+                "electrum-$electrumVersion.exe",
                 "electrum-$electrumVersion-x86_64.AppImage"
             )
         }

--- a/wallets/electrum/build.gradle
+++ b/wallets/electrum/build.gradle
@@ -9,7 +9,7 @@ electrum {
 
     appImageHash = '1256a0ca453f28553195deb6f12015b41ee6a043602ac2cca2c4358b1015ea00'
     dmgHash = 'f13fabfa4c227c2a8fbba7ea82eb7ef8c726c52b6f3468cd5e3ef89fdf11902d'
-    exeHash = '9a37a90bf6456d4d37e9db79c7af316cec4cc5a9a28009013fad67d258618013'
+    exeHash = '4b65f322822c405442e5653b31ba7c73c2cf5a273f92af64dc85e9c28e806b38'
 }
 
 sourceSets {

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumProcess.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumProcess.java
@@ -109,7 +109,7 @@ public class ElectrumProcess implements BisqProcess {
             Path path = binaryPath.get();
             String fileName = path.getFileName().toString();
 
-            // File name: electrum-4.2.2.dmg / electrum-4.2.2-portable.exe / electrum-4.2.2-x86_64.AppImage
+            // File name: electrum-4.2.2.dmg / electrum-4.2.2.exe / electrum-4.2.2-x86_64.AppImage
             String secondPart = fileName.split("-")[1];
             secondPart = secondPart.replace(".dmg", "");
             electrumVersion = Optional.of(secondPart);


### PR DESCRIPTION
Switch from portable Windows executable to regular executable.