### PR TITLE
Linux notification

### DIFF
--- a/desktop/src/main/java/bisq/desktop/common/notifications/linux/LinuxNotifications.java
+++ b/desktop/src/main/java/bisq/desktop/common/notifications/linux/LinuxNotifications.java
@@ -33,12 +33,11 @@ public class LinuxNotifications implements NotificationsDelegate {
 
     @Override
     public void notify(String title, String message) {
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add("notify-send");
 
-        // todo add icon support
-        //command.add("-i");
-        //command.add("...");
+        command.add("-i");
+        command.add(System.getProperty("java.home") + "/../Bisq_2.png");
 
         command.add("--app-name");
         command.add("Bisq");
@@ -46,7 +45,7 @@ public class LinuxNotifications implements NotificationsDelegate {
         command.add(title);
         command.add(message);
         try {
-            Runtime.getRuntime().exec(command.toArray(new String[command.size()]));
+            Runtime.getRuntime().exec(command.toArray(new String[0]));
         } catch (IOException e) {
             throw new RuntimeException("Unable to notify with Notify OSD", e);
         }

--- a/desktopapp/build.gradle
+++ b/desktopapp/build.gradle
@@ -140,7 +140,6 @@ tasks.jpackage {
         // Setting runtimeImage to java.home failed when using JDK from package manager (user vs root ownership of files?)
         // runtimeImage can alternatively be set to a downloaded and extracted JDK
         // Worked well when using IntelliJ IDEA SDKs (File > Project Structure > SDKs > + > Download JDK)
-        runtimeImage = "/home/user/.jdks/openjdk-17.0.2"
         icon = "package/linux/icon.png"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.parallel=true
+version=0.0.1


### PR DESCRIPTION
Version was needed for jpackage to work for linux.

Icon and description show after installing the deb.

Using the the app icon, notification show the icon, but app name is not visible. I don't know where it should show though, it doesn't show when notify-send is run manually either.