### PR TITLE
Observable: Make observers field final

### DIFF
--- a/common/src/main/java/bisq/common/observable/Observable.java
+++ b/common/src/main/java/bisq/common/observable/Observable.java
@@ -26,7 +26,7 @@ public class Observable<T> {
     // todo as observers is transient we get null after reading persisted data
     // we will likely not persist it when we impl protobuf serialisation, so the Observable can be considered 
     // not serializable
-    private transient Set<Consumer<T>> observers = new CopyOnWriteArraySet<>();
+    private final Set<Consumer<T>> observers = new CopyOnWriteArraySet<>();
 
     public Observable() {
     }
@@ -36,9 +36,6 @@ public class Observable<T> {
     }
 
     public Pin addObserver(Consumer<T> observer) {
-        if (observers == null) {
-            observers = new CopyOnWriteArraySet<>();
-        }
         observers.add(observer);
         observer.accept(value);
         return () -> observers.remove(observer);
@@ -46,9 +43,6 @@ public class Observable<T> {
 
     public void set(T value) {
         this.value = value;
-        if (observers == null) {
-            observers = new CopyOnWriteArraySet<>();
-        }
         observers.forEach(observer -> observer.accept(value));
     }
 


### PR DESCRIPTION
We create the set upon class construction, and it's never null. So, we can make the field final and remove all null-checks.