### PR TITLE
DmgImageMounter: Check if image mounted and always unmount image

### DIFF
--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/DmgImageMounter.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/DmgImageMounter.kt
@@ -1,0 +1,53 @@
+package bisq.gradle.electrum
+
+import java.io.Closeable
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class DmgImageMounter(
+    private val dmgFile: File,
+    private val mountDirectory: File
+) : Closeable {
+
+    companion object {
+        private const val CMD_TIMEOUT: Long = 25
+    }
+
+    fun mount() {
+        if (isImageMounted()) {
+            return
+        }
+
+        val attachDmgFileProcess: Process = ProcessBuilder("hdiutil", "attach", dmgFile.absolutePath).start()
+        var isSuccess: Boolean = attachDmgFileProcess.waitFor(CMD_TIMEOUT, TimeUnit.SECONDS)
+        val exitCode = attachDmgFileProcess.exitValue()
+
+        isSuccess = isSuccess && exitCode == 0
+        if (!isSuccess) {
+            throw IllegalStateException("Could not attach DMG file. hdiutil attach exit code: $exitCode")
+        }
+    }
+
+    private fun unmount() {
+        if (!isImageMounted()) {
+            return
+        }
+
+        val detachDmgFileProcess: Process = ProcessBuilder("hdiutil", "detach", mountDirectory.absolutePath).start()
+        var isSuccess: Boolean = detachDmgFileProcess.waitFor(CMD_TIMEOUT, TimeUnit.SECONDS)
+        val exitCode = detachDmgFileProcess.exitValue()
+
+        isSuccess = isSuccess && exitCode == 0
+        if (!isSuccess) {
+            throw IllegalStateException("Could not detach DMG file. hdiutil detach exit code: $exitCode")
+        }
+    }
+
+    override fun close() {
+        unmount()
+    }
+
+    private fun isImageMounted(): Boolean {
+        return mountDirectory.exists()
+    }
+}


### PR DESCRIPTION
This change checks whether the DMG image is already mounted and unmounts the image even if an exception gets thrown during the extraction. We check the exit code of the mount and unmount process too.