### PR TITLE
Introduce bisq2 green palette

### DIFF
--- a/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
+++ b/desktop/src/main/java/bisq/desktop/common/utils/ImageUtil.java
@@ -111,7 +111,7 @@ public class ImageUtil {
 
     /**
      * @param size
-     * @param cssStrokeColor E.g. -bisq-green
+     * @param cssStrokeColor E.g. -bisq2-green
      */
     public static StackPane addRingToNode(Node node, double size, double strokeWidth, String cssStrokeColor) {
         StackPane pane = new StackPane();

--- a/desktop/src/main/java/bisq/desktop/main/content/user/bonded_roles/BondedRolesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/user/bonded_roles/BondedRolesView.java
@@ -98,7 +98,7 @@ public abstract class BondedRolesView<M extends BondedRolesModel, C extends Bond
                     userName.setText(item.getUserName());
                     if (item.isStaticPublicKeysProvided()) {
                         userName.setTooltip(tooltip);
-                        userName.setStyle("-fx-text-fill: -bisq-green;");
+                        userName.setStyle("-fx-text-fill: -bisq2-green;");
                     } else {
                         userName.setTooltip(null);
                         userName.setStyle("-fx-text-fill: -fx-light-text-color;");

--- a/desktop/src/main/resources/css/application.css
+++ b/desktop/src/main/resources/css/application.css
@@ -23,7 +23,7 @@
 .splash-bootstrap-progress {
     -fx-font-size: 1em;
     -fx-font-family: "IBM Plex Sans Light";
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 

--- a/desktop/src/main/resources/css/base.css
+++ b/desktop/src/main/resources/css/base.css
@@ -41,7 +41,6 @@
 
     /* Colors */
     -bisq-green: #56ae48; /* #56ae48 rgb(86,174,72) */
-    -bisq-turquoise: #2cacaf;
     -bisq-buy: #006600;
     -bisq-sell: #660000;
     -bisq-red: #d02c1f;

--- a/desktop/src/main/resources/css/base.css
+++ b/desktop/src/main/resources/css/base.css
@@ -38,7 +38,6 @@
     -fx-font-size: 13;
 
     /* Colors */
-    -bisq-green: #56ae48; /* #56ae48 rgb(86,174,72) */
     -bisq-buy: #006600;
     -bisq-sell: #660000;
     -bisq-red: #d02c1f;
@@ -81,16 +80,16 @@
 
 
     -fx-base: -bisq-content-bg-grey;
-    -fx-accent: -bisq-green;
+    -fx-accent: -bisq2-green;
     -fx-background: -bisq-content-bg-grey;
 
     -fx-color: -bisq-dark-grey-mid;
     -fx-body-color: -fx-color;
 
     -fx-box-border: transparent;
-    -fx-focus-color: -bisq-green;
-    -fx-faint-focus-color: -bisq-green;
-    -fx-default-button: derive(-bisq-green, -15%);
+    -fx-focus-color: -bisq2-green;
+    -fx-faint-focus-color: -bisq2-green;
+    -fx-default-button: derive(-bisq2-green, -15%);
     -bisq-green-hover: derive(-fx-default-button, 10%);
     -bisq-green-pressed: derive(-fx-default-button, -5%);
 

--- a/desktop/src/main/resources/css/base.css
+++ b/desktop/src/main/resources/css/base.css
@@ -89,9 +89,9 @@
     -fx-box-border: transparent;
     -fx-focus-color: -bisq2-green;
     -fx-faint-focus-color: -bisq2-green;
-    -fx-default-button: derive(-bisq2-green, -15%);
-    -bisq-green-hover: derive(-fx-default-button, 10%);
-    -bisq-green-pressed: derive(-fx-default-button, -5%);
+    -fx-default-button: -bisq2-green-dim-20;
+    -bisq-green-hover: -bisq2-green-dim-10;
+    -bisq-green-pressed: -bisq2-green-dim-30;
 
     -fx-dark-text-color: -bisq-black-dim;
     -fx-mid-text-color: -bisq-medium-grey-mid;

--- a/desktop/src/main/resources/css/base.css
+++ b/desktop/src/main/resources/css/base.css
@@ -37,8 +37,6 @@
     -fx-font-family: "IBM Plex Sans";
     -fx-font-size: 13;
 
-    /* Green logo color used in Bisq 1 is #25b135*/
-
     /* Colors */
     -bisq-green: #56ae48; /* #56ae48 rgb(86,174,72) */
     -bisq-buy: #006600;
@@ -46,6 +44,13 @@
     -bisq-red: #d02c1f;
     -bisq-warning: #d0831f;
     -bisq-yellow: #e5a500;
+
+    /* Bisq 2 Colors */
+    -bisq-green-logo: #25b135;
+    -bisq2-green: #56ae48;
+    -bisq2-green-dim-10: #4d9c40;
+    -bisq2-green-dim-20: #448b39;
+    -bisq2-green-dim-30: #3c7932;
 
     /* Bisq Grey Palette */
     -bisq-black-dim: #050505;

--- a/desktop/src/main/resources/css/bisq_easy.css
+++ b/desktop/src/main/resources/css/bisq_easy.css
@@ -240,7 +240,7 @@
 }
 
 .bisq-easy-trade-state-phase-badge-active .badge-pane {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 .bisq-easy-trade-state-phase-badge .badge-pane .label {
@@ -475,7 +475,7 @@
 }
 
 .bisq-easy-trade-wizard-market.table-view .table-row-cell:selected .table-cell {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 
@@ -504,7 +504,7 @@
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:selected .table-cell {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty {
@@ -525,7 +525,7 @@
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:hover .button.outlined-button .text {
-    -fx-fill: -bisq-green;
+    -fx-fill: -bisq2-green;
     -fx-font-family: "IBM Plex Sans Medium";
 }
 
@@ -552,7 +552,7 @@
 
 .bisq-easy-offerbook-search-box-active {
     -fx-background-color: rgba(255, 255, 255, 0.075);
-    -fx-border-color: -bisq-green;
+    -fx-border-color: -bisq2-green;
 }
 
 

--- a/desktop/src/main/resources/css/chat.css
+++ b/desktop/src/main/resources/css/chat.css
@@ -6,7 +6,7 @@
 
 
 .keyword-customTags {
-    -fx-fill: -bisq-green;
+    -fx-fill: -bisq2-green;
 }
 
 .keyword-none {
@@ -98,7 +98,7 @@
 #chat-messages-send-button {
     -fx-background-color: -bisq-white-lit;
     -fx-background-radius: 8;
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 #chat-messages-headline {
@@ -311,7 +311,7 @@
 }
 
 .channel-selection-list-view .list-cell:selected .label {
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 

--- a/desktop/src/main/resources/css/containers.css
+++ b/desktop/src/main/resources/css/containers.css
@@ -251,7 +251,7 @@
 
 /* Custom style used in selection column for vertical green bar */
 #selection-marker {
-    -fx-background-color: -bisq-green !important;
+    -fx-background-color: -bisq2-green !important;
 }
 
 /* empty */
@@ -500,7 +500,7 @@
 }
 
 .tab-view-selection {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 /*******************************************************************************
@@ -537,7 +537,7 @@
 }
 
 .bisq-green-line {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 .bisq-white-bg {
@@ -630,7 +630,7 @@
 }
 
 .overlay-headline-information {
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 .overlay-headline-warning {
@@ -642,7 +642,7 @@
 }
 
 .overlay-icon-information {
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 .overlay-icon-warning {

--- a/desktop/src/main/resources/css/controls.css
+++ b/desktop/src/main/resources/css/controls.css
@@ -136,10 +136,10 @@
 
 .outlined-button {
     -fx-background-color: transparent;
-    -fx-border-color: -bisq-green;
+    -fx-border-color: -bisq2-green;
     -fx-border-width: 1;
     -fx-border-radius: 4;
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
     -fx-font-size: 1em;
     -fx-padding: 5 32 5 32;
 }
@@ -280,7 +280,7 @@
 .text-button {
     -fx-background-color: transparent;
     -fx-border-width: 0px;
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
     -fx-font-size: 1em;
     -fx-padding: 5 16 5 16;
     -fx-cursor: hand;
@@ -569,20 +569,20 @@
 
 .card-button-border:default {
     -fx-background-color: transparent;
-    -fx-border-color: derive(-bisq-green, -20%);
-    -fx-text-fill: derive(-bisq-green, -20%);
+    -fx-border-color: derive(-bisq2-green, -20%);
+    -fx-text-fill: derive(-bisq2-green, -20%);
 }
 
 .card-button-border:default:hover {
     -fx-background-color: rgba(0, 0, 0, 0.15);
-    -fx-border-color: derive(-bisq-green, -5%);
-    -fx-text-fill: derive(-bisq-green, -5%);
+    -fx-border-color: derive(-bisq2-green, -5%);
+    -fx-text-fill: derive(-bisq2-green, -5%);
 }
 
 .card-button-border:default:pressed {
     -fx-background-color: rgba(0, 0, 0, 0.2);
-    -fx-border-color: derive(-bisq-green, -10%);
-    -fx-text-fill: derive(-bisq-green, -10%);
+    -fx-border-color: derive(-bisq2-green, -10%);
+    -fx-text-fill: derive(-bisq2-green, -10%);
 }
 
 
@@ -767,7 +767,7 @@
 
 .progress-bar > .bar,
 .progress-bar:indeterminate > .bar {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
     -fx-padding: 1.5;
 }
 
@@ -813,7 +813,7 @@
 }
 
 .slider .thumb {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 

--- a/desktop/src/main/resources/css/text.css
+++ b/desktop/src/main/resources/css/text.css
@@ -222,8 +222,8 @@
 }
 
 .bisq-text-15 {
-    -fx-fill: -bisq-green;
-    -fx-text-fill: -bisq-green;
+    -fx-fill: -bisq2-green;
+    -fx-text-fill: -bisq2-green;
     -fx-font-size: 2.15em;
     -fx-font-family: "IBM Plex Sans Light";
 }
@@ -288,8 +288,8 @@
 }
 
 .text-fill-green {
-    -fx-fill: -bisq-green !Important;
-    -fx-text-fill: -bisq-green !Important;
+    -fx-fill: -bisq2-green !Important;
+    -fx-text-fill: -bisq2-green !Important;
 }
 
 /* sizes */
@@ -400,23 +400,23 @@
 }
 
 .text-color-green {
-    -fx-fill: -bisq-green !Important;
-    -fx-text-fill: -bisq-green !Important;
+    -fx-fill: -bisq2-green !Important;
+    -fx-text-fill: -bisq2-green !Important;
 }
 
 .text-input {
-    -fx-highlight-fill: -bisq-green;
+    -fx-highlight-fill: -bisq2-green;
 }
 
 .text-input:focused {
-    -fx-highlight-fill: -bisq-green;
+    -fx-highlight-fill: -bisq2-green;
 }
 
 #base-amount-text-field {
     -fx-background-color: transparent;
     -fx-border-style: none;
     -fx-text-fill: -fx-light-text-color;
-    -fx-highlight-fill: -bisq-green;
+    -fx-highlight-fill: -bisq2-green;
     -fx-font-size: 5.2em;
     -fx-font-family: "IBM Plex Sans Thin";
 }
@@ -425,7 +425,7 @@
     -fx-background-color: transparent;
     -fx-border-style: none;
     -fx-text-fill: -fx-light-text-color;
-    -fx-highlight-fill: -bisq-green;
+    -fx-highlight-fill: -bisq2-green;
     -fx-font-size: 3em;
     -fx-font-family: "IBM Plex Sans Thin";
 }
@@ -484,7 +484,7 @@
 .bisq-popup-headline-label {
     -fx-font-size: 1.35em;
     -fx-font-family: "IBM Plex Sans Light";
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 .bisq-tab-button-label {
@@ -512,7 +512,7 @@
 }
 
 .bisq-text-green {
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 .bisq-text-grey-9 {
@@ -576,7 +576,7 @@
 }
 
 .material-text-field-selection-line {
-    -fx-background-color: -bisq-green;
+    -fx-background-color: -bisq2-green;
 }
 
 .material-text-field-selection-line:error {
@@ -605,7 +605,7 @@
 }
 
 .material-text-field-description-selected {
-    -fx-text-fill: -bisq-green;
+    -fx-text-fill: -bisq2-green;
 }
 
 .material-text-field-description-selected:error {


### PR DESCRIPTION
As discussed in issue #1255, introducing a static set of green shades and renaming the existing greens accordingly.

&#12288;
<img width="1267" alt="56ae48_pallet2_map" src="https://github.com/bisq-network/bisq2/assets/145597137/97a5d94a-a6a0-421c-8f49-79db8de90796">
&#12288;

Towards #1211 

