### PR TITLE
Fix crash if clicking on non-editable TextInputControl with prompt text

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/MaterialTextField.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/MaterialTextField.java
@@ -408,6 +408,17 @@ public class MaterialTextField extends Pane {
         }
     }
 
+    public void filterMouseEventOnNonEditableText() {
+        javafx.event.EventHandler<MouseEvent> weakEventFilter = new WeakReference<>((javafx.event.EventHandler<MouseEvent>) event -> {
+            if (!textInputControl.isEditable()) {
+                event.consume();
+            }
+        }).get();
+        if (weakEventFilter != null) {
+            textInputControl.addEventFilter(MouseEvent.ANY, weakEventFilter);
+        }
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     // Layout

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState3b.java
@@ -186,6 +186,7 @@ public class BuyerState3b extends BaseState {
             btcBalance = FormUtils.getTextField(Res.get("bisqEasy.tradeState.info.buyer.phase3b.balance"), "", false);
             btcBalance.setHelpText(Res.get("bisqEasy.tradeState.info.phase4.balance.help.explorerLookup"));
             btcBalance.setPromptText(Res.get("bisqEasy.tradeState.info.buyer.phase3b.balance.prompt"));
+            btcBalance.filterMouseEventOnNonEditableText();
 
             button = new Button(Res.get("bisqEasy.tradeState.info.phase4.buttonText"));
             VBox.setMargin(button, new Insets(5, 0, 5, 0));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState3b.java
@@ -186,6 +186,7 @@ public class SellerState3b extends BaseState {
             btcBalance = FormUtils.getTextField(Res.get("bisqEasy.tradeState.info.seller.phase3b.balance"), "", false);
             btcBalance.setHelpText(Res.get("bisqEasy.tradeState.info.phase4.balance.help.explorerLookup"));
             btcBalance.setPromptText(Res.get("bisqEasy.tradeState.info.seller.phase3b.balance.prompt"));
+            btcBalance.filterMouseEventOnNonEditableText();
 
             button = new Button(Res.get("bisqEasy.tradeState.info.phase4.buttonText"));
             VBox.setMargin(button, new Insets(5, 0, 5, 0));


### PR DESCRIPTION
Previous to this fix, if the user tried clicking on the `MaterialTextField` > "Bitcoin payment" > "Waiting for blockchain data..."

![image](https://github.com/bisq-network/bisq2/assets/144623880/619a8c56-2fba-45b7-8c9c-8aacdd9a8e9a)

the program was crashing as editing was not allowed:

![image](https://github.com/bisq-network/bisq2/assets/144623880/21950b73-a34f-4a10-b789-34b55626b8e9)
