### PR TITLE
Fix bug in selection marker column and use it in chat peer menu

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/BisqTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/BisqTableView.java
@@ -131,8 +131,7 @@ public class BisqTableView<T> extends TableView<T> {
                 .build();
     }
 
-    public Callback<TableColumn<T, T>, TableCell<T, T>> getSelectionMarkerCellFactory
-            () {
+    public Callback<TableColumn<T, T>, TableCell<T, T>> getSelectionMarkerCellFactory() {
         return column -> new TableCell<>() {
             private Subscription selectedPin;
 
@@ -140,16 +139,17 @@ public class BisqTableView<T> extends TableView<T> {
             public void updateItem(final T item, boolean empty) {
                 super.updateItem(item, empty);
 
-                if (item != null && !empty) {
-                    selectedPin = EasyBind.subscribe(BisqTableView.this.getSelectionModel().selectedItemProperty(),
-                            selected -> {
-                                setId(item.equals(selected) ? "selection-marker" : null);
-                            });
-                } else {
-                    if (selectedPin != null) {
-                        selectedPin.unsubscribe();
-                        selectedPin = null;
-                    }
+                // Clean up previous row
+                if (getTableRow() != null && selectedPin != null) {
+                    selectedPin.unsubscribe();
+                }
+
+                // Set up new row
+                TableRow<T> newRow = getTableRow();
+                if (newRow != null) {
+                    selectedPin = EasyBind.subscribe(newRow.selectedProperty(), isSelected ->
+                        setId(isSelected ? "selection-marker" : null)
+                    );
                 }
             }
         };

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
@@ -140,8 +140,9 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
 
         PrivateChatsModel model = getModel();
 
-        selectedModelItemPin = EasyBind.subscribe(model.getSelectedItem(), selected ->
-                tableView.getSelectionModel().select(selected));
+        selectedModelItemPin = EasyBind.subscribe(model.getSelectedItem(), selected -> {
+            tableView.getSelectionModel().select(selected);
+        });
 
         tableViewSelectionPin = EasyBind.subscribe(tableView.getSelectionModel().selectedItemProperty(), item -> {
             if (item != null) {
@@ -199,6 +200,8 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
     }
 
     private void configTableView() {
+        tableView.getColumns().add(tableView.getSelectionMarkerColumn());
+
         tableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
                 .minWidth(100)
                 .left()


### PR DESCRIPTION
Previously, non-selected rows were occasionally displaying the selection marker:
![image](https://github.com/bisq-network/bisq2/assets/145597137/9ad94af9-e11b-4af0-87c8-ba32c581bb4e)

This is fixed now.