### PR TITLE
Distribute market price to p2p network

### DIFF
--- a/application/src/main/java/bisq/application/ResolverConfig.java
+++ b/application/src/main/java/bisq/application/ResolverConfig.java
@@ -19,6 +19,7 @@ package bisq.application;
 
 import bisq.bonded_roles.alert.AuthorizedAlertData;
 import bisq.bonded_roles.bonded_role.AuthorizedBondedRole;
+import bisq.bonded_roles.market_price.AuthorizedMarketPriceData;
 import bisq.bonded_roles.oracle.AuthorizedOracleNode;
 import bisq.bonded_roles.registration.BondedRoleRegistrationRequest;
 import bisq.bonded_roles.release.ReleaseNotification;
@@ -73,6 +74,7 @@ public class ResolverConfig {
         DistributedDataResolver.addResolver("bonded_roles.AuthorizedBondedRole", AuthorizedBondedRole.getResolver());
         DistributedDataResolver.addResolver("bonded_roles.AuthorizedAlertData", AuthorizedAlertData.getResolver());
         DistributedDataResolver.addResolver("bonded_roles.ReleaseNotification", ReleaseNotification.getResolver());
+        DistributedDataResolver.addResolver("bonded_roles.AuthorizedMarketPriceData", AuthorizedMarketPriceData.getResolver());
         DistributedDataResolver.addResolver("user.AuthorizedProofOfBurnData", AuthorizedProofOfBurnData.getResolver());
         DistributedDataResolver.addResolver("user.AuthorizedBondedReputationData", AuthorizedBondedReputationData.getResolver());
         DistributedDataResolver.addResolver("user.AuthorizedAccountAgeData", AuthorizedAccountAgeData.getResolver());

--- a/bonded_roles/src/main/java/bisq/bonded_roles/BondedRolesService.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/BondedRolesService.java
@@ -30,7 +30,6 @@ import bisq.persistence.PersistenceService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -38,20 +37,20 @@ import java.util.concurrent.CompletableFuture;
 public class BondedRolesService implements Service {
     @Getter
     public static class Config {
-        private final List<? extends com.typesafe.config.Config> marketPriceServiceProviders;
         private final com.typesafe.config.Config blockchainExplorer;
         private final boolean ignoreSecurityManager;
+        private final com.typesafe.config.Config marketPrice;
 
-        public Config(List<? extends com.typesafe.config.Config> marketPriceServiceProviders,
+        public Config(com.typesafe.config.Config marketPrice,
                       com.typesafe.config.Config blockchainExplorer,
                       boolean ignoreSecurityManager) {
-            this.marketPriceServiceProviders = marketPriceServiceProviders;
+            this.marketPrice = marketPrice;
             this.blockchainExplorer = blockchainExplorer;
             this.ignoreSecurityManager = ignoreSecurityManager;
         }
 
         public static Config from(com.typesafe.config.Config config) {
-            return new Config(config.getConfigList("marketPriceServiceProviders"),
+            return new Config(config.getConfig("marketPrice"),
                     config.getConfig("blockchainExplorer"),
                     config.getBoolean("ignoreSecurityManager"));
         }
@@ -67,8 +66,7 @@ public class BondedRolesService implements Service {
     public BondedRolesService(Config config, Version version, PersistenceService persistenceService, NetworkService networkService) {
         authorizedBondedRolesService = new AuthorizedBondedRolesService(networkService, config.isIgnoreSecurityManager());
         bondedRoleRegistrationService = new BondedRoleRegistrationService(networkService, authorizedBondedRolesService);
-        List<? extends com.typesafe.config.Config> marketPriceServiceProviders = config.getMarketPriceServiceProviders();
-        marketPriceService = new MarketPriceService(marketPriceServiceProviders, version, persistenceService, networkService);
+        marketPriceService = new MarketPriceService(config.getMarketPrice(), version, persistenceService, networkService);
         explorerService = new ExplorerService(ExplorerService.Config.from(config.getBlockchainExplorer()),
                 networkService,
                 version);

--- a/bonded_roles/src/main/java/bisq/bonded_roles/BondedRolesService.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/BondedRolesService.java
@@ -26,6 +26,7 @@ import bisq.bonded_roles.release.ReleaseNotificationsService;
 import bisq.common.application.Service;
 import bisq.common.util.Version;
 import bisq.network.NetworkService;
+import bisq.persistence.PersistenceService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -63,12 +64,11 @@ public class BondedRolesService implements Service {
     private final AlertService alertService;
     private final ReleaseNotificationsService releaseNotificationsService;
 
-    public BondedRolesService(Config config, Version version, NetworkService networkService) {
+    public BondedRolesService(Config config, Version version, PersistenceService persistenceService, NetworkService networkService) {
         authorizedBondedRolesService = new AuthorizedBondedRolesService(networkService, config.isIgnoreSecurityManager());
         bondedRoleRegistrationService = new BondedRoleRegistrationService(networkService, authorizedBondedRolesService);
-        marketPriceService = new MarketPriceService(MarketPriceService.Config.from(config.getMarketPriceServiceProviders()),
-                networkService,
-                version);
+        List<? extends com.typesafe.config.Config> marketPriceServiceProviders = config.getMarketPriceServiceProviders();
+        marketPriceService = new MarketPriceService(marketPriceServiceProviders, version, persistenceService, networkService);
         explorerService = new ExplorerService(ExplorerService.Config.from(config.getBlockchainExplorer()),
                 networkService,
                 version);

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bonded_roles.market_price;
+
+import bisq.bonded_roles.AuthorizedPubKeys;
+import bisq.common.application.DevMode;
+import bisq.common.currency.Market;
+import bisq.common.currency.MarketRepository;
+import bisq.common.proto.ProtoResolver;
+import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.network.p2p.services.data.storage.DistributedData;
+import bisq.network.p2p.services.data.storage.MetaData;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedDistributedData;
+import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+@EqualsAndHashCode
+@Getter
+public final class AuthorizedMarketPriceData implements AuthorizedDistributedData {
+    public static final long TTL = TimeUnit.MINUTES.toMillis(10);
+    private final MetaData metaData = new MetaData(TTL, getClass().getSimpleName());
+    private final Map<Market, MarketPrice> marketPriceByCurrencyMap;
+    private final boolean staticPublicKeysProvided;
+
+    public AuthorizedMarketPriceData(Map<Market, MarketPrice> marketPriceByCurrencyMap, boolean staticPublicKeysProvided) {
+        this.marketPriceByCurrencyMap = marketPriceByCurrencyMap;
+        this.staticPublicKeysProvided = staticPublicKeysProvided;
+
+        checkArgument(marketPriceByCurrencyMap.size() < 100,
+                "marketPriceByCurrencyMap size must not be >= 100" + marketPriceByCurrencyMap.size());
+        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); // 5498
+    }
+
+    @Override
+    public bisq.bonded_roles.protobuf.AuthorizedMarketPriceData toProto() {
+        return bisq.bonded_roles.protobuf.AuthorizedMarketPriceData.newBuilder()
+                .putAllMarketPriceByCurrencyMap(marketPriceByCurrencyMap.entrySet().stream()
+                        .collect(Collectors.toMap(e -> e.getKey().getMarketCodes(),
+                                e -> e.getValue().toProto())))
+                .setStaticPublicKeysProvided(staticPublicKeysProvided)
+                .build();
+    }
+
+    public static AuthorizedMarketPriceData fromProto(bisq.bonded_roles.protobuf.AuthorizedMarketPriceData proto) {
+        Map<Market, MarketPrice> map = proto.getMarketPriceByCurrencyMapMap().entrySet().stream()
+                .filter(e -> MarketRepository.findAnyMarketByMarketCodes(e.getKey()).isPresent())
+                .collect(Collectors.toMap(e -> MarketRepository.findAnyMarketByMarketCodes(e.getKey()).orElseThrow(),
+                        e -> MarketPrice.fromProto(e.getValue())));
+        return new AuthorizedMarketPriceData(map, proto.getStaticPublicKeysProvided());
+    }
+
+    public static ProtoResolver<DistributedData> getResolver() {
+        return any -> {
+            try {
+                return fromProto(any.unpack(bisq.bonded_roles.protobuf.AuthorizedMarketPriceData.class));
+            } catch (InvalidProtocolBufferException e) {
+                throw new UnresolvableProtobufMessageException(e);
+            }
+        };
+    }
+
+    @Override
+    public double getCostFactor() {
+        return 0.5;
+    }
+
+    @Override
+    public boolean isDataInvalid(byte[] pubKeyHash) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getAuthorizedPublicKeys() {
+        if (DevMode.isDevMode()) {
+            return DevMode.AUTHORIZED_DEV_PUBLIC_KEYS;
+        } else {
+            return AuthorizedPubKeys.KEYS;
+        }
+    }
+
+    @Override
+    public boolean staticPublicKeysProvided() {
+        return staticPublicKeysProvided;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizedMarketPriceData{" +
+                ",\r\n                    marketPriceByCurrencyMap=" + marketPriceByCurrencyMap +
+                ",\r\n                    staticPublicKeysProvided=" + staticPublicKeysProvided +
+                ",\r\n                    authorizedPublicKeys=" + getAuthorizedPublicKeys() +
+                "\r\n}";
+    }
+}

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
@@ -19,6 +19,7 @@ package bisq.bonded_roles.market_price;
 
 import bisq.common.currency.Market;
 import bisq.common.monetary.PriceQuote;
+import bisq.common.proto.Proto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -26,7 +27,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class MarketPrice {
+public final class MarketPrice implements Proto {
     private final PriceQuote priceQuote;
     private final String code;
     private final long timestamp;
@@ -37,6 +38,22 @@ public final class MarketPrice {
         this.code = code;
         this.timestamp = timestamp;
         this.provider = provider;
+    }
+
+    public bisq.bonded_roles.protobuf.MarketPrice toProto() {
+        return bisq.bonded_roles.protobuf.MarketPrice.newBuilder()
+                .setPriceQuote(priceQuote.toProto())
+                .setCode(code)
+                .setTimestamp(timestamp)
+                .setProvider(provider)
+                .build();
+    }
+
+    public static MarketPrice fromProto(bisq.bonded_roles.protobuf.MarketPrice proto) {
+        return new MarketPrice(PriceQuote.fromProto(proto.getPriceQuote()),
+                proto.getCode(),
+                proto.getTimestamp(),
+                proto.getProvider());
     }
 
     public Market getMarket() {

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
@@ -20,43 +20,52 @@ package bisq.bonded_roles.market_price;
 import bisq.common.currency.Market;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.proto.Proto;
+import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
+
+@Slf4j
 @Getter
 @ToString
 @EqualsAndHashCode
 public final class MarketPrice implements Proto {
     private final PriceQuote priceQuote;
-    private final String code;
     private final long timestamp;
-    private final String provider;
+    private final MarketPriceProvider marketPriceProvider;
 
-    public MarketPrice(PriceQuote priceQuote, String code, long timestamp, String provider) {
+    public MarketPrice(PriceQuote priceQuote, long timestamp, MarketPriceProvider marketPriceProvider) {
         this.priceQuote = priceQuote;
-        this.code = code;
         this.timestamp = timestamp;
-        this.provider = provider;
+        this.marketPriceProvider = marketPriceProvider;
     }
 
     public bisq.bonded_roles.protobuf.MarketPrice toProto() {
         return bisq.bonded_roles.protobuf.MarketPrice.newBuilder()
                 .setPriceQuote(priceQuote.toProto())
-                .setCode(code)
                 .setTimestamp(timestamp)
-                .setProvider(provider)
+                .setMarketPriceProvider(marketPriceProvider.toProto())
                 .build();
     }
 
     public static MarketPrice fromProto(bisq.bonded_roles.protobuf.MarketPrice proto) {
         return new MarketPrice(PriceQuote.fromProto(proto.getPriceQuote()),
-                proto.getCode(),
                 proto.getTimestamp(),
-                proto.getProvider());
+                MarketPriceProvider.fromProto(proto.getMarketPriceProvider()));
     }
 
     public Market getMarket() {
         return priceQuote.getMarket();
+    }
+
+    public String getProviderName() {
+        return Optional.ofNullable(marketPriceProvider.getDisplayName()).orElse(Res.get("data.na"));
+    }
+
+    public long getAge() {
+        return System.currentTimeMillis() - timestamp;
     }
 }

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
@@ -23,6 +23,7 @@ import bisq.common.proto.Proto;
 import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,9 +34,17 @@ import java.util.Optional;
 @ToString
 @EqualsAndHashCode
 public final class MarketPrice implements Proto {
+    public enum Source {
+        PERSISTED,
+        PROPAGATED_IN_NETWORK,
+        REQUESTED_FROM_PRICE_NODE
+    }
+
     private final PriceQuote priceQuote;
     private final long timestamp;
     private final MarketPriceProvider marketPriceProvider;
+    @Setter
+    private transient Source source;
 
     public MarketPrice(PriceQuote priceQuote, long timestamp, MarketPriceProvider marketPriceProvider) {
         this.priceQuote = priceQuote;

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProvider.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProvider.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 @Slf4j
 @ToString
 public enum MarketPriceProvider implements ProtoEnum {
-    BISQAGGREGATE("Bisq"),
+    BISQAGGREGATE("Bisq price aggregator"),
     COINGECKO("CoinGecko"),
     POLO("Poloniex"),
     BITFINEX("Bitfinex"),

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProvider.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProvider.java
@@ -1,0 +1,53 @@
+package bisq.bonded_roles.market_price;
+
+import bisq.common.proto.ProtoEnum;
+import bisq.common.util.ProtobufUtils;
+import com.google.common.base.Enums;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+
+@Slf4j
+@ToString
+public enum MarketPriceProvider implements ProtoEnum {
+    BISQAGGREGATE("Bisq"),
+    COINGECKO("CoinGecko"),
+    POLO("Poloniex"),
+    BITFINEX("Bitfinex"),
+    OTHER;
+
+    public static MarketPriceProvider fromName(String name) {
+        return Enums.getIfPresent(MarketPriceProvider.class, name).or(otherWithName(name));
+    }
+
+    private static MarketPriceProvider otherWithName(String name) {
+        MarketPriceProvider other = OTHER;
+        other.setDisplayName(name);
+        return other;
+    }
+
+
+    @Nullable
+    @Getter
+    @Setter
+    private String displayName;
+
+    MarketPriceProvider() {
+    }
+
+    MarketPriceProvider(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public bisq.bonded_roles.protobuf.MarketPriceProvider toProto() {
+        return bisq.bonded_roles.protobuf.MarketPriceProvider.valueOf(getProtobufEnumPrefix() + name());
+    }
+
+    public static MarketPriceProvider fromProto(bisq.bonded_roles.protobuf.MarketPriceProvider proto) {
+        return ProtobufUtils.enumFromProto(MarketPriceProvider.class, proto.name(), OTHER);
+    }
+}

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
@@ -217,15 +217,15 @@ public class MarketPriceRequestService {
 
                     double price = (Double) treeMap.get("price");
                     // json uses double for our timestamp long value...
-                    long timestampSec = MathUtils.doubleToLong((Double) treeMap.get("timestampSec"));
-
+                    // We get milliseconds not seconds
+                    long timestamp = MathUtils.doubleToLong((Double) treeMap.get("timestampSec"));
                     // We only get BTC based prices not fiat-fiat or altcoin-altcoin
                     boolean isFiat = TradeCurrency.isFiat(currencyCode);
                     String baseCurrencyCode = isFiat ? "BTC" : currencyCode;
                     String quoteCurrencyCode = isFiat ? currencyCode : "BTC";
                     PriceQuote priceQuote = PriceQuote.fromPrice(price, baseCurrencyCode, quoteCurrencyCode);
                     map.put(priceQuote.getMarket(), new MarketPrice(priceQuote,
-                            timestampSec * 1000,
+                            timestamp,
                             MarketPriceProvider.fromName(provider)));
                 }
             } catch (Throwable t) {

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
@@ -1,0 +1,257 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bonded_roles.market_price;
+
+import bisq.common.currency.Market;
+import bisq.common.currency.TradeCurrency;
+import bisq.common.data.Pair;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.common.threading.ExecutorFactory;
+import bisq.common.timer.Scheduler;
+import bisq.common.util.CollectionUtil;
+import bisq.common.util.ExceptionUtil;
+import bisq.common.util.MathUtils;
+import bisq.common.util.Version;
+import bisq.network.NetworkService;
+import bisq.network.common.TransportType;
+import bisq.network.http.BaseHttpClient;
+import com.google.gson.Gson;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+
+@Slf4j
+public class MarketPriceRequestService {
+    private static final ExecutorService POOL = ExecutorFactory.newFixedThreadPool("MarketPriceService.pool", 3);
+    private static final long INTERVAL = 180;
+
+    @Getter
+    @ToString
+    public static final class Config {
+        public static Config from(List<? extends com.typesafe.config.Config> marketPriceServiceProviders) {
+            Set<Provider> marketPriceProviders = marketPriceServiceProviders.stream()
+                    .map(config -> {
+                        String url = config.getString("url");
+                        String operator = config.getString("operator");
+                        TransportType transportType = getTransportTypeFromUrl(url);
+                        return new Provider(url, operator, transportType);
+                    }).collect(Collectors.toUnmodifiableSet());
+
+            return new MarketPriceRequestService.Config(marketPriceProviders);
+        }
+
+        private static TransportType getTransportTypeFromUrl(String url) {
+            if (url.endsWith(".i2p/")) {
+                return TransportType.I2P;
+            } else if (url.endsWith(".onion/")) {
+                return TransportType.TOR;
+            } else {
+                return TransportType.CLEAR;
+            }
+        }
+
+        private final Set<Provider> providers;
+
+        public Config(Set<Provider> providers) {
+            this.providers = providers;
+        }
+    }
+
+    @Getter
+    @ToString
+    @EqualsAndHashCode
+    public static final class Provider {
+        private final String url;
+        private final String operator;
+        private final TransportType transportType;
+
+        public Provider(String url, String operator, TransportType transportType) {
+            this.url = url;
+            this.operator = operator;
+            this.transportType = transportType;
+        }
+    }
+
+    private static class PendingRequestException extends Exception {
+        public PendingRequestException() {
+            super("We have a pending request");
+        }
+    }
+
+    private final List<Provider> providers;
+    private final NetworkService networkService;
+    @Getter
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+
+    private final String userAgent;
+    private final List<Provider> candidates = new ArrayList<>();
+    private Optional<BaseHttpClient> currentHttpClient = Optional.empty();
+    private volatile boolean shutdownStarted;
+    @Nullable
+    private Scheduler scheduler;
+    private long initialDelay = 0;
+
+    public MarketPriceRequestService(Config conf,
+                                     Version version,
+                                     NetworkService networkService) {
+        providers = new ArrayList<>(conf.providers);
+        checkArgument(!providers.isEmpty(), "providers must not be empty");
+        userAgent = "bisq-v2/" + version.toString();
+        this.networkService = networkService;
+    }
+
+    public CompletableFuture<Boolean> initialize() {
+        log.info("initialize");
+
+        startRequesting();
+
+        return CompletableFuture.completedFuture(true);
+    }
+
+    public CompletableFuture<Boolean> shutdown() {
+        log.info("shutdown");
+        shutdownStarted = true;
+        if (scheduler != null) {
+            scheduler.stop();
+        }
+        return currentHttpClient.map(BaseHttpClient::shutdown)
+                .orElse(CompletableFuture.completedFuture(true));
+    }
+
+    private void startRequesting() {
+        scheduler = Scheduler.run(() -> {
+            findNextHttpClient().ifPresent(httpClient -> {
+                request(httpClient)
+                        .whenComplete((result, throwable) -> {
+                            if (throwable != null) {
+                                if (scheduler != null) {
+                                    scheduler.stop();
+                                }
+                                // Increase delay for retry each time it fails by 5 sec.
+                                initialDelay += 5;
+                                startRequesting();
+                            }
+                        });
+            });
+        }).periodically(initialDelay, INTERVAL, TimeUnit.SECONDS);
+    }
+
+    private CompletableFuture<Void> request(BaseHttpClient httpClient) {
+        if (httpClient.hasPendingRequest()) {
+            return CompletableFuture.failedFuture(new PendingRequestException());
+        }
+
+        return CompletableFuture.runAsync(() -> {
+            try {
+                long ts = System.currentTimeMillis();
+                log.info("Request market price from {}", httpClient.getBaseUrl());
+                String json = httpClient.get("getAllMarketPrices", Optional.of(new Pair<>("User-Agent", userAgent)));
+                Map<Market, MarketPrice> map = parseResponse(json);
+                long now = System.currentTimeMillis();
+                log.info("Market price request from {} resulted in {} items took {} ms",
+                        httpClient.getBaseUrl(), map.size(), now - ts);
+
+                marketPriceByCurrencyMap.clear();
+                marketPriceByCurrencyMap.putAll(map);
+            } catch (IOException e) {
+                if (!shutdownStarted) {
+                    log.warn("Request to market price provider {} failed. Error={}", httpClient.getBaseUrl(), ExceptionUtil.print(e));
+                }
+                throw new RuntimeException(e);
+            }
+        }, POOL);
+    }
+
+    private Map<Market, MarketPrice> parseResponse(String json) {
+        // size of json is about 8kb
+        Map<Market, MarketPrice> map = new HashMap<>();
+        Map<?, ?> linkedTreeMap = new Gson().fromJson(json, Map.class);
+        List<?> list = (ArrayList<?>) linkedTreeMap.get("data");
+        list.forEach(obj -> {
+            try {
+                Map<?, ?> treeMap = (Map<?, ?>) obj;
+                String currencyCode = (String) treeMap.get("currencyCode");
+                if (!currencyCode.startsWith("NON_EXISTING_SYMBOL")) {
+                    String dataProvider = (String) treeMap.get("provider"); // Bisq-Aggregate or name of exchange of price feed
+                    double price = (Double) treeMap.get("price");
+                    // json uses double for our timestamp long value...
+                    long timestampSec = MathUtils.doubleToLong((Double) treeMap.get("timestampSec"));
+
+                    // We only get BTC based prices not fiat-fiat or altcoin-altcoin
+                    boolean isFiat = TradeCurrency.isFiat(currencyCode);
+                    String baseCurrencyCode = isFiat ? "BTC" : currencyCode;
+                    String quoteCurrencyCode = isFiat ? currencyCode : "BTC";
+                    PriceQuote priceQuote = PriceQuote.fromPrice(price, baseCurrencyCode, quoteCurrencyCode);
+                    map.put(priceQuote.getMarket(), new MarketPrice(priceQuote, currencyCode, timestampSec * 1000, dataProvider));
+                }
+            } catch (Throwable t) {
+                // We do not fail the whole request if one entry would be invalid
+                log.warn("Market price conversion failed: {} ", obj);
+                t.printStackTrace();
+            }
+        });
+        return map;
+    }
+
+    private Optional<BaseHttpClient> findNextHttpClient() {
+        return findProvider().map(this::getNewHttpClient);
+    }
+
+    private Optional<Provider> findProvider() {
+        if (candidates.isEmpty()) {
+            // First try to use the clear net candidate if clear net is supported
+            candidates.addAll(providers.stream()
+                    .filter(provider -> networkService.getSupportedTransportTypes().contains(TransportType.CLEAR))
+                    .filter(provider -> TransportType.CLEAR == provider.transportType)
+                    .collect(Collectors.toList()));
+            if (candidates.isEmpty()) {
+                candidates.addAll(providers.stream()
+                        .filter(provider -> networkService.getSupportedTransportTypes().contains(provider.transportType))
+                        .collect(Collectors.toList()));
+            }
+        }
+        if (candidates.isEmpty()) {
+            log.warn("No provider is available for the supportedTransportTypes. providers={}, supportedTransportTypes={}",
+                    providers, networkService.getSupportedTransportTypes());
+            return Optional.empty();
+        }
+        Provider candidate = Objects.requireNonNull(CollectionUtil.getRandomElement(candidates));
+        candidates.remove(candidate);
+        return Optional.of(candidate);
+    }
+
+    private BaseHttpClient getNewHttpClient(Provider provider) {
+        currentHttpClient.ifPresent(BaseHttpClient::shutdown);
+        BaseHttpClient newClient = networkService.getHttpClient(provider.url, userAgent, provider.transportType);
+        currentHttpClient = Optional.of(newClient);
+        return newClient;
+    }
+}

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
@@ -122,7 +122,7 @@ public class MarketPriceRequestService {
     private volatile boolean shutdownStarted;
     @Nullable
     private Scheduler scheduler;
-    private long initialDelay = 0;
+    private long initialDelay = 10;
 
     public MarketPriceRequestService(Config conf,
                                      Version version,
@@ -224,9 +224,11 @@ public class MarketPriceRequestService {
                     String baseCurrencyCode = isFiat ? "BTC" : currencyCode;
                     String quoteCurrencyCode = isFiat ? currencyCode : "BTC";
                     PriceQuote priceQuote = PriceQuote.fromPrice(price, baseCurrencyCode, quoteCurrencyCode);
-                    map.put(priceQuote.getMarket(), new MarketPrice(priceQuote,
+                    MarketPrice marketPrice = new MarketPrice(priceQuote,
                             timestamp,
-                            MarketPriceProvider.fromName(provider)));
+                            MarketPriceProvider.fromName(provider));
+                    marketPrice.setSource(MarketPrice.Source.REQUESTED_FROM_PRICE_NODE);
+                    map.put(priceQuote.getMarket(), marketPrice);
                 }
             } catch (Throwable t) {
                 // We do not fail the whole request if one entry would be invalid

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceService.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceService.java
@@ -22,59 +22,99 @@ import bisq.common.currency.Market;
 import bisq.common.currency.MarketRepository;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.observable.Observable;
+import bisq.common.observable.Pin;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.common.util.Version;
 import bisq.network.NetworkService;
+import bisq.network.p2p.services.data.DataService;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedDistributedData;
 import bisq.persistence.Persistence;
 import bisq.persistence.PersistenceClient;
 import bisq.persistence.PersistenceService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
+/**
+ * Getting the market price data from either the marketPriceRequestService or as AuthorizedMarketPriceData
+ * from the P2P network. We update the map in the store with the entries which have a more recent timestamp.
+ * We persist the price data so after the first start they are available initially.
+ * Client code need to ensure that the price data are not too old to be considered reliable.
+ */
 
 @Slf4j
-public class MarketPriceService implements Service, PersistenceClient<MarketPriceStore> {
+public class MarketPriceService implements Service, PersistenceClient<MarketPriceStore>, DataService.Listener {
     @Getter
     private final MarketPriceStore persistableStore = new MarketPriceStore();
     @Getter
     private final Persistence<MarketPriceStore> persistence;
+    private final NetworkService networkService;
     private final MarketPriceRequestService marketPriceRequestService;
+    private Pin marketPriceByCurrencyMapPin;
 
-    public MarketPriceService(List<? extends com.typesafe.config.Config> marketPriceServiceProviders,
+    public MarketPriceService(com.typesafe.config.Config marketPrice,
                               Version version,
                               PersistenceService persistenceService,
                               NetworkService networkService) {
-        persistence = persistenceService.getOrCreatePersistence(this, persistableStore);
-        marketPriceRequestService = new MarketPriceRequestService(MarketPriceRequestService.Config.from(marketPriceServiceProviders),
+        this.networkService = networkService;
+        marketPriceRequestService = new MarketPriceRequestService(MarketPriceRequestService.Config.from(marketPrice),
                 version,
                 networkService);
+        persistence = persistenceService.getOrCreatePersistence(this, persistableStore);
     }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // Service
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
 
     public CompletableFuture<Boolean> initialize() {
         log.info("initialize");
+
+        networkService.addDataServiceListener(this);
+
         setSelectedMarket(MarketRepository.getDefault());
 
-        marketPriceRequestService.getMarketPriceByCurrencyMap().addObserver(() -> {
-            if (marketPriceRequestService.getMarketPriceByCurrencyMap().isEmpty()) {
-                return;
-            }
-            // We do not clear to leave potentially missing entries available. Client code need to check the timestamp
-            // to decide if the market price is still relevant.
-            getMarketPriceByCurrencyMap().putAll(marketPriceRequestService.getMarketPriceByCurrencyMap());
-            persist();
-        });
+        marketPriceByCurrencyMapPin = marketPriceRequestService.getMarketPriceByCurrencyMap().addObserver(() ->
+                applyNewMap(marketPriceRequestService.getMarketPriceByCurrencyMap()));
 
         return marketPriceRequestService.initialize();
     }
 
     public CompletableFuture<Boolean> shutdown() {
         log.info("shutdown");
+        marketPriceByCurrencyMapPin.unbind();
+        networkService.removeDataServiceListener(this);
         return marketPriceRequestService.shutdown();
     }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // DataService.Listener
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void onAuthorizedDataAdded(AuthorizedData authorizedData) {
+        AuthorizedDistributedData data = authorizedData.getAuthorizedDistributedData();
+        if (data instanceof AuthorizedMarketPriceData) {
+            AuthorizedMarketPriceData authorizedMarketPriceData = (AuthorizedMarketPriceData) data;
+            applyNewMap(authorizedMarketPriceData.getMarketPriceByCurrencyMap());
+        }
+    }
+
+    @Override
+    public void onAuthorizedDataRemoved(AuthorizedData authorizedData) {
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
 
     public void setSelectedMarket(Market market) {
         getSelectedMarket().set(market);
@@ -96,4 +136,36 @@ public class MarketPriceService implements Service, PersistenceClient<MarketPric
     public Observable<Market> getSelectedMarket() {
         return persistableStore.getSelectedMarket();
     }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // Private
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    private void applyNewMap(Map<Market, MarketPrice> newMap) {
+        if (newMap.isEmpty()) {
+            return;
+        }
+
+        Map<Market, MarketPrice> mapOfNewEntries = getMapOfNewEntries(newMap);
+        if (mapOfNewEntries.isEmpty()) {
+            return;
+        }
+        getMarketPriceByCurrencyMap().putAll(mapOfNewEntries);
+        persist();
+    }
+
+    private Map<Market, MarketPrice> getMapOfNewEntries(Map<Market, MarketPrice> newMap) {
+        Map<Market, MarketPrice> marketPriceByCurrencyMap = getMarketPriceByCurrencyMap();
+        return newMap.entrySet().stream()
+                .filter(e -> {
+                    MarketPrice marketPrice = marketPriceByCurrencyMap.get(e.getKey());
+                    if (marketPrice == null) {
+                        return true;
+                    }
+                    return e.getValue().getTimestamp() > marketPrice.getTimestamp();
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
 }

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceStore.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceStore.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bonded_roles.market_price;
+
+import bisq.common.currency.Market;
+import bisq.common.currency.MarketRepository;
+import bisq.common.observable.Observable;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.common.proto.ProtoResolver;
+import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.persistence.PersistableStore;
+import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+public final class MarketPriceStore implements PersistableStore<MarketPriceStore> {
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+    private final Observable<Market> selectedMarket = new Observable<>(MarketRepository.getDefault());
+
+    public MarketPriceStore() {
+    }
+
+    private MarketPriceStore(Map<Market, MarketPrice> marketPriceByCurrencyMap, Market selectedMarket) {
+        this.marketPriceByCurrencyMap.putAll(marketPriceByCurrencyMap);
+        this.selectedMarket.set(selectedMarket);
+    }
+
+    @Override
+    public bisq.bonded_roles.protobuf.MarketPriceStore toProto() {
+        return bisq.bonded_roles.protobuf.MarketPriceStore.newBuilder()
+                .putAllMarketPriceByCurrencyMap(marketPriceByCurrencyMap.entrySet().stream()
+                        .collect(Collectors.toMap(e -> e.getKey().getMarketCodes(),
+                                e -> e.getValue().toProto())))
+                .setSelectedMarket(selectedMarket.get().toProto())
+                .build();
+    }
+
+    public static MarketPriceStore fromProto(bisq.bonded_roles.protobuf.MarketPriceStore proto) {
+        Map<Market, MarketPrice> map = proto.getMarketPriceByCurrencyMapMap().entrySet().stream()
+                .filter(e -> MarketRepository.findAnyMarketByMarketCodes(e.getKey()).isPresent())
+                .collect(Collectors.toMap(e -> MarketRepository.findAnyMarketByMarketCodes(e.getKey()).orElseThrow(),
+                        e -> MarketPrice.fromProto(e.getValue())));
+        return new MarketPriceStore(map, Market.fromProto(proto.getSelectedMarket()));
+    }
+
+    @Override
+    public ProtoResolver<PersistableStore<?>> getResolver() {
+        return any -> {
+            try {
+                return fromProto(any.unpack(bisq.bonded_roles.protobuf.MarketPriceStore.class));
+            } catch (InvalidProtocolBufferException e) {
+                throw new UnresolvableProtobufMessageException(e);
+            }
+        };
+    }
+
+    @Override
+    public MarketPriceStore getClone() {
+        return new MarketPriceStore(marketPriceByCurrencyMap, selectedMarket.get());
+    }
+
+    @Override
+    public void applyPersisted(MarketPriceStore persisted) {
+        marketPriceByCurrencyMap.clear();
+        marketPriceByCurrencyMap.putAll(persisted.getMarketPriceByCurrencyMap());
+        selectedMarket.set(persisted.getSelectedMarket().get());
+    }
+
+    ObservableHashMap<Market, MarketPrice> getMarketPriceByCurrencyMap() {
+        return marketPriceByCurrencyMap;
+    }
+
+    Observable<Market> getSelectedMarket() {
+        return selectedMarket;
+    }
+}

--- a/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceStore.java
+++ b/bonded_roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceStore.java
@@ -80,7 +80,10 @@ public final class MarketPriceStore implements PersistableStore<MarketPriceStore
     @Override
     public void applyPersisted(MarketPriceStore persisted) {
         marketPriceByCurrencyMap.clear();
-        marketPriceByCurrencyMap.putAll(persisted.getMarketPriceByCurrencyMap());
+        Map<Market, MarketPrice> map = persisted.getMarketPriceByCurrencyMap().entrySet().stream()
+                .peek(e -> e.getValue().setSource(MarketPrice.Source.PERSISTED))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        marketPriceByCurrencyMap.putAll(map);
         selectedMarket.set(persisted.getSelectedMarket().get());
     }
 

--- a/bonded_roles/src/main/proto/bonded_roles.proto
+++ b/bonded_roles/src/main/proto/bonded_roles.proto
@@ -80,3 +80,15 @@ message ReleaseNotification {
   string releaseManagerProfileId = 7;
   bool staticPublicKeysProvided = 8;
 }
+
+message MarketPrice {
+  common.PriceQuote priceQuote = 1;
+  string code = 2;
+  sint64 timestamp = 3;
+  string provider = 4;
+}
+
+message MarketPriceStore {
+  map<string, MarketPrice> marketPriceByCurrencyMap = 1;
+  common.Market selectedMarket = 2;
+}

--- a/bonded_roles/src/main/proto/bonded_roles.proto
+++ b/bonded_roles/src/main/proto/bonded_roles.proto
@@ -81,11 +81,24 @@ message ReleaseNotification {
   bool staticPublicKeysProvided = 8;
 }
 
+enum MarketPriceProvider {
+  MARKETPRICEPROVIDER_UNSPECIFIED = 0;
+  MARKETPRICEPROVIDER_BISQAGGREGATE = 1;
+  MARKETPRICEPROVIDER_COINGECKO = 2;
+  MARKETPRICEPROVIDER_POLO = 3;
+  MARKETPRICEPROVIDER_BITFINEX = 4;
+  MARKETPRICEPROVIDER_OTHER = 5;
+}
+
 message MarketPrice {
   common.PriceQuote priceQuote = 1;
-  string code = 2;
-  sint64 timestamp = 3;
-  string provider = 4;
+  sint64 timestamp = 2;
+  MarketPriceProvider marketPriceProvider = 3;
+}
+
+message AuthorizedMarketPriceData {
+  map<string, MarketPrice> marketPriceByCurrencyMap = 1;
+  bool staticPublicKeysProvided = 2;
 }
 
 message MarketPriceStore {

--- a/common/src/main/java/bisq/common/currency/MarketRepository.java
+++ b/common/src/main/java/bisq/common/currency/MarketRepository.java
@@ -19,6 +19,7 @@ package bisq.common.currency;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -107,5 +108,17 @@ public class MarketRepository {
         list.addAll(getMajorFiatMarkets());
         list.addAll(getMinorFiatMarkets());
         return list.stream().distinct().collect(Collectors.toList());
+    }
+
+    public static Optional<Market> findAnyMarketByMarketCodes(String marketCodes) {
+        return MarketRepository.getAllMarkets().stream()
+                .filter(e -> e.getMarketCodes().equals(marketCodes))
+                .findAny();
+    }
+
+    public static Optional<Market> findAnyFiatMarketByMarketCodes(String marketCodes) {
+        return MarketRepository.getAllFiatMarkets().stream()
+                .filter(e -> e.getMarketCodes().equals(marketCodes))
+                .findAny();
     }
 }

--- a/common/src/main/java/bisq/common/observable/map/SimpleHashMapObserver.java
+++ b/common/src/main/java/bisq/common/observable/map/SimpleHashMapObserver.java
@@ -20,6 +20,8 @@ package bisq.common.observable.map;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.Map;
+
 /**
  * Simple Observer which notifies about any change of the source map.
  *
@@ -40,6 +42,11 @@ final class SimpleHashMapObserver<K, V> implements HashMapObserver<K, V> {
 
     @Override
     public void put(K key, V value) {
+        onChange();
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
         onChange();
     }
 

--- a/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
+++ b/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
@@ -82,7 +82,7 @@ public class NetworkDataValidation {
 
     public static void validateByteArray(byte[] bytes, int maxLength) {
         checkArgument(bytes.length <= maxLength,
-                "Byte array must not be longer than " + maxLength);
+                "Byte array must not be longer than " + maxLength + ". bytes.length=" + bytes.length);
     }
 
     // Longest supported version is xxx.xxx.xxx

--- a/desktop/src/main/java/bisq/desktop/main/top/MarketPriceComponent.java
+++ b/desktop/src/main/java/bisq/desktop/main/top/MarketPriceComponent.java
@@ -204,6 +204,7 @@ public class MarketPriceComponent {
                 ListItem item = model.selected.get();
                 tooltip.setText(Res.get("component.marketPrice.tooltip",
                         item.provider,
+                        item.source,
                         TimeFormatter.getAgeInSeconds(System.currentTimeMillis() - item.marketPrice.getTimestamp()),
                         item.date));
             });
@@ -253,6 +254,7 @@ public class MarketPriceComponent {
                         Tooltip.install(hBox, tooltip);
                         tooltip.setText(Res.get("component.marketPrice.tooltip",
                                 item.provider,
+                                item.source,
                                 TimeFormatter.getAgeInSeconds(System.currentTimeMillis() - item.marketPrice.getTimestamp()),
                                 item.date));
 
@@ -274,12 +276,14 @@ public class MarketPriceComponent {
         private final String codes;
         private final String provider;
         private final String date;
+        private final String source;
 
         private ListItem(MarketPrice marketPrice) {
             this.marketPrice = marketPrice;
             codes = marketPrice.getMarket().getMarketCodes();
             price = PriceFormatter.format(marketPrice.getPriceQuote(), true);
             provider = marketPrice.getProviderName();
+            source = Res.get("component.marketPrice.source." + marketPrice.getSource());
             date = DateFormatter.formatDateTime(marketPrice.getTimestamp());
         }
 

--- a/desktop_app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/desktop_app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -115,7 +115,10 @@ public class DesktopApplicationService extends bisq.application.ApplicationServi
                 securityService,
                 networkService);
 
-        bondedRolesService = new BondedRolesService(BondedRolesService.Config.from(getConfig("bondedRoles")), config.getVersion(), networkService);
+        bondedRolesService = new BondedRolesService(BondedRolesService.Config.from(getConfig("bondedRoles")),
+                config.getVersion(),
+                getPersistenceService(),
+                networkService);
 
         accountService = new AccountService(persistenceService);
 

--- a/desktop_app/src/main/resources/desktop.conf
+++ b/desktop_app/src/main/resources/desktop.conf
@@ -26,10 +26,6 @@ application {
                 operator = "wiz",
             },
             {
-                url = "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/"
-                operator = "wiz",
-            },
-            {
                 url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
                 operator = "emzy",
             },

--- a/desktop_app/src/main/resources/desktop.conf
+++ b/desktop_app/src/main/resources/desktop.conf
@@ -20,28 +20,31 @@ application {
     bondedRoles = { 
         ignoreSecurityManager = false
 
-        marketPriceServiceProviders = [
-            {
-                url = "https://price.bisq.wiz.biz/"
-                operator = "wiz",
-            },
-            {
-                url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
-                operator = "emzy",
-            },
-            {
-                url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
-                operator = "mrosseel",
-            },
-            {
-                url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
-                operator = "devinbileck",
-            },
-            {
-                url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
-                operator = "alexej996",
-            },
-        ]
+        marketPrice = {
+            interval = 60 // in seconds
+            providers = [
+                        {
+                            url = "https://price.bisq.wiz.biz/"
+                            operator = "wiz",
+                        },
+                        {
+                            url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
+                            operator = "emzy",
+                        },
+                        {
+                            url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
+                            operator = "mrosseel",
+                        },
+                        {
+                            url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
+                            operator = "devinbileck",
+                        },
+                        {
+                            url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
+                            operator = "alexej996",
+                        },
+                    ]
+        }
 
         blockchainExplorer = {
         }

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -106,6 +106,9 @@ validation.tooLong=Input text must not be longer than {0} characters
 component.priceInput.prompt=Enter price
 component.priceInput.description={0} price
 component.marketPrice.requesting=Requesting market price
+component.marketPrice.tooltip=Provided by: {0}\n\
+  Updated {1} ago\n\
+  Update date: {2}
 
 
 

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -106,9 +106,13 @@ validation.tooLong=Input text must not be longer than {0} characters
 component.priceInput.prompt=Enter price
 component.priceInput.description={0} price
 component.marketPrice.requesting=Requesting market price
+component.marketPrice.source.PERSISTED=Persisted data
+component.marketPrice.source.PROPAGATED_IN_NETWORK=P2P network
+component.marketPrice.source.REQUESTED_FROM_PRICE_NODE=Bisq market price node
 component.marketPrice.tooltip=Provided by: {0}\n\
-  Updated {1} ago\n\
-  Update date: {2}
+  Source: {1}\n\
+  Updated {2} ago\n\
+  Update date: {3}
 
 
 

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
@@ -97,8 +97,11 @@ public class AuthorizationService {
         receivedMessageCounters.add(messageCounter);
 
         // Verify payload
-        if (!Arrays.equals(getPayload(message), proofOfWork.getPayload())) {
-            log.warn("Invalid payload");
+        byte[] payload = getPayload(message);
+        if (!Arrays.equals(payload, proofOfWork.getPayload())) {
+            log.warn("Message payload not matching proof of work payload. getPayload(message).length={}; " +
+                            "proofOfWork.getPayload().length={}",
+                    payload.length, proofOfWork.getPayload().length);
             return false;
         }
 

--- a/oracle_node/src/main/java/bisq/oracle_node/market_price/MarketPricePropagationService.java
+++ b/oracle_node/src/main/java/bisq/oracle_node/market_price/MarketPricePropagationService.java
@@ -1,0 +1,72 @@
+package bisq.oracle_node.market_price;
+
+import bisq.bonded_roles.market_price.AuthorizedMarketPriceData;
+import bisq.bonded_roles.market_price.MarketPriceRequestService;
+import bisq.common.application.Service;
+import bisq.common.observable.Pin;
+import bisq.identity.Identity;
+import bisq.network.NetworkService;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedDistributedData;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+public class MarketPricePropagationService implements Service {
+    private final NetworkService networkService;
+    private final MarketPriceRequestService marketPriceRequestService;
+    private final PrivateKey authorizedPrivateKey;
+    private final PublicKey authorizedPublicKey;
+    private final boolean staticPublicKeysProvided;
+    @Setter
+    private Identity identity;
+    private Pin marketPriceByCurrencyMapPin;
+
+    public MarketPricePropagationService(NetworkService networkService,
+                                         MarketPriceRequestService marketPriceRequestService,
+                                         PrivateKey authorizedPrivateKey,
+                                         PublicKey authorizedPublicKey,
+                                         boolean staticPublicKeysProvided) {
+        this.networkService = networkService;
+        this.marketPriceRequestService = marketPriceRequestService;
+        this.authorizedPrivateKey = authorizedPrivateKey;
+        this.authorizedPublicKey = authorizedPublicKey;
+        this.staticPublicKeysProvided = staticPublicKeysProvided;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> initialize() {
+        marketPriceByCurrencyMapPin = marketPriceRequestService.getMarketPriceByCurrencyMap().addObserver(() -> {
+            if (marketPriceRequestService.getMarketPriceByCurrencyMap().isEmpty()) {
+                return;
+            }
+            publishAuthorizedData(new AuthorizedMarketPriceData(marketPriceRequestService.getMarketPriceByCurrencyMap(),
+                    staticPublicKeysProvided));
+        });
+
+        return marketPriceRequestService.initialize();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> shutdown() {
+        marketPriceByCurrencyMapPin.unbind();
+        return marketPriceRequestService.shutdown();
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // Private
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+    private CompletableFuture<Boolean> publishAuthorizedData(AuthorizedDistributedData data) {
+        return networkService.publishAuthorizedData(data,
+                        identity.getNodeIdAndKeyPair().getKeyPair(),
+                        authorizedPrivateKey,
+                        authorizedPublicKey)
+                .thenApply(broadCastDataResult -> true);
+    }
+
+}

--- a/oracle_node/src/main/java/bisq/oracle_node/timestamp/TimestampService.java
+++ b/oracle_node/src/main/java/bisq/oracle_node/timestamp/TimestampService.java
@@ -17,7 +17,6 @@
 
 package bisq.oracle_node.timestamp;
 
-import bisq.bonded_roles.oracle.AuthorizedOracleNode;
 import bisq.common.application.Service;
 import bisq.identity.Identity;
 import bisq.network.NetworkService;
@@ -51,8 +50,6 @@ public class TimestampService implements Service, PersistenceClient<TimestampSto
     private final PrivateKey authorizedPrivateKey;
     private final PublicKey authorizedPublicKey;
     @Setter
-    private AuthorizedOracleNode authorizedOracleNode;
-    @Setter
     private Identity identity;
 
     public TimestampService(PersistenceService persistenceService,
@@ -63,9 +60,9 @@ public class TimestampService implements Service, PersistenceClient<TimestampSto
         this.networkService = networkService;
         this.authorizedPrivateKey = authorizedPrivateKey;
         this.authorizedPublicKey = authorizedPublicKey;
+        this.staticPublicKeysProvided = staticPublicKeysProvided;
 
         persistence = persistenceService.getOrCreatePersistence(this, persistableStore);
-        this.staticPublicKeysProvided = staticPublicKeysProvided;
     }
 
 

--- a/oracle_node/src/main/proto/oracle_node.proto
+++ b/oracle_node/src/main/proto/oracle_node.proto
@@ -6,7 +6,6 @@ import "common.proto";
 import "network.proto";
 import "user.proto";
 
-
 message TimestampStore {
   repeated common.StringLongPair stringLongPairs = 1;
 }

--- a/oracle_node_app/src/main/java/bisq/oracle_node_app/OracleNodeApplicationService.java
+++ b/oracle_node_app/src/main/java/bisq/oracle_node_app/OracleNodeApplicationService.java
@@ -19,6 +19,7 @@ package bisq.oracle_node_app;
 
 import bisq.application.ApplicationService;
 import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
+import bisq.bonded_roles.market_price.MarketPriceRequestService;
 import bisq.identity.IdentityService;
 import bisq.network.NetworkService;
 import bisq.network.NetworkServiceConfig;
@@ -62,13 +63,20 @@ public class OracleNodeApplicationService extends ApplicationService {
         com.typesafe.config.Config bondedRolesConfig = getConfig("bondedRoles");
         authorizedBondedRolesService = new AuthorizedBondedRolesService(networkService, bondedRolesConfig.getBoolean("ignoreSecurityManager"));
 
+        com.typesafe.config.Config marketPriceConfig = bondedRolesConfig.getConfig("marketPrice");
+        MarketPriceRequestService marketPriceRequestService = new MarketPriceRequestService(
+                MarketPriceRequestService.Config.from(marketPriceConfig),
+                config.getVersion(),
+                networkService);
+
         OracleNodeService.Config oracleNodeConfig = OracleNodeService.Config.from(getConfig("oracleNode"));
         oracleNodeService = new OracleNodeService(oracleNodeConfig,
                 securityService.getKeyPairService(),
                 identityService,
                 networkService,
                 persistenceService,
-                authorizedBondedRolesService);
+                authorizedBondedRolesService,
+                marketPriceRequestService);
     }
 
     @Override

--- a/oracle_node_app/src/main/resources/oracle_node.conf
+++ b/oracle_node_app/src/main/resources/oracle_node.conf
@@ -35,10 +35,6 @@ application {
                 operator = "wiz",
             },
             {
-                url = "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/"
-                operator = "wiz",
-            },
-            {
                 url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
                 operator = "emzy",
             },

--- a/oracle_node_app/src/main/resources/oracle_node.conf
+++ b/oracle_node_app/src/main/resources/oracle_node.conf
@@ -29,28 +29,31 @@ application {
     bondedRoles = { 
         ignoreSecurityManager = true
 
-        marketPriceServiceProviders = [
-            {
-                url = "https://price.bisq.wiz.biz/"
-                operator = "wiz",
-            },
-            {
-                url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
-                operator = "emzy",
-            },
-            {
-                url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
-                operator = "mrosseel",
-            },
-            {
-                url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
-                operator = "devinbileck",
-            },
-            {
-                url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
-                operator = "alexej996",
-            },
-        ]
+        marketPrice = {
+            interval = 180 // in seconds
+            providers = [
+                        {
+                            url = "https://price.bisq.wiz.biz/"
+                            operator = "wiz",
+                        },
+                        {
+                            url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
+                            operator = "emzy",
+                        },
+                        {
+                            url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
+                            operator = "mrosseel",
+                        },
+                        {
+                            url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
+                            operator = "devinbileck",
+                        },
+                        {
+                            url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
+                            operator = "alexej996",
+                        },
+                    ]
+        }
 
         blockchainExplorer = {
         }

--- a/presentation/src/main/java/bisq/presentation/formatters/TimeFormatter.java
+++ b/presentation/src/main/java/bisq/presentation/formatters/TimeFormatter.java
@@ -43,6 +43,11 @@ public class TimeFormatter {
         }
     }
 
+    public static String getAgeInSeconds(long duration) {
+        long sec = duration / 1000;
+        return sec + " sec";
+    }
+
     public static long getAgeInDays(long date) {
         return (System.currentTimeMillis() - date) / DAY_AS_MS;
     }

--- a/rest_api_app/src/main/java/bisq/rest_api/RestApiApplicationService.java
+++ b/rest_api_app/src/main/java/bisq/rest_api/RestApiApplicationService.java
@@ -117,7 +117,10 @@ public class RestApiApplicationService extends ApplicationService {
                 securityService,
                 networkService);
 
-        bondedRolesService = new BondedRolesService(BondedRolesService.Config.from(getConfig("bondedRoles")), config.getVersion(), networkService);
+        bondedRolesService = new BondedRolesService(BondedRolesService.Config.from(getConfig("bondedRoles")),
+                config.getVersion(),
+                persistenceService,
+                networkService);
 
         accountService = new AccountService(persistenceService);
 

--- a/rest_api_app/src/main/resources/rest_api.conf
+++ b/rest_api_app/src/main/resources/rest_api.conf
@@ -30,28 +30,31 @@ application {
     bondedRoles = { 
         ignoreSecurityManager = false
 
-        marketPriceServiceProviders = [
-            {
-                url = "https://price.bisq.wiz.biz/"
-                operator = "wiz",
-            },
-            {
-                url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
-                operator = "emzy",
-            },
-            {
-                url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
-                operator = "mrosseel",
-            },
-            {
-                url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
-                operator = "devinbileck",
-            },
-            {
-                url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
-                operator = "alexej996",
-            },
-        ]
+        marketPrice = {
+            interval = 60 // in seconds
+            providers = [
+                        {
+                            url = "https://price.bisq.wiz.biz/"
+                            operator = "wiz",
+                        },
+                        {
+                            url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
+                            operator = "emzy",
+                        },
+                        {
+                            url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
+                            operator = "mrosseel",
+                        },
+                        {
+                            url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
+                            operator = "devinbileck",
+                        },
+                        {
+                            url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
+                            operator = "alexej996",
+                        },
+                    ]
+        }
 
         blockchainExplorer = {
         }

--- a/rest_api_app/src/main/resources/rest_api.conf
+++ b/rest_api_app/src/main/resources/rest_api.conf
@@ -36,10 +36,6 @@ application {
                 operator = "wiz",
             },
             {
-                url = "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/"
-                operator = "wiz",
-            },
-            {
                 url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
                 operator = "emzy",
             },

--- a/security/src/main/java/bisq/security/pow/ProofOfWork.java
+++ b/security/src/main/java/bisq/security/pow/ProofOfWork.java
@@ -57,7 +57,8 @@ public final class ProofOfWork implements Proto {
         this.solution = solution;
         this.duration = duration;
 
-        NetworkDataValidation.validateByteArray(payload, 20_000);
+        // We have to allow a large size here as InventoryData can be large
+        NetworkDataValidation.validateByteArray(payload, 10_000_000);
         if (challenge != null) {
             NetworkDataValidation.validateByteArray(challenge, 32);
         }

--- a/seed_node_app/src/main/resources/seed_node.conf
+++ b/seed_node_app/src/main/resources/seed_node.conf
@@ -13,28 +13,31 @@ application {
     bondedRoles = { 
         ignoreSecurityManager = false
 
-        marketPriceServiceProviders = [
-            {
-                url = "https://price.bisq.wiz.biz/"
-                operator = "wiz",
-            },
-            {
-                url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
-                operator = "emzy",
-            },
-            {
-                url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
-                operator = "mrosseel",
-            },
-            {
-                url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
-                operator = "devinbileck",
-            },
-            {
-                url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
-                operator = "alexej996",
-            },
-        ]
+        marketPrice = {
+            interval = 60 // in seconds
+            providers = [
+                        {
+                            url = "https://price.bisq.wiz.biz/"
+                            operator = "wiz",
+                        },
+                        {
+                            url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
+                            operator = "emzy",
+                        },
+                        {
+                            url = "http://aprcndeiwdrkbf4fq7iozxbd27dl72oeo76n7zmjwdi4z34agdrnheyd.onion/"
+                            operator = "mrosseel",
+                        },
+                        {
+                            url = "http://devinpndvdwll4wiqcyq5e7itezmarg7rzicrvf6brzkwxdm374kmmyd.onion/"
+                            operator = "devinbileck",
+                        },
+                        {
+                            url = "http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion/"
+                            operator = "alexej996",
+                        },
+                    ]
+        }
 
         blockchainExplorer = {
         }

--- a/seed_node_app/src/main/resources/seed_node.conf
+++ b/seed_node_app/src/main/resources/seed_node.conf
@@ -19,10 +19,6 @@ application {
                 operator = "wiz",
             },
             {
-                url = "http://wizpriceje6q5tdrxkyiazsgu7irquiqjy2dptezqhrtu7l2qelqktid.onion/"
-                operator = "wiz",
-            },
-            {
                 url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion/"
                 operator = "emzy",
             },


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq2/issues/1318

We persist the market price data so after the first start up price data is immediately available. This data might be outdated and this need to be handled in the client code.
Next to the http requests to price nodes we get market price data provided via the p2p network. The oracle node is requesting from the price nodes and propagate the price to the network. Always the more recent price data will be used.

The UI shows detail information as tooltips:

![Screenshot from 2023-11-10 20-04-21](https://github.com/bisq-network/bisq2/assets/146422224/27dc0df7-16ef-4167-b0f0-25dfe2c372e4)
![Screenshot from 2023-11-10 20-04-13](https://github.com/bisq-network/bisq2/assets/146422224/2fdae368-dca0-4f88-a5e1-8d49b97abdf7)
