### PR TITLE
Tor: Bind Process to Connection

### DIFF
--- a/network/tor/src/main/java/bisq/tor/process/NativeTorController.java
+++ b/network/tor/src/main/java/bisq/tor/process/NativeTorController.java
@@ -36,9 +36,10 @@ public class NativeTorController {
         torControlConnection = Optional.of(controlConnection);
     }
 
-    public void takeOwnership() throws IOException {
+    public void bindTorToConnection() throws IOException {
         TorControlConnection controlConnection = torControlConnection.orElseThrow();
         controlConnection.takeOwnership();
+        controlConnection.resetConf(NativeTorProcess.ARG_OWNER_PID);
     }
 
     public void shutdown() throws IOException {

--- a/network/tor/src/main/java/bisq/tor/process/NativeTorProcess.java
+++ b/network/tor/src/main/java/bisq/tor/process/NativeTorProcess.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeoutException;
 @Slf4j
 public class NativeTorProcess {
 
-    private static final String ARG_OWNER_PID = "__OwningControllerProcess";
+    public static final String ARG_OWNER_PID = "__OwningControllerProcess";
     private final Path torrcPath;
     private Optional<Process> process = Optional.empty();
     private Optional<Future<Path>> logFileCreationWaiter = Optional.empty();


### PR DESCRIPTION
If the the owner pid is set with __OwningControllerProcess, Tor polls to see whether the parent is still running. After establishing the controller connection, we can bind the process to the control socket using the TAKEOWNERSHIP command.