### PR TITLE
Change quote message background colour to differentiate from list view

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
@@ -136,7 +136,7 @@ public class CitationBlock {
             super(new VBox(), model, controller);
             root.setSpacing(10);
             root.setAlignment(Pos.CENTER_LEFT);
-            root.setStyle("-fx-background-color: -bisq-dark-grey;");
+            root.setStyle("-fx-background-color: -bisq-black-lit;");
             root.setPadding(new Insets(0, 15, 0, 20));
 
             Label headline = new Label(Res.get("chat.message.citation.headline"));


### PR DESCRIPTION
Add fix for the quote message issue. I keep working on reviewing the Bisq 2 grey shades.

![image](https://github.com/bisq-network/bisq2/assets/145597137/e06d2651-d841-44b0-972c-ab10216b2789)

Resolve #1326