### PR TITLE
Fix encoding issues in UnorderedList component

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/controls/UnorderedList.java
+++ b/desktop/src/main/java/bisq/desktop/components/controls/UnorderedList.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 
 public class UnorderedList extends TextList {
     private static final String REGEX = "- ";
-    private static final String MARK = "•";
+    private static final String MARK = "\u2022"; // Unicode code for "•"
 
     public UnorderedList(String text, String style, String regex, String mark) {
         this(text, style, 7, 0, regex, mark);


### PR DESCRIPTION
Represent the bullet point "•" as a Unicode escape sequence to avoid encoding mismatch.

Towards #1211

Some examples below. Testing on Windows.

![before1](https://github.com/bisq-network/bisq2/assets/145597137/ac8d99fb-b82e-4795-a2f3-949eecf15c2b)
![after1](https://github.com/bisq-network/bisq2/assets/145597137/9ff7930f-b387-47fb-9baa-70d44d39d311)

![before2](https://github.com/bisq-network/bisq2/assets/145597137/c52e5ba5-551b-47d8-80b1-bb74c4ebe5ac)
![after2](https://github.com/bisq-network/bisq2/assets/145597137/463fef4f-d88e-4ab8-8d47-ded34da5f696)

![before3](https://github.com/bisq-network/bisq2/assets/145597137/ae823ca9-95fa-450f-b7c0-ebe724060eff)
![after3](https://github.com/bisq-network/bisq2/assets/145597137/0000a253-b231-452b-9c64-ba83a9d18330)

![before4](https://github.com/bisq-network/bisq2/assets/145597137/2bd29aa1-bee8-42a0-b46f-f425db294b93)
![after4](https://github.com/bisq-network/bisq2/assets/145597137/e9735647-9f47-418d-8a6b-ebc6889fbe4e)

![before5](https://github.com/bisq-network/bisq2/assets/145597137/fa5a8e32-2571-4f74-823f-1cd41b2e0595)
![after5](https://github.com/bisq-network/bisq2/assets/145597137/592e8239-300e-416d-b211-1a13d5bea347)

