### PR TITLE
Electrum: Remove Jackson Databind dependency

### DIFF
--- a/wallets/electrum/build.gradle
+++ b/wallets/electrum/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation project(':json-rpc')
     implementation project(':process')
 
-    implementation libs.jackson.databind
     implementation libs.bundles.glassfish.jersey
 
     testImplementation project(':bitcoind')


### PR DESCRIPTION
This dependecy was needed for the old JSON-RPC library.