### PR TITLE
Packaging: Disable incompatible Windows resources

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/WindowsPackage.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/WindowsPackage.kt
@@ -7,7 +7,7 @@ class WindowsPackage(private val resourcesPath: Path) : JPackagePackageFormatCon
 
     override fun createArgumentsForJPackage(packageFormat: PackageFormat): List<String> =
             mutableListOf(
-                    "--resource-dir", resourcesPath.toAbsolutePath().toString(),
+                    // "--resource-dir", resourcesPath.toAbsolutePath().toString(),
                     "--icon", resourcesPath.resolve("Bisq2.ico").toAbsolutePath().toString(),
 
                     "--win-dir-chooser",


### PR DESCRIPTION
We had the same bug in Bisq 1.
See: https://github.com/bisq-network/bisq/pull/6870