### PR TITLE
Fix chat performance issues

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -459,7 +459,7 @@ public class ChatMessagesListView {
             return channel.getChatMessages().addObserver(new CollectionObserver<>() {
                 @Override
                 public void add(M chatMessage) {
-                    UIThread.run(() -> {
+                    UIThread.runOnNextRenderFrame(() -> {
                         model.chatMessages.add(new ChatMessageListItem<>(chatMessage, userProfileService, reputationService,
                                 bisqEasyTradeService, userIdentityService, networkService));
                     });
@@ -468,7 +468,7 @@ public class ChatMessagesListView {
                 @Override
                 public void remove(Object element) {
                     if (element instanceof ChatMessage) {
-                        UIThread.run(() -> {
+                        UIThread.runOnNextRenderFrame(() -> {
                             ChatMessage chatMessage = (ChatMessage) element;
                             Optional<ChatMessageListItem<? extends ChatMessage>> toRemove = model.chatMessages.stream()
                                     .filter(item -> item.getChatMessage().getId().equals(chatMessage.getId()))
@@ -483,7 +483,7 @@ public class ChatMessagesListView {
 
                 @Override
                 public void clear() {
-                    UIThread.run(() -> {
+                    UIThread.runOnNextRenderFrame(() -> {
                         model.chatMessages.forEach(ChatMessageListItem::dispose);
                         model.chatMessages.clear();
                     });


### PR DESCRIPTION
Metrics based on a 1 minute session scrolling and switching back and forth an offerbook channel with a large amount of messages (similar test as [here](https://github.com/bisq-network/bisq2/issues/948#issuecomment-1753631855)).

Now:
![performancenew](https://github.com/bisq-network/bisq2/assets/138292162/59fe63a8-a101-469c-bfc3-f12c1fb8c832)

Before:
![performanceold](https://github.com/bisq-network/bisq2/assets/138292162/49d65071-c34f-4fc8-a048-f0d3fe1d82ce)

#948
