### PR TITLE
Use protobuf aarch64 binaries for ARM processors

### DIFF
--- a/build-logic/commons/src/main/groovy/bisq.protobuf.gradle
+++ b/build-logic/commons/src/main/groovy/bisq.protobuf.gradle
@@ -26,15 +26,12 @@ ext {
     def operatingSystem = current()
     osFamily = operatingSystem.familyName
     osArch = System.getProperty("os.arch")
-    // Extra OSX Arch property needed to workaround lack of protobuf support in M1 Mac system.
-    osxArch = System.getProperty('os.arch') == 'aarch64' ? ':osx-x86_64' : ''
     osDescription = operatingSystem.toString()
 }
 
 protobuf {
     protoc {
-        // Append 'osxArch' property to workaround M1 Mac bug.
-        artifact = "com.google.protobuf:protoc:3.19.4${osxArch}"
+        artifact = "com.google.protobuf:protoc:3.19.4"
     }
     generateProtoTasks {
         all()*.plugins {}


### PR DESCRIPTION
aarch64 binaries have been available since version 3.5.0, therefore it shouldn't be needed to default to x86_64.

I could successfully run the app in an Apple M2 Pro. Would be great if someone with M1 could test and verify.