### PR TITLE
Add symlink to electrum binary on linux

### DIFF
--- a/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumBinaryExtractor.java
+++ b/wallets/electrum/src/main/java/bisq/wallets/electrum/ElectrumBinaryExtractor.java
@@ -55,7 +55,13 @@ public class ElectrumBinaryExtractor {
                 if (OsUtils.isMac()) {
                     extractElectrumAppFileToDataDir(inputStream);
                     return destDir.toPath().resolve("Electrum.app");
-
+                } else if (OsUtils.isLinux()) {
+                    File extractedFile = extractFileWithSuffixFromStream(inputStream, fileNameSuffix);
+                    Path symLink = extractedFile.toPath().getParent().resolve("Electrum." + fileNameSuffix);
+                    if (Files.exists(symLink)) {
+                        Files.delete(symLink);
+                    }
+                    return Files.createSymbolicLink(symLink, extractedFile.toPath());
                 } else {
                     File extractedFile = extractFileWithSuffixFromStream(inputStream, fileNameSuffix);
                     return extractedFile.toPath();


### PR DESCRIPTION
This allows the client to start on linux with the wallet enabled. This is not meant as a permanent solution, just to allow devs on linux to run with the wallet enabled.