### PR TITLE
Fix missing dashboard content at first start

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/content/ContentModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/ContentModel.java
@@ -33,6 +33,6 @@ public class ContentModel extends NavigationModel {
 
     @Override
     public NavigationTarget getDefaultNavigationTarget() {
-        return NavigationTarget.NONE;
+        return NavigationTarget.DASHBOARD;
     }
 }


### PR DESCRIPTION
At a fresh startup the Dashboard did not get initialized as NONE was defined as default navigation target in ContentModel.