### PR TITLE
Avoid -1 value at progress bar at startup

### DIFF
--- a/desktop/src/main/java/bisq/desktop/splash/SplashController.java
+++ b/desktop/src/main/java/bisq/desktop/splash/SplashController.java
@@ -79,11 +79,11 @@ public class SplashController implements Controller {
     }
 
     public void startAnimation() {
-        model.getProgress().set(-1);
+        applyMaxProgress(-1);
     }
 
     public void stopAnimation() {
-        model.getProgress().set(0);
+        applyMaxProgress(0);
     }
 
     private void applyMaxProgress(double progress) {

--- a/network/network/src/main/java/bisq/network/p2p/node/transport/TransportService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/transport/TransportService.java
@@ -17,8 +17,8 @@
 
 package bisq.network.p2p.node.transport;
 
-import bisq.network.common.TransportConfig;
 import bisq.network.common.Address;
+import bisq.network.common.TransportConfig;
 import bisq.network.common.TransportType;
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 
@@ -59,4 +59,9 @@ public interface TransportService {
     Optional<Address> getServerAddress(String serverId);
 
     boolean isPeerOnline(Address address);
+
+    default void updateStartBootstrapProgress(BootstrapInfo bootstrapInfo) {
+        double newValue = Math.min(0.24, bootstrapInfo.getBootstrapProgress().get() + 0.01);
+        bootstrapInfo.getBootstrapProgress().set(Math.max(0, newValue));
+    }
 }


### PR DESCRIPTION
Set progress at bootstrap start to a value of 1-24% instead of keeping -1 which would trigger the progress bar animation which is very CPU intense.