### PR TITLE
Add leave channel button when peer left channel

### DIFF
--- a/chat/src/main/java/bisq/chat/channel/ChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/channel/ChatChannelService.java
@@ -77,6 +77,10 @@ public abstract class ChatChannelService<M extends ChatMessage, C extends ChatCh
 
     public abstract ObservableArray<C> getChannels();
 
+    public void leaveChannel(String id) {
+        findChannel(id).ifPresent(this::leaveChannel);
+    }
+
     public abstract void leaveChannel(C channel);
 
     protected void doRemoveExpiredMessages(C channel) {

--- a/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMessagesComponent.java
+++ b/desktop/src/main/java/bisq/desktop/primary/main/content/components/ChatMessagesComponent.java
@@ -27,10 +27,12 @@ import bisq.chat.bisqeasy.message.BisqEasyPrivateTradeChatMessage;
 import bisq.chat.channel.ChatChannel;
 import bisq.chat.channel.ChatChannelDomain;
 import bisq.chat.channel.ChatChannelSelectionService;
+import bisq.chat.channel.priv.PrivateChatChannel;
 import bisq.chat.channel.priv.TwoPartyPrivateChatChannel;
 import bisq.chat.channel.pub.CommonPublicChatChannel;
 import bisq.chat.channel.pub.PublicChatChannel;
 import bisq.chat.message.ChatMessage;
+import bisq.chat.message.ChatMessageType;
 import bisq.chat.message.Citation;
 import bisq.common.observable.Pin;
 import bisq.common.util.StringUtils;
@@ -195,8 +197,12 @@ public class ChatMessagesComponent {
 
                 boolean isBisqEasyPublicChatChannel = chatChannel instanceof BisqEasyPublicChatChannel;
                 boolean isBisqEasyPrivateTradeChatChannel = chatChannel instanceof BisqEasyPrivateTradeChatChannel;
+                boolean isTwoPartyPrivateChatChannel = chatChannel instanceof TwoPartyPrivateChatChannel;
+                model.getLeaveChannelButtonVisible().set(false);
                 model.getCreateOfferButtonVisible().set(isBisqEasyPublicChatChannel);
                 model.getOpenDisputeButtonVisible().set(isBisqEasyPrivateTradeChatChannel);
+                model.getSendBtcAddressButtonVisible().set(false);
+                model.getSendPaymentAccountButtonVisible().set(false);
 
                 if (chatMessagesPin != null) {
                     chatMessagesPin.unbind();
@@ -210,9 +216,8 @@ public class ChatMessagesComponent {
                     inMediationPin = privateChannel.isInMediationObservable().addObserver(isInMediation ->
                             model.getOpenDisputeButtonVisible().set(!isInMediation &&
                                     !privateChannel.isMediator()));
-                } else {
-                    model.getSendBtcAddressButtonVisible().set(false);
-                    model.getSendPaymentAccountButtonVisible().set(false);
+                } else if (isTwoPartyPrivateChatChannel) {
+                    chatMessagesPin = chatChannel.getChatMessages().addListener(() -> twoPartyPeerLeft((TwoPartyPrivateChatChannel) chatChannel));
                 }
 
                 accountsChanged();
@@ -256,7 +261,7 @@ public class ChatMessagesComponent {
         private void showChatUserDetailsHandler(ChatMessage chatMessage) {
             model.selectedChatMessage = chatMessage;
             userProfileService.findUserProfile(chatMessage.getAuthorUserProfileId())
-                    .ifPresent(openUserProfileSidebarHandler::accept);
+                    .ifPresent(openUserProfileSidebarHandler);
         }
 
         private void mentionUserHandler(UserProfile userProfile) {
@@ -308,7 +313,17 @@ public class ChatMessagesComponent {
                     model.getSendBtcAddressButtonVisible().set(walletService.isPresent());
                 }
             });
+            twoPartyPeerLeft(chatChannel);
         }
+
+        private void twoPartyPeerLeft(PrivateChatChannel<?> chatChannel) {
+            UIThread.run(() -> {
+                boolean peerLeft = chatChannel.getChatMessages().stream()
+                        .anyMatch(message -> message.getChatMessageType() == ChatMessageType.LEAVE);
+                model.getLeaveChannelButtonVisible().set(peerLeft);
+            });
+        }
+
 
         private void accountsChanged() {
             UIThread.run(() ->
@@ -335,6 +350,19 @@ public class ChatMessagesComponent {
         ///////////////////////////////////////////////////////////////////////////////////////////////////
         // UI handlers
         ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+        void onLeaveChannel() {
+            ChatChannel<?> chatChannel = model.getSelectedChannel().get();
+            if (!(chatChannel instanceof PrivateChatChannel))
+                return;
+
+            chatService.findChatChannelService(chatChannel).ifPresent(
+                    service -> {
+                        service.leaveChannel(chatChannel.getId());
+                        chatService.getChatChannelSelectionServices().get(model.getChatChannelDomain()).maybeSelectFirstChannel();
+                    }
+            );
+        }
 
         void onCreateOffer() {
             ChatChannel<? extends ChatMessage> chatChannel = model.getSelectedChannel().get();
@@ -506,6 +534,7 @@ public class ChatMessagesComponent {
 
     @Getter
     private static class Model implements bisq.desktop.common.view.Model {
+        private final BooleanProperty leaveChannelButtonVisible = new SimpleBooleanProperty();
         private final BooleanProperty createOfferButtonVisible = new SimpleBooleanProperty();
         private final BooleanProperty openDisputeButtonVisible = new SimpleBooleanProperty();
         private final BooleanProperty sendBtcAddressButtonVisible = new SimpleBooleanProperty();
@@ -555,7 +584,7 @@ public class ChatMessagesComponent {
         public final static String EDITED_POST_FIX = " " + Res.get("social.message.wasEdited");
 
         private final BisqTextArea inputField;
-        private final Button sendButton, createOfferButton, sendBtcAddressButton, sendPaymentAccountButton, openDisputeButton;
+        private final Button sendButton, createOfferButton, sendBtcAddressButton, sendPaymentAccountButton, openDisputeButton, leaveChannelButton;
         private final AutoCompleteComboBox<BisqEasyPaymentAccount> paymentAccountsComboBox;
         private final ChatMentionPopupMenu<UserProfile> userMentionPopup;
         private final ChatMentionPopupMenu<ChatChannel<?>> channelMentionPopup;
@@ -618,6 +647,9 @@ public class ChatMessagesComponent {
             openDisputeButton = createAndGetChatButton(Res.get("bisqEasy.openDispute"), 110);
             openDisputeButton.getStyleClass().add("outlined-button");
 
+            leaveChannelButton = createAndGetChatButton(Res.get("social.privateChannel.leave"), 120);
+            leaveChannelButton.getStyleClass().add("outlined-button");
+
             //todo
             paymentAccountsComboBox = new AutoCompleteComboBox<>(model.getPaymentAccounts());
             paymentAccountsComboBox.setConverter(new StringConverter<>() {
@@ -632,7 +664,7 @@ public class ChatMessagesComponent {
                 }
             });
 
-            bottomHBox.getChildren().addAll(userProfileSelectionRoot, bottomBoxStackPane,
+            bottomHBox.getChildren().addAll(userProfileSelectionRoot, bottomBoxStackPane, leaveChannelButton,
                     createOfferButton, sendBtcAddressButton, sendPaymentAccountButton, openDisputeButton);
             bottomHBox.getStyleClass().add("bg-grey-5");
             bottomHBox.setAlignment(Pos.CENTER);
@@ -652,6 +684,8 @@ public class ChatMessagesComponent {
 
         @Override
         protected void onViewAttached() {
+            leaveChannelButton.visibleProperty().bind(model.getLeaveChannelButtonVisible());
+            leaveChannelButton.managedProperty().bind(model.getLeaveChannelButtonVisible());
             createOfferButton.visibleProperty().bind(model.getCreateOfferButtonVisible());
             createOfferButton.managedProperty().bind(model.getCreateOfferButtonVisible());
             openDisputeButton.visibleProperty().bind(model.getOpenDisputeButtonVisible());
@@ -687,6 +721,7 @@ public class ChatMessagesComponent {
                 controller.onSendMessage(inputField.getText().trim());
                 inputField.clear();
             });
+            leaveChannelButton.setOnAction(e -> controller.onLeaveChannel());
             createOfferButton.setOnAction(e -> controller.onCreateOffer());
             sendBtcAddressButton.setOnAction(e -> controller.onSendBtcAddress());
             sendPaymentAccountButton.setOnAction(e -> controller.onSendPaymentAccount());
@@ -706,6 +741,8 @@ public class ChatMessagesComponent {
 
         @Override
         protected void onViewDetached() {
+            leaveChannelButton.visibleProperty().unbind();
+            leaveChannelButton.managedProperty().unbind();
             createOfferButton.visibleProperty().unbind();
             createOfferButton.managedProperty().unbind();
             openDisputeButton.visibleProperty().unbind();
@@ -722,6 +759,7 @@ public class ChatMessagesComponent {
 
             inputField.setOnKeyPressed(null);
             sendButton.setOnAction(null);
+            leaveChannelButton.setOnAction(null);
             createOfferButton.setOnAction(null);
             sendBtcAddressButton.setOnAction(null);
             sendPaymentAccountButton.setOnAction(null);


### PR DESCRIPTION
Leave channel by id, let services handle generics.

Cleanup

@HenrikJannsen I see what you mean with the generics in #894. I let the generic classes themself handle the generics by adding a convenience function that takes a String. Similar to what you did in your usage of leaveChannel().

This works and is cleaner than the other suggestions as I see it.

Again, I have added an unsolicited feature. If it's not welcome, please close the PR.