### PR TITLE
Show notification for selected channel only

### DIFF
--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -128,16 +128,12 @@ public class ChatNotificationService implements Service {
                 onChatChannelsChanged(bisqEasyOfferbookChannelService.getChannels()));
 
         chatService.getCommonPublicChatChannelServices().values()
-                .forEach(commonPublicChatChannelService -> {
-                    commonPublicChatChannelService.getChannels().addListener(() ->
-                            onChatChannelsChanged(commonPublicChatChannelService.getChannels()));
-                });
+                .forEach(commonPublicChatChannelService -> commonPublicChatChannelService.getChannels().addListener(() ->
+                        onChatChannelsChanged(commonPublicChatChannelService.getChannels())));
 
         chatService.getTwoPartyPrivateChatChannelServices().values()
-                .forEach(twoPartyPrivateChatChannelService -> {
-                    twoPartyPrivateChatChannelService.getChannels().addListener(() ->
-                            onChatChannelsChanged(twoPartyPrivateChatChannelService.getChannels()));
-                });
+                .forEach(twoPartyPrivateChatChannelService -> twoPartyPrivateChatChannelService.getChannels().addListener(() ->
+                        onChatChannelsChanged(twoPartyPrivateChatChannelService.getChannels())));
 
         return CompletableFuture.completedFuture(true);
     }
@@ -245,6 +241,11 @@ public class ChatNotificationService implements Service {
         // If user is ignored we do not notify, but we still keep the messageIds to not trigger 
         // notifications after un-ignore.
         if (userProfileService.isChatUserIgnored(chatMessage.getAuthorUserProfileId())) {
+            return;
+        }
+
+        // Only notify for the currently selected channel
+        if (!chatService.getChatChannelSelectionService(chatChannel.getChatChannelDomain()).getSelectedChannel().get().equals(chatChannel)) {
             return;
         }
 


### PR DESCRIPTION
Fix https://github.com/bisq-network/bisq2/issues/1194

There are some other oddities concerning the badges when switching between markets. They show the total amount of messages in a market in the dropdown, but I suspect the idea is to show number of unread messages for each market channel.

I don't think it's a good idea to track this for all markets. Probably best to track only for some selected. The UI would become overwhelming if all markets show a lot of unread messages, and likely it's also irrelevant since most users would be interested in just one market, or maybe two.