### PR TITLE
disabling Wallet start by default

### DIFF
--- a/application/src/main/resources/default.conf
+++ b/application/src/main/resources/default.conf
@@ -123,6 +123,6 @@ application {
     }
 
     electrumWallet = {
-        enabled = true
+        enabled = false
     }
 }


### PR DESCRIPTION
The wallet functionality does not start correctly on some OSes. So for now I suggest to disable it by default until the code and documentation is mature enough for new devs to get Bisq2 started without asking lots of questions.