### PR TITLE
Extend range of allowed sig lengths

### DIFF
--- a/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
+++ b/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
@@ -47,7 +47,7 @@ public class NetworkDataValidation {
 
     // Signature are usually 71 - 73 chars
     public static void validateECSignature(byte[] signature) {
-        checkArgument(signature.length >= 70 && signature.length <= 74,
+        checkArgument(signature.length >= 68 && signature.length <= 74,
                 "Signature not of the expected size. signature=" + Arrays.toString(signature));
     }
 


### PR DESCRIPTION
Extend range of allowed sig lengths as https://github.com/bisq-network/bisq2/issues/1243 reported failed tests with a 69 size signature.
Fixes https://github.com/bisq-network/bisq2/issues/1243