### PR TITLE
ObservableArray: Make observers field final

### DIFF
--- a/common/src/main/java/bisq/common/observable/ObservableArray.java
+++ b/common/src/main/java/bisq/common/observable/ObservableArray.java
@@ -126,7 +126,7 @@ public class ObservableArray<T> extends CopyOnWriteArrayList<T> {
     }
 
     // Must be a list, not a set as otherwise if 2 instances of the same component is using it, one would get replaced.
-    private transient List<Observer<T, ?>> observableListMappers = new CopyOnWriteArrayList<>();
+    private final List<Observer<T, ?>> observableListMappers = new CopyOnWriteArrayList<>();
 
     public ObservableArray() {
     }
@@ -136,9 +136,6 @@ public class ObservableArray<T> extends CopyOnWriteArrayList<T> {
     }
 
     private List<Observer<T, ?>> getObservers() {
-        if (observableListMappers == null) {
-            observableListMappers = new CopyOnWriteArrayList<>();
-        }
         return observableListMappers;
     }
 


### PR DESCRIPTION
We create the set upon class construction, and it's never null. So, we can make the field final and remove all null-checks.