### PR TITLE
Keep previous userprofile selection on nothing selected

### DIFF
--- a/desktop/src/main/java/bisq/desktop/primary/main/content/settings/userProfile/UserProfileView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/settings/userProfile/UserProfileView.java
@@ -137,7 +137,13 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         deletedButton.setOnAction(e -> controller.onDelete());
         saveButton.setOnAction(e -> controller.onSave());
         createNewProfileButton.setOnAction(e -> controller.onAddNewChatUser());
-        comboBox.setOnChangeConfirmed(e -> controller.onSelected(comboBox.getSelectionModel().getSelectedItem()));
+        comboBox.setOnChangeConfirmed(e -> {
+            if (comboBox.getSelectionModel().getSelectedItem() == null) {
+                comboBox.getSelectionModel().select(model.getSelectedUserIdentity().get());
+                return;
+            }
+            controller.onSelected(comboBox.getSelectionModel().getSelectedItem());
+        });
 
         selectedChatUserIdentityPin = EasyBind.subscribe(model.getSelectedUserIdentity(),
                 userIdentity -> {


### PR DESCRIPTION
When clicking the combobox for user profile selection and then clicking outside without selecting a new userprofile, the combobox is left with no userprofile selected. This fix resets the combobox to the globally selected userprofile.