### PR TITLE
Fix notifications constructor

### DIFF
--- a/desktop/src/main/java/bisq/desktop/common/notifications/AwtNotifications.java
+++ b/desktop/src/main/java/bisq/desktop/common/notifications/AwtNotifications.java
@@ -36,6 +36,8 @@ public class AwtNotifications implements NotificationsDelegate {
             // With MessageType.NONE the line for the application (would be likely Bisq.exe in binary) 
             // should not be displayed on windows
             trayIcon.displayMessage(title, message, TrayIcon.MessageType.NONE);
+            // Trayicon does not remove itself in all cases for Linux
+            trayIcon.addActionListener(l -> systemTray.remove(trayIcon));
         } catch (AWTException e) {
             throw new RuntimeException(e);
         }

--- a/desktop/src/main/java/bisq/desktop/common/notifications/Notifications.java
+++ b/desktop/src/main/java/bisq/desktop/common/notifications/Notifications.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.common.notifications;
 
+import bisq.common.util.OperatingSystem;
 import bisq.common.util.OsUtils;
 import bisq.desktop.common.notifications.linux.LinuxNotifications;
 import bisq.desktop.common.notifications.osx.OsxNotifications;
@@ -48,20 +49,16 @@ public class Notifications {
     private final NotificationsDelegate delegate;
 
     private Notifications() {
-        switch (OsUtils.getOperatingSystem()) {
-            case LINUX:
-                if (LinuxNotifications.isSupported()) {
-                    delegate = new LinuxNotifications();
-                    break;
-                }
-            case MAC:
-                if (OsxNotifications.isSupported()) {
-                    delegate = new OsxNotifications();
-                    break;
-                }
-            case WIN:
-            default:
-                delegate = new AwtNotifications();
+        if (OsUtils.getOperatingSystem() == OperatingSystem.LINUX &&
+                LinuxNotifications.isSupported()) {
+            delegate = new LinuxNotifications();
+            return;
         }
+        if (OsUtils.getOperatingSystem() == OperatingSystem.MAC &&
+                OsxNotifications.isSupported()) {
+            delegate = new OsxNotifications();
+            return;
+        }
+        delegate = new AwtNotifications();
     }
 }


### PR DESCRIPTION
Switch doesn't work when support fails and it falls through to the next OS. Remove tray icon when using AwtNotifications