### PR TITLE
Fix: Electrum Windows Executable Hash

### DIFF
--- a/wallets/electrum/build.gradle
+++ b/wallets/electrum/build.gradle
@@ -9,7 +9,7 @@ electrum {
 
     appImageHash = '1256a0ca453f28553195deb6f12015b41ee6a043602ac2cca2c4358b1015ea00'
     dmgHash = 'f13fabfa4c227c2a8fbba7ea82eb7ef8c726c52b6f3468cd5e3ef89fdf11902d'
-    exeHash = '4b65f322822c405442e5653b31ba7c73c2cf5a273f92af64dc85e9c28e806b38'
+    exeHash = '60d504998a4538f1d47a1947923bf9e6ac2744687ce6ea2b3ccbe39bf8e65f63'
 }
 
 sourceSets {


### PR DESCRIPTION
When we switched to the regular Electrum executable (instead of the portable) I forgot to update the hash.