### PR TITLE
Electrum: Fix ElectrumX (server) hostname

### DIFF
--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumRegtestProcess.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumRegtestProcess.java
@@ -79,7 +79,7 @@ public class ElectrumRegtestProcess extends DaemonProcess {
                         "daemon",
 
                         "-s",
-                        electrumProcessConfig.getElectrumConfig().getRpcHost() + ":" +
+                        electrumProcessConfig.getElectrumXServerHost() + ":" +
                                 electrumProcessConfig.getElectrumXServerPort() + ":t",
 
                         ElectrumCli.ELECTRUM_DATA_DIR_ARG,


### PR DESCRIPTION
Electrum assumed that ElectrumX (server) is running on the same host. This assumption is not true on Windows because ElectrumX is not officially supported on Windows. Most devs run the ElectrumX server in a Linux container or VM and connect to it from Windows.