### PR TITLE
Downgraded Protobuf Java to Protobuf Lite

### DIFF
--- a/account/src/main/java/bisq/account/AccountStore.java
+++ b/account/src/main/java/bisq/account/AccountStore.java
@@ -61,7 +61,7 @@ public final class AccountStore implements PersistableStore<AccountStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.account.protobuf.AccountStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.account.protobuf.AccountStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/account/src/main/java/bisq/account/accounts/CountryBasedAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/CountryBasedAccountPayload.java
@@ -17,7 +17,7 @@
 
 package bisq.account.accounts;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -37,7 +37,7 @@ public class CountryBasedAccountPayload extends AccountPayload {
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/accounts/RevolutAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/RevolutAccountPayload.java
@@ -17,7 +17,7 @@
 
 package bisq.account.accounts;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -36,7 +36,7 @@ public final class RevolutAccountPayload extends AccountPayload {
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/accounts/SepaAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/SepaAccountPayload.java
@@ -17,7 +17,7 @@
 
 package bisq.account.accounts;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -40,7 +40,7 @@ public final class SepaAccountPayload extends CountryBasedAccountPayload {
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/protocol/LoanProtocolType.java
+++ b/account/src/main/java/bisq/account/protocol/LoanProtocolType.java
@@ -17,14 +17,14 @@
 
 package bisq.account.protocol;
 
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.Internal.EnumLite;
 
 public enum LoanProtocolType implements ProtocolType {
     COLLATERALIZED,
     REPUTATION;
 
     @Override
-    public ProtocolMessageEnum toProto() {
+    public EnumLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/protocol/SwapProtocolType.java
+++ b/account/src/main/java/bisq/account/protocol/SwapProtocolType.java
@@ -18,7 +18,7 @@
 package bisq.account.protocol;
 
 import bisq.common.util.ProtobufUtils;
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.Internal.EnumLite;
 
 // Versioning is handled by adding new entries. That way we could support multiple versions of the same protocol 
 // if needed.
@@ -34,7 +34,7 @@ public enum SwapProtocolType implements ProtocolType {
     }
 
     @Override
-    public ProtocolMessageEnum toProto() {
+    public EnumLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/settlement/BitcoinSettlementMethod.java
+++ b/account/src/main/java/bisq/account/settlement/BitcoinSettlementMethod.java
@@ -18,7 +18,7 @@
 package bisq.account.settlement;
 
 import bisq.account.protocol.SwapProtocolType;
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.Internal.EnumLite;
 
 import java.util.List;
 
@@ -50,7 +50,7 @@ public enum BitcoinSettlementMethod implements SettlementMethod {
     }
 
     @Override
-    public ProtocolMessageEnum toProto() {
+    public EnumLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/settlement/CryptoSettlementMethod.java
+++ b/account/src/main/java/bisq/account/settlement/CryptoSettlementMethod.java
@@ -19,7 +19,7 @@ package bisq.account.settlement;
 
 import bisq.account.protocol.SwapProtocolType;
 import bisq.i18n.Res;
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.Internal.EnumLite;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public enum CryptoSettlementMethod implements SettlementMethod {
     }
 
     @Override
-    public ProtocolMessageEnum toProto() {
+    public EnumLite toProto() {
         return null;
     }
 }

--- a/account/src/main/java/bisq/account/settlement/FiatSettlementMethod.java
+++ b/account/src/main/java/bisq/account/settlement/FiatSettlementMethod.java
@@ -22,7 +22,7 @@ import bisq.common.currency.FiatCurrencyRepository;
 import bisq.common.currency.TradeCurrency;
 import bisq.common.locale.Country;
 import bisq.common.locale.CountryRepository;
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.Internal.EnumLite;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -122,7 +122,7 @@ public enum FiatSettlementMethod implements SettlementMethod {
     }
 
     @Override
-    public ProtocolMessageEnum toProto() {
+    public EnumLite toProto() {
         return null;
     }
 }

--- a/build-logic/commons/src/main/groovy/bisq.protobuf.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.protobuf.gradle
@@ -31,7 +31,13 @@ protobuf {
         artifact = "com.google.protobuf:protoc:3.19.4${osxArch}"
     }
     generateProtoTasks {
-        all()*.plugins {}
+        all().each { task ->
+            task.builtins {
+                java {
+                    option "lite"
+                }
+            }
+        }
     }
     generatedFilesBaseDir = "$projectDir/build/generated/source"
 }

--- a/chat/src/main/java/bisq/chat/discuss/DiscussionChannelSelectionStore.java
+++ b/chat/src/main/java/bisq/chat/discuss/DiscussionChannelSelectionStore.java
@@ -57,7 +57,7 @@ public final class DiscussionChannelSelectionStore implements PersistableStore<D
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.DiscussionChannelSelectionStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.DiscussionChannelSelectionStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/discuss/priv/PrivateDiscussionChannelStore.java
+++ b/chat/src/main/java/bisq/chat/discuss/priv/PrivateDiscussionChannelStore.java
@@ -56,7 +56,7 @@ public class PrivateDiscussionChannelStore implements PersistableStore<PrivateDi
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PrivateDiscussionChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PrivateDiscussionChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/discuss/priv/PrivateDiscussionChatMessage.java
+++ b/chat/src/main/java/bisq/chat/discuss/priv/PrivateDiscussionChatMessage.java
@@ -69,7 +69,7 @@ public final class PrivateDiscussionChatMessage extends PrivateChatMessage {
     @Override
     public NetworkMessage toProto() {
         return getNetworkMessageBuilder()
-                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(Any.pack(toChatMessageProto())))
+                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(bisq.common.util.ProtobufUtils.pack(toChatMessageProto())))
                 .build();
     }
 

--- a/chat/src/main/java/bisq/chat/discuss/pub/PublicDiscussionChannelStore.java
+++ b/chat/src/main/java/bisq/chat/discuss/pub/PublicDiscussionChannelStore.java
@@ -56,7 +56,7 @@ public class PublicDiscussionChannelStore implements PersistableStore<PublicDisc
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PublicDiscussionChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PublicDiscussionChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/events/EventsChannelSelectionStore.java
+++ b/chat/src/main/java/bisq/chat/events/EventsChannelSelectionStore.java
@@ -57,7 +57,7 @@ public final class EventsChannelSelectionStore implements PersistableStore<Event
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.EventsChannelSelectionStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.EventsChannelSelectionStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/events/priv/PrivateEventsChannelStore.java
+++ b/chat/src/main/java/bisq/chat/events/priv/PrivateEventsChannelStore.java
@@ -56,7 +56,7 @@ public class PrivateEventsChannelStore implements PersistableStore<PrivateEvents
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PrivateEventsChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PrivateEventsChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/events/priv/PrivateEventsChatMessage.java
+++ b/chat/src/main/java/bisq/chat/events/priv/PrivateEventsChatMessage.java
@@ -69,7 +69,7 @@ public final class PrivateEventsChatMessage extends PrivateChatMessage {
     @Override
     public NetworkMessage toProto() {
         return getNetworkMessageBuilder()
-                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(Any.pack(toChatMessageProto())))
+                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(bisq.common.util.ProtobufUtils.pack(toChatMessageProto())))
                 .build();
     }
 

--- a/chat/src/main/java/bisq/chat/events/pub/PublicEventsChannelStore.java
+++ b/chat/src/main/java/bisq/chat/events/pub/PublicEventsChannelStore.java
@@ -56,7 +56,7 @@ public class PublicEventsChannelStore implements PersistableStore<PublicEventsCh
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PublicEventsChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PublicEventsChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/message/ChatMessage.java
+++ b/chat/src/main/java/bisq/chat/message/ChatMessage.java
@@ -132,7 +132,7 @@ public abstract class ChatMessage implements Proto {
     public static ProtoResolver<DistributedData> getDistributedDataResolver() {
         return any -> {
             try {
-                bisq.chat.protobuf.ChatMessage proto = any.unpack(bisq.chat.protobuf.ChatMessage.class);
+                bisq.chat.protobuf.ChatMessage proto = bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.ChatMessage.class);
                 switch (proto.getMessageCase()) {
                     case PUBLICTRADECHATMESSAGE: {
                         return PublicTradeChatMessage.fromProto(proto);
@@ -160,7 +160,7 @@ public abstract class ChatMessage implements Proto {
     public static ProtoResolver<bisq.network.p2p.message.NetworkMessage> getNetworkMessageResolver() {
         return any -> {
             try {
-                bisq.chat.protobuf.ChatMessage proto = any.unpack(bisq.chat.protobuf.ChatMessage.class);
+                bisq.chat.protobuf.ChatMessage proto = bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.ChatMessage.class);
                 switch (proto.getMessageCase()) {
                     case PRIVATETRADECHATMESSAGE: {
                         return PrivateTradeChatMessage.fromProto(proto);

--- a/chat/src/main/java/bisq/chat/support/SupportChannelSelectionStore.java
+++ b/chat/src/main/java/bisq/chat/support/SupportChannelSelectionStore.java
@@ -57,7 +57,7 @@ public final class SupportChannelSelectionStore implements PersistableStore<Supp
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.SupportChannelSelectionStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.SupportChannelSelectionStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/support/priv/PrivateSupportChannelStore.java
+++ b/chat/src/main/java/bisq/chat/support/priv/PrivateSupportChannelStore.java
@@ -56,7 +56,7 @@ public class PrivateSupportChannelStore implements PersistableStore<PrivateSuppo
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PrivateSupportChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PrivateSupportChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/support/priv/PrivateSupportChatMessage.java
+++ b/chat/src/main/java/bisq/chat/support/priv/PrivateSupportChatMessage.java
@@ -69,7 +69,7 @@ public final class PrivateSupportChatMessage extends PrivateChatMessage {
     @Override
     public NetworkMessage toProto() {
         return getNetworkMessageBuilder()
-                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(Any.pack(toChatMessageProto())))
+                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(bisq.common.util.ProtobufUtils.pack(toChatMessageProto())))
                 .build();
     }
 

--- a/chat/src/main/java/bisq/chat/support/pub/PublicSupportChannelStore.java
+++ b/chat/src/main/java/bisq/chat/support/pub/PublicSupportChannelStore.java
@@ -56,7 +56,7 @@ public class PublicSupportChannelStore implements PersistableStore<PublicSupport
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PublicSupportChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PublicSupportChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/trade/TradeChannelSelectionStore.java
+++ b/chat/src/main/java/bisq/chat/trade/TradeChannelSelectionStore.java
@@ -57,7 +57,7 @@ public final class TradeChannelSelectionStore implements PersistableStore<TradeC
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.TradeChannelSelectionStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.TradeChannelSelectionStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/trade/priv/PrivateTradeChannelStore.java
+++ b/chat/src/main/java/bisq/chat/trade/priv/PrivateTradeChannelStore.java
@@ -56,7 +56,7 @@ public class PrivateTradeChannelStore implements PersistableStore<PrivateTradeCh
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PrivateTradeChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PrivateTradeChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/chat/src/main/java/bisq/chat/trade/priv/PrivateTradeChatMessage.java
+++ b/chat/src/main/java/bisq/chat/trade/priv/PrivateTradeChatMessage.java
@@ -74,7 +74,7 @@ public final class PrivateTradeChatMessage extends PrivateChatMessage {
     @Override
     public NetworkMessage toProto() {
         return getNetworkMessageBuilder()
-                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(Any.pack(toChatMessageProto())))
+                .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder().setAny(bisq.common.util.ProtobufUtils.pack(toChatMessageProto())))
                 .build();
     }
 

--- a/chat/src/main/java/bisq/chat/trade/pub/PublicTradeChannelStore.java
+++ b/chat/src/main/java/bisq/chat/trade/pub/PublicTradeChannelStore.java
@@ -62,7 +62,7 @@ public class PublicTradeChannelStore implements PersistableStore<PublicTradeChan
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.chat.protobuf.PublicTradeChannelStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.chat.protobuf.PublicTradeChannelStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -17,13 +17,13 @@
 
 package bisq.common.proto;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
 
 /**
  * Interface for any object which gets serialized using protobuf
  */
 public interface Proto {
-    Message toProto();
+    MessageLite toProto();
 
     default byte[] serialize() {
         return toProto().toByteArray();

--- a/common/src/main/java/bisq/common/proto/ProtoEnum.java
+++ b/common/src/main/java/bisq/common/proto/ProtoEnum.java
@@ -17,11 +17,11 @@
 
 package bisq.common.proto;
 
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.Internal;
 
 /**
  * Interface for any enum which gets serialized using protobuf
  */
 public interface ProtoEnum {
-    ProtocolMessageEnum toProto();
+    Internal.EnumLite toProto();
 }

--- a/common/src/main/java/bisq/common/proto/UnresolvableProtobufMessageException.java
+++ b/common/src/main/java/bisq/common/proto/UnresolvableProtobufMessageException.java
@@ -19,12 +19,12 @@ package bisq.common.proto;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
+import com.google.protobuf.MessageLite;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class UnresolvableProtobufMessageException extends RuntimeException {
-    public UnresolvableProtobufMessageException(Message proto) {
+    public UnresolvableProtobufMessageException(MessageLite proto) {
         super("Message case not found for proto message: \n" + proto.toString());
     }
 

--- a/common/src/main/java/bisq/common/util/ProtobufUtils.java
+++ b/common/src/main/java/bisq/common/util/ProtobufUtils.java
@@ -19,8 +19,13 @@ package bisq.common.util;
 
 import com.google.common.base.Enums;
 import com.google.protobuf.Any;
+import com.google.protobuf.Internal;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageLite;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
 
 @Slf4j
 public class ProtobufUtils {
@@ -38,6 +43,96 @@ public class ProtobufUtils {
     }
 
     public static String getProtoType(Any any) {
-        return any.getTypeUrl().split("/")[1];
+        log.info("TypeUrl={}", any.getTypeUrl());
+        String fullName = any.getTypeUrl().split("/")[1];
+        String[] tokens = fullName.split("[.]");
+        String protoTypeResolverName = fullName;
+        if(tokens.length > 2) {
+            protoTypeResolverName = tokens[1] + "." + tokens[tokens.length - 1];
+        }
+        log.info("PrototypeResolverName={}", protoTypeResolverName);
+        return protoTypeResolverName;
+    }
+
+    public static <T extends MessageLite> Any pack(T message) {
+        return Any.newBuilder()
+                .setTypeUrl("type.googleapis.com/" + message.getClass().getName())
+                .setValue(message.toByteString())
+                .build();
+    }
+
+    public static <T extends MessageLite> T unpack(Any any, Class<T> clazz) throws InvalidProtocolBufferException {
+        boolean invalidClazz = false;
+        Object val = getCachedUnpackValue(any, clazz);//TODO really returns toProto
+        if (val != null) {
+            if (val.getClass() == clazz) {
+                return (T) val;
+            }
+            invalidClazz = true;
+        }
+
+        if (!invalidClazz && isAny(any, clazz)) {
+            return getResult(any, clazz);
+        } else {
+            throw new InvalidProtocolBufferException("Type of the Any message does not match the given class.");
+        }
+    }
+
+    private static <T extends MessageLite> T getResult(Any any, Class<T> clazz) {
+        T defaultInstance = (T) Internal.getDefaultInstance(clazz);
+        T result = null;
+        try {
+            result = (T) defaultInstance.getParserForType().parseFrom(any.getValue());
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+        setCachedUnpackValue(any, result);
+        return result;
+    }
+
+    private static <T extends MessageLite> void setCachedUnpackValue(Any any, T val) {
+        //TODO really does nothing for now. The cachedUnpackValue will be a property
+        //TODO of type MessageLite that that holds the parsed value for quick reference
+    }
+
+    private static <T extends MessageLite> T getCachedUnpackValue(Any any, Class<T> clazz) {
+        //TODO First try to get the cached value already set before calling getResult
+        return getResult(any, clazz);
+    }
+
+    private static Object invokeMethod(Object object, String methodName) {
+        java.lang.reflect.Method method = null;
+        Object val = null;
+        try {
+            method = object.getClass().getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            val = method.invoke(object);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        return val;
+    }
+
+    private static Object invokeMethod(Object object, String methodName, Object... args) {
+        java.lang.reflect.Method method = null;
+        Object val = null;
+        try {
+            method = object.getClass().getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            val = method.invoke(object, args);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        return val;
+    }
+
+    private static <T extends MessageLite> boolean isAny(Any any, Class<T> clazz) {
+        T defaultInstance = Internal.getDefaultInstance(clazz);
+        Object o = invokeMethod(invokeMethod(defaultInstance, "getDescriptorForType"),"getFullName");
+
+        Object o1 = invokeMethod(any, "getTypeNameFromTypeUrl", any.getTypeUrl());
+        return o1.equals(o);
     }
 }

--- a/contract/src/main/java/bisq/contract/Contract.java
+++ b/contract/src/main/java/bisq/contract/Contract.java
@@ -20,9 +20,9 @@ package bisq.contract;
 import bisq.account.protocol.SwapProtocolType;
 import bisq.common.monetary.Monetary;
 import bisq.common.proto.Proto;
+import com.google.protobuf.MessageLite;
 import bisq.network.NetworkId;
 import bisq.offer.Offer;
-import com.google.protobuf.Message;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,7 @@ public final class Contract implements Proto {
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         log.error("Not impl yet");
         return null;
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,7 +117,7 @@ logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback-
 logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback-lib' }
 lombok = { module = 'org.projectlombok:lombok', version.ref = 'lombok-lib' }
 
-protobuf-java = { module = 'com.google.protobuf:protobuf-java', version.ref = 'protobuf-java-lib' }
+protobuf-java = { module = 'com.google.protobuf:protobuf-javalite', version.ref = 'protobuf-java-lib' }
 protobuf-gradle-plugin = { module = 'gradle.plugin.com.google.protobuf:protobuf-gradle-plugin', version.ref = 'protobuf-gradle-plugin-lib' }
 protobuf-java-util = { module = 'com.google.protobuf:protobuf-java-util', version.ref = 'protobuf-java-lib' }
 

--- a/identity/src/main/java/bisq/identity/IdentityStore.java
+++ b/identity/src/main/java/bisq/identity/IdentityStore.java
@@ -67,7 +67,7 @@ public final class IdentityStore implements PersistableStore<IdentityStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.identity.protobuf.IdentityStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.identity.protobuf.IdentityStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Tue Dec 20 13:16:20 WAT 2022
+sdk.dir=/run/media/odada/PHOENIX_BAK/android-sdk

--- a/network/network/src/main/java/bisq/network/NetworkServiceStore.java
+++ b/network/network/src/main/java/bisq/network/NetworkServiceStore.java
@@ -57,7 +57,7 @@ public final class NetworkServiceStore implements PersistableStore<NetworkServic
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.network.protobuf.NetworkServiceStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.network.protobuf.NetworkServiceStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/network/network/src/main/java/bisq/network/p2p/message/ExternalNetworkMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/message/ExternalNetworkMessage.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p.message;
 
+import bisq.common.util.ProtobufUtils;
 import com.google.protobuf.Any;
 
 // Wrapper for NetworkMessages which are not part of the network module (e.g. PrivateChatMessage).
@@ -30,7 +31,7 @@ public final class ExternalNetworkMessage {
 
     public bisq.network.protobuf.ExternalNetworkMessage toProto() {
         return bisq.network.protobuf.ExternalNetworkMessage.newBuilder()
-                .setAny(Any.pack(networkMessage.toProto()))
+                .setAny(ProtobufUtils.pack(networkMessage.toProto()))
                 .build();
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStore.java
@@ -68,7 +68,7 @@ public final class DataStore<T extends DataRequest> implements PersistableStore<
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.network.protobuf.DataStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.network.protobuf.DataStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DistributedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DistributedData.java
@@ -28,7 +28,10 @@ public interface DistributedData extends Proto {
     }
 
     default Any toAny() {
-        return Any.pack(toProto());
+        return Any.newBuilder()
+                .setTypeUrl("type.googleapis.com/bisq.network.p2p.services.data.storage.DistributedData")
+                .setValue(toProto().toByteString())
+                .build();
     }
 
     MetaData getMetaData();

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/PeerGroupStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/PeerGroupStore.java
@@ -57,7 +57,7 @@ public final class PeerGroupStore implements PersistableStore<PeerGroupStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.network.protobuf.PeerGroupStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.network.protobuf.PeerGroupStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/network/network/src/test/java/bisq/network/p2p/TestProtobufAny.java
+++ b/network/network/src/test/java/bisq/network/p2p/TestProtobufAny.java
@@ -32,7 +32,7 @@ public class TestProtobufAny {
 
         public static bisq.network.protobuf.MockOffer unpack(Any any)
                 throws InvalidProtocolBufferException {
-            return any.unpack( bisq.network.protobuf.MockOffer.class);
+            return bisq.common.util.ProtobufUtils.unpack(any,  bisq.network.protobuf.MockOffer.class);
         }
 
         public static MockOffer fromProto(bisq.network.protobuf.MockOffer proto) {
@@ -79,7 +79,7 @@ public class TestProtobufAny {
         String type = mockOfferProtoAsAny.getTypeUrl();
         log.error("type {}", type);
         try {
-            bisq.network.protobuf.MockOffer unpacked = mockOfferProtoAsAny.unpack(bisq.network.protobuf.MockOffer.class);
+            bisq.network.protobuf.MockOffer unpacked = mockOfferProtoAsbisq.common.util.ProtobufUtils.unpack(any, bisq.network.protobuf.MockOffer.class);
             MockOffer resolved = MockOffer.fromProto(unpacked);
             assertEquals(mockOffer.text, resolved.text);
 

--- a/offer/src/main/java/bisq/offer/Offer.java
+++ b/offer/src/main/java/bisq/offer/Offer.java
@@ -182,7 +182,7 @@ public final class Offer implements DistributedData {
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.offer.protobuf.Offer.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.offer.protobuf.Offer.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/offer/src/main/java/bisq/offer/OpenOfferStore.java
+++ b/offer/src/main/java/bisq/offer/OpenOfferStore.java
@@ -55,7 +55,7 @@ public final class OpenOfferStore implements PersistableStore<OpenOfferStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.offer.protobuf.OpenOfferStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.offer.protobuf.OpenOfferStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizeAccountAgeRequest.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizeAccountAgeRequest.java
@@ -19,6 +19,7 @@ package bisq.oracle.daobridge.model;
 
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.ProtobufUtils;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
 import bisq.network.protobuf.ExternalNetworkMessage;
@@ -59,7 +60,7 @@ public final class AuthorizeAccountAgeRequest implements MailboxMessage {
     public bisq.network.protobuf.NetworkMessage toProto() {
         return getNetworkMessageBuilder()
                 .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder()
-                        .setAny(Any.pack(toAuthorizeAccountAgeRequestProto())))
+                        .setAny(ProtobufUtils.pack(toAuthorizeAccountAgeRequestProto())))
                 .build();
     }
 
@@ -84,7 +85,7 @@ public final class AuthorizeAccountAgeRequest implements MailboxMessage {
     public static ProtoResolver<bisq.network.p2p.message.NetworkMessage> getNetworkMessageResolver() {
         return any -> {
             try {
-                bisq.oracle.protobuf.AuthorizeAccountAgeRequest proto = any.unpack(bisq.oracle.protobuf.AuthorizeAccountAgeRequest.class);
+                bisq.oracle.protobuf.AuthorizeAccountAgeRequest proto = ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizeAccountAgeRequest.class);
                 return AuthorizeAccountAgeRequest.fromProto(proto);
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizeSignedWitnessRequest.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizeSignedWitnessRequest.java
@@ -19,6 +19,7 @@ package bisq.oracle.daobridge.model;
 
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.ProtobufUtils;
 import bisq.network.p2p.message.NetworkMessage;
 import bisq.network.protobuf.ExternalNetworkMessage;
 import com.google.protobuf.Any;
@@ -56,7 +57,7 @@ public final class AuthorizeSignedWitnessRequest implements NetworkMessage {
     public bisq.network.protobuf.NetworkMessage toProto() {
         return getNetworkMessageBuilder()
                 .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder()
-                        .setAny(Any.pack(toAuthorizeSignedWitnessRequestProto())))
+                        .setAny(ProtobufUtils.pack(toAuthorizeSignedWitnessRequestProto())))
                 .build();
     }
 
@@ -83,7 +84,7 @@ public final class AuthorizeSignedWitnessRequest implements NetworkMessage {
     public static ProtoResolver<NetworkMessage> getNetworkMessageResolver() {
         return any -> {
             try {
-                bisq.oracle.protobuf.AuthorizeSignedWitnessRequest proto = any.unpack(bisq.oracle.protobuf.AuthorizeSignedWitnessRequest.class);
+                bisq.oracle.protobuf.AuthorizeSignedWitnessRequest proto = ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizeSignedWitnessRequest.class);
                 return AuthorizeSignedWitnessRequest.fromProto(proto);
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedAccountAgeData.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedAccountAgeData.java
@@ -71,7 +71,7 @@ public final class AuthorizedAccountAgeData implements AuthorizedDistributedData
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.AuthorizedAccountAgeData.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizedAccountAgeData.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedBondedReputationData.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedBondedReputationData.java
@@ -89,7 +89,7 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.AuthorizedBondedReputationData.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizedBondedReputationData.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedDaoBridgeServiceProvider.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedDaoBridgeServiceProvider.java
@@ -66,7 +66,7 @@ public final class AuthorizedDaoBridgeServiceProvider implements AuthorizedDistr
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.AuthorizedDaoBridgeServiceProvider.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizedDaoBridgeServiceProvider.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedProofOfBurnData.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedProofOfBurnData.java
@@ -84,7 +84,7 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.AuthorizedProofOfBurnData.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizedProofOfBurnData.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedSignedWitnessData.java
+++ b/oracle/src/main/java/bisq/oracle/daobridge/model/AuthorizedSignedWitnessData.java
@@ -71,7 +71,7 @@ public final class AuthorizedSignedWitnessData implements AuthorizedDistributedD
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.AuthorizedSignedWitnessData.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizedSignedWitnessData.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/timestamp/AuthorizeTimestampRequest.java
+++ b/oracle/src/main/java/bisq/oracle/timestamp/AuthorizeTimestampRequest.java
@@ -19,6 +19,7 @@ package bisq.oracle.timestamp;
 
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.ProtobufUtils;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
 import bisq.network.protobuf.ExternalNetworkMessage;
@@ -47,7 +48,7 @@ public final class AuthorizeTimestampRequest implements MailboxMessage {
     public bisq.network.protobuf.NetworkMessage toProto() {
         return getNetworkMessageBuilder()
                 .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder()
-                        .setAny(Any.pack(toAuthorizeTimestampRequestProto())))
+                        .setAny(ProtobufUtils.pack(toAuthorizeTimestampRequestProto())))
                 .build();
     }
 
@@ -64,7 +65,7 @@ public final class AuthorizeTimestampRequest implements MailboxMessage {
     public static ProtoResolver<bisq.network.p2p.message.NetworkMessage> getNetworkMessageResolver() {
         return any -> {
             try {
-                bisq.oracle.protobuf.AuthorizeTimestampRequest proto = any.unpack(bisq.oracle.protobuf.AuthorizeTimestampRequest.class);
+                bisq.oracle.protobuf.AuthorizeTimestampRequest proto = bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizeTimestampRequest.class);
                 return AuthorizeTimestampRequest.fromProto(proto);
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);

--- a/oracle/src/main/java/bisq/oracle/timestamp/AuthorizedTimestampData.java
+++ b/oracle/src/main/java/bisq/oracle/timestamp/AuthorizedTimestampData.java
@@ -72,7 +72,7 @@ public final class AuthorizedTimestampData implements AuthorizedDistributedData 
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.AuthorizedTimestampData.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.AuthorizedTimestampData.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/oracle/src/main/java/bisq/oracle/timestamp/TimestampStore.java
+++ b/oracle/src/main/java/bisq/oracle/timestamp/TimestampStore.java
@@ -62,7 +62,7 @@ public final class TimestampStore implements PersistableStore<TimestampStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.oracle.protobuf.TimestampStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.oracle.protobuf.TimestampStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/persistence/src/main/java/bisq/persistence/PersistableStore.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStore.java
@@ -19,6 +19,7 @@ package bisq.persistence;
 
 import bisq.common.proto.Proto;
 import bisq.common.proto.ProtoResolver;
+import bisq.common.util.ProtobufUtils;
 import com.google.protobuf.Any;
 
 /**
@@ -30,7 +31,7 @@ public interface PersistableStore<T> extends Proto {
     }
 
     default Any toAny() {
-        return Any.pack(toProto());
+        return ProtobufUtils.pack(toProto());
     }
 
     T getClone();

--- a/persistence/src/test/java/bisq/persistence/PersistenceIntegrationTest.java
+++ b/persistence/src/test/java/bisq/persistence/PersistenceIntegrationTest.java
@@ -18,8 +18,8 @@
 package bisq.persistence;
 
 import bisq.common.proto.Proto;
+import com.google.protobuf.MessageLite;
 import bisq.common.util.OsUtils;
-import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,7 +36,7 @@ public class PersistenceIntegrationTest {
         }
 
         @Override
-        public Message toProto() {
+        public MessageLite toProto() {
             return null;
         }
     }

--- a/protocol/src/main/java/bisq/protocol/ProtocolStore.java
+++ b/protocol/src/main/java/bisq/protocol/ProtocolStore.java
@@ -58,7 +58,7 @@ public final class ProtocolStore implements PersistableStore<ProtocolStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.protocol.protobuf.ProtocolStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.protocol.protobuf.ProtocolStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapMakerAsBuyerProtocol.java
+++ b/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapMakerAsBuyerProtocol.java
@@ -17,13 +17,13 @@
 
 package bisq.protocol.liquidswap;
 
+import com.google.protobuf.MessageLite;
 import bisq.network.NetworkIdWithKeyPair;
 import bisq.network.NetworkService;
 import bisq.persistence.PersistenceClient;
 import bisq.protocol.BuyerProtocol;
 import bisq.protocol.MakerProtocolModel;
 import bisq.protocol.ProtocolStore;
-import com.google.protobuf.Message;
 
 public class LiquidSwapMakerAsBuyerProtocol extends LiquidSwapMakerProtocol implements BuyerProtocol {
 
@@ -38,7 +38,7 @@ public class LiquidSwapMakerAsBuyerProtocol extends LiquidSwapMakerProtocol impl
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         //todo
         return null;
     }

--- a/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapMakerAsSellerProtocol.java
+++ b/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapMakerAsSellerProtocol.java
@@ -17,13 +17,13 @@
 
 package bisq.protocol.liquidswap;
 
+import com.google.protobuf.MessageLite;
 import bisq.network.NetworkIdWithKeyPair;
 import bisq.network.NetworkService;
 import bisq.persistence.PersistenceClient;
 import bisq.protocol.MakerProtocolModel;
 import bisq.protocol.ProtocolStore;
 import bisq.protocol.SellerProtocol;
-import com.google.protobuf.Message;
 
 public class LiquidSwapMakerAsSellerProtocol extends LiquidSwapMakerProtocol implements SellerProtocol {
 
@@ -38,7 +38,7 @@ public class LiquidSwapMakerAsSellerProtocol extends LiquidSwapMakerProtocol imp
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         //todo
         return null;
     }

--- a/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapTakerAsBuyerProtocol.java
+++ b/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapTakerAsBuyerProtocol.java
@@ -17,13 +17,13 @@
 
 package bisq.protocol.liquidswap;
 
+import com.google.protobuf.MessageLite;
 import bisq.network.NetworkIdWithKeyPair;
 import bisq.network.NetworkService;
 import bisq.persistence.PersistenceClient;
 import bisq.protocol.BuyerProtocol;
 import bisq.protocol.ProtocolStore;
 import bisq.protocol.TakerProtocolModel;
-import com.google.protobuf.Message;
 
 public class LiquidSwapTakerAsBuyerProtocol extends LiquidSwapTakerProtocol implements BuyerProtocol {
     public LiquidSwapTakerAsBuyerProtocol(NetworkService networkService,
@@ -37,7 +37,7 @@ public class LiquidSwapTakerAsBuyerProtocol extends LiquidSwapTakerProtocol impl
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         //todo
         return null;
     }

--- a/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapTakerAsSellerProtocol.java
+++ b/protocol/src/main/java/bisq/protocol/liquidswap/LiquidSwapTakerAsSellerProtocol.java
@@ -17,13 +17,13 @@
 
 package bisq.protocol.liquidswap;
 
+import com.google.protobuf.MessageLite;
 import bisq.network.NetworkIdWithKeyPair;
 import bisq.network.NetworkService;
 import bisq.persistence.PersistenceClient;
 import bisq.protocol.ProtocolStore;
 import bisq.protocol.SellerProtocol;
 import bisq.protocol.TakerProtocolModel;
-import com.google.protobuf.Message;
 
 public class LiquidSwapTakerAsSellerProtocol extends LiquidSwapTakerProtocol implements SellerProtocol {
     public LiquidSwapTakerAsSellerProtocol(NetworkService networkService,
@@ -37,7 +37,7 @@ public class LiquidSwapTakerAsSellerProtocol extends LiquidSwapTakerProtocol imp
     }
 
     @Override
-    public Message toProto() {
+    public MessageLite toProto() {
         //todo
         return null;
     }

--- a/security/src/main/java/bisq/security/KeyPairStore.java
+++ b/security/src/main/java/bisq/security/KeyPairStore.java
@@ -63,7 +63,7 @@ public final class KeyPairStore implements PersistableStore<KeyPairStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.security.protobuf.KeyPairStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.security.protobuf.KeyPairStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -104,7 +104,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.settings.protobuf.SettingsStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.settings.protobuf.SettingsStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/support/src/main/java/bisq/support/MediationRequest.java
+++ b/support/src/main/java/bisq/support/MediationRequest.java
@@ -21,6 +21,7 @@ import bisq.chat.trade.priv.PrivateTradeChatMessage;
 import bisq.common.data.ByteArray;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.ProtobufUtils;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
 import bisq.network.protobuf.ExternalNetworkMessage;
@@ -60,7 +61,7 @@ public final class MediationRequest implements MailboxMessage {
     public bisq.network.protobuf.NetworkMessage toProto() {
         return getNetworkMessageBuilder()
                 .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder()
-                        .setAny(Any.pack(toMediationRequestProto())))
+                        .setAny(ProtobufUtils.pack(toMediationRequestProto())))
                 .build();
     }
 
@@ -85,7 +86,7 @@ public final class MediationRequest implements MailboxMessage {
     public static ProtoResolver<bisq.network.p2p.message.NetworkMessage> getNetworkMessageResolver() {
         return any -> {
             try {
-                bisq.support.protobuf.MediationRequest proto = any.unpack(bisq.support.protobuf.MediationRequest.class);
+                bisq.support.protobuf.MediationRequest proto = bisq.common.util.ProtobufUtils.unpack(any, bisq.support.protobuf.MediationRequest.class);
                 return MediationRequest.fromProto(proto);
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);

--- a/support/src/main/java/bisq/support/MediationResponse.java
+++ b/support/src/main/java/bisq/support/MediationResponse.java
@@ -19,6 +19,7 @@ package bisq.support;
 
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.ProtobufUtils;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
 import bisq.network.protobuf.ExternalNetworkMessage;
@@ -49,7 +50,7 @@ public final class MediationResponse implements MailboxMessage {
     public bisq.network.protobuf.NetworkMessage toProto() {
         return getNetworkMessageBuilder()
                 .setExternalNetworkMessage(ExternalNetworkMessage.newBuilder()
-                        .setAny(Any.pack(toMediationResponseProto())))
+                        .setAny(ProtobufUtils.pack(toMediationResponseProto())))
                 .build();
     }
 
@@ -67,7 +68,7 @@ public final class MediationResponse implements MailboxMessage {
     public static ProtoResolver<bisq.network.p2p.message.NetworkMessage> getNetworkMessageResolver() {
         return any -> {
             try {
-                bisq.support.protobuf.MediationResponse proto = any.unpack(bisq.support.protobuf.MediationResponse.class);
+                bisq.support.protobuf.MediationResponse proto = bisq.common.util.ProtobufUtils.unpack(any, bisq.support.protobuf.MediationResponse.class);
                 return MediationResponse.fromProto(proto);
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);

--- a/user/src/main/java/bisq/user/identity/UserIdentityStore.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityStore.java
@@ -67,7 +67,7 @@ public final class UserIdentityStore implements PersistableStore<UserIdentitySto
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.UserIdentityStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.UserIdentityStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -100,7 +100,7 @@ public final class UserProfile implements DistributedData {
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.UserProfile.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.UserProfile.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/profile/UserProfileStore.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileStore.java
@@ -83,7 +83,7 @@ public final class UserProfileStore implements PersistableStore<UserProfileStore
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.UserProfileStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.UserProfileStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/reputation/AccountAgeStore.java
+++ b/user/src/main/java/bisq/user/reputation/AccountAgeStore.java
@@ -60,7 +60,7 @@ public final class AccountAgeStore implements PersistableStore<AccountAgeStore> 
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.AccountAgeStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.AccountAgeStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/reputation/ProfileAgeStore.java
+++ b/user/src/main/java/bisq/user/reputation/ProfileAgeStore.java
@@ -60,7 +60,7 @@ public final class ProfileAgeStore implements PersistableStore<ProfileAgeStore> 
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.ProfileAgeStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.ProfileAgeStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/reputation/SignedWitnessStore.java
+++ b/user/src/main/java/bisq/user/reputation/SignedWitnessStore.java
@@ -60,7 +60,7 @@ public final class SignedWitnessStore implements PersistableStore<SignedWitnessS
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.SignedWitnessStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.SignedWitnessStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/role/AuthorizedRoleRegistrationData.java
+++ b/user/src/main/java/bisq/user/role/AuthorizedRoleRegistrationData.java
@@ -76,7 +76,7 @@ public final class AuthorizedRoleRegistrationData implements AuthorizedDistribut
     public static ProtoResolver<DistributedData> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.AuthorizedRoleRegistrationData.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.AuthorizedRoleRegistrationData.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/user/src/main/java/bisq/user/role/RoleRegistrationServiceStore.java
+++ b/user/src/main/java/bisq/user/role/RoleRegistrationServiceStore.java
@@ -62,7 +62,7 @@ public final class RoleRegistrationServiceStore implements PersistableStore<Role
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.user.protobuf.RoleRegistrationServiceStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.user.protobuf.RoleRegistrationServiceStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/BitcoinWalletStore.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/BitcoinWalletStore.java
@@ -67,7 +67,7 @@ public final class BitcoinWalletStore implements PersistableStore<BitcoinWalletS
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.wallets.protobuf.BitcoinWalletStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.wallets.protobuf.BitcoinWalletStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWalletStore.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWalletStore.java
@@ -65,7 +65,7 @@ public final class LiquidWalletStore implements PersistableStore<LiquidWalletSto
     public ProtoResolver<PersistableStore<?>> getResolver() {
         return any -> {
             try {
-                return fromProto(any.unpack(bisq.wallets.protobuf.LiquidWalletStore.class));
+                return fromProto(bisq.common.util.ProtobufUtils.unpack(any, bisq.wallets.protobuf.LiquidWalletStore.class));
             } catch (InvalidProtocolBufferException e) {
                 throw new UnresolvableProtobufMessageException(e);
             }


### PR DESCRIPTION
This is to ensure protocol compatibility across all devices (including PC and Android).

The rationale is to keep the code for PC and Android (and other devices) the same across all the devices to prevent code fragmentation.

Android has several limitations one of which it only supports Protobuf Lite. And Protobuf Lite limits the message type to `com.google.protobuf.MessageLite`. The standard `com.google.protobuf.Message` is not available.

Also `com.google.protobuf.Any` in Protobuf Lite is missing helper methods `pack()` and `unpack()`.

Without harmonizing the protocol, PC and Android devices will not be able to communicate as the PC will use the standard Protobuf Java while the Android will use Protobuf Lite.