### PR TITLE
Add ability to check whether a given onion service is online

### DIFF
--- a/network/src/main/java/bisq/network/p2p/node/transport/ClearNetTransport.java
+++ b/network/src/main/java/bisq/network/p2p/node/transport/ClearNetTransport.java
@@ -83,4 +83,13 @@ public class ClearNetTransport implements Transport {
     public Optional<Address> getServerAddress(String serverId) {
         return Optional.empty();
     }
+
+    @Override
+    public boolean isAddressAvailable(Address address) {
+        try (Socket ignored = getSocket(address)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
 }

--- a/network/src/main/java/bisq/network/p2p/node/transport/I2PTransport.java
+++ b/network/src/main/java/bisq/network/p2p/node/transport/I2PTransport.java
@@ -176,6 +176,11 @@ public class I2PTransport implements Transport {
     }
 
     @Override
+    public boolean isAddressAvailable(Address address) {
+        throw new UnsupportedOperationException("isAddressAvailable needs to be implemented for I2P.");
+    }
+
+    @Override
     public CompletableFuture<Void> shutdown() {
         initializeCalled = false;
         if (i2pClient == null) {

--- a/network/src/main/java/bisq/network/p2p/node/transport/TorTransport.java
+++ b/network/src/main/java/bisq/network/p2p/node/transport/TorTransport.java
@@ -90,6 +90,11 @@ public class TorTransport implements Transport {
         return socket;
     }
 
+    @Override
+    public boolean isAddressAvailable(Address address) {
+        return tor.isHiddenServiceAvailable(address.getHost());
+    }
+
     public Optional<Socks5Proxy> getSocksProxy() throws IOException {
         return Optional.of(tor.getSocks5Proxy(null));
     }

--- a/network/src/main/java/bisq/network/p2p/node/transport/Transport.java
+++ b/network/src/main/java/bisq/network/p2p/node/transport/Transport.java
@@ -83,5 +83,7 @@ public interface Transport {
 
     Optional<Address> getServerAddress(String serverId);
 
+    boolean isAddressAvailable(Address address);
+
     CompletableFuture<Void> shutdown();
 }

--- a/tor/src/main/java/bisq/tor/Tor.java
+++ b/tor/src/main/java/bisq/tor/Tor.java
@@ -282,6 +282,10 @@ public class Tor {
         return Optional.empty();
     }
 
+    public boolean isHiddenServiceAvailable(String onionUrl) {
+        return torController.isHiddenServiceAvailable(onionUrl);
+    }
+
     private void setState(State newState) {
         log.info("Set new state {}", newState);
         checkArgument(newState.ordinal() > state.get().ordinal(),

--- a/tor/src/main/java/bisq/tor/TorController.java
+++ b/tor/src/main/java/bisq/tor/TorController.java
@@ -119,6 +119,14 @@ public class TorController {
         return Integer.parseInt(port);
     }
 
+    boolean isHiddenServiceAvailable(String onionUrl) {
+        try {
+            return torControlConnection().isHSAvailable(onionUrl);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
     TorControlConnection.CreateHiddenServiceResult createHiddenService(int hiddenServicePort,
                                                                        int localPort) throws IOException {
         assertState();


### PR DESCRIPTION
When another peer connects to us over Tor the connecting peer can lie about its onion address. We can challenge the peer to sign a payload to proof that the connecting peer has the private key of the provided onion address. This change adds the ability to check whether the onion service is known to the Tor directory servers.