### PR TITLE
Fix bug in ComboBoxWithSearch menu

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/overlay/ComboBoxWithSearch.java
+++ b/desktop/src/main/java/bisq/desktop/components/overlay/ComboBoxWithSearch.java
@@ -175,8 +175,11 @@ public class ComboBoxWithSearch<T> {
             }
         });
 
-        scene.setOnMousePressed(e -> close());
-        ownerRoot.setOnMousePressed(e -> close());
+        stage.focusedProperty().addListener((observable, hadFocus, hasFocus) -> {
+            if (!hasFocus) {
+                close();
+            }
+        });
 
         rootWindow.xProperty().addListener(positionListener);
         rootWindow.yProperty().addListener(positionListener);
@@ -229,7 +232,7 @@ public class ComboBoxWithSearch<T> {
         ObservableList<T> items = comboBox.getItems();
 
         double x = 0;
-        double listOffset = -17.5;
+        double listOffset = items.isEmpty() ? 0 : -17.5;
         // relative to visible top-left point 
         double arrowX_l = -9.5;
         double arrowX_m = 0;


### PR DESCRIPTION
Fix the following bugs:

* When search result is empty, the placeholder text should stay within the menu. (At the moment it was overflowing).

Before:
![overflow-bug](https://github.com/bisq-network/bisq2/assets/144623880/dcde072a-bc1a-4622-91c4-3d1f72212c41)

After:
![overflow-bug-fixed](https://github.com/bisq-network/bisq2/assets/144623880/e29ee29e-bea9-4cd1-8f89-c81d57fd43ec)

* When clicking outside the menu, the menu should close. (At the moment it was getting stuck - only closing when clicking in very specific places - and if clicking on the parent, multiple instances of it were being created).

Before:
![closing-bug](https://github.com/bisq-network/bisq2/assets/144623880/021bf212-a60d-466f-82f4-7382926e7a5f)

After:
![closing-bugfix](https://github.com/bisq-network/bisq2/assets/144623880/debf1008-5edb-407f-aa10-1ffcd99a5f69)
