### PR TITLE
ServerChannel: Don't set serverSocketChannel to non-blocking

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/node/ServerChannel.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/ServerChannel.java
@@ -76,8 +76,6 @@ public class ServerChannel {
                 );
                 serverSocketChannel.socket().bind(socketAddress);
 
-                serverSocketChannel.configureBlocking(false);
-
                 Selector selector = SelectorProvider.provider().openSelector();
                 InboundConnectionsManager inboundConnectionsManager =
                         new InboundConnectionsManager(


### PR DESCRIPTION
The InboundConnectionsManager sets the serverSocketChannel to non-blocking mode in registerOpAccept().