### PR TITLE
Avoid running multiple instances on one directory

### DIFF
--- a/application/src/main/java/bisq/application/NoFileLockException.java
+++ b/application/src/main/java/bisq/application/NoFileLockException.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.application;
+
+public class NoFileLockException extends RuntimeException {
+    public NoFileLockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Acquire an exclusive lock on a file in the data directory to avoid multiple instances using the same directory. This works on Linux, other systems might handle file locks differently.