### PR TITLE
Improve key event handling in popups

### DIFF
--- a/desktop/src/main/java/bisq/desktop/DesktopView.java
+++ b/desktop/src/main/java/bisq/desktop/DesktopView.java
@@ -107,9 +107,7 @@ public class DesktopView extends NavigationView<AnchorPane, DesktopModel, Deskto
     }
 
     private void configKeyEventHandlers() {
-        scene.setOnKeyPressed(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
+        scene.setOnKeyPressed(keyEvent ->
+                KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit));
     }
 }

--- a/desktop/src/main/java/bisq/desktop/common/utils/KeyHandlerUtil.java
+++ b/desktop/src/main/java/bisq/desktop/common/utils/KeyHandlerUtil.java
@@ -17,10 +17,6 @@
 
 package bisq.desktop.common.utils;
 
-import bisq.common.application.DevMode;
-import bisq.desktop.common.view.Navigation;
-import bisq.desktop.common.view.NavigationTarget;
-import bisq.desktop.overlay.OverlayController;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 
@@ -44,34 +40,6 @@ public class KeyHandlerUtil {
         if (keyEvent.getCode() == KeyCode.ENTER) {
             keyEvent.consume();
             handler.run();
-        }
-    }
-
-    public static void handleDevModeKeyEvent(KeyEvent keyEvent) {
-        if (DevMode.isDevMode()) {
-            if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT0, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.ONBOARDING_WELCOME);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT1, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.ONBOARDING_GENERATE_NYM);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT2, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.CREATE_PROFILE_STEP1);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT3, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.CREATE_PROFILE_STEP2);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT4, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.BISQ_EASY_ONBOARDING);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT5, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.TRADE_WIZARD_DIRECTION);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT6, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.TRADE_WIZARD_MARKET);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT7, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.TRADE_WIZARD_AMOUNT);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT8, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.TRADE_WIZARD_PAYMENT_METHOD);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.DIGIT9, keyEvent)) {
-                Navigation.navigateTo(NavigationTarget.TRADE_WIZARD_REVIEW_OFFER);
-            } else if (KeyCodeUtils.isCtrlPressed(KeyCode.H, keyEvent)) {
-                OverlayController.hide();
-            }
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/TakeOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/TakeOfferView.java
@@ -20,7 +20,6 @@ package bisq.desktop.main.content.bisq_easy.take_offer;
 import bisq.desktop.common.Layout;
 import bisq.desktop.common.Transitions;
 import bisq.desktop.common.threading.UIScheduler;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Model;
 import bisq.desktop.common.view.NavigationView;
@@ -33,7 +32,6 @@ import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Parent;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -62,7 +60,6 @@ public class TakeOfferView extends NavigationView<VBox, TakeOfferModel, TakeOffe
     private final VBox content;
     private final ChangeListener<Number> currentIndexListener;
     private final ChangeListener<View<? extends Parent, ? extends Model, ? extends Controller>> viewChangeListener;
-    private Scene rootScene;
     private Subscription showProgressBoxPin, takeOfferButtonVisiblePin;
 
     public TakeOfferView(TakeOfferModel model, TakeOfferController controller) {
@@ -183,13 +180,6 @@ public class TakeOfferView extends NavigationView<VBox, TakeOfferModel, TakeOffe
             }
         });
 
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, controller::onClose);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
-
       /*  if (!model.getShowProgressBox().get()) {
             progressBox.setOpacity(0);
             topPane.setStyle("-fx-background-color: transparent");
@@ -241,7 +231,6 @@ public class TakeOfferView extends NavigationView<VBox, TakeOfferModel, TakeOffe
         backButton.setOnAction(null);
         closeButton.setOnAction(null);
         takeOfferButton.setOnAction(null);
-        rootScene.setOnKeyReleased(null);
     }
 
     private Region getHLine() {

--- a/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardView.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardView.java
@@ -21,7 +21,6 @@ import bisq.common.data.Triple;
 import bisq.desktop.common.Layout;
 import bisq.desktop.common.Transitions;
 import bisq.desktop.common.threading.UIScheduler;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Model;
 import bisq.desktop.common.view.NavigationView;
@@ -35,7 +34,6 @@ import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Parent;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -64,7 +62,6 @@ public class TradeWizardView extends NavigationView<VBox, TradeWizardModel, Trad
     private final VBox content;
     private final ChangeListener<Number> currentIndexListener;
     private final ChangeListener<View<? extends Parent, ? extends Model, ? extends Controller>> viewChangeListener;
-    private Scene rootScene;
     private Label priceProgressItemLabel;
     private Region priceProgressItemLine;
     private Subscription priceProgressItemVisiblePin;
@@ -145,12 +142,6 @@ public class TradeWizardView extends NavigationView<VBox, TradeWizardModel, Trad
         model.getCurrentIndex().addListener(currentIndexListener);
         model.getView().addListener(viewChangeListener);
 
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, controller::onClose);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
         priceProgressItemVisiblePin = EasyBind.subscribe(model.getPriceProgressItemVisible(), isVisible -> {
             if (isVisible) {
                 progressItemsBox.getChildren().add(5, priceProgressItemLine);
@@ -192,7 +183,6 @@ public class TradeWizardView extends NavigationView<VBox, TradeWizardModel, Trad
         nextButton.setOnAction(null);
         backButton.setOnAction(null);
         closeButton.setOnAction(null);
-        rootScene.setOnKeyReleased(null);
 
         if (progressLabelAnimationScheduler != null) {
             progressLabelAnimationScheduler.stop();

--- a/desktop/src/main/java/bisq/desktop/main/content/components/ReportToModeratorWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/components/ReportToModeratorWindow.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.components;
 
 import bisq.chat.ChatChannelDomain;
 import bisq.desktop.ServiceProvider;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.InitWithDataController;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.overlay.Popup;
@@ -35,7 +34,6 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -135,7 +133,6 @@ public class ReportToModeratorWindow {
     private static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
         private final Button reportButton, cancelButton;
         private final MaterialTextArea message;
-        private Scene rootScene;
 
         private View(Model model, Controller controller) {
             super(new VBox(20), model, controller);
@@ -162,18 +159,10 @@ public class ReportToModeratorWindow {
 
         @Override
         protected void onViewAttached() {
-            rootScene = root.getScene();
-
             message.textProperty().bindBidirectional(model.getMessage());
             reportButton.disableProperty().bind(model.getReportButtonDisabled());
             reportButton.setOnAction(e -> controller.onReport());
             cancelButton.setOnAction(e -> controller.onCancel());
-
-            // Replace the key handler of OverlayView as we do not support escape/enter at this popup
-            rootScene.setOnKeyReleased(keyEvent -> {
-                KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-                KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-            });
         }
 
         @Override
@@ -182,7 +171,6 @@ public class ReportToModeratorWindow {
             reportButton.disableProperty().unbind();
             reportButton.setOnAction(null);
             cancelButton.setOnAction(null);
-            rootScene.setOnKeyReleased(null);
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/content/user/accounts/create/CreatePaymentAccountView.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/accounts/create/CreatePaymentAccountView.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.content.user.accounts.create;
 
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
@@ -25,7 +24,6 @@ import bisq.desktop.overlay.OverlayModel;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -39,7 +37,6 @@ public class CreatePaymentAccountView extends View<VBox, CreatePaymentAccountMod
     private final MaterialTextArea accountData;
     private final Button saveButton, cancelButton;
     private final Label headLineLabel;
-    private Scene rootScene;
 
     public CreatePaymentAccountView(CreatePaymentAccountModel model, CreatePaymentAccountController controller) {
         super(new VBox(), model, controller);
@@ -103,13 +100,6 @@ public class CreatePaymentAccountView extends View<VBox, CreatePaymentAccountMod
 
         saveButton.setOnAction((event) -> controller.onSave());
         cancelButton.setOnAction((event) -> controller.onCancel());
-
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, controller::onCancel);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
     }
 
     @Override
@@ -120,9 +110,5 @@ public class CreatePaymentAccountView extends View<VBox, CreatePaymentAccountMod
 
         saveButton.setOnAction(null);
         cancelButton.setOnAction(null);
-
-        if (rootScene != null) {
-            rootScene.setOnKeyReleased(null);
-        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step1/CreateNewProfileStep1View.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step1/CreateNewProfileStep1View.java
@@ -17,23 +17,16 @@
 
 package bisq.desktop.main.content.user.user_profile.create.step1;
 
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.overlay.onboarding.create_profile.CreateProfileView;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
-import javafx.scene.Scene;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CreateNewProfileStep1View extends CreateProfileView {
 
-    private final CreateNewProfileStep1Controller createNewProfileStep1Controller;
-    private Scene rootScene;
-
     public CreateNewProfileStep1View(CreateNewProfileStep1Model model, CreateNewProfileStep1Controller controller) {
         super(model, controller);
-
-        this.createNewProfileStep1Controller = controller;
 
         createProfileButton.setText(Res.get("action.next"));
 
@@ -43,21 +36,10 @@ public class CreateNewProfileStep1View extends CreateProfileView {
     @Override
     protected void onViewAttached() {
         super.onViewAttached();
-
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, createNewProfileStep1Controller::onQuit);
-            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, createNewProfileStep1Controller::onCancel);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
     }
 
     @Override
     protected void onViewDetached() {
         super.onViewDetached();
-        
-        if (rootScene != null) {
-            rootScene.setOnKeyReleased(null);
-        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2View.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2View.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.content.user.user_profile.create.step2;
 
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
@@ -25,7 +24,6 @@ import bisq.desktop.overlay.OverlayModel;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
@@ -42,7 +40,6 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
     private final Button saveButton, cancelButton;
     private final Label nickName, nym;
     protected final Label headLineLabel;
-    private Scene rootScene;
 
     public CreateNewProfileStep2View(CreateNewProfileStep2Model model, CreateNewProfileStep2Controller controller) {
         super(new VBox(25), model, controller);
@@ -122,13 +119,6 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
         statement.textProperty().bindBidirectional(model.getStatement());
         saveButton.setOnAction((event) -> controller.onSave());
         cancelButton.setOnAction((event) -> controller.onCancel());
-
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, controller::onCancel);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
     }
 
     @Override
@@ -138,8 +128,5 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
         nym.textProperty().unbind();
         terms.textProperty().unbindBidirectional(model.getTerms());
         statement.textProperty().unbindBidirectional(model.getStatement());
-        if (rootScene != null) {
-            rootScene.setOnKeyReleased(null);
-        }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/overlay/OverlayController.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/OverlayController.java
@@ -19,6 +19,7 @@ package bisq.desktop.overlay;
 
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Transitions;
+import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.NavigationController;
 import bisq.desktop.common.view.NavigationTarget;
@@ -39,8 +40,10 @@ import bisq.desktop.overlay.onboarding.OnboardingController;
 import bisq.desktop.overlay.tac.TacController;
 import bisq.desktop.overlay.unlock.UnlockController;
 import bisq.desktop.overlay.update.UpdaterController;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -81,6 +84,10 @@ public class OverlayController extends NavigationController {
     private final ServiceProvider serviceProvider;
     @Nullable
     private Runnable onHiddenHandler;
+    @Setter
+    private boolean useEscapeKeyHandler;
+    @Setter
+    private Runnable enterKeyHandler;
 
     public OverlayController(ServiceProvider serviceProvider, Region applicationRoot) {
         super(NavigationTarget.OVERLAY);
@@ -91,6 +98,7 @@ public class OverlayController extends NavigationController {
         model = new OverlayModel(serviceProvider);
         view = new OverlayView(model, this, applicationRoot);
         INSTANCE = this;
+        // We activate the OverlayController, and it stays active during the application lifetime
         onActivateInternal();
 
         model.getView().addListener((observable, oldValue, newValue) -> {
@@ -174,6 +182,17 @@ public class OverlayController extends NavigationController {
             default: {
                 return Optional.empty();
             }
+        }
+    }
+
+    void onKeyPressed(KeyEvent keyEvent) {
+        KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, this::onQuit);
+
+        if (useEscapeKeyHandler) {
+            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, () -> getView().hide());
+        }
+        if (enterKeyHandler != null) {
+            KeyHandlerUtil.handleEnterKeyEvent(keyEvent, enterKeyHandler);
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/overlay/OverlayView.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/OverlayView.java
@@ -22,7 +22,6 @@ import bisq.desktop.common.Layout;
 import bisq.desktop.common.Transitions;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.threading.UIThread;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.NavigationView;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
@@ -112,22 +111,8 @@ public class OverlayView extends NavigationView<AnchorPane, OverlayModel, Overla
     }
 
     private void show(double prefWidth, double prefHeight) {
-        if (scene.getOnKeyReleased() == null) {
-            scene.setOnKeyReleased(keyEvent -> {
-                KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-                KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::hide);
-                KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::hide);
-                KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-            });
-        }
-        if (ownerScene.getOnKeyReleased() == null) {
-            ownerScene.setOnKeyReleased(keyEvent -> {
-                KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-                KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::hide);
-                KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::hide);
-                KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-            });
-        }
+        scene.setOnKeyPressed(controller::onKeyPressed);
+        ownerScene.setOnKeyPressed(controller::onKeyPressed);
 
         prefWidth = Math.min(prefWidth, owner.getWidth());
         prefHeight = Math.min(prefHeight, owner.getHeight());
@@ -150,9 +135,9 @@ public class OverlayView extends NavigationView<AnchorPane, OverlayModel, Overla
                 .after(150);
     }
 
-    private void hide() {
-        scene.setOnKeyReleased(null);
-        ownerScene.setOnKeyReleased(null);
+    void hide() {
+        scene.setOnKeyPressed(null);
+        ownerScene.setOnKeyPressed(null);
         Transitions.removeEffect(owner);
         animateHide(() -> {
             if (stage != null) {

--- a/desktop/src/main/java/bisq/desktop/overlay/onboarding/OnboardingView.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/onboarding/OnboardingView.java
@@ -18,18 +18,14 @@
 package bisq.desktop.overlay.onboarding;
 
 import bisq.desktop.common.Transitions;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.NavigationView;
 import bisq.desktop.overlay.OverlayModel;
-import javafx.scene.Scene;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class OnboardingView extends NavigationView<VBox, OnboardingModel, OnboardingController> {
-    private Scene rootScene;
-
     public OnboardingView(OnboardingModel model, OnboardingController controller) {
         super(new VBox(), model, controller);
 
@@ -50,19 +46,11 @@ public class OnboardingView extends NavigationView<VBox, OnboardingModel, Onboar
 
     @Override
     protected void onViewAttached() {
-        // Replace the key handler of OverlayView as we do not support escape/enter at onboarding
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
-
-        rootScene.getWindow().setWidth(OverlayModel.WIDTH);
-        rootScene.getWindow().setHeight(OverlayModel.HEIGHT);
+        root.getScene().getWindow().setWidth(OverlayModel.WIDTH);
+        root.getScene().getWindow().setHeight(OverlayModel.HEIGHT);
     }
 
     @Override
     protected void onViewDetached() {
-        rootScene.setOnKeyReleased(null);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileController.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileController.java
@@ -59,6 +59,7 @@ public class CreateProfileController implements Controller {
     protected final KeyPairService keyPairService;
     protected final ProofOfWorkService proofOfWorkService;
     protected final IdentityService identityService;
+    private final OverlayController overlayController;
     protected Optional<CompletableFuture<ProofOfWork>> mintNymProofOfWorkFuture = Optional.empty();
     protected Subscription nickNameSubscription;
     protected final List<Identity> pooledIdentities = new ArrayList<>();
@@ -69,6 +70,7 @@ public class CreateProfileController implements Controller {
         proofOfWorkService = serviceProvider.getSecurityService().getProofOfWorkService();
         userIdentityService = serviceProvider.getUserService().getUserIdentityService();
         identityService = serviceProvider.getIdentityService();
+        overlayController = OverlayController.getInstance();
 
         model = getGenerateProfileModel();
         view = getGenerateProfileView();
@@ -84,6 +86,8 @@ public class CreateProfileController implements Controller {
 
     @Override
     public void onActivate() {
+        overlayController.setEnterKeyHandler(this::onCreateUserProfile);
+        overlayController.setUseEscapeKeyHandler(false);
         if (!pooledIdentitiesInitialized) {
             pooledIdentitiesInitialized = true;
             pooledIdentities.addAll(identityService.getPool());
@@ -99,6 +103,8 @@ public class CreateProfileController implements Controller {
 
     @Override
     public void onDeactivate() {
+        overlayController.setEnterKeyHandler(null);
+        overlayController.setUseEscapeKeyHandler(true);
         if (nickNameSubscription != null) {
             nickNameSubscription.unsubscribe();
         }

--- a/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.overlay.onboarding.create_profile;
 
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.MaterialTextField;
@@ -163,8 +162,6 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
             root.requestFocus();
         });
 
-        root.setOnKeyReleased(keyEvent -> KeyHandlerUtil.handleEnterKeyEvent(keyEvent, controller::onCreateUserProfile));
-
         nickname.requestFocus();
     }
 
@@ -196,6 +193,5 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         regenerateButton.setOnMouseClicked(null);
         roboIconView.setOnMouseClicked(null);
         createProfileButton.setOnMouseClicked(null);
-        root.setOnKeyReleased(null);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/overlay/onboarding/welcome/WelcomeController.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/onboarding/welcome/WelcomeController.java
@@ -21,6 +21,7 @@ import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.common.view.NavigationTarget;
+import bisq.desktop.overlay.OverlayController;
 import bisq.settings.DontShowAgainService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -31,14 +32,18 @@ import static bisq.settings.DontShowAgainKey.WELCOME;
 public class WelcomeController implements Controller {
     @Getter
     private final WelcomeView view;
+    private final OverlayController overlayController;
 
     public WelcomeController(ServiceProvider serviceProvider) {
+        overlayController = OverlayController.getInstance();
         WelcomeModel model = new WelcomeModel();
         view = new WelcomeView(model, this);
     }
 
     @Override
     public void onActivate() {
+        overlayController.setEnterKeyHandler(this::onNext);
+        overlayController.setUseEscapeKeyHandler(false);
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/overlay/onboarding/welcome/WelcomeView.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/onboarding/welcome/WelcomeView.java
@@ -18,7 +18,6 @@
 package bisq.desktop.overlay.onboarding.welcome;
 
 import bisq.desktop.common.utils.ImageUtil;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
@@ -73,13 +72,12 @@ public class WelcomeView extends View<VBox, WelcomeModel, WelcomeController> {
     @Override
     protected void onViewAttached() {
         nextButton.setOnMouseClicked(e -> controller.onNext());
-        root.setOnKeyReleased(keyEvent -> KeyHandlerUtil.handleEnterKeyEvent(keyEvent, controller::onNext));
+        root.requestFocus();
     }
 
     @Override
     protected void onViewDetached() {
         nextButton.setOnMouseClicked(null);
-        root.setOnKeyReleased(null);
     }
 
     private VBox getWidgetBox(String headline, String content, String imageId) {

--- a/desktop/src/main/java/bisq/desktop/overlay/tac/TacController.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/tac/TacController.java
@@ -40,11 +40,13 @@ public class TacController implements InitWithDataController<TacController.InitD
     private final TacView view;
     private final ServiceProvider serviceProvider;
     private final SettingsService settingsService;
+    private final OverlayController overlayController;
     private Runnable completeHandler;
 
     public TacController(ServiceProvider serviceProvider) {
         this.serviceProvider = serviceProvider;
         settingsService = serviceProvider.getSettingsService();
+        overlayController = OverlayController.getInstance();
         model = new TacModel();
         view = new TacView(model, this);
     }
@@ -57,6 +59,9 @@ public class TacController implements InitWithDataController<TacController.InitD
     @Override
     public void onActivate() {
         model.getTacConfirmed().set(settingsService.isTacAccepted());
+
+        overlayController.setEnterKeyHandler(null);
+        overlayController.setUseEscapeKeyHandler(false);
     }
 
     @Override
@@ -70,6 +75,11 @@ public class TacController implements InitWithDataController<TacController.InitD
     void onConfirm(boolean selected) {
         model.getTacConfirmed().set(selected);
         settingsService.setTacAccepted(selected);
+        if (selected) {
+            overlayController.setEnterKeyHandler(this::onAccept);
+        } else {
+            overlayController.setEnterKeyHandler(null);
+        }
     }
 
     void onAccept() {

--- a/desktop/src/main/java/bisq/desktop/overlay/tac/TacView.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/tac/TacView.java
@@ -19,7 +19,6 @@ package bisq.desktop.overlay.tac;
 
 import bisq.desktop.DesktopModel;
 import bisq.desktop.common.threading.UIThread;
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.OrderedList;
@@ -90,10 +89,14 @@ public class TacView extends View<VBox, TacModel, TacController> {
         UnorderedList rulesList = new UnorderedList(rules, "tac-text");
 
         confirmCheckBox = new CheckBox(Res.get("tac.confirm"));
+        confirmCheckBox.setFocusTraversable(false);
 
         acceptButton = new Button(Res.get("tac.accept"));
+        acceptButton.setFocusTraversable(false);
+
         rejectButton = new Button(Res.get("tac.reject"));
         rejectButton.getStyleClass().add("outlined-button");
+        rejectButton.setFocusTraversable(false);
 
         HBox buttons = new HBox(20, acceptButton, Spacer.fillHBox(), rejectButton);
         VBox.setMargin(rulesList, new Insets(-20, 0, 0, 20));
@@ -107,6 +110,7 @@ public class TacView extends View<VBox, TacModel, TacController> {
 
     @Override
     protected void onViewAttached() {
+        root.requestFocus();
         rootScene = root.getScene();
 
         Region applicationRoot = OverlayController.getInstance().getApplicationRoot();
@@ -129,12 +133,6 @@ public class TacView extends View<VBox, TacModel, TacController> {
 
         acceptButton.setOnAction(e -> controller.onAccept());
         rejectButton.setOnAction(e -> controller.onReject());
-
-        // Replace the key handler of OverlayView as we do not support escape/enter at this popup
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-        });
     }
 
     @Override
@@ -144,7 +142,6 @@ public class TacView extends View<VBox, TacModel, TacController> {
         tacConfirmedPin.unsubscribe();
         acceptButton.setOnAction(null);
         rejectButton.setOnAction(null);
-        rootScene.setOnKeyReleased(null);
     }
 
     private void updateHeight() {

--- a/desktop/src/main/java/bisq/desktop/overlay/unlock/UnlockView.java
+++ b/desktop/src/main/java/bisq/desktop/overlay/unlock/UnlockView.java
@@ -17,14 +17,12 @@
 
 package bisq.desktop.overlay.unlock;
 
-import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.MaterialPasswordField;
 import bisq.desktop.components.controls.validator.RequiredFieldValidator;
 import bisq.desktop.components.controls.validator.TextMinLengthValidator;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -36,11 +34,8 @@ import static org.fxmisc.easybind.EasyBind.subscribe;
 
 @Slf4j
 public class UnlockView extends View<VBox, UnlockModel, UnlockController> {
-
-    private Scene rootScene;
     private final MaterialPasswordField password;
     private final Button unlockButton, cancelButton;
-    private final Label headline;
     private boolean isFirstTimeThatFocusChanges;
     private Subscription focusPin;
 
@@ -50,16 +45,21 @@ public class UnlockView extends View<VBox, UnlockModel, UnlockController> {
         root.setPrefWidth(750);
         root.setPadding(new Insets(30, 30, 30, 30));
 
-        headline = new Label(Res.get("unlock.headline"));
+        Label headline = new Label(Res.get("unlock.headline"));
         headline.getStyleClass().addAll("bisq-text-headline-2", "wrap-text");
 
         password = new MaterialPasswordField(Res.get("user.password.enterPassword"));
         password.setValidators(
                 new RequiredFieldValidator(Res.get("validation.empty")),
                 new TextMinLengthValidator(Res.get("validation.password.tooShort")));
+
         unlockButton = new Button(Res.get("unlock.button"));
         unlockButton.setDefaultButton(true);
+        unlockButton.setFocusTraversable(false);
+
         cancelButton = new Button(Res.get("action.cancel"));
+        cancelButton.setFocusTraversable(false);
+
         isFirstTimeThatFocusChanges = true;
         HBox buttons = new HBox(20, unlockButton, cancelButton);
         HBox.setMargin(buttons, new Insets(20, 0, 0, 0));
@@ -68,22 +68,12 @@ public class UnlockView extends View<VBox, UnlockModel, UnlockController> {
 
     @Override
     protected void onViewAttached() {
+        password.requestFocus();
         password.passwordProperty().bindBidirectional(model.getPassword());
         password.isMaskedProperty().bindBidirectional(model.getPasswordIsMasked());
 
         unlockButton.setOnAction(e -> controller.onUnlock());
         cancelButton.setOnAction(e -> controller.onCancel());
-
-        // Replace the key handler of OverlayView as we do not support escape/enter at this popup
-        rootScene = root.getScene();
-        rootScene.setOnKeyReleased(keyEvent -> {
-            KeyHandlerUtil.handleShutDownKeyEvent(keyEvent, controller::onQuit);
-            KeyHandlerUtil.handleDevModeKeyEvent(keyEvent);
-            KeyHandlerUtil.handleEnterKeyEvent(keyEvent, () -> {
-            });
-            KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, () -> {
-            });
-        });
 
         focusPin = subscribe(password.textInputFocusedProperty(), this::validatePasswordWhenFocusOut);
     }
@@ -95,7 +85,6 @@ public class UnlockView extends View<VBox, UnlockModel, UnlockController> {
 
         unlockButton.setOnAction(null);
         cancelButton.setOnAction(null);
-        rootScene.setOnKeyReleased(null);
 
         focusPin.unsubscribe();
     }


### PR DESCRIPTION
Remove KeyHandlerUtil.handleDevModeKeyEvent method.
Add useEscapeKeyHandler and enterKeyHandler fields to OverlayController. 
Apply key handler to owner scene and overlay scene. 
Remove key handlers in custom popups and/or use the new fields in OverlayController. 
Set focusTraversable to 'false' to avoid (invisible) focus change by tabbing. 

We do not support tabbed controls navigation as focus stye is disabled at the moment. If we want to support that in future this might get changed again.