### PR TITLE
Fix path for icon shown in OS notifications on Linux.

### DIFF
--- a/presentation/src/main/java/bisq/presentation/notifications/linux/LinuxNotifications.java
+++ b/presentation/src/main/java/bisq/presentation/notifications/linux/LinuxNotifications.java
@@ -37,7 +37,7 @@ public class LinuxNotifications implements NotificationsDelegate {
         command.add("notify-send");
 
         command.add("-i");
-        command.add(System.getProperty("java.home") + "/../Bisq_2.png");
+        command.add(System.getProperty("java.home") + "/../Bisq2.png");
 
         command.add("--app-name");
         command.add("Bisq");


### PR DESCRIPTION
Tested with installation from binary and displayed icon at Ubuntu.