### PR TITLE
KeyFingerprintReader: Return optional in read method

### DIFF
--- a/network/tor-local-network/src/main/java/bisq/tor/local_network/KeyFingerprintReader.java
+++ b/network/tor-local-network/src/main/java/bisq/tor/local_network/KeyFingerprintReader.java
@@ -17,13 +17,17 @@
 
 package bisq.tor.local_network;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
+@Slf4j
 public class KeyFingerprintReader {
     private final File fingerprintFile;
     private final Predicate<String> lineMatcher;
@@ -38,19 +42,23 @@ public class KeyFingerprintReader {
     }
 
 
-    public String read() throws IOException {
+    public Optional<String> read() {
         try (var reader = new BufferedReader(new FileReader(fingerprintFile))) {
             String line = reader.readLine();
             while (line != null) {
 
                 if (lineMatcher.test(line)) {
-                    return dataExtractor.apply(line);
+                    return Optional.of(
+                            dataExtractor.apply(line)
+                    );
                 }
 
                 line = reader.readLine();
             }
+        } catch (IOException e) {
+            log.error("Cannot read " + fingerprintFile.getAbsolutePath(), e);
         }
 
-        throw new IllegalStateException(fingerprintFile.getAbsolutePath() + " was never created.");
+        return Optional.empty();
     }
 }

--- a/network/tor-local-network/src/main/java/bisq/tor/local_network/da/keygen/RelayKeyGenProcess.java
+++ b/network/tor-local-network/src/main/java/bisq/tor/local_network/da/keygen/RelayKeyGenProcess.java
@@ -56,7 +56,7 @@ public class RelayKeyGenProcess {
         return readKeyFingerprint();
     }
 
-    private String readKeyFingerprint() throws IOException {
+    private String readKeyFingerprint() {
         File dataDirFile = directoryAuthority.getDataDir().toFile();
         File fingerprintFile = new File(dataDirFile, "fingerprint");
 
@@ -64,6 +64,6 @@ public class RelayKeyGenProcess {
         UnaryOperator<String> dataExtractor = s -> s.split(" ")[1].strip();
 
         var keyFingerprintReader = new KeyFingerprintReader(fingerprintFile, lineMatcher, dataExtractor);
-        return keyFingerprintReader.read();
+        return keyFingerprintReader.read().orElseThrow();
     }
 }

--- a/network/tor-local-network/src/main/java/bisq/tor/local_network/da/keygen/process/DirectoryIdentityKeyGenProcess.java
+++ b/network/tor-local-network/src/main/java/bisq/tor/local_network/da/keygen/process/DirectoryIdentityKeyGenProcess.java
@@ -60,19 +60,19 @@ public class DirectoryIdentityKeyGenProcess {
         outputStream = Optional.of(process.getOutputStream());
     }
 
-    public String getKeyFingerprint() throws InterruptedException, IOException {
+    public String getKeyFingerprint() throws InterruptedException {
         Process process = this.process.orElseThrow();
         process.waitFor(1, TimeUnit.MINUTES);
         return readKeyFingerprint();
     }
 
-    private String readKeyFingerprint() throws IOException {
+    private String readKeyFingerprint() {
         File certificateFile = new File(torKeyDirPath.toFile(), "authority_certificate");
 
         Predicate<String> lineMatcher = s -> s.startsWith("fingerprint ");
         UnaryOperator<String> dataExtractor = s -> s.split(" ")[1].strip();
 
         var keyFingerprintReader = new KeyFingerprintReader(certificateFile, lineMatcher, dataExtractor);
-        return keyFingerprintReader.read();
+        return keyFingerprintReader.read().orElseThrow();
     }
 }


### PR DESCRIPTION
We return an empty optional if the file doesn't exist or the read fails due to an I/O error.