### PR TITLE
Gradle Plugin: Discard subprocess output streams

### DIFF
--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/DmgImageMounter.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/DmgImageMounter.kt
@@ -18,7 +18,11 @@ class DmgImageMounter(
             return
         }
 
-        val attachDmgFileProcess: Process = ProcessBuilder("hdiutil", "attach", dmgFile.absolutePath).start()
+        val attachDmgFileProcess: Process = ProcessBuilder("hdiutil", "attach", dmgFile.absolutePath)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
         var isSuccess: Boolean = attachDmgFileProcess.waitFor(CMD_TIMEOUT, TimeUnit.SECONDS)
         val exitCode = attachDmgFileProcess.exitValue()
 
@@ -33,7 +37,11 @@ class DmgImageMounter(
             return
         }
 
-        val detachDmgFileProcess: Process = ProcessBuilder("hdiutil", "detach", mountDirectory.absolutePath).start()
+        val detachDmgFileProcess: Process = ProcessBuilder("hdiutil", "detach", mountDirectory.absolutePath)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
         var isSuccess: Boolean = detachDmgFileProcess.waitFor(CMD_TIMEOUT, TimeUnit.SECONDS)
         val exitCode = detachDmgFileProcess.exitValue()
 

--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/tasks/ExtractElectrumAppFromDmgFile.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/tasks/ExtractElectrumAppFromDmgFile.kt
@@ -80,7 +80,11 @@ abstract class ExtractElectrumAppFromDmgFile : DefaultTask() {
         val destinationDir = outputDirectory.get().asFile.absolutePath
         val copyProcess: Process = ProcessBuilder(
             "cp", "-r", MOUNTED_ELECTRUM_APP_PATH, destinationDir
-        ).start()
+        )
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
         val isSuccess: Boolean = copyProcess.waitFor(CMD_TIMEOUT, TimeUnit.SECONDS)
         if (!isSuccess) {
             throw IllegalStateException("Could not copy Electrum.app to output directory.")

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumBinaryExtractor.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumBinaryExtractor.java
@@ -136,6 +136,7 @@ public class ElectrumBinaryExtractor {
             Process extractProcess = new ProcessBuilder("unzip", ARCHIVE_FILENAME)
                     .directory(destDir)
                     .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
                     .start();
             boolean isSuccess = extractProcess.waitFor(1, TimeUnit.MINUTES);
             if (!isSuccess) {


### PR DESCRIPTION
There have been issues (on macOS) in the past because the OS waited until we read its output streams which we never happened.