### PR TITLE
Fix Electrum empty password failures

### DIFF
--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumWallet.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumWallet.java
@@ -46,12 +46,11 @@ public class ElectrumWallet implements Wallet {
 
     @Override
     public void initialize(Optional<String> walletPassphrase) {
-        String password = walletPassphrase.orElse("");
         if (!doesWalletExist(walletPath)) {
-            daemon.create(password);
+            daemon.create(walletPassphrase);
         }
 
-        daemon.loadWallet(password);
+        daemon.loadWallet(walletPassphrase);
     }
 
     @Override
@@ -86,16 +85,14 @@ public class ElectrumWallet implements Wallet {
 
     @Override
     public String sendToAddress(Optional<String> passphrase, String address, double amount) {
-        String password = passphrase.orElse("");
-        String unsignedTx = daemon.payTo(password, address, amount);
-        String signedTx = daemon.signTransaction(password, unsignedTx);
+        String unsignedTx = daemon.payTo(passphrase, address, amount);
+        String signedTx = daemon.signTransaction(passphrase, unsignedTx);
         return daemon.broadcast(signedTx);
     }
 
     @Override
     public String signMessage(Optional<String> passphrase, String address, String message) {
-        String password = passphrase.orElse("");
-        return daemon.signMessage(password, address, message);
+        return daemon.signMessage(passphrase, address, message);
     }
 
     private boolean doesWalletExist(Path walletPath) {

--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/rpc/ElectrumDaemon.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/rpc/ElectrumDaemon.java
@@ -23,6 +23,7 @@ import bisq.wallets.json_rpc.JsonRpcClient;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class ElectrumDaemon {
     private final JsonRpcClient rpcClient;
@@ -37,8 +38,8 @@ public class ElectrumDaemon {
         return rpcClient.call(rpcCall).getResult();
     }
 
-    public ElectrumCreateResponse create(String password) {
-        var request = new ElectrumCreateRpcCall.Request(password);
+    public ElectrumCreateResponse create(Optional<String> password) {
+        var request = new ElectrumCreateRpcCall.Request(password.orElse(null));
         var rpcCall = new ElectrumCreateRpcCall(request);
         return rpcClient.call(rpcCall);
     }
@@ -65,8 +66,8 @@ public class ElectrumDaemon {
         return rpcClient.call(rpcCall);
     }
 
-    public String getSeed(String password) {
-        var request = new ElectrumGetSeedRpcCall.Request(password);
+    public String getSeed(Optional<String> password) {
+        var request = new ElectrumGetSeedRpcCall.Request(password.orElse(null));
         var rpcCall = new ElectrumGetSeedRpcCall(request);
         return rpcClient.call(rpcCall).getResult();
     }
@@ -87,8 +88,8 @@ public class ElectrumDaemon {
         return Arrays.asList(rpcClient.call(rpcCall));
     }
 
-    public void loadWallet(String password) {
-        var request = new ElectrumLoadWalletRpcCall.Request(password);
+    public void loadWallet(Optional<String> password) {
+        var request = new ElectrumLoadWalletRpcCall.Request(password.orElse(null));
         var rpcCall = new ElectrumLoadWalletRpcCall(request);
         rpcClient.call(rpcCall);
     }
@@ -104,28 +105,28 @@ public class ElectrumDaemon {
         return rpcClient.call(rpcCall);
     }
 
-    public void password(String password, String newPassword) {
+    public void password(Optional<String> password, String newPassword) {
         var request = ElectrumPasswordRpcCall.Request.builder()
-                .password(password)
+                .password(password.orElse(null))
                 .newPassword(newPassword)
                 .build();
         var rpcCall = new ElectrumPasswordRpcCall(request);
         rpcClient.call(rpcCall);
     }
 
-    public String payTo(String password, String destination, double amount) {
+    public String payTo(Optional<String> password, String destination, double amount) {
         var request = ElectrumPayToRpcCall.Request.builder()
                 .destination(destination)
                 .amount(amount)
-                .password(password)
+                .password(password.orElse(null))
                 .build();
         var rpcCall = new ElectrumPayToRpcCall(request);
         return rpcClient.call(rpcCall).getResult();
     }
 
-    public String signMessage(String password, String address, String message) {
+    public String signMessage(Optional<String> password, String address, String message) {
         var request = ElectrumSignMessageRpcCall.Request.builder()
-                .password(password)
+                .password(password.orElse(null))
                 .address(address)
                 .message(message)
                 .build();
@@ -133,8 +134,8 @@ public class ElectrumDaemon {
         return rpcClient.call(rpcCall).getResult();
     }
 
-    public String signTransaction(String password, String tx) {
-        var request = new ElectrumSignTransactionRpcCall.Request(tx, password);
+    public String signTransaction(Optional<String> password, String tx) {
+        var request = new ElectrumSignTransactionRpcCall.Request(tx, password.orElse(null));
         var rpcCall = new ElectrumSignTransactionRpcCall(request);
         return rpcClient.call(rpcCall).getResult();
     }

--- a/wallets/electrum/src/test/java/bisq/wallets/electrum/ElectrumEmptyPasswordSerializationTest.java
+++ b/wallets/electrum/src/test/java/bisq/wallets/electrum/ElectrumEmptyPasswordSerializationTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.wallets.electrum;
+
+import bisq.wallets.electrum.rpc.calls.ElectrumPayToRpcCall;
+import bisq.wallets.json_rpc.JsonRpcCall;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElectrumEmptyPasswordSerializationTest {
+
+    @Test
+    void testWithoutPassword() {
+        var request = ElectrumPayToRpcCall.Request.builder()
+                .destination("destination")
+                .amount(0.1)
+                .password(null)
+                .build();
+
+        JsonRpcCall jsonRpcCall = new JsonRpcCall("test_method", request);
+
+        Moshi moshi = new Moshi.Builder().build();
+        JsonAdapter<JsonRpcCall> jsonRpcCallJsonAdapter = moshi.adapter(JsonRpcCall.class);
+        String jsonRequest = jsonRpcCallJsonAdapter.toJson(jsonRpcCall);
+
+        assertThat(jsonRequest).doesNotContain("password");
+    }
+
+    @Test
+    void testWithPassword() {
+        var request = ElectrumPayToRpcCall.Request.builder()
+                .destination("destination")
+                .amount(0.1)
+                .password("password")
+                .build();
+
+        JsonRpcCall jsonRpcCall = new JsonRpcCall("test_method", request);
+
+        Moshi moshi = new Moshi.Builder().build();
+        JsonAdapter<JsonRpcCall> jsonRpcCallJsonAdapter = moshi.adapter(JsonRpcCall.class);
+        String jsonRequest = jsonRpcCallJsonAdapter.toJson(jsonRpcCall);
+
+        System.out.println(jsonRequest);
+        assertThat(jsonRequest).contains("password");
+    }
+}


### PR DESCRIPTION
When the Electrum wallet is not encrypted we have to ommit the password field in all JSON requests. Sending an empty string causes the RPC calls to fail.