### PR TITLE
Fix sending stop signal twice to Electrum daemon

### DIFF
--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumWallet.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumWallet.java
@@ -56,7 +56,7 @@ public class ElectrumWallet implements Wallet {
 
     @Override
     public void shutdown() {
-        daemon.stop();
+        // Electrum does not provide an unload wallet rpc call.
     }
 
     @Override


### PR DESCRIPTION
The ElectrumProcess and ElectrumWallet both called the stop RPC call in their shutdown methods. The ElectrumProcess should be the one who is responsible for shutting down the daemon. Sadly, Electrum does not provide a unload wallet RPC method.