### PR TITLE
Userprofile selection

### DIFF
--- a/desktop/src/main/java/bisq/desktop/primary/main/content/settings/userProfile/UserProfileView.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/settings/userProfile/UserProfileView.java
@@ -149,14 +149,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         });
 
         selectedChatUserIdentityPin = EasyBind.subscribe(model.getSelectedUserIdentity(),
-                userIdentity -> {
-                    if (userIdentity != null) {
-                        // Setting selection via selectionModel.select displays the label from the base class. 
-                        // Did not find out how to avoid that... ;-(
-                        // With setting our selection to the editorTextField it behaves as expected.
-                        UIThread.runOnNextRenderFrame(() -> comboBox.getEditorTextField().setText(comboBox.getConverter().toString(userIdentity)));
-                    }
-                });
+                userIdentity -> comboBox.getSelectionModel().select(model.getSelectedUserIdentity().get()));
     }
 
     @Override

--- a/user/src/main/java/bisq/user/identity/UserIdentityStore.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityStore.java
@@ -44,7 +44,9 @@ public final class UserIdentityStore implements PersistableStore<UserIdentitySto
 
     private UserIdentityStore(UserIdentity selectedUserIdentity,
                               Set<UserIdentity> userIdentities) {
-        this.selectedUserIdentity.set(selectedUserIdentity);
+        this.selectedUserIdentity.set(userIdentities.stream()
+                .filter(userIdentity -> userIdentity.equals(selectedUserIdentity))
+                .findAny().orElse(null));
         this.userIdentities = new ObservableSet<>(userIdentities);
     }
 


### PR DESCRIPTION
> Setting selection via selectionModel.select displays the label from the base class

My suspicion is that the issue was `selectedUserIdentity` not being one of the instances in the `userIdentities` set and `equals()` not working as expected. That would cause `select()` to fail. `UserIdentity.equals()` now work but I still think it's better to use the same instances rather than a copy for `selectedUserIdentity`.