### PR TITLE
Fix remove password

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/content/user/password/PasswordController.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/password/PasswordController.java
@@ -62,7 +62,6 @@ public class PasswordController implements Controller {
 
     void onButtonClicked() {
         CharSequence password = model.getPassword().get();
-        checkArgument(model.getPasswordIsValid().get() && model.getConfirmedPasswordIsValid().get());
 
         if (userIdentityService.getAESSecretKey().isPresent()) {
             removePassword(password);


### PR DESCRIPTION
This isn't working because confirmedPassword is always false (as there's no confirmedPassword in the remove screen), so an exception is thrown.

This check doesn't add any value as password validation already happens on text input, so it's safe to remove.