### PR TITLE
Reenable delete profile button

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileModel.java
@@ -23,6 +23,7 @@ import bisq.user.reputation.ReputationScore;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -42,4 +43,6 @@ public class UserProfileModel implements Model {
     private final ObjectProperty<ReputationScore> reputationScore = new SimpleObjectProperty<>();
     private final StringProperty profileAge = new SimpleStringProperty();
     private final BooleanProperty saveButtonDisabled = new SimpleBooleanProperty();
+    private final BooleanProperty deleteButtonDisabled = new SimpleBooleanProperty();
+    private final ObjectProperty<Tooltip> deleteTooltip = new SimpleObjectProperty<>();
 }

--- a/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileView.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileView.java
@@ -28,6 +28,7 @@ import bisq.user.identity.UserIdentity;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
+import javafx.scene.control.SplitPane;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -43,7 +44,8 @@ import javax.annotation.Nullable;
 
 @Slf4j
 public class UserProfileView extends View<HBox, UserProfileModel, UserProfileController> {
-    private final Button createNewProfileButton, deletedButton, saveButton;
+    private final Button createNewProfileButton, deleteButton, saveButton;
+    private final SplitPane deleteWrapper;
     private final MaterialTextField nymId, profileId, profileAge, reputationScoreField, statement;
     private final ImageView roboIconImageView;
     private final MaterialTextArea terms;
@@ -110,11 +112,10 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         saveButton = new Button(Res.get("action.save"));
         saveButton.setDefaultButton(true);
 
-        deletedButton = new Button(Res.get("user.userProfile.deleteProfile"));
+        deleteButton = new Button(Res.get("user.userProfile.deleteProfile"));
+        deleteWrapper = new SplitPane(deleteButton);
 
-        // todo For now we hide the deletedButton because it comes with some complexities
-        // See https://github.com/bisq-network/bisq2/issues/794
-        HBox buttonsHBox = new HBox(20, saveButton/*, deletedButton*/);
+        HBox buttonsHBox = new HBox(20, saveButton, deleteWrapper);
         formVBox.getChildren().add(buttonsHBox);
     }
 
@@ -128,6 +129,8 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         terms.textProperty().bindBidirectional(model.getTerms());
         roboIconImageView.imageProperty().bind(model.getRoboHash());
         saveButton.disableProperty().bind(model.getSaveButtonDisabled());
+        deleteButton.disableProperty().bind(model.getDeleteButtonDisabled());
+        deleteWrapper.tooltipProperty().bind(model.getDeleteTooltip());
 
         reputationScorePin = EasyBind.subscribe(model.getReputationScore(), reputationScore -> {
             if (reputationScore != null) {
@@ -135,7 +138,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
             }
         });
 
-        deletedButton.setOnAction(e -> controller.onDelete());
+        deleteButton.setOnAction(e -> controller.onDeleteProfile());
         saveButton.setOnAction(e -> controller.onSave());
         createNewProfileButton.setOnAction(e -> controller.onAddNewChatUser());
         comboBox.setOnChangeConfirmed(e -> {
@@ -160,11 +163,13 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         terms.textProperty().unbindBidirectional(model.getTerms());
         roboIconImageView.imageProperty().unbind();
         saveButton.disableProperty().unbind();
+        deleteButton.disableProperty().unbind();
+        deleteWrapper.tooltipProperty().unbind();
 
         reputationScorePin.unsubscribe();
         selectedChatUserIdentityPin.unsubscribe();
 
-        deletedButton.setOnAction(null);
+        deleteButton.setOnAction(null);
         saveButton.setOnAction(null);
         createNewProfileButton.setOnAction(null);
         comboBox.setOnChangeConfirmed(null);

--- a/i18n/src/main/resources/user.properties
+++ b/i18n/src/main/resources/user.properties
@@ -54,12 +54,12 @@ user.userProfile.terms.tooLong=Trade terms must not be longer than {0} character
 
 user.userProfile.createNewProfile=Create new profile
 user.userProfile.deleteProfile=Delete this profile
-user.userProfile.deleteProfile.warning=Do you really want to delete that user profile? You cannot un-do this operation.
-user.userProfile.deleteProfile.warning.yes=Yes, delete my user profile
-user.userProfile.deleteProfile.lastProfile.warning=Deleting user profile is not permitted. \
-  There need to be at least one user profile set up. Please create first another user profile. Once you have more than one user \
-  profiles you can delete this one.
-
+user.userProfile.deleteProfile.warning=Do you really want to delete {0}? You cannot un-do this operation.
+user.userProfile.deleteProfile.warning.yes=Yes, delete profile
+user.userProfile.deleteProfile.unable.warning=Unable to delete. To delete this profile, first:\n\
+  - Delete all messages posted with this profile\n\
+  - Close all private channels for this profile\n\
+  - Make sure to have at least one more profile
 
 
 


### PR DESCRIPTION
Fix https://github.com/bisq-network/bisq2/issues/794

Check if delete profile allowed and disable button if not allowed

Add delete profile button tooltip when button is disabled

Set callback from ChatService to UsedIdentityService to test if there are any open private channels or messages in public channels from the profile that is about to be deleted.

Setting the callback from ChatService for the check of user profile activity doesn't really follow the style of the project. Is there another recommended way to handle this?

Messages to a deleted profile are not handled. I tried handling that but it doesn't make much sense. If a profile is deleted it's meant to not be active anymore so all messages to the deleted profile are ignored.