### PR TITLE
Electrum: Remove unused libraries

### DIFF
--- a/build-logic/electrum-binaries/build.gradle
+++ b/build-logic/electrum-binaries/build.gradle
@@ -18,5 +18,4 @@ gradlePlugin {
 
 dependencies {
     implementation project(':gradle-tasks')
-    implementation libs.bouncycastle.pg
 }


### PR DESCRIPTION
- [Electrum Gradle: Remove libs.google.guava dependency](https://github.com/bisq-network/bisq2/commit/315f99b6d47b5d61af28a24a33a925104b2e960a)
- [Electrum Gradle: Remove libs.bouncycastle.pg dependency](https://github.com/bisq-network/bisq2/commit/8d83986854cf499212ac40e0a383803c1c95e2da)