### PR TITLE
Change receive amount description when creating an offer as buyer

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -337,7 +337,7 @@ public class TradeWizardReviewController implements Controller {
             } else {
                 model.setPriceDescription(Res.get("bisqEasy.tradeWizard.review.priceDescription.maker.buyer"));
                 toSendAmountDescription = Res.get("bisqEasy.tradeWizard.review.toPay");
-                toReceiveAmountDescription = Res.get("bisqEasy.tradeWizard.review.toReceive");
+                toReceiveAmountDescription = Res.get("bisqEasy.tradeWizard.review.btcAtMarketPrice");
             }
         } else {
             model.setHeadline(Res.get("bisqEasy.tradeWizard.review.headline.taker"));

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -187,6 +187,7 @@ bisqEasy.tradeWizard.review.feeDetails.seller=There are no trade fees in Bisq Ea
 bisqEasy.tradeWizard.review.toPay=Amount to pay
 bisqEasy.tradeWizard.review.toSend=Amount to send
 bisqEasy.tradeWizard.review.toReceive=Amount to receive
+bisqEasy.tradeWizard.review.btcAtMarketPrice=Amount at market price
 bisqEasy.tradeWizard.review.paymentMethodDescription=Payment method
 bisqEasy.tradeWizard.review.paymentMethodDescriptions.maker=Payment methods
 bisqEasy.tradeWizard.review.paymentMethodDescriptions.taker=Select payment method


### PR DESCRIPTION
When creating an offer as buyer, at the review screen the amount in BTC stated is just the amount in BTC at the current market price. I.e., not the amount to receive nor the expected amount to receive. Add an additional text description to make this clearer.

Fix #1342

![image](https://github.com/bisq-network/bisq2/assets/144623880/a919d03d-55f2-4ef3-832a-b1acd2ad06b0)
