### PR TITLE
ElementsDaemon: Create/Use legacy wallet

### DIFF
--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
@@ -39,16 +39,20 @@ public class BitcoindDaemon {
     }
 
     public void createOrLoadWallet(String walletName, Optional<String> passphrase) {
-        createOrLoadWallet(walletName, passphrase, false, false);
+        createOrLoadWallet(walletName, passphrase, true, false, false);
+    }
+
+    public void createOrLoadLegacyWallet(String walletName, Optional<String> passphrase) {
+        createOrLoadWallet(walletName, passphrase, false, false, false);
     }
 
     public void createOrLoadWatchOnlyWallet(String walletName) {
-        createOrLoadWallet(walletName, Optional.empty(), true, true);
+        createOrLoadWallet(walletName, Optional.empty(), true, true, true);
     }
 
-    private void createOrLoadWallet(String walletName, Optional<String> passphrase, boolean disablePrivateKeys, boolean blank) {
+    private void createOrLoadWallet(String walletName, Optional<String> passphrase, boolean descriptors, boolean disablePrivateKeys, boolean blank) {
         try {
-            createWallet(walletName, passphrase.orElse(""), disablePrivateKeys, blank);
+            createWallet(walletName, passphrase.orElse(""), descriptors, disablePrivateKeys, blank);
         } catch (RpcCallFailureException e) {
             if (doesWalletExist(e)) {
                 List<String> loadedWallets = listWallets();
@@ -146,9 +150,10 @@ public class BitcoindDaemon {
         return e.getCause().getMessage().contains("Database already exists.");
     }
 
-    private void createWallet(String walletName, String passphrase, boolean disablePrivateKeys, boolean blank) {
+    private void createWallet(String walletName, String passphrase, boolean descriptors, boolean disablePrivateKeys, boolean blank) {
         var request = BitcoindCreateWalletRpcCall.Request.builder()
                 .walletName(walletName)
+                .descriptors(descriptors)
                 .disablePrivateKeys(disablePrivateKeys)
                 .blank(blank)
                 .passphrase(passphrase)

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindCreateWalletRpcCall.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindCreateWalletRpcCall.java
@@ -39,7 +39,7 @@ public class BitcoindCreateWalletRpcCall
         private String passphrase;
         @JsonProperty("avoid_reuse")
         private Boolean avoidReuse;
-        private final boolean descriptors = true;
+        private boolean descriptors;
     }
 
     public BitcoindCreateWalletRpcCall(Request request) {

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/ElementsdDaemon.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/ElementsdDaemon.java
@@ -39,7 +39,7 @@ public class ElementsdDaemon {
     }
 
     public void createOrLoadWallet(String walletName, Optional<String> passphrase) {
-        bitcoindDaemon.createOrLoadWallet(walletName, passphrase);
+        bitcoindDaemon.createOrLoadLegacyWallet(walletName, passphrase);
     }
 
     public ElementsdDecodeRawTransactionResponse decodeRawTransaction(String txInHex) {


### PR DESCRIPTION
Bitcoin Core creates by default descriptor wallets but Elements Core does not support them yet. This change adds a method to create a legacy wallet to the BitcoinDaemon class and the ElementsDaemon calls that method.