### PR TITLE
Fix alignment in main left menu

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavView.java
@@ -72,6 +72,7 @@ public class LeftNavView extends View<AnchorPane, LeftNavModel, LeftNavControlle
 
         mainMenuItems = new VBox();
         mainMenuItems.setSpacing(6);
+        mainMenuItems.setPadding(new Insets(0, MARKER_WIDTH, 0, 0));
 
         LeftNavButton dashBoard = createNavigationButton(Res.get("navigation.dashboard"),
                 "nav-community",


### PR DESCRIPTION
Change `mainMenuItems` to account for the `selectionMarker` as its children so that they have the same width.

Before
![image](https://github.com/bisq-network/bisq2/assets/145597137/a322ab61-fdd3-479b-b404-b9ec599800dd)

After
![image](https://github.com/bisq-network/bisq2/assets/145597137/f38f3778-30cf-4be1-a879-0991f1851289)

This was also affecting the collapsed menu.