### PR TITLE
Fix issues in ComboBoxWithSearch

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/overlay/ComboBoxWithSearch.java
+++ b/desktop/src/main/java/bisq/desktop/components/overlay/ComboBoxWithSearch.java
@@ -175,6 +175,9 @@ public class ComboBoxWithSearch<T> {
             }
         });
 
+        scene.setOnMousePressed(e -> close());
+        ownerRoot.setOnMousePressed(e -> close());
+
         stage.focusedProperty().addListener((observable, hadFocus, hasFocus) -> {
             if (!hasFocus) {
                 close();

--- a/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -36,4 +36,9 @@ class MarketChannelItem {
     public String getMarketString() {
         return market.toString();
     }
+
+    @Override
+    public String toString() {
+        return market.toString();
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/top/MarketPriceComponent.java
+++ b/desktop/src/main/java/bisq/desktop/main/top/MarketPriceComponent.java
@@ -36,6 +36,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.image.ImageView;
@@ -142,6 +143,7 @@ public class MarketPriceComponent {
             super(new HBox(7), model, controller);
 
             root.setAlignment(Pos.CENTER);
+            root.setCursor(Cursor.HAND);
 
             codes = new Label();
             codes.setMouseTransparent(true);
@@ -203,6 +205,8 @@ public class MarketPriceComponent {
                 private final HBox hBox;
 
                 {
+                    setCursor(Cursor.HAND);
+
                     codes = new Label();
                     codes.setMouseTransparent(true);
                     codes.getStyleClass().add("bisq-text-18");


### PR DESCRIPTION
* Fix closing `ComboBoxWithSearch` in `MarketPriceComponent` when clicking outside (#1327).
* Use `Cursor.HAND` for `ComboBoxWithSearch` in `MarketPriceComponent`.
* Add missing `toString()` override in `MarketChannelItem`.

After
![after](https://github.com/bisq-network/bisq2/assets/144623880/4dae8e0c-bff1-48f7-99f3-82de2c69d8bd)

Before
![before](https://github.com/bisq-network/bisq2/assets/144623880/948b5960-2cbe-4b8c-81be-bdf31679e904)
