### PR TITLE
Send unused btc address

### DIFF
--- a/chat/src/main/java/bisq/chat/trade/TradeChatOffer.java
+++ b/chat/src/main/java/bisq/chat/trade/TradeChatOffer.java
@@ -1,4 +1,4 @@
-package bisq.chat.trade.pub;
+package bisq.chat.trade;
 
 
 import bisq.common.currency.Market;

--- a/chat/src/main/java/bisq/chat/trade/TradeChatOfferMessage.java
+++ b/chat/src/main/java/bisq/chat/trade/TradeChatOfferMessage.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.chat.trade;
+
+import java.util.Optional;
+
+public interface TradeChatOfferMessage {
+    Optional<TradeChatOffer> getTradeChatOffer();
+
+    boolean hasTradeChatOffer();
+}

--- a/chat/src/main/java/bisq/chat/trade/pub/PublicTradeChatMessage.java
+++ b/chat/src/main/java/bisq/chat/trade/pub/PublicTradeChatMessage.java
@@ -22,6 +22,7 @@ import bisq.chat.message.BasePublicChatMessage;
 import bisq.chat.message.ChatMessage;
 import bisq.chat.message.MessageType;
 import bisq.chat.message.Quotation;
+import bisq.chat.trade.TradeChatOffer;
 import bisq.common.util.StringUtils;
 import bisq.network.p2p.services.data.storage.MetaData;
 import lombok.EqualsAndHashCode;

--- a/chat/src/main/java/bisq/chat/trade/pub/PublicTradeChatMessage.java
+++ b/chat/src/main/java/bisq/chat/trade/pub/PublicTradeChatMessage.java
@@ -23,6 +23,7 @@ import bisq.chat.message.ChatMessage;
 import bisq.chat.message.MessageType;
 import bisq.chat.message.Quotation;
 import bisq.chat.trade.TradeChatOffer;
+import bisq.chat.trade.TradeChatOfferMessage;
 import bisq.common.util.StringUtils;
 import bisq.network.p2p.services.data.storage.MetaData;
 import lombok.EqualsAndHashCode;
@@ -36,7 +37,7 @@ import java.util.Optional;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class PublicTradeChatMessage extends BasePublicChatMessage {
+public final class PublicTradeChatMessage extends BasePublicChatMessage implements TradeChatOfferMessage {
     private final Optional<TradeChatOffer> tradeChatOffer;
 
     public PublicTradeChatMessage(String channelName,
@@ -123,7 +124,8 @@ public final class PublicTradeChatMessage extends BasePublicChatMessage {
         return metaData;
     }
 
-    public boolean isOfferMessage() {
+    @Override
+    public boolean hasTradeChatOffer() {
         return tradeChatOffer.isPresent();
     }
 }

--- a/chat/src/main/proto/chat.proto
+++ b/chat/src/main/proto/chat.proto
@@ -123,6 +123,8 @@ message PrivateTradeChatMessage {
   string receiversId = 1;
   user.UserProfile sender = 2;
   optional user.UserProfile mediator = 3;
+  optional TradeChatOffer tradeChatOffer = 4;
+
 }
 
 message TradeChatOffer {

--- a/desktop/src/main/java/bisq/desktop/notifications/chat/ChatNotifications.java
+++ b/desktop/src/main/java/bisq/desktop/notifications/chat/ChatNotifications.java
@@ -185,7 +185,7 @@ public class ChatNotifications {
         if (chatMessage instanceof BasePublicChatMessage) {
             if (chatMessage instanceof PublicTradeChatMessage) {
                 PublicTradeChatMessage publicTradeChatMessage = (PublicTradeChatMessage) chatMessage;
-                if (settingsService.getOffersOnly().get() && !publicTradeChatMessage.isOfferMessage()) {
+                if (settingsService.getOffersOnly().get() && !publicTradeChatMessage.hasTradeChatOffer()) {
                     return;
                 }
                 PublicTradeChannel publicTradeChannel = (PublicTradeChannel) channel;

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMessagesListView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMessagesListView.java
@@ -28,7 +28,7 @@ import bisq.chat.trade.priv.PrivateTradeChatMessage;
 import bisq.chat.trade.pub.PublicTradeChannel;
 import bisq.chat.trade.pub.PublicTradeChannelService;
 import bisq.chat.trade.pub.PublicTradeChatMessage;
-import bisq.chat.trade.pub.TradeChatOffer;
+import bisq.chat.trade.TradeChatOffer;
 import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
 import bisq.common.observable.Pin;

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMessagesListView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMessagesListView.java
@@ -509,7 +509,7 @@ public class ChatMessagesListView {
                 boolean offerOnlyPredicate = true;
                 if (item.getChatMessage() instanceof PublicTradeChatMessage) {
                     PublicTradeChatMessage publicTradeChatMessage = (PublicTradeChatMessage) item.getChatMessage();
-                    offerOnlyPredicate = !offerOnly || publicTradeChatMessage.isOfferMessage();
+                    offerOnlyPredicate = !offerOnly || publicTradeChatMessage.hasTradeChatOffer();
                 }
                 return offerOnlyPredicate &&
                         item.getSenderUserProfile().isPresent() &&
@@ -556,7 +556,7 @@ public class ChatMessagesListView {
 
         boolean isOfferMessage(ChatMessage chatMessage) {
             return chatMessage instanceof PublicTradeChatMessage &&
-                    ((PublicTradeChatMessage) chatMessage).isOfferMessage();
+                    ((PublicTradeChatMessage) chatMessage).hasTradeChatOffer();
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/dashboard/DashboardController.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/dashboard/DashboardController.java
@@ -108,7 +108,7 @@ public class DashboardController implements Controller {
         if (allowUpdateOffersOnline) {
             UIThread.run(() ->
                     model.getOffersOnline().set(String.valueOf(publicTradeChannelService.getChannels().stream().flatMap(channel -> channel.getChatMessages().stream())
-                            .filter(PublicTradeChatMessage::isOfferMessage)
+                            .filter(PublicTradeChatMessage::hasTradeChatOffer)
                             .count())));
         }
     }

--- a/desktop/src/main/java/bisq/desktop/primary/overlay/createOffer/review/ReviewOfferController.java
+++ b/desktop/src/main/java/bisq/desktop/primary/overlay/createOffer/review/ReviewOfferController.java
@@ -27,7 +27,7 @@ import bisq.chat.trade.priv.PrivateTradeChannelService;
 import bisq.chat.trade.pub.PublicTradeChannel;
 import bisq.chat.trade.pub.PublicTradeChannelService;
 import bisq.chat.trade.pub.PublicTradeChatMessage;
-import bisq.chat.trade.pub.TradeChatOffer;
+import bisq.chat.trade.TradeChatOffer;
 import bisq.common.currency.Market;
 import bisq.common.monetary.Fiat;
 import bisq.common.monetary.Monetary;

--- a/desktop/src/main/java/bisq/desktop/primary/overlay/createOffer/review/ReviewOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/overlay/createOffer/review/ReviewOfferView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.primary.overlay.createOffer.review;
 
 import bisq.chat.trade.pub.PublicTradeChatMessage;
-import bisq.chat.trade.pub.TradeChatOffer;
+import bisq.chat.trade.TradeChatOffer;
 import bisq.common.currency.Market;
 import bisq.common.monetary.Fiat;
 import bisq.desktop.common.utils.Transitions;

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -42,6 +42,7 @@ lightning=Lightning-X
 createOffer=Create offer
 takeOffer=Take offer
 deleteOffer=Delete offer
+completeTrade=Complete trade
 markets=Markets
 dashboard=Dashboard
 grid=Grid
@@ -469,6 +470,8 @@ wallet.txs.txId=Transaction ID
 wallet.txs.amount=Amount in BTC
 wallet.txs.confirmations=Confirmations
 
+wallet.unavailable=No wallet available
+
 # Balance Box
 wallet.availableBalance=Available Balance
 # Wallet UI
@@ -567,6 +570,8 @@ roboIconWithId.id=ID: {0}
 satoshisquareapp.createOffer.maxAmount=Maximum 0.007 BTC
 createOffer.tradeChatOffer.chatMessage=I would like to {0} Bitcoin for {1} using {2}
 bisqEasy.takeOffer.takerRequest=I want to {0} Bitcoin and would like to take your offer.
+bisqEasy.completeOffer.sendRequest=Please send {0} BTC to {1} {2}
+bisqEasy.completeOffer.tooltip=Ask seller to send BTC to one of your unused addresses
 satoshisquareapp.chat.messageMenu.copyMessage=Copy message
 satoshisquareapp.chat.messageMenu.ignoreUser=Ignore user
 satoshisquareapp.chat.messageMenu.reportUser=Report user to moderator


### PR DESCRIPTION
## Description
Add feature to send an unused bitcoin address from the internal wallet to the trade peer when completing a trade in the private trade chat.

## Details
This was an exercise in learning a bit more about the code base. If the feature is not appropriate, please disregard. The other PRs are a result of working on this feature.

- Refactor TradeChatOffer
- Add TradeChatOfferInterface for public and private trade messages to use
- Add TradeChatOfferInterface to private messages to have the details of the offer within the private chat
- Add button to automatically get an unused bitcoin address and send message to the bitcoin seller

Further features related to this work would be adding the same functionality for bitcoin sellers. Display fiat payment details with a button push to increase ease of use and avoid errors.

## Questions
- Is bitcoin supposed to be one side of each trade or can other pairs be traded? I looks like bitcoin is intended to be one side of every trade but that seems quite restrictive as a design choice.
- Is default.properties meant to be translated? It looks like it and will affect design when sending generated text messages as text instead of as operations.
- There looks to be a work in process framework for a more extensive trade protocol. Is this discussed somewhere?