### PR TITLE
Verify network data [5]

### DIFF
--- a/account/src/main/java/bisq/account/accounts/Account.java
+++ b/account/src/main/java/bisq/account/accounts/Account.java
@@ -19,7 +19,7 @@ package bisq.account.accounts;
 
 import bisq.account.payment_method.PaymentMethod;
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @ToString
 @EqualsAndHashCode
-public abstract class Account<P extends AccountPayload, M extends PaymentMethod<?>> implements Proto {
+public abstract class Account<P extends AccountPayload, M extends PaymentMethod<?>> implements NetworkProto {
     protected final long creationDate;
     protected final String accountName;
     protected final P accountPayload;

--- a/account/src/main/java/bisq/account/accounts/Account.java
+++ b/account/src/main/java/bisq/account/accounts/Account.java
@@ -19,7 +19,7 @@ package bisq.account.accounts;
 
 import bisq.account.payment_method.PaymentMethod;
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @ToString
 @EqualsAndHashCode
-public abstract class Account<P extends AccountPayload, M extends PaymentMethod<?>> implements NetworkProto {
+public abstract class Account<P extends AccountPayload, M extends PaymentMethod<?>> implements PersistableProto {
     protected final long creationDate;
     protected final String accountName;
     protected final P accountPayload;

--- a/account/src/main/java/bisq/account/accounts/AccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/AccountPayload.java
@@ -19,6 +19,7 @@ package bisq.account.accounts;
 
 import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -38,6 +39,12 @@ public abstract class AccountPayload implements NetworkProto {
     public AccountPayload(String id, String paymentMethodName) {
         this.id = id;
         this.paymentMethodName = paymentMethodName;
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateId(id);
+        NetworkDataValidation.validateText(paymentMethodName, 100);
     }
 
     public abstract bisq.account.protobuf.AccountPayload toProto();

--- a/account/src/main/java/bisq/account/accounts/AccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/AccountPayload.java
@@ -17,7 +17,7 @@
 
 package bisq.account.accounts;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @ToString
 @EqualsAndHashCode
-public abstract class AccountPayload implements Proto {
+public abstract class AccountPayload implements NetworkProto {
     protected final String id;
     private final String paymentMethodName;
 

--- a/account/src/main/java/bisq/account/accounts/BankAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/BankAccountPayload.java
@@ -1,6 +1,7 @@
 package bisq.account.accounts;
 
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,10 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import java.util.Optional;
 
-import static bisq.account.protobuf.Account.MessageCase.MESSAGE_NOT_SET;
-import static bisq.account.protobuf.BankAccountPayload.MessageCase.ACHTRANSFERACCOUNTPAYLOAD;
-import static bisq.account.protobuf.BankAccountPayload.MessageCase.NATIONALBANKACCOUNTPAYLOAD;
-
+//TODO use Optional instead of Nullable
 @EqualsAndHashCode(callSuper = true)
 @Setter
 @Getter
@@ -24,7 +22,6 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
     protected String bankName;
     protected String branchId;
     protected String accountNr;
-    @Nullable
     protected String accountType;
     @Nullable
     protected String holderTaxId;
@@ -44,6 +41,7 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
                                  @Nullable String bankId,
                                  @Nullable String nationalAccountId) {
         super(id, paymentMethodName, countryCode);
+
         this.holderName = Optional.ofNullable(holderName).orElse("");
         this.bankName = Optional.ofNullable(bankName).orElse("");
         this.branchId = Optional.ofNullable(branchId).orElse("");
@@ -52,6 +50,23 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
         this.holderTaxId = holderTaxId;
         this.bankId = Optional.ofNullable(bankId).orElse("");
         this.nationalAccountId = nationalAccountId;
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+        NetworkDataValidation.validateText(holderName, 100);
+        NetworkDataValidation.validateText(bankName, 100);
+        NetworkDataValidation.validateText(branchId, 30);
+        NetworkDataValidation.validateText(accountNr, 30);
+        NetworkDataValidation.validateText(accountType, 20);
+        if (holderTaxId != null) {
+            NetworkDataValidation.validateText(holderTaxId, 50);
+        }
+        NetworkDataValidation.validateText(bankId, 50);
+        if (nationalAccountId != null) {
+            NetworkDataValidation.validateText(nationalAccountId, 50);
+        }
     }
 
     protected bisq.account.protobuf.BankAccountPayload.Builder getBankAccountPayloadBuilder() {

--- a/account/src/main/java/bisq/account/accounts/CashDepositAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/CashDepositAccountPayload.java
@@ -1,6 +1,7 @@
 package bisq.account.accounts;
 
 import bisq.account.protobuf.AccountPayload;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -14,16 +15,25 @@ public final class CashDepositAccountPayload extends BankAccountPayload {
 
     private final String requirements;
 
-    protected CashDepositAccountPayload(String id, String paymentMethodName, String countryCode,
-                                         String holderName, String bankName, String branchId,
-                                         String accountNr, String accountType,
-                                         String holderTaxId, String bankId,
-                                         String nationalAccountId, String requirements) {
+    public CashDepositAccountPayload(String id, String paymentMethodName, String countryCode,
+                                     String holderName, String bankName, String branchId,
+                                     String accountNr, String accountType,
+                                     String holderTaxId, String bankId,
+                                     String nationalAccountId, String requirements) {
         super(id, paymentMethodName, countryCode,
                 holderName, bankName, branchId,
                 accountNr, accountType, holderTaxId,
                 bankId, nationalAccountId);
         this.requirements = requirements;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+
+        NetworkDataValidation.validateText(requirements, 500);
     }
 
     @Override

--- a/account/src/main/java/bisq/account/accounts/CountryBasedAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/CountryBasedAccountPayload.java
@@ -18,6 +18,7 @@
 package bisq.account.accounts;
 
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -33,6 +34,12 @@ public abstract class CountryBasedAccountPayload extends AccountPayload {
     public CountryBasedAccountPayload(String id, String paymentMethodName, String countryCode) {
         super(id, paymentMethodName);
         this.countryCode = countryCode;
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+        NetworkDataValidation.validateCode(countryCode);
     }
 
     protected bisq.account.protobuf.CountryBasedAccountPayload.Builder getCountryBasedAccountPayloadBuilder() {

--- a/account/src/main/java/bisq/account/accounts/FasterPaymentsAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/FasterPaymentsAccountPayload.java
@@ -1,5 +1,6 @@
 package bisq.account.accounts;
 
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -18,6 +19,14 @@ public final class FasterPaymentsAccountPayload extends AccountPayload {
         super(id, paymentMethodName);
         this.sortCode = sortCode;
         this.accountNr = accountNr;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateText(sortCode, 50);
+        NetworkDataValidation.validateText(accountNr, 50);
     }
 
     @Override

--- a/account/src/main/java/bisq/account/payment_method/CryptoPaymentMethod.java
+++ b/account/src/main/java/bisq/account/payment_method/CryptoPaymentMethod.java
@@ -30,7 +30,7 @@ import java.util.List;
 @ToString(callSuper = true)
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class CryptoPaymentMethod extends PaymentMethod<CryptoPaymentRail> {
+public final class CryptoPaymentMethod extends PaymentMethod<CryptoPaymentRail> {
     private final String currencyCode;
 
     public static CryptoPaymentMethod fromPaymentRail(CryptoPaymentRail cryptoPaymentRail, String currencyCode) {
@@ -52,6 +52,13 @@ public class CryptoPaymentMethod extends PaymentMethod<CryptoPaymentRail> {
     private CryptoPaymentMethod(String name, String currencyCode) {
         super(name);
         this.currencyCode = currencyCode;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateCode(currencyCode);
     }
 
     @Override

--- a/account/src/main/java/bisq/account/payment_method/PaymentMethod.java
+++ b/account/src/main/java/bisq/account/payment_method/PaymentMethod.java
@@ -18,7 +18,7 @@
 package bisq.account.payment_method;
 
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.i18n.Res;
@@ -40,7 +40,7 @@ import java.util.List;
 @ToString
 @EqualsAndHashCode
 @Getter
-public abstract class PaymentMethod<R extends PaymentRail> implements Comparable<PaymentMethod<R>>, Proto {
+public abstract class PaymentMethod<R extends PaymentRail> implements Comparable<PaymentMethod<R>>, NetworkProto {
     public final static int MAX_NAME_LENGTH = 50;
 
     protected final String name;

--- a/account/src/main/java/bisq/account/payment_method/PaymentMethod.java
+++ b/account/src/main/java/bisq/account/payment_method/PaymentMethod.java
@@ -78,6 +78,13 @@ public abstract class PaymentMethod<R extends PaymentRail> implements Comparable
         // Avoid accidentally using a translation string in case the customName would match a key
         displayString = name;
         shortDisplayString = name;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateText(name, 100);
     }
 
     protected String createDisplayString() {

--- a/application/src/main/java/bisq/application/ResolverConfig.java
+++ b/application/src/main/java/bisq/application/ResolverConfig.java
@@ -46,25 +46,7 @@ import bisq.user.reputation.requests.AuthorizeTimestampRequest;
 
 public class ResolverConfig {
     public static void config() {
-        // If the classes added via `addResolver` are not final classes, we need to add manually the subclasses.
-        // Otherwise, the className gets added from the `addResolver` method call.
-
-        // ChatMessage subclasses
-        NetworkStorageWhiteList.add(CommonPublicChatMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyOfferbookMessage.class);
-        NetworkStorageWhiteList.add(TwoPartyPrivateChatMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyOpenTradeMessage.class);
-
-        // TradeMessage subclasses
-        NetworkStorageWhiteList.add(BisqEasyAccountDataMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyBtcAddressMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyConfirmBtcSentMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyConfirmFiatReceiptMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyConfirmFiatSentMessage.class);
-        NetworkStorageWhiteList.add(BisqEasyTakeOfferRequest.class);
-        NetworkStorageWhiteList.add(BisqEasyTakeOfferResponse.class);
-
-        // Register resolvers for distributedData 
+        // Register resolvers for distributedData
         // Abstract classes
         DistributedDataResolver.addResolver("chat.ChatMessage", ChatMessage.getDistributedDataResolver());
 
@@ -96,5 +78,26 @@ public class ResolverConfig {
         NetworkMessageResolver.addResolver("support.MediationRequest", MediationRequest.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MediatorsResponse", MediatorsResponse.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.ReportToModeratorMessage", ReportToModeratorMessage.getNetworkMessageResolver());
+
+
+        // If the classes added via `addResolver` are not final classes, we need to add manually the subclasses.
+        // Otherwise, the className gets added from the `addResolver` method call.
+
+        // ChatMessage subclasses
+        NetworkStorageWhiteList.add(CommonPublicChatMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyOfferbookMessage.class);
+        NetworkStorageWhiteList.add(TwoPartyPrivateChatMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyOpenTradeMessage.class);
+
+        // TradeMessage subclasses
+        NetworkStorageWhiteList.add(BisqEasyAccountDataMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyBtcAddressMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyCancelTradeMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyConfirmBtcSentMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyConfirmFiatReceiptMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyConfirmFiatSentMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyRejectTradeMessage.class);
+        NetworkStorageWhiteList.add(BisqEasyTakeOfferRequest.class);
+        NetworkStorageWhiteList.add(BisqEasyTakeOfferResponse.class);
     }
 }

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -56,6 +56,8 @@ application {
     }
     
     network = {
+        version = 1
+
         supportedTransportTypes = ["TOR"]
 
         serviceNode {

--- a/apps/oracle-node/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node/oracle-node-app/src/main/resources/oracle_node.conf
@@ -60,6 +60,8 @@ application {
     }
   
     network = {
+        version = 1
+
         supportedTransportTypes = ["TOR"]
 
         serviceNode {

--- a/apps/rest-api-app/src/main/resources/rest_api.conf
+++ b/apps/rest-api-app/src/main/resources/rest_api.conf
@@ -56,6 +56,8 @@ application {
     }
 
     network = {
+        version = 1
+
         supportedTransportTypes = ["TOR"]
 
         serviceNode {

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -38,6 +38,8 @@ application {
     }
       
     network = {
+        version = 1
+
         supportedTransportTypes = ["TOR"]
 
         serviceNode {

--- a/bonded-roles/src/main/java/bisq/bonded_roles/alert/AuthorizedAlertData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/alert/AuthorizedAlertData.java
@@ -83,13 +83,16 @@ public final class AuthorizedAlertData implements AuthorizedDistributedData {
         this.securityManagerProfileId = securityManagerProfileId;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateId(id);
         NetworkDataValidation.validateDate(date);
         NetworkDataValidation.validateText(message, MAX_MESSAGE_LENGTH);
         minVersion.ifPresent(NetworkDataValidation::validateVersion);
         NetworkDataValidation.validateProfileId(securityManagerProfileId);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//957
     }
 
     @Override

--- a/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
@@ -74,12 +74,15 @@ public final class AuthorizedBondedRole implements AuthorizedDistributedData {
         this.authorizingOracleNode = authorizingOracleNode;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validatePubKeyHex(authorizedPublicKey);
         NetworkDataValidation.validateBondUserName(bondUserName);
         NetworkDataValidation.validateSignatureBase64(signatureBase64);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//862
     }
 
     @Override

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
@@ -54,9 +54,13 @@ public final class AuthorizedMarketPriceData implements AuthorizedDistributedDat
         this.marketPriceByCurrencyMap = marketPriceByCurrencyMap;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
-        checkArgument(marketPriceByCurrencyMap.size() < 100,
-                "marketPriceByCurrencyMap size must not be >= 100" + marketPriceByCurrencyMap.size());
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); // 5498
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(marketPriceByCurrencyMap.size() < 200,
+                "marketPriceByCurrencyMap size must be < 200" + marketPriceByCurrencyMap.size());
     }
 
     @Override

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
@@ -19,7 +19,7 @@ package bisq.bonded_roles.market_price;
 
 import bisq.common.currency.Market;
 import bisq.common.monetary.PriceQuote;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -33,7 +33,7 @@ import java.util.Optional;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class MarketPrice implements Proto {
+public final class MarketPrice implements NetworkProto {
     public enum Source {
         PERSISTED,
         PROPAGATED_IN_NETWORK,

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
@@ -20,6 +20,7 @@ package bisq.bonded_roles.market_price;
 import bisq.common.currency.Market;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.proto.NetworkProto;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,8 +51,16 @@ public final class MarketPrice implements NetworkProto {
         this.priceQuote = priceQuote;
         this.timestamp = timestamp;
         this.marketPriceProvider = marketPriceProvider;
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateDate(timestamp);
+    }
+
+    @Override
     public bisq.bonded_roles.protobuf.MarketPrice toProto() {
         return bisq.bonded_roles.protobuf.MarketPrice.newBuilder()
                 .setPriceQuote(priceQuote.toProto())

--- a/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
@@ -61,12 +61,15 @@ public final class AuthorizedOracleNode implements AuthorizedDistributedData {
         this.signatureBase64 = signatureBase64;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validatePubKeyHex(authorizedPublicKey);
         NetworkDataValidation.validateBondUserName(bondUserName);
         NetworkDataValidation.validateSignatureBase64(signatureBase64);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//326
     }
 
     @Override

--- a/bonded-roles/src/main/java/bisq/bonded_roles/registration/BondedRoleRegistrationRequest.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/registration/BondedRoleRegistrationRequest.java
@@ -22,10 +22,10 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.common.AddressByTransportTypeMap;
+import bisq.network.identity.NetworkId;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
-import bisq.network.identity.NetworkId;
 import bisq.network.protobuf.ExternalNetworkMessage;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -69,13 +69,15 @@ public final class BondedRoleRegistrationRequest implements MailboxMessage {
         this.networkId = networkId;
         this.isCancellationRequest = isCancellationRequest;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validatePubKeyHex(authorizedPublicKey);
         NetworkDataValidation.validateBondUserName(bondUserName);
         NetworkDataValidation.validateSignatureBase64(signatureBase64);
-
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//637
     }
 
     @Override

--- a/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
@@ -80,13 +80,16 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
 
         version = new Version(versionString);
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateId(id);
         NetworkDataValidation.validateDate(date);
         NetworkDataValidation.validateText(releaseNotes, MAX_MESSAGE_LENGTH);
         NetworkDataValidation.validateVersion(versionString);
         NetworkDataValidation.validateProfileId(releaseManagerProfileId);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //3545
     }
 
     @Override

--- a/chat/src/main/java/bisq/chat/ChatChannel.java
+++ b/chat/src/main/java/bisq/chat/ChatChannel.java
@@ -23,7 +23,7 @@ import bisq.chat.common.CommonPublicChatChannel;
 import bisq.chat.two_party.TwoPartyPrivateChatChannel;
 import bisq.common.observable.Observable;
 import bisq.common.observable.collection.ObservableSet;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @ToString
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public abstract class ChatChannel<M extends ChatMessage> implements Proto {
+public abstract class ChatChannel<M extends ChatMessage> implements NetworkProto {
     @EqualsAndHashCode.Include
     protected final String id;
     protected final ChatChannelDomain chatChannelDomain;

--- a/chat/src/main/java/bisq/chat/ChatChannel.java
+++ b/chat/src/main/java/bisq/chat/ChatChannel.java
@@ -23,7 +23,7 @@ import bisq.chat.common.CommonPublicChatChannel;
 import bisq.chat.two_party.TwoPartyPrivateChatChannel;
 import bisq.common.observable.Observable;
 import bisq.common.observable.collection.ObservableSet;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @ToString
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public abstract class ChatChannel<M extends ChatMessage> implements NetworkProto {
+public abstract class ChatChannel<M extends ChatMessage> implements PersistableProto {
     @EqualsAndHashCode.Include
     protected final String id;
     protected final ChatChannelDomain chatChannelDomain;

--- a/chat/src/main/java/bisq/chat/ChatMessage.java
+++ b/chat/src/main/java/bisq/chat/ChatMessage.java
@@ -21,7 +21,7 @@ import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeMessage;
 import bisq.chat.common.CommonPublicChatMessage;
 import bisq.chat.two_party.TwoPartyPrivateChatMessage;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.util.StringUtils;
@@ -45,7 +45,7 @@ import java.util.Optional;
 @ToString
 @Getter
 @EqualsAndHashCode
-public abstract class ChatMessage implements Proto, Comparable<ChatMessage> {
+public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessage> {
     public static final int MAX_TEXT_LENGTH = 10_000;
 
     protected final String id;

--- a/chat/src/main/java/bisq/chat/ChatMessage.java
+++ b/chat/src/main/java/bisq/chat/ChatMessage.java
@@ -24,7 +24,6 @@ import bisq.chat.two_party.TwoPartyPrivateChatMessage;
 import bisq.common.proto.NetworkProto;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
-import bisq.common.util.StringUtils;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.i18n.Res;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
@@ -51,7 +50,7 @@ public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessag
     protected final String id;
     private final ChatChannelDomain chatChannelDomain;
     protected final String channelId;
-    protected final Optional<String> optionalText;
+    protected final Optional<String> text;
     protected String authorUserProfileId;
     protected final Optional<Citation> citation;
     protected final long date;
@@ -71,12 +70,15 @@ public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessag
         this.chatChannelDomain = chatChannelDomain;
         this.channelId = channelId;
         this.authorUserProfileId = authorUserProfileId;
-        this.optionalText = text.map(e -> StringUtils.truncate(e, MAX_TEXT_LENGTH - 10));
+        this.text = text;
         this.citation = citation;
         this.date = date;
         this.wasEdited = wasEdited;
         this.chatMessageType = chatMessageType;
+    }
 
+    @Override
+    public void verify() {
         NetworkDataValidation.validateId(id);
         NetworkDataValidation.validateText(channelId, 200); // For private channels we combine user profile IDs for channelId
         NetworkDataValidation.validateProfileId(authorUserProfileId);
@@ -94,7 +96,7 @@ public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessag
                 .setWasEdited(wasEdited)
                 .setChatMessageType(chatMessageType.toProto());
         citation.ifPresent(citation -> builder.setCitation(citation.toProto()));
-        optionalText.ifPresent(builder::setText);
+        text.ifPresent(builder::setText);
         return builder;
     }
 
@@ -174,7 +176,7 @@ public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessag
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public String getText() {
-        return optionalText.orElse(Res.get("data.na"));
+        return text.orElse(Res.get("data.na"));
     }
 
     public boolean wasMentioned(UserIdentity userIdentity) {

--- a/chat/src/main/java/bisq/chat/Citation.java
+++ b/chat/src/main/java/bisq/chat/Citation.java
@@ -24,6 +24,7 @@ public final class Citation implements NetworkProto {
         NetworkDataValidation.validateText(text, MAX_TEXT_LENGTH);
     }
 
+    @Override
     public bisq.chat.protobuf.Citation toProto() {
         return bisq.chat.protobuf.Citation.newBuilder()
                 .setAuthorUserProfileId(authorUserProfileId)

--- a/chat/src/main/java/bisq/chat/Citation.java
+++ b/chat/src/main/java/bisq/chat/Citation.java
@@ -1,6 +1,6 @@
 package bisq.chat;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.StringUtils;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
@@ -10,7 +10,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class Citation implements Proto {
+public final class Citation implements NetworkProto {
     public static final int MAX_TEXT_LENGTH = 1000;
 
     private final String authorUserProfileId;

--- a/chat/src/main/java/bisq/chat/Citation.java
+++ b/chat/src/main/java/bisq/chat/Citation.java
@@ -1,7 +1,6 @@
 package bisq.chat;
 
 import bisq.common.proto.NetworkProto;
-import bisq.common.util.StringUtils;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,8 +17,13 @@ public final class Citation implements NetworkProto {
 
     public Citation(String authorUserProfileId, String text) {
         this.authorUserProfileId = authorUserProfileId;
-        this.text = StringUtils.truncate(text, MAX_TEXT_LENGTH - 10);
+        this.text = text;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(authorUserProfileId);
         NetworkDataValidation.validateText(text, MAX_TEXT_LENGTH);
     }

--- a/chat/src/main/java/bisq/chat/common/CommonPublicChatChannel.java
+++ b/chat/src/main/java/bisq/chat/common/CommonPublicChatChannel.java
@@ -68,6 +68,7 @@ public final class CommonPublicChatChannel extends PublicChatChannel<CommonPubli
         description = Res.get(id + ".description");
     }
 
+    @Override
     public bisq.chat.protobuf.ChatChannel toProto() {
         bisq.chat.protobuf.CommonPublicChatChannel.Builder builder = bisq.chat.protobuf.CommonPublicChatChannel.newBuilder()
                 .setChannelTitle(channelTitle)

--- a/chat/src/main/java/bisq/chat/common/CommonPublicChatMessage.java
+++ b/chat/src/main/java/bisq/chat/common/CommonPublicChatMessage.java
@@ -76,7 +76,12 @@ public final class CommonPublicChatMessage extends PublicChatMessage {
                 wasEdited,
                 chatMessageType);
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //755
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/chat/src/main/java/bisq/chat/common/CommonPublicChatMessage.java
+++ b/chat/src/main/java/bisq/chat/common/CommonPublicChatMessage.java
@@ -79,6 +79,7 @@ public final class CommonPublicChatMessage extends PublicChatMessage {
         // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //755
     }
 
+    @Override
     public bisq.chat.protobuf.ChatMessage toProto() {
         return getChatMessageBuilder().setCommonPublicChatMessage(bisq.chat.protobuf.CommonPublicChatMessage.newBuilder()).build();
     }

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
@@ -21,7 +21,7 @@ import bisq.chat.ChatChannel;
 import bisq.chat.ChatChannelDomain;
 import bisq.chat.ChatMessage;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannel;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.presentation.notifications.Notification;
 import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
@@ -35,7 +35,7 @@ import java.util.Optional;
 @ToString
 @Getter
 @EqualsAndHashCode
-public class ChatNotification implements Notification, Proto {
+public class ChatNotification implements Notification, NetworkProto {
     public static String createId(String channelId, String messageId) {
         return channelId + "." + messageId;
     }

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
@@ -21,7 +21,7 @@ import bisq.chat.ChatChannel;
 import bisq.chat.ChatChannelDomain;
 import bisq.chat.ChatMessage;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannel;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.presentation.notifications.Notification;
 import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
@@ -35,7 +35,7 @@ import java.util.Optional;
 @ToString
 @Getter
 @EqualsAndHashCode
-public class ChatNotification implements Notification, NetworkProto {
+public class ChatNotification implements Notification, PersistableProto {
     public static String createId(String channelId, String messageId) {
         return channelId + "." + messageId;
     }

--- a/common/src/main/java/bisq/common/currency/Market.java
+++ b/common/src/main/java/bisq/common/currency/Market.java
@@ -18,6 +18,7 @@
 package bisq.common.currency;
 
 import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Getter
 @EqualsAndHashCode
-public final class Market implements NetworkProto, Comparable<Market> {
+public final class Market implements NetworkProto, PersistableProto, Comparable<Market> {
     public final static int MAX_NAME_LENGTH = 50;
     private static final String QUOTE_SEPARATOR = "/";
 
@@ -49,6 +50,7 @@ public final class Market implements NetworkProto, Comparable<Market> {
         NetworkDataValidation.validateText(quoteCurrencyName, MAX_NAME_LENGTH);
     }
 
+    @Override
     public bisq.common.protobuf.Market toProto() {
         return bisq.common.protobuf.Market.newBuilder()
                 .setBaseCurrencyCode(baseCurrencyCode)

--- a/common/src/main/java/bisq/common/currency/Market.java
+++ b/common/src/main/java/bisq/common/currency/Market.java
@@ -17,7 +17,7 @@
 
 package bisq.common.currency;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Getter
 @EqualsAndHashCode
-public final class Market implements Proto, Comparable<Market> {
+public final class Market implements NetworkProto, Comparable<Market> {
     public final static int MAX_NAME_LENGTH = 50;
     private static final String QUOTE_SEPARATOR = "/";
 

--- a/common/src/main/java/bisq/common/currency/Market.java
+++ b/common/src/main/java/bisq/common/currency/Market.java
@@ -44,6 +44,11 @@ public final class Market implements NetworkProto, PersistableProto, Comparable<
         this.baseCurrencyName = baseCurrencyName;
         this.quoteCurrencyName = quoteCurrencyName;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateCode(baseCurrencyCode);
         NetworkDataValidation.validateCode(quoteCurrencyCode);
         NetworkDataValidation.validateText(baseCurrencyName, MAX_NAME_LENGTH);

--- a/common/src/main/java/bisq/common/currency/TradeCurrency.java
+++ b/common/src/main/java/bisq/common/currency/TradeCurrency.java
@@ -17,8 +17,9 @@
 
 package bisq.common.currency;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -26,7 +27,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 @Getter
-public abstract class TradeCurrency implements Comparable<TradeCurrency>, Proto {
+public abstract class TradeCurrency implements Comparable<TradeCurrency>, NetworkProto {
     protected final String code;
     @EqualsAndHashCode.Exclude
     protected final String name;

--- a/common/src/main/java/bisq/common/currency/TradeCurrency.java
+++ b/common/src/main/java/bisq/common/currency/TradeCurrency.java
@@ -19,6 +19,7 @@ package bisq.common.currency;
 
 import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -27,6 +28,8 @@ import lombok.ToString;
 @ToString
 @Getter
 public abstract class TradeCurrency implements Comparable<TradeCurrency>, PersistableProto {
+    public final static int MAX_NAME_LENGTH = 100;
+
     protected final String code;
     @EqualsAndHashCode.Exclude
     protected final String name;
@@ -50,6 +53,9 @@ public abstract class TradeCurrency implements Comparable<TradeCurrency>, Persis
     public TradeCurrency(String code, String name) {
         this.code = code;
         this.name = name;
+
+        NetworkDataValidation.validateCode(code);
+        NetworkDataValidation.validateText(name, MAX_NAME_LENGTH);
     }
 
     public bisq.common.protobuf.TradeCurrency.Builder getTradeCurrencyBuilder() {

--- a/common/src/main/java/bisq/common/currency/TradeCurrency.java
+++ b/common/src/main/java/bisq/common/currency/TradeCurrency.java
@@ -17,9 +17,8 @@
 
 package bisq.common.currency;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
-import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -27,7 +26,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 @Getter
-public abstract class TradeCurrency implements Comparable<TradeCurrency>, NetworkProto {
+public abstract class TradeCurrency implements Comparable<TradeCurrency>, PersistableProto {
     protected final String code;
     @EqualsAndHashCode.Exclude
     protected final String name;

--- a/common/src/main/java/bisq/common/data/ByteArray.java
+++ b/common/src/main/java/bisq/common/data/ByteArray.java
@@ -18,7 +18,7 @@
 package bisq.common.data;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -26,7 +26,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 @Getter
-public final class ByteArray implements Proto, Comparable<ByteArray> {
+public final class ByteArray implements NetworkProto, Comparable<ByteArray> {
     private final byte[] bytes;
 
     public ByteArray(byte[] bytes) {

--- a/common/src/main/java/bisq/common/data/ByteArray.java
+++ b/common/src/main/java/bisq/common/data/ByteArray.java
@@ -18,7 +18,7 @@
 package bisq.common.data;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -26,7 +26,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 @Getter
-public final class ByteArray implements NetworkProto, Comparable<ByteArray> {
+public final class ByteArray implements PersistableProto, Comparable<ByteArray> {
     private final byte[] bytes;
 
     public ByteArray(byte[] bytes) {

--- a/common/src/main/java/bisq/common/data/ByteArrayMapEntry.java
+++ b/common/src/main/java/bisq/common/data/ByteArrayMapEntry.java
@@ -17,7 +17,7 @@
 
 package bisq.common.data;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class ByteArrayMapEntry implements Proto {
+public final class ByteArrayMapEntry implements NetworkProto {
     private final ByteArray key;
     private final ByteArray value;
 

--- a/common/src/main/java/bisq/common/data/ByteArrayMapEntry.java
+++ b/common/src/main/java/bisq/common/data/ByteArrayMapEntry.java
@@ -17,7 +17,7 @@
 
 package bisq.common.data;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class ByteArrayMapEntry implements NetworkProto {
+public final class ByteArrayMapEntry implements PersistableProto {
     private final ByteArray key;
     private final ByteArray value;
 

--- a/common/src/main/java/bisq/common/data/StringLongPair.java
+++ b/common/src/main/java/bisq/common/data/StringLongPair.java
@@ -17,7 +17,7 @@
 
 package bisq.common.data;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class StringLongPair implements NetworkProto {
+public final class StringLongPair implements PersistableProto {
     private final String key;
     private final Long value;
 

--- a/common/src/main/java/bisq/common/data/StringLongPair.java
+++ b/common/src/main/java/bisq/common/data/StringLongPair.java
@@ -17,7 +17,7 @@
 
 package bisq.common.data;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class StringLongPair implements Proto {
+public final class StringLongPair implements NetworkProto {
     private final String key;
     private final Long value;
 

--- a/common/src/main/java/bisq/common/locale/Country.java
+++ b/common/src/main/java/bisq/common/locale/Country.java
@@ -17,7 +17,7 @@
 
 package bisq.common.locale;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class Country implements Proto {
+public final class Country implements NetworkProto {
     private final String code;
     private final String name;
     private final Region region;

--- a/common/src/main/java/bisq/common/locale/Country.java
+++ b/common/src/main/java/bisq/common/locale/Country.java
@@ -17,7 +17,7 @@
 
 package bisq.common.locale;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class Country implements NetworkProto {
+public final class Country implements PersistableProto {
     private final String code;
     private final String name;
     private final Region region;

--- a/common/src/main/java/bisq/common/locale/Region.java
+++ b/common/src/main/java/bisq/common/locale/Region.java
@@ -17,7 +17,7 @@
 
 package bisq.common.locale;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class Region implements Proto {
+public final class Region implements NetworkProto {
     private final String code;
     private final String name;
 

--- a/common/src/main/java/bisq/common/locale/Region.java
+++ b/common/src/main/java/bisq/common/locale/Region.java
@@ -17,7 +17,7 @@
 
 package bisq.common.locale;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 @ToString
-public final class Region implements NetworkProto {
+public final class Region implements PersistableProto {
     private final String code;
     private final String name;
 

--- a/common/src/main/java/bisq/common/monetary/Monetary.java
+++ b/common/src/main/java/bisq/common/monetary/Monetary.java
@@ -18,7 +18,7 @@
 package bisq.common.monetary;
 
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
@@ -32,7 +32,7 @@ import java.math.BigDecimal;
 @Getter
 @ToString
 @Slf4j
-public abstract class Monetary implements Comparable<Monetary>, NetworkProto {
+public abstract class Monetary implements Comparable<Monetary>, PersistableProto {
     public static long doubleValueToLong(double value, int precision) {
         double max = BigDecimal.valueOf(Long.MAX_VALUE).movePointLeft(precision).doubleValue();
         if (value > max) {

--- a/common/src/main/java/bisq/common/monetary/Monetary.java
+++ b/common/src/main/java/bisq/common/monetary/Monetary.java
@@ -18,7 +18,7 @@
 package bisq.common.monetary;
 
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
@@ -32,7 +32,7 @@ import java.math.BigDecimal;
 @Getter
 @ToString
 @Slf4j
-public abstract class Monetary implements Comparable<Monetary>, Proto {
+public abstract class Monetary implements Comparable<Monetary>, NetworkProto {
     public static long doubleValueToLong(double value, int precision) {
         double max = BigDecimal.valueOf(Long.MAX_VALUE).movePointLeft(precision).doubleValue();
         if (value > max) {

--- a/common/src/main/java/bisq/common/monetary/PriceQuote.java
+++ b/common/src/main/java/bisq/common/monetary/PriceQuote.java
@@ -19,7 +19,7 @@ package bisq.common.monetary;
 
 import bisq.common.currency.Market;
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.MathUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -44,7 +44,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Getter
 @ToString
 @Slf4j
-public final class PriceQuote implements Comparable<PriceQuote>, Proto {
+public final class PriceQuote implements Comparable<PriceQuote>, NetworkProto {
     @Setter
     private static String QUOTE_SEPARATOR = "/";
 

--- a/common/src/main/java/bisq/common/monetary/PriceQuote.java
+++ b/common/src/main/java/bisq/common/monetary/PriceQuote.java
@@ -19,7 +19,7 @@ package bisq.common.monetary;
 
 import bisq.common.currency.Market;
 import bisq.common.currency.TradeCurrency;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.util.MathUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -44,7 +44,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Getter
 @ToString
 @Slf4j
-public final class PriceQuote implements Comparable<PriceQuote>, NetworkProto {
+public final class PriceQuote implements Comparable<PriceQuote>, PersistableProto {
     @Setter
     private static String QUOTE_SEPARATOR = "/";
 

--- a/common/src/main/java/bisq/common/proto/NetworkProto.java
+++ b/common/src/main/java/bisq/common/proto/NetworkProto.java
@@ -17,8 +17,6 @@
 
 package bisq.common.proto;
 
-import com.google.protobuf.Message;
-
 /**
  * Interface for any object which gets serialized using protobuf
  * <p>
@@ -29,9 +27,5 @@ import com.google.protobuf.Message;
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
 public interface NetworkProto extends Proto {
-    Message toProto();
-
-    default byte[] serialize() {
-        return toProto().toByteArray();
-    }
+    void verify();
 }

--- a/common/src/main/java/bisq/common/proto/NetworkProto.java
+++ b/common/src/main/java/bisq/common/proto/NetworkProto.java
@@ -28,7 +28,7 @@ import com.google.protobuf.Message;
  * in HashMap - there is no guarantee that all JVms will support that and non-Java implementations need to be able
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
-public interface Proto {
+public interface NetworkProto {
     Message toProto();
 
     default byte[] serialize() {

--- a/common/src/main/java/bisq/common/proto/NetworkProto.java
+++ b/common/src/main/java/bisq/common/proto/NetworkProto.java
@@ -27,5 +27,7 @@ package bisq.common.proto;
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
 public interface NetworkProto extends Proto {
-    void verify();
+    // TODO Remove default implementation
+    default void verify() {
+    }
 }

--- a/common/src/main/java/bisq/common/proto/NetworkProto.java
+++ b/common/src/main/java/bisq/common/proto/NetworkProto.java
@@ -27,7 +27,5 @@ package bisq.common.proto;
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
 public interface NetworkProto extends Proto {
-    // TODO Remove default implementation
-    default void verify() {
-    }
+    void verify();
 }

--- a/common/src/main/java/bisq/common/proto/NetworkProtoResolverMap.java
+++ b/common/src/main/java/bisq/common/proto/NetworkProtoResolverMap.java
@@ -26,19 +26,14 @@ import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
-public class ProtoResolverMap<T extends NetworkProto> {
-    private final boolean addToNetworkStorageWhiteList;
-
-    public ProtoResolverMap(boolean addToNetworkStorageWhiteList) {
-        this.addToNetworkStorageWhiteList = addToNetworkStorageWhiteList;
+public class NetworkProtoResolverMap<T extends NetworkProto> {
+    public NetworkProtoResolverMap() {
     }
 
     private final Map<String, ProtoResolver<T>> map = new HashMap<>();
 
     public void addProtoResolver(String protoTypeName, ProtoResolver<T> resolver) {
-        if (addToNetworkStorageWhiteList) {
-            NetworkStorageWhiteList.add(protoTypeName, resolver);
-        }
+        NetworkStorageWhiteList.add(protoTypeName, resolver);
         map.put(protoTypeName, resolver);
     }
 

--- a/common/src/main/java/bisq/common/proto/NetworkStorageWhiteList.java
+++ b/common/src/main/java/bisq/common/proto/NetworkStorageWhiteList.java
@@ -36,7 +36,7 @@ public class NetworkStorageWhiteList {
         classNames.add(clazz.getSimpleName());
     }
 
-    public static <T extends Proto> void add(String protoTypeName, ProtoResolver<T> resolver) {
+    public static <T extends NetworkProto> void add(String protoTypeName, ProtoResolver<T> resolver) {
         try {
             String[] resolverTokens = resolver.getClass().getSimpleName().split("\\$\\$");
             String[] protoTypeNameTokens = protoTypeName.split("\\.");

--- a/common/src/main/java/bisq/common/proto/PersistableProto.java
+++ b/common/src/main/java/bisq/common/proto/PersistableProto.java
@@ -17,8 +17,6 @@
 
 package bisq.common.proto;
 
-import com.google.protobuf.Message;
-
 /**
  * Interface for any object which gets serialized using protobuf
  * <p>
@@ -29,9 +27,4 @@ import com.google.protobuf.Message;
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
 public interface PersistableProto extends Proto {
-    Message toProto();
-
-    default byte[] serialize() {
-        return toProto().toByteArray();
-    }
 }

--- a/common/src/main/java/bisq/common/proto/PersistableProto.java
+++ b/common/src/main/java/bisq/common/proto/PersistableProto.java
@@ -28,7 +28,7 @@ import com.google.protobuf.Message;
  * in HashMap - there is no guarantee that all JVms will support that and non-Java implementations need to be able
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
-public interface NetworkProto extends Proto {
+public interface PersistableProto extends Proto {
     Message toProto();
 
     default byte[] serialize() {

--- a/common/src/main/java/bisq/common/proto/PersistableProtoResolverMap.java
+++ b/common/src/main/java/bisq/common/proto/PersistableProtoResolverMap.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.proto;
+
+import bisq.common.util.ProtobufUtils;
+import com.google.protobuf.Any;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class PersistableProtoResolverMap<T extends PersistableProto> {
+    public PersistableProtoResolverMap() {
+    }
+
+    private final Map<String, ProtoResolver<T>> map = new HashMap<>();
+
+    public void addProtoResolver(String protoTypeName, ProtoResolver<T> resolver) {
+        map.put(protoTypeName, resolver);
+    }
+
+    public T fromAny(Any anyProto) {
+        String protoTypeName = ProtobufUtils.getProtoType(anyProto);
+        return Optional.ofNullable(map.get(protoTypeName))
+                .map(resolver -> resolver.fromAny(anyProto))
+                .orElseThrow(() -> new UnresolvableProtobufMessageException(anyProto));
+    }
+}

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -17,6 +17,8 @@
 
 package bisq.common.proto;
 
+import com.google.protobuf.Message;
+
 /**
  * Interface for any object which gets serialized using protobuf
  * <p>
@@ -27,4 +29,9 @@ package bisq.common.proto;
  * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
  */
 public interface Proto {
+    Message toProto();
+
+    default byte[] serialize() {
+        return toProto().toByteArray();
+    }
 }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -15,20 +15,16 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.persistence;
+package bisq.common.proto;
 
-import bisq.common.proto.PersistableProtoResolverMap;
-import bisq.common.proto.ProtoResolver;
-import com.google.protobuf.Any;
-
-public class PersistableStoreResolver {
-    private static final PersistableProtoResolverMap<PersistableStore<?>> protoResolverMap = new PersistableProtoResolverMap<>();
-
-    public static void addResolver(ProtoResolver<PersistableStore<?>> resolver) {
-        protoResolverMap.addProtoResolver(ProtoResolver.getProtoType(resolver), resolver);
-    }
-
-    static PersistableStore<?> fromAny(Any anyProto) {
-        return protoResolverMap.fromAny(anyProto);
-    }
+/**
+ * Interface for any object which gets serialized using protobuf
+ * <p>
+ * We require deterministic serialisation (e.g. used for hashes) for most data.
+ * We need to ensure that Collections are deterministically sorted.
+ * Maps are not allowed as they do not guarantee that (even if Java have deterministic implementation for it as
+ * in HashMap - there is no guarantee that all JVms will support that and non-Java implementations need to be able
+ * to deal with it as well. Rust for instance randomize the key set in maps by default for security reasons).
+ */
+public interface Proto {
 }

--- a/common/src/main/java/bisq/common/proto/ProtoResolver.java
+++ b/common/src/main/java/bisq/common/proto/ProtoResolver.java
@@ -19,7 +19,7 @@ package bisq.common.proto;
 
 import com.google.protobuf.Any;
 
-public interface ProtoResolver<T extends NetworkProto> {
+public interface ProtoResolver<T extends Proto> {
     T fromAny(Any any);
 
     static String getProtoType(ProtoResolver<?> resolver) {

--- a/common/src/main/java/bisq/common/proto/ProtoResolver.java
+++ b/common/src/main/java/bisq/common/proto/ProtoResolver.java
@@ -19,7 +19,7 @@ package bisq.common.proto;
 
 import com.google.protobuf.Any;
 
-public interface ProtoResolver<T extends Proto> {
+public interface ProtoResolver<T extends NetworkProto> {
     T fromAny(Any any);
 
     static String getProtoType(ProtoResolver<?> resolver) {

--- a/common/src/main/java/bisq/common/proto/ProtoResolverMap.java
+++ b/common/src/main/java/bisq/common/proto/ProtoResolverMap.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
-public class ProtoResolverMap<T extends Proto> {
+public class ProtoResolverMap<T extends NetworkProto> {
     private final boolean addToNetworkStorageWhiteList;
 
     public ProtoResolverMap(boolean addToNetworkStorageWhiteList) {

--- a/common/src/main/java/bisq/common/util/Version.java
+++ b/common/src/main/java/bisq/common/util/Version.java
@@ -21,8 +21,8 @@ import lombok.Getter;
 
 public class Version implements Comparable<Version> {
     public static void validate(String versionAsString) {
-        if (versionAsString == null) {
-            throw new IllegalArgumentException("Version must not be null");
+        if (versionAsString == null || versionAsString.isEmpty()) {
+            throw new IllegalArgumentException("Version must not be null or empty");
         }
         if (!versionAsString.matches("[0-9]+(\\.[0-9]+)*")) {
             throw new IllegalArgumentException("Invalid version format. version=" + versionAsString);

--- a/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
+++ b/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
@@ -21,6 +21,7 @@ import bisq.common.util.DateUtils;
 import bisq.common.util.Version;
 import lombok.extern.slf4j.Slf4j;
 
+import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -56,6 +57,11 @@ public class NetworkDataValidation {
                 "Public key not of the expected size. pubKey=" + Arrays.toString(pubKey));
     }
 
+    public static void validateECPubKey(PublicKey publicKey) {
+        validateECPubKey(publicKey.getEncoded());
+    }
+
+
     // IDs are created with StringUtils.createUid() which generates 36 chars. We allow upt to 50 for more flexibility.
     // Can be short id as well or custom IDs...
     public static void validateId(String id) {
@@ -69,6 +75,11 @@ public class NetworkDataValidation {
     // Profile ID is hash as hex
     public static void validateProfileId(String profileId) {
         checkArgument(profileId.length() == 40, "Profile ID must be 40 characters. profileId=" + profileId);
+    }
+
+    public static void validateTradeId(String tradeId) {
+        // For private channels we combine user profile IDs for channelId
+        validateText(tradeId, 200);
     }
 
     public static void validateText(String text, int maxLength) {
@@ -88,8 +99,8 @@ public class NetworkDataValidation {
     // Longest supported version is xxx.xxx.xxx
     public static void validateVersion(String version) {
         Version.validate(version);
-        checkArgument(version.length() <= 11 && version.length() > 0,
-                "Version too long. version=" + version);
+        checkArgument(version.length() <= 11 && !version.isEmpty(),
+                "Version too long or empty. version=" + version);
     }
 
     // Language or country code

--- a/contract/src/main/java/bisq/contract/Contract.java
+++ b/contract/src/main/java/bisq/contract/Contract.java
@@ -18,7 +18,7 @@
 package bisq.contract;
 
 import bisq.account.protocol_type.TradeProtocolType;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.offer.Offer;
 import lombok.EqualsAndHashCode;
@@ -31,7 +31,7 @@ import lombok.ToString;
 @ToString
 @Getter
 @EqualsAndHashCode
-public abstract class Contract<T extends Offer<?, ?>> implements Proto {
+public abstract class Contract<T extends Offer<?, ?>> implements NetworkProto {
     protected final long takeOfferDate;
     protected final T offer;
     protected final TradeProtocolType protocolType;

--- a/contract/src/main/java/bisq/contract/Contract.java
+++ b/contract/src/main/java/bisq/contract/Contract.java
@@ -20,6 +20,7 @@ package bisq.contract;
 import bisq.account.protocol_type.TradeProtocolType;
 import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.offer.Offer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -43,6 +44,11 @@ public abstract class Contract<T extends Offer<?, ?>> implements NetworkProto {
         this.offer = offer;
         this.protocolType = protocolType;
         this.maker = new Party(Role.MAKER, offer.getMakerNetworkId());
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateDate(takeOfferDate);
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/ContractSignatureData.java
+++ b/contract/src/main/java/bisq/contract/ContractSignatureData.java
@@ -18,7 +18,7 @@
 package bisq.contract;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
@@ -32,7 +32,7 @@ import java.security.PublicKey;
 @Slf4j
 @Getter
 @EqualsAndHashCode
-public class ContractSignatureData implements Proto {
+public class ContractSignatureData implements NetworkProto {
     private final byte[] contractHash;
     private final byte[] signature;
     private final PublicKey publicKey;

--- a/contract/src/main/java/bisq/contract/ContractSignatureData.java
+++ b/contract/src/main/java/bisq/contract/ContractSignatureData.java
@@ -42,8 +42,14 @@ public class ContractSignatureData implements NetworkProto {
         this.signature = signature;
         this.publicKey = publicKey;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateHash(contractHash);
         NetworkDataValidation.validateECSignature(signature);
+        NetworkDataValidation.validateECPubKey(publicKey);
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/Party.java
+++ b/contract/src/main/java/bisq/contract/Party.java
@@ -17,7 +17,7 @@
 
 package bisq.contract;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.network.identity.NetworkId;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -26,7 +26,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class Party implements Proto {
+public final class Party implements NetworkProto {
     private final Role role;
     private final NetworkId networkId;
 

--- a/contract/src/main/java/bisq/contract/Party.java
+++ b/contract/src/main/java/bisq/contract/Party.java
@@ -33,6 +33,12 @@ public final class Party implements NetworkProto {
     public Party(Role role, NetworkId networkId) {
         this.role = role;
         this.networkId = networkId;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/SignedTwoPartyContract.java
+++ b/contract/src/main/java/bisq/contract/SignedTwoPartyContract.java
@@ -35,6 +35,12 @@ public class SignedTwoPartyContract<T extends Offer<?, ?>> implements NetworkPro
         this.contract = contract;
         this.makerSignatureData = makerSignatureData;
         this.takerSignatureData = takerSignatureData;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/SignedTwoPartyContract.java
+++ b/contract/src/main/java/bisq/contract/SignedTwoPartyContract.java
@@ -17,7 +17,7 @@
 
 package bisq.contract;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.offer.Offer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -26,7 +26,7 @@ import lombok.ToString;
 @ToString
 @Getter
 @EqualsAndHashCode
-public class SignedTwoPartyContract<T extends Offer<?, ?>> implements Proto {
+public class SignedTwoPartyContract<T extends Offer<?, ?>> implements NetworkProto {
     private final TwoPartyContract<T> contract;
     private final ContractSignatureData makerSignatureData;
     private final ContractSignatureData takerSignatureData;

--- a/contract/src/main/java/bisq/contract/bisq_easy/BisqEasyContract.java
+++ b/contract/src/main/java/bisq/contract/bisq_easy/BisqEasyContract.java
@@ -37,11 +37,11 @@ import java.util.Optional;
 @ToString(callSuper = true)
 @Getter
 @EqualsAndHashCode(callSuper = true)
-public class BisqEasyContract extends TwoPartyContract<BisqEasyOffer> {
+public final class BisqEasyContract extends TwoPartyContract<BisqEasyOffer> {
     private final long baseSideAmount;
     private final long quoteSideAmount;
-    protected final BitcoinPaymentMethodSpec baseSidePaymentMethodSpec;
-    protected final FiatPaymentMethodSpec quoteSidePaymentMethodSpec;
+    private final BitcoinPaymentMethodSpec baseSidePaymentMethodSpec;
+    private final FiatPaymentMethodSpec quoteSidePaymentMethodSpec;
     private final Optional<UserProfile> mediator;
     private final PriceSpec agreedPriceSpec;
     private final long marketPrice;
@@ -90,6 +90,13 @@ public class BisqEasyContract extends TwoPartyContract<BisqEasyOffer> {
         this.agreedPriceSpec = agreedPriceSpec;
         this.marketPrice = marketPrice;
         this.takeOfferDate = takeOfferDate;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/multisig/MultisigContract.java
+++ b/contract/src/main/java/bisq/contract/multisig/MultisigContract.java
@@ -46,6 +46,13 @@ public class MultisigContract extends TwoPartyContract<MultisigOffer> {
                              TradeProtocolType protocolType,
                              Party taker) {
         super(takeOfferDate, offer, protocolType, taker);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/poc/PocContract.java
+++ b/contract/src/main/java/bisq/contract/poc/PocContract.java
@@ -54,6 +54,12 @@ public final class PocContract implements NetworkProto {
         this.quoteSideAmount = quoteSideAmount;
         this.baseSidePaymentMethod = baseSidePaymentMethod;
         this.quoteSidePaymentMethod = quoteSidePaymentMethod;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/contract/src/main/java/bisq/contract/poc/PocContract.java
+++ b/contract/src/main/java/bisq/contract/poc/PocContract.java
@@ -19,7 +19,7 @@ package bisq.contract.poc;
 
 import bisq.account.protocol_type.TradeProtocolType;
 import bisq.common.monetary.Monetary;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.network.identity.NetworkId;
 import bisq.offer.poc.PocOffer;
 import com.google.protobuf.Message;
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @EqualsAndHashCode
 @Getter
-public final class PocContract implements Proto {
+public final class PocContract implements NetworkProto {
     private final NetworkId takerNetworkId;
     private final TradeProtocolType protocolType;
     private final PocOffer offer;

--- a/contract/src/main/java/bisq/contract/submarine/SubmarineContract.java
+++ b/contract/src/main/java/bisq/contract/submarine/SubmarineContract.java
@@ -46,6 +46,12 @@ public class SubmarineContract extends TwoPartyContract<SubmarineOffer> {
                               TradeProtocolType protocolType,
                               Party taker) {
         super(takeOfferDate, offer, protocolType, taker);
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/identity/src/main/java/bisq/identity/Identity.java
+++ b/identity/src/main/java/bisq/identity/Identity.java
@@ -17,7 +17,7 @@
 
 package bisq.identity;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.network.identity.NetworkId;
 import bisq.network.identity.NetworkIdWithKeyPair;
 import bisq.security.keys.KeyBundle;
@@ -28,7 +28,7 @@ import lombok.ToString;
 
 @EqualsAndHashCode
 @ToString
-public final class Identity implements NetworkProto {
+public final class Identity implements PersistableProto {
     // Reference to usage (e.g. offerId)
     @Getter
     private final String tag;

--- a/identity/src/main/java/bisq/identity/Identity.java
+++ b/identity/src/main/java/bisq/identity/Identity.java
@@ -17,7 +17,7 @@
 
 package bisq.identity;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.network.identity.NetworkId;
 import bisq.network.identity.NetworkIdWithKeyPair;
 import bisq.security.keys.KeyBundle;
@@ -28,7 +28,7 @@ import lombok.ToString;
 
 @EqualsAndHashCode
 @ToString
-public final class Identity implements Proto {
+public final class Identity implements NetworkProto {
     // Reference to usage (e.g. offerId)
     @Getter
     private final String tag;

--- a/network/network-common/src/main/java/bisq/network/common/Address.java
+++ b/network/network-common/src/main/java/bisq/network/common/Address.java
@@ -45,20 +45,34 @@ public final class Address implements NetworkProto, Comparable<Address> {
             this.port = -1;
         }
 
-        NetworkDataValidation.validateText(host, 700);
+        verify();
     }
 
     public Address(String host, int port) {
         this.host = maybeConvertLocalHost(host);
         this.port = port;
 
-        NetworkDataValidation.validateText(host, 700);
+        verify();
     }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Protobuf
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    @Override
+    public void verify() {
+        if (isTorAddress()) {
+            NetworkDataValidation.validateText(host, 62);
+        } else if (isClearNetAddress()) {
+            NetworkDataValidation.validateText(host, 45);
+        } else {
+            // I2P
+            NetworkDataValidation.validateText(host, 512);
+        }
+    }
+
+    @Override
     public bisq.network.common.protobuf.Address toProto() {
         return bisq.network.common.protobuf.Address.newBuilder()
                 .setHost(host)

--- a/network/network-common/src/main/java/bisq/network/common/Address.java
+++ b/network/network-common/src/main/java/bisq/network/common/Address.java
@@ -17,7 +17,7 @@
 
 package bisq.network.common;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.StringUtils;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.common.net.InetAddresses;
@@ -28,7 +28,7 @@ import java.util.StringTokenizer;
 
 @EqualsAndHashCode
 @Getter
-public final class Address implements Proto, Comparable<Address> {
+public final class Address implements NetworkProto, Comparable<Address> {
     public static Address localHost(int port) {
         return new Address("127.0.0.1", port);
     }

--- a/network/network-common/src/main/java/bisq/network/common/AddressByTransportTypeMap.java
+++ b/network/network-common/src/main/java/bisq/network/common/AddressByTransportTypeMap.java
@@ -17,7 +17,7 @@
 
 package bisq.network.common;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 @EqualsAndHashCode
 @ToString
 @Getter
-public class AddressByTransportTypeMap implements Map<TransportType, Address>, Proto {
+public class AddressByTransportTypeMap implements Map<TransportType, Address>, NetworkProto {
     // We use a TreeMap to get deterministic sorting.
     private final TreeMap<TransportType, Address> map = new TreeMap<>();
 

--- a/network/network-common/src/main/java/bisq/network/common/AddressByTransportTypeMap.java
+++ b/network/network-common/src/main/java/bisq/network/common/AddressByTransportTypeMap.java
@@ -28,27 +28,39 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Wrapper for a (sorted) TreeMap for the address by transport type map and for convenient protobuf methods.
  */
 @EqualsAndHashCode
 @ToString
 @Getter
-public class AddressByTransportTypeMap implements Map<TransportType, Address>, NetworkProto {
+public final class AddressByTransportTypeMap implements Map<TransportType, Address>, NetworkProto {
     // We use a TreeMap to get deterministic sorting.
     private final TreeMap<TransportType, Address> map = new TreeMap<>();
 
     public AddressByTransportTypeMap() {
+        verify();
+    }
+
+    public AddressByTransportTypeMap(AddressByTransportTypeMap map) {
+        this(map.getMap());
     }
 
     public AddressByTransportTypeMap(Map<TransportType, Address> map) {
         this.map.putAll(map);
+
+        verify();
     }
 
-    public AddressByTransportTypeMap(AddressByTransportTypeMap map) {
-        this.map.putAll(map);
+    @Override
+    public void verify() {
+        checkArgument(map.size() <= TransportType.values().length);
+        checkArgument(!map.isEmpty());
     }
 
+    @Override
     public bisq.network.common.protobuf.AddressByTransportTypeMap toProto() {
         return bisq.network.common.protobuf.AddressByTransportTypeMap.newBuilder()
                 .putAllAddressByTransportType(map.entrySet().stream()

--- a/network/network-identity/src/main/java/bisq/network/identity/NetworkId.java
+++ b/network/network-identity/src/main/java/bisq/network/identity/NetworkId.java
@@ -25,8 +25,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
 @Getter
 @EqualsAndHashCode
@@ -36,9 +34,11 @@ public final class NetworkId implements NetworkProto {
 
     public NetworkId(AddressByTransportTypeMap addressByTransportTypeMap, PubKey pubKey) {
         this.pubKey = pubKey;
-        checkArgument(!addressByTransportTypeMap.isEmpty(),
-                "We require at least 1 addressByNetworkType for a valid NetworkId");
         this.addressByTransportTypeMap.putAll(addressByTransportTypeMap);
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network-identity/src/main/java/bisq/network/identity/NetworkId.java
+++ b/network/network-identity/src/main/java/bisq/network/identity/NetworkId.java
@@ -17,7 +17,7 @@
 
 package bisq.network.identity;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.StringUtils;
 import bisq.network.common.AddressByTransportTypeMap;
 import bisq.security.keys.PubKey;
@@ -30,7 +30,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Slf4j
 @Getter
 @EqualsAndHashCode
-public final class NetworkId implements Proto {
+public final class NetworkId implements NetworkProto {
     private final PubKey pubKey;
     private final AddressByTransportTypeMap addressByTransportTypeMap = new AddressByTransportTypeMap();
 

--- a/network/network-identity/src/main/java/bisq/network/identity/NetworkId.java
+++ b/network/network-identity/src/main/java/bisq/network/identity/NetworkId.java
@@ -41,6 +41,7 @@ public final class NetworkId implements NetworkProto {
         this.addressByTransportTypeMap.putAll(addressByTransportTypeMap);
     }
 
+    @Override
     public bisq.network.identity.protobuf.NetworkId toProto() {
         return bisq.network.identity.protobuf.NetworkId.newBuilder()
                 .setAddressByNetworkTypeMap(addressByTransportTypeMap.toProto())

--- a/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
+++ b/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
@@ -47,6 +47,7 @@ import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -186,7 +187,7 @@ public class NetworkEnvelopeSocketChannelTests {
         supportedTransportTypes.add(TransportType.CLEAR);
 
         Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes);
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationService authorizationService = createAuthorizationService();
 
         Capability responderCapability = new Capability(Address.localHost(1234), supportedTransportTypes);

--- a/network/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/network/src/main/java/bisq/network/NetworkService.java
@@ -34,6 +34,7 @@ import bisq.network.identity.NetworkIdWithKeyPair;
 import bisq.network.p2p.ServiceNode;
 import bisq.network.p2p.ServiceNodesByTransport;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
+import bisq.network.p2p.message.NetworkEnvelope;
 import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
 import bisq.network.p2p.node.network_load.NetworkLoadService;
@@ -115,6 +116,7 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
         supportedTransportTypes = config.getSupportedTransportTypes();
         defaultPortByTransportType = config.getDefaultPortByTransportType();
         this.keyBundleService = keyBundleService;
+        NetworkEnvelope.setNetworkVersion(config.getVersion());
 
         httpClientsByTransport = new HttpClientsByTransport();
 

--- a/network/network/src/main/java/bisq/network/NetworkServiceConfig.java
+++ b/network/network/src/main/java/bisq/network/NetworkServiceConfig.java
@@ -74,6 +74,7 @@ public final class NetworkServiceConfig {
         Map<TransportType, TransportConfig> configByTransportType = createConfigByTransportType(config, baseDir);
 
         return new NetworkServiceConfig(baseDir.toAbsolutePath().toString(),
+                config.getInt("version"),
                 supportedTransportTypes,
                 configByTransportType,
                 serviceNodeConfig,
@@ -166,6 +167,7 @@ public final class NetworkServiceConfig {
     }
 
     private final String baseDir;
+    private final int version;
     private final Set<TransportType> supportedTransportTypes;
     private final InventoryService.Config inventoryServiceConfig;
     private final Map<TransportType, TransportConfig> configByTransportType;
@@ -176,6 +178,7 @@ public final class NetworkServiceConfig {
     private final Optional<String> socks5ProxyAddress;
 
     public NetworkServiceConfig(String baseDir,
+                                int version,
                                 Set<TransportType> supportedTransportTypes,
                                 Map<TransportType, TransportConfig> configByTransportType,
                                 ServiceNode.Config serviceNodeConfig,
@@ -185,6 +188,7 @@ public final class NetworkServiceConfig {
                                 Map<TransportType, Set<Address>> seedAddressesByTransport,
                                 Optional<String> socks5ProxyAddress) {
         this.baseDir = baseDir;
+        this.version = version;
         this.supportedTransportTypes = supportedTransportTypes;
         this.inventoryServiceConfig = inventoryServiceConfig;
         this.configByTransportType = filterMap(supportedTransportTypes, configByTransportType);

--- a/network/network/src/main/java/bisq/network/p2p/message/EnvelopePayloadMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/message/EnvelopePayloadMessage.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.message;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.network.p2p.node.CloseConnectionMessage;
 import bisq.network.p2p.node.handshake.ConnectionHandshake;
@@ -36,7 +36,7 @@ import bisq.network.p2p.services.peergroup.network_load.NetworkLoadExchangeRespo
 /**
  * Interface for any message sent as payload in NetworkEnvelope
  */
-public interface EnvelopePayloadMessage extends Proto {
+public interface EnvelopePayloadMessage extends NetworkProto {
     double getCostFactor();
 
     default bisq.network.protobuf.EnvelopePayloadMessage.Builder getNetworkMessageBuilder() {

--- a/network/network/src/main/java/bisq/network/p2p/message/NetworkEnvelope.java
+++ b/network/network/src/main/java/bisq/network/p2p/message/NetworkEnvelope.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.message;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.network.p2p.node.ConnectionException;
 import bisq.network.p2p.node.authorization.AuthorizationToken;
 import lombok.EqualsAndHashCode;
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @EqualsAndHashCode
 @Getter
 @Slf4j
-public final class NetworkEnvelope implements Proto {
+public final class NetworkEnvelope implements NetworkProto {
     // For live network we use networkVersion=1
     // For dev testing networkVersion=0
     @Setter

--- a/network/network/src/main/java/bisq/network/p2p/message/NetworkEnvelope.java
+++ b/network/network/src/main/java/bisq/network/p2p/message/NetworkEnvelope.java
@@ -22,6 +22,7 @@ import bisq.network.p2p.node.ConnectionException;
 import bisq.network.p2p.node.authorization.AuthorizationToken;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,14 +34,17 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @Slf4j
 public final class NetworkEnvelope implements Proto {
-    public static final int VERSION = 1;
+    // For live network we use networkVersion=1
+    // For dev testing networkVersion=0
+    @Setter
+    public static int networkVersion;
 
     private final int version;
     private final AuthorizationToken authorizationToken;
     private final EnvelopePayloadMessage envelopePayloadMessage;
 
     public NetworkEnvelope(AuthorizationToken authorizationToken, EnvelopePayloadMessage envelopePayloadMessage) {
-        this(VERSION, authorizationToken, envelopePayloadMessage);
+        this(networkVersion, authorizationToken, envelopePayloadMessage);
     }
 
     public NetworkEnvelope(int version, AuthorizationToken authorizationToken, EnvelopePayloadMessage envelopePayloadMessage) {
@@ -64,10 +68,10 @@ public final class NetworkEnvelope implements Proto {
     }
 
     public void verifyVersion() throws ConnectionException {
-        if (version != VERSION) {
+        if (version != networkVersion) {
             throw new ConnectionException("Invalid networkEnvelopeVersion. " +
                     "version=" + version +
-                    "; NetworkEnvelope.VERSION=" + VERSION +
+                    "; networkVersion=" + networkVersion +
                     "; networkMessage=" + envelopePayloadMessage.getClass().getSimpleName());
         }
     }

--- a/network/network/src/main/java/bisq/network/p2p/message/NetworkEnvelope.java
+++ b/network/network/src/main/java/bisq/network/p2p/message/NetworkEnvelope.java
@@ -51,8 +51,15 @@ public final class NetworkEnvelope implements NetworkProto {
         this.version = version;
         this.authorizationToken = authorizationToken;
         this.envelopePayloadMessage = envelopePayloadMessage;
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+    }
+
+    @Override
     public bisq.network.protobuf.NetworkEnvelope toProto() {
         return bisq.network.protobuf.NetworkEnvelope.newBuilder()
                 .setVersion(version)

--- a/network/network/src/main/java/bisq/network/p2p/message/NetworkMessageResolver.java
+++ b/network/network/src/main/java/bisq/network/p2p/message/NetworkMessageResolver.java
@@ -17,12 +17,12 @@
 
 package bisq.network.p2p.message;
 
+import bisq.common.proto.NetworkProtoResolverMap;
 import bisq.common.proto.ProtoResolver;
-import bisq.common.proto.ProtoResolverMap;
 import com.google.protobuf.Any;
 
 public class NetworkMessageResolver {
-    private static final ProtoResolverMap<EnvelopePayloadMessage> protoResolverMap = new ProtoResolverMap<>(true);
+    private static final NetworkProtoResolverMap<EnvelopePayloadMessage> protoResolverMap = new NetworkProtoResolverMap<>();
 
     public static void addResolver(String protoTypeName, ProtoResolver<EnvelopePayloadMessage> resolver) {
         protoResolverMap.addProtoResolver(protoTypeName, resolver);

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -19,8 +19,8 @@ package bisq.network.p2p.node;
 
 import bisq.common.proto.Proto;
 import bisq.common.util.ProtobufUtils;
-import bisq.network.common.TransportType;
 import bisq.network.common.Address;
+import bisq.network.common.TransportType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.node;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.ProtobufUtils;
 import bisq.network.common.Address;
 import bisq.network.common.TransportType;
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class Capability implements Proto {
+public final class Capability implements NetworkProto {
     private final Address address;
     private final List<TransportType> supportedTransportTypes;
 

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -41,8 +43,16 @@ public final class Capability implements NetworkProto {
         this.supportedTransportTypes = supportedTransportTypes;
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.supportedTransportTypes);
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+        checkArgument(supportedTransportTypes.size() <= TransportType.values().length);
+    }
+
+    @Override
     public bisq.network.protobuf.Capability toProto() {
         return bisq.network.protobuf.Capability.newBuilder()
                 .setAddress(address.toProto())

--- a/network/network/src/main/java/bisq/network/p2p/node/CloseConnectionMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/CloseConnectionMessage.java
@@ -14,6 +14,12 @@ public final class CloseConnectionMessage implements EnvelopePayloadMessage {
 
     public CloseConnectionMessage(CloseReason closeReason) {
         this.closeReason = closeReason;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
@@ -29,6 +29,12 @@ public final class AuthorizationToken implements NetworkProto {
     public AuthorizationToken(ProofOfWork proofOfWork, int messageCounter) {
         this.proofOfWork = proofOfWork;
         this.messageCounter = messageCounter;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
@@ -17,12 +17,12 @@
 
 package bisq.network.p2p.node.authorization;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.security.pow.ProofOfWork;
 import lombok.Data;
 
 @Data
-public final class AuthorizationToken implements Proto {
+public final class AuthorizationToken implements NetworkProto {
     private final ProofOfWork proofOfWork;
     private final int messageCounter;
 

--- a/network/network/src/main/java/bisq/network/p2p/node/envelope/parser/nio/NetworkEnvelopeDeserializer.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/envelope/parser/nio/NetworkEnvelopeDeserializer.java
@@ -96,6 +96,7 @@ public class NetworkEnvelopeDeserializer {
             NetworkEnvelope message = NetworkEnvelope.parseFrom(currentProtobufMessage);
             bisq.network.p2p.message.NetworkEnvelope
                     networkEnvelope = bisq.network.p2p.message.NetworkEnvelope.fromProto(message);
+            networkEnvelope.verifyVersion();
             parsedNetworkEnvelopes.add(networkEnvelope);
 
         } catch (InvalidProtocolBufferException e) {

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
@@ -78,7 +78,13 @@ public final class ConnectionHandshake {
             this.networkLoad = networkLoad;
             this.signatureDate = signatureDate;
 
+            verify();
+        }
+
+        @Override
+        public void verify() {
             addressOwnershipProof.ifPresent(signature -> {
+                // Tor signature has 64 bytes
                 checkArgument(signature.length == 64,
                         "Signature not of the expected size. signature.length=" + signature.length);
             });
@@ -119,6 +125,12 @@ public final class ConnectionHandshake {
         public Response(Capability capability, NetworkLoad networkLoad) {
             this.capability = capability;
             this.networkLoad = networkLoad;
+
+            verify();
+        }
+
+        @Override
+        public void verify() {
         }
 
         @Override

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/OnionAddressValidation.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/OnionAddressValidation.java
@@ -1,0 +1,49 @@
+package bisq.network.p2p.node.handshake;
+
+import bisq.network.common.Address;
+import bisq.security.TorSignatureUtil;
+import bisq.security.keys.TorKeyUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.crypto.CryptoException;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+public class OnionAddressValidation {
+    private static final long MAX_SIG_AGE = TimeUnit.HOURS.toMillis(2);
+
+    private static String buildMessageForSigning(Address signersAddress, Address verifiersAddress, long date) {
+        return signersAddress.getFullAddress() + "|" + verifiersAddress.getFullAddress() + "@" + date;
+    }
+
+    static Optional<byte[]> sign(Address myAddress, Address peerAddress, long date, byte[] privateKey) {
+        if (!peerAddress.isTorAddress()) {
+            return Optional.empty();
+        }
+        String message = buildMessageForSigning(myAddress, peerAddress, date);
+        try {
+            return Optional.of(TorSignatureUtil.sign(privateKey, message.getBytes()));
+        } catch (CryptoException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static boolean verify(Address myAddress, Address peerAddress, long date, Optional<byte[]> signature) {
+        if (!peerAddress.isTorAddress()) {
+            return true;
+        }
+        String errorMsg = "Peer onion address proof failed because the signatureDate is outside the 2 hour tolerance: " +
+                peerAddress.getFullAddress() +
+                ", \nsignatureDate: " + new Date(date) +
+                ", \nmy date: " + new Date(System.currentTimeMillis());
+        checkArgument(Math.abs(System.currentTimeMillis() - date) <= MAX_SIG_AGE, errorMsg);
+
+        String message = buildMessageForSigning(peerAddress, myAddress, date);
+        byte[] pubKey = TorKeyUtils.getPublicKeyFromOnionAddress(peerAddress.getHost());
+        return TorSignatureUtil.verify(pubKey, message.getBytes(), signature.orElseThrow());
+    }
+}

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoad.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoad.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.node.network_load;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +25,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class NetworkLoad implements Proto {
+public final class NetworkLoad implements NetworkProto {
     public final static NetworkLoad INITIAL_LOAD = new NetworkLoad();
 
     private final double value;

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoad.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoad.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -36,8 +38,16 @@ public final class NetworkLoad implements NetworkProto {
 
     public NetworkLoad(double value) {
         this.value = Math.min(1, value);
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+        checkArgument(value > 0);
+    }
+
+    @Override
     public bisq.network.protobuf.NetworkLoad toProto() {
         return bisq.network.protobuf.NetworkLoad.newBuilder()
                 .setValue(value)

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessage.java
@@ -43,6 +43,11 @@ public final class ConfidentialMessage implements EnvelopePayloadMessage, Distri
         this.confidentialData = confidentialData;
         this.receiverKeyId = receiverKeyId;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateId(receiverKeyId);
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/AckMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/AckMessage.java
@@ -27,6 +27,11 @@ public final class AckMessage implements MailboxMessage {
     public AckMessage(String id) {
         this.id = id;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateText(id, 100);
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/DataFilter.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/DataFilter.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.services.data.inventory;
 
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class DataFilter implements Proto {
+public final class DataFilter implements NetworkProto {
     private final List<FilterEntry> filterEntries;
 
     public DataFilter(List<FilterEntry> filterEntries) {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/DataFilter.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/DataFilter.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -37,8 +39,17 @@ public final class DataFilter implements NetworkProto {
         this.filterEntries = filterEntries;
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.filterEntries);
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+
+        checkArgument(filterEntries.size() < 1000);
+    }
+
+    @Override
     public bisq.network.protobuf.DataFilter toProto() {
         return bisq.network.protobuf.DataFilter.newBuilder()
                 .addAllFilterEntries(filterEntries.stream()

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/FilterEntry.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/FilterEntry.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.services.data.inventory;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
@@ -30,7 +30,7 @@ import java.util.Arrays;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class FilterEntry implements Proto, Comparable<FilterEntry> {
+public final class FilterEntry implements NetworkProto, Comparable<FilterEntry> {
     private final byte[] hash;
     private final int sequenceNumber;
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/FilterEntry.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/FilterEntry.java
@@ -38,9 +38,15 @@ public final class FilterEntry implements NetworkProto, Comparable<FilterEntry> 
         this.hash = hash;
         this.sequenceNumber = sequenceNumber;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateHash(hash);
     }
 
+    @Override
     public bisq.network.protobuf.FilterEntry toProto() {
         return bisq.network.protobuf.FilterEntry.newBuilder()
                 .setHash(ByteString.copyFrom(hash))

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.services.data.inventory;
 
 import bisq.common.data.ByteArray;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.network.p2p.services.data.DataRequest;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 @ToString
 @EqualsAndHashCode
 @Slf4j
-public final class Inventory implements Proto {
+public final class Inventory implements NetworkProto {
     private final List<? extends DataRequest> entries;
     private final boolean maxSizeReached;
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
@@ -31,6 +31,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -46,8 +48,16 @@ public final class Inventory implements NetworkProto {
         // We need to sort deterministically as the data is used in the proof of work check
         // todo find cheaper solution or cache serialized result to avoid that its done repeatedly 
         this.entries.sort(Comparator.comparing((DataRequest e) -> new ByteArray(e.serialize())));
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+        checkArgument(entries.size() < 1000);
+    }
+
+    @Override
     public bisq.network.protobuf.Inventory toProto() {
         return bisq.network.protobuf.Inventory.newBuilder()
                 .addAllEntries(entries.stream().map(e -> e.toProto().getDataRequest()).collect(Collectors.toList()))

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequest.java
@@ -32,6 +32,12 @@ public final class InventoryRequest implements BroadcastMessage {
     public InventoryRequest(DataFilter dataFilter, int nonce) {
         this.dataFilter = dataFilter;
         this.nonce = nonce;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
@@ -32,6 +32,12 @@ public final class InventoryResponse implements BroadcastMessage {
     public InventoryResponse(Inventory inventory, int requestNonce) {
         this.inventory = inventory;
         this.requestNonce = requestNonce;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DistributedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DistributedData.java
@@ -17,12 +17,12 @@
 
 package bisq.network.p2p.services.data.storage;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.Any;
 
 // Interface for any data which gets distributed to the P2P network. Usually data from outside the network module 
 // like Offer, ChatMessage,...
-public interface DistributedData extends Proto {
+public interface DistributedData extends NetworkProto {
     static DistributedData fromAny(Any any) {
         return DistributedDataResolver.fromAny(any);
     }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DistributedDataResolver.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DistributedDataResolver.java
@@ -17,12 +17,12 @@
 
 package bisq.network.p2p.services.data.storage;
 
+import bisq.common.proto.NetworkProtoResolverMap;
 import bisq.common.proto.ProtoResolver;
-import bisq.common.proto.ProtoResolverMap;
 import com.google.protobuf.Any;
 
 public class DistributedDataResolver {
-    private static final ProtoResolverMap<DistributedData> protoResolverMap = new ProtoResolverMap<>(true);
+    private static final NetworkProtoResolverMap<DistributedData> protoResolverMap = new NetworkProtoResolverMap<>();
 
     public static void addResolver(String protoTypeName, ProtoResolver<DistributedData> resolver) {
         protoResolverMap.addProtoResolver(protoTypeName, resolver);

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
@@ -80,6 +80,7 @@ public final class MetaData implements NetworkProto {
         NetworkDataValidation.validateText(className, 50);
     }
 
+    @Override
     public bisq.network.protobuf.MetaData toProto() {
         return bisq.network.protobuf.MetaData.newBuilder()
                 .setTtl(ttl)

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.services.data.storage;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.MathUtils;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 @EqualsAndHashCode
 @ToString
 @Getter
-public final class MetaData implements Proto {
+public final class MetaData implements NetworkProto {
     public static final long TTL_2_DAYS = TimeUnit.DAYS.toMillis(2);
     public static final long TTL_10_DAYS = TimeUnit.DAYS.toMillis(10);
     public static final long TTL_15_DAYS = TimeUnit.DAYS.toMillis(15);

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
@@ -77,6 +77,11 @@ public final class MetaData implements NetworkProto {
         this.className = className;
         this.maxMapSize = maxMapSize;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateText(className, 50);
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageData.java
@@ -17,10 +17,10 @@
 
 package bisq.network.p2p.services.data.storage;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 
 // Interface covering data for storage. Implemented by AppendOnlyData, AuthenticatedData
-public interface StorageData extends Proto {
+public interface StorageData extends NetworkProto {
     MetaData getMetaData();
 
     boolean isDataInvalid(byte[] ownerPubKeyHash);

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageService.java
@@ -399,8 +399,8 @@ public class StorageService {
 
     private Set<String> getExistingStoreKeys(String directory) {
         return NetworkStorageWhiteList.getClassNames().stream()
-                .filter(storeKey -> {
-                    String storageFileName = StringUtils.camelCaseToSnakeCase(storeKey + DataStorageService.STORE_POST_FIX) + Persistence.EXTENSION;
+                .filter(className -> {
+                    String storageFileName = StringUtils.camelCaseToSnakeCase(className + DataStorageService.STORE_POST_FIX) + Persistence.EXTENSION;
                     return Path.of(directory, storageFileName).toFile().exists();
                 })
                 .collect(Collectors.toSet());

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/append/AddAppendOnlyDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/append/AddAppendOnlyDataRequest.java
@@ -34,6 +34,12 @@ public final class AddAppendOnlyDataRequest implements AddDataRequest {
 
     public AddAppendOnlyDataRequest(AppendOnlyData appendOnlyData) {
         this.appendOnlyData = appendOnlyData;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AddAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AddAuthenticatedDataRequest.java
@@ -87,8 +87,13 @@ public final class AddAuthenticatedDataRequest implements AuthenticatedDataReque
         this.ownerPublicKeyBytes = ownerPublicKeyBytes;
         this.ownerPublicKey = ownerPublicKey;
 
-        NetworkDataValidation.validateECPubKey(ownerPublicKeyBytes);
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateECSignature(signature);
+        NetworkDataValidation.validateECPubKey(ownerPublicKeyBytes);
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedData.java
@@ -40,6 +40,7 @@ public abstract class AuthenticatedData implements StorageData {
         this.distributedData = distributedData;
     }
 
+    @Override
     public abstract bisq.network.protobuf.AuthenticatedData toProto();
 
     public bisq.network.protobuf.AuthenticatedData.Builder getAuthenticatedDataBuilder() {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedSequentialData.java
@@ -54,10 +54,16 @@ public final class AuthenticatedSequentialData implements NetworkProto {
         this.pubKeyHash = pubKeyHash;
         this.created = created;
 
-        NetworkDataValidation.validateDate(created);
-        NetworkDataValidation.validateHash(pubKeyHash);
+        verify();
     }
 
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateHash(pubKeyHash);
+        NetworkDataValidation.validateDate(created);
+    }
+
+    @Override
     public bisq.network.protobuf.AuthenticatedSequentialData toProto() {
         return bisq.network.protobuf.AuthenticatedSequentialData.newBuilder()
                 .setAuthenticatedData(authenticatedData.toProto())

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedSequentialData.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.services.data.storage.auth;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 @EqualsAndHashCode
-public final class AuthenticatedSequentialData implements Proto {
+public final class AuthenticatedSequentialData implements NetworkProto {
     public static AuthenticatedSequentialData from(AuthenticatedSequentialData data, int sequenceNumber) {
         return new AuthenticatedSequentialData(data.getAuthenticatedData(),
                 sequenceNumber,

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RefreshAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RefreshAuthenticatedDataRequest.java
@@ -86,6 +86,11 @@ public final class RefreshAuthenticatedDataRequest implements DataRequest {
         this.sequenceNumber = sequenceNumber;
         this.signature = signature;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateHash(hash);
         NetworkDataValidation.validateECPubKey(ownerPublicKeyBytes);
         NetworkDataValidation.validateECSignature(signature);

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
@@ -30,7 +30,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.PublicKey;
@@ -56,7 +55,6 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
     private final MetaData metaData;
     private final byte[] hash;
     private final byte[] ownerPublicKeyBytes;
-    @Nullable
     transient private PublicKey ownerPublicKey;
     private final int sequenceNumber;
     private final byte[] signature;
@@ -105,9 +103,15 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
         this.signature = signature;
         this.created = created;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateHash(hash);
         NetworkDataValidation.validateECPubKey(ownerPublicKeyBytes);
         NetworkDataValidation.validateECSignature(signature);
+        NetworkDataValidation.validateDate(created);
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
@@ -65,10 +65,16 @@ public final class AuthorizedData extends AuthenticatedData {
         this.authorizedPublicKey = authorizedPublicKey;
         this.authorizedPublicKeyBytes = authorizedPublicKeyBytes;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         signature.ifPresent(NetworkDataValidation::validateECSignature);
         NetworkDataValidation.validateECPubKey(authorizedPublicKeyBytes);
     }
 
+    @Override
     public bisq.network.protobuf.AuthenticatedData toProto() {
         bisq.network.protobuf.AuthorizedData.Builder builder = bisq.network.protobuf.AuthorizedData.newBuilder()
                 .setAuthorizedPublicKeyBytes(ByteString.copyFrom(authorizedPublicKeyBytes));

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/AddMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/AddMailboxRequest.java
@@ -76,8 +76,13 @@ public final class AddMailboxRequest implements MailboxRequest, AddDataRequest {
         this.senderPublicKeyBytes = senderPublicKeyBytes;
         this.senderPublicKey = senderPublicKey;
 
-        NetworkDataValidation.validateECPubKey(senderPublicKeyBytes);
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateECSignature(signature);
+        NetworkDataValidation.validateECPubKey(senderPublicKeyBytes);
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
@@ -47,8 +47,15 @@ public final class MailboxData implements StorageData {
     public MailboxData(ConfidentialMessage confidentialMessage, MetaData metaData) {
         this.confidentialMessage = confidentialMessage;
         this.metaData = metaData;
+
+        verify();
     }
 
+    @Override
+    public void verify() {
+    }
+
+    @Override
     public bisq.network.protobuf.MailboxData toProto() {
         return bisq.network.protobuf.MailboxData.newBuilder()
                 .setConfidentialMessage(confidentialMessage.toProto().getConfidentialMessage())

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.services.data.storage.mailbox;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
@@ -31,7 +31,7 @@ import java.security.PublicKey;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class MailboxSequentialData implements Proto {
+public final class MailboxSequentialData implements NetworkProto {
     private final MailboxData mailboxData;
     private final byte[] senderPublicKeyHash;
     private final byte[] receiversPublicKeyHash;

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
@@ -90,6 +90,7 @@ public final class MailboxSequentialData implements NetworkProto {
         NetworkDataValidation.validateDate(created);
     }
 
+    @Override
     public bisq.network.protobuf.MailboxSequentialData toProto() {
         return bisq.network.protobuf.MailboxSequentialData.newBuilder()
                 .setMailboxData(mailboxData.toProto())

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
@@ -83,7 +83,11 @@ public final class MailboxSequentialData implements NetworkProto {
         this.created = created;
         this.sequenceNumber = sequenceNumber;
 
+        verify();
+    }
 
+    @Override
+    public void verify() {
         NetworkDataValidation.validateHash(senderPublicKeyHash);
         NetworkDataValidation.validateHash(receiversPublicKeyHash);
         NetworkDataValidation.validateECPubKey(receiversPubKeyBytes);

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
@@ -78,6 +78,11 @@ public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataReq
         this.signature = signature;
         this.created = created;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateHash(hash);
         NetworkDataValidation.validateECPubKey(receiverPublicKeyBytes);
         NetworkDataValidation.validateECSignature(signature);

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/Peer.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/Peer.java
@@ -19,9 +19,9 @@ package bisq.network.p2p.services.peergroup;
 
 import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
+import bisq.network.common.Address;
 import bisq.network.p2p.node.Capability;
 import bisq.network.p2p.node.network_load.NetworkLoad;
-import bisq.network.common.Address;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -49,9 +49,15 @@ public final class Peer implements NetworkProto, Comparable<Peer> {
         this.isOutboundConnection = isOutboundConnection;
         this.created = created;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateDate(created);
     }
 
+    @Override
     public bisq.network.protobuf.Peer toProto() {
         return bisq.network.protobuf.Peer.newBuilder()
                 .setCapability(capability.toProto())

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/Peer.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/Peer.java
@@ -17,7 +17,7 @@
 
 package bisq.network.p2p.services.peergroup;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.p2p.node.Capability;
 import bisq.network.p2p.node.network_load.NetworkLoad;
@@ -32,7 +32,7 @@ import java.util.Date;
 @Getter
 @ToString
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public final class Peer implements Proto, Comparable<Peer> {
+public final class Peer implements NetworkProto, Comparable<Peer> {
     @EqualsAndHashCode.Include
     private final Capability capability;
     private final NetworkLoad networkLoad;

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeRequest.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -39,6 +41,13 @@ public final class PeerExchangeRequest implements EnvelopePayloadMessage {
         this.peers = peers;
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.peers);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(peers.size() < 10000);
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/exchange/PeerExchangeResponse.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -39,7 +41,15 @@ public final class PeerExchangeResponse implements EnvelopePayloadMessage {
         this.peers = peers;
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.peers);
+
+        verify();
     }
+
+    @Override
+    public void verify() {
+        checkArgument(peers.size() < 10000);
+    }
+
 
     @Override
     public bisq.network.protobuf.EnvelopePayloadMessage toProto() {

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/keepalive/Ping.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/keepalive/Ping.java
@@ -30,13 +30,17 @@ public final class Ping implements EnvelopePayloadMessage {
 
     public Ping(int nonce) {
         this.nonce = nonce;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override
     public bisq.network.protobuf.EnvelopePayloadMessage toProto() {
-        return getNetworkMessageBuilder().setPing(
-                        bisq.network.protobuf.Ping.newBuilder().setNonce(nonce))
-                .build();
+        return getNetworkMessageBuilder().setPing(bisq.network.protobuf.Ping.newBuilder().setNonce(nonce)).build();
     }
 
     public static Ping fromProto(bisq.network.protobuf.Ping proto) {

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/keepalive/Pong.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/keepalive/Pong.java
@@ -33,6 +33,10 @@ public final class Pong implements EnvelopePayloadMessage {
     }
 
     @Override
+    public void verify() {
+    }
+
+    @Override
     public bisq.network.protobuf.EnvelopePayloadMessage toProto() {
         return getNetworkMessageBuilder().setPong(
                         bisq.network.protobuf.Pong.newBuilder()

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/network_load/NetworkLoadExchangeRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/network_load/NetworkLoadExchangeRequest.java
@@ -33,6 +33,12 @@ public final class NetworkLoadExchangeRequest implements EnvelopePayloadMessage 
     public NetworkLoadExchangeRequest(int nonce, NetworkLoad networkLoad) {
         this.nonce = nonce;
         this.networkLoad = networkLoad;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/peergroup/network_load/NetworkLoadExchangeResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peergroup/network_load/NetworkLoadExchangeResponse.java
@@ -33,6 +33,12 @@ public final class NetworkLoadExchangeResponse implements EnvelopePayloadMessage
     public NetworkLoadExchangeResponse(int requestNonce, NetworkLoad networkLoad) {
         this.requestNonce = requestNonce;
         this.networkLoad = networkLoad;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -91,7 +92,7 @@ public class ConnectionHandshakeResponderTest {
 
     @Test
     void wrongEnvelopeVersion() throws IOException {
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 Address.localHost(1234).toString(),
@@ -124,7 +125,7 @@ public class ConnectionHandshakeResponderTest {
 
     @Test
     void bannedPeer() throws IOException {
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 Address.localHost(1234).toString(),
@@ -144,7 +145,7 @@ public class ConnectionHandshakeResponderTest {
 
     @Test
     void invalidPoW() throws IOException {
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 Address.localHost(1234).toString(),
@@ -163,7 +164,7 @@ public class ConnectionHandshakeResponderTest {
     @Test
     void correctPoW() throws IOException {
         Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes);
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 responderCapability.getAddress().getFullAddress(),
@@ -181,7 +182,7 @@ public class ConnectionHandshakeResponderTest {
 
     private NetworkEnvelope createValidRequest() {
         Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes);
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 responderCapability.getAddress().getFullAddress(),

--- a/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
@@ -96,7 +96,7 @@ public class ConnectionHandshakeResponderTest {
                 new NetworkLoad(),
                 Address.localHost(1234).toString(),
                 0);
-        NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(NetworkEnvelope.VERSION + 1000, token, request);
+        NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(NetworkEnvelope.networkVersion + 1000, token, request);
         List<NetworkEnvelope> allEnvelopesToReceive = List.of(requestNetworkEnvelope);
         when(networkEnvelopeSocketChannel.receiveNetworkEnvelopes()).thenReturn(allEnvelopesToReceive);
 

--- a/network/network/src/test/java/bisq/network/p2p/InboundConnectionsManagerTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/InboundConnectionsManagerTests.java
@@ -46,10 +46,7 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -248,7 +245,7 @@ public class InboundConnectionsManagerTests {
         supportedTransportTypes.add(TransportType.CLEAR);
         Capability peerCapability = new Capability(peerAddress, supportedTransportTypes);
 
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationService authorizationService = createAuthorizationService();
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),

--- a/network/network/src/test/java/bisq/network/p2p/ProtoBufMessageLengthTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/ProtoBufMessageLengthTests.java
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,7 +104,7 @@ public class ProtoBufMessageLengthTests {
 
     private bisq.network.protobuf.NetworkEnvelope createValidRequest() {
         Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes);
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, null, new NetworkLoad(), 0);
+        ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 Address.localHost(1234).getFullAddress(),

--- a/offer/src/main/java/bisq/offer/Offer.java
+++ b/offer/src/main/java/bisq/offer/Offer.java
@@ -87,7 +87,10 @@ public abstract class Offer<B extends PaymentMethodSpec<?>, Q extends PaymentMet
         this.baseSidePaymentMethodSpecs.sort(Comparator.comparingInt(PaymentMethodSpec::hashCode));
         this.quoteSidePaymentMethodSpecs.sort(Comparator.comparingInt(PaymentMethodSpec::hashCode));
         this.offerOptions.sort(Comparator.comparingInt(OfferOption::hashCode));
+    }
 
+    @Override
+    public void verify() {
         NetworkDataValidation.validateId(id);
         NetworkDataValidation.validateDate(date);
 
@@ -97,6 +100,7 @@ public abstract class Offer<B extends PaymentMethodSpec<?>, Q extends PaymentMet
         checkArgument(offerOptions.size() < 10);
     }
 
+    @Override
     public abstract bisq.offer.protobuf.Offer toProto();
 
     protected bisq.offer.protobuf.Offer.Builder getOfferBuilder() {

--- a/offer/src/main/java/bisq/offer/Offer.java
+++ b/offer/src/main/java/bisq/offer/Offer.java
@@ -19,7 +19,7 @@ package bisq.offer;
 
 import bisq.account.protocol_type.TradeProtocolType;
 import bisq.common.currency.Market;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.identity.NetworkId;
@@ -45,7 +45,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Getter
 @ToString
 @EqualsAndHashCode
-public abstract class Offer<B extends PaymentMethodSpec<?>, Q extends PaymentMethodSpec<?>> implements Proto {
+public abstract class Offer<B extends PaymentMethodSpec<?>, Q extends PaymentMethodSpec<?>> implements NetworkProto {
     protected final String id;
     protected final long date;
     protected final NetworkId makerNetworkId;

--- a/offer/src/main/java/bisq/offer/OfferMessage.java
+++ b/offer/src/main/java/bisq/offer/OfferMessage.java
@@ -40,7 +40,11 @@ public final class OfferMessage implements DistributedData {
     public OfferMessage(Offer<?, ?> offer) {
         this.offer = offer;
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/amount/spec/AmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/AmountSpec.java
@@ -17,10 +17,10 @@
 
 package bisq.offer.amount.spec;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 
-public interface AmountSpec extends Proto {
+public interface AmountSpec extends NetworkProto {
 
     bisq.offer.protobuf.AmountSpec toProto();
 

--- a/offer/src/main/java/bisq/offer/amount/spec/BaseSideFixedAmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/BaseSideFixedAmountSpec.java
@@ -30,6 +30,13 @@ import lombok.ToString;
 public final class BaseSideFixedAmountSpec extends FixedAmountSpec implements BaseSideAmountSpec {
     public BaseSideFixedAmountSpec(long amount) {
         super(amount);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/amount/spec/BaseSideRangeAmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/BaseSideRangeAmountSpec.java
@@ -27,6 +27,13 @@ import lombok.ToString;
 public final class BaseSideRangeAmountSpec extends RangeAmountSpec implements BaseSideAmountSpec {
     public BaseSideRangeAmountSpec(long minAmount, long maxAmount) {
         super(minAmount, maxAmount);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/amount/spec/FixedAmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/FixedAmountSpec.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * No min. amount supported
  */
@@ -33,6 +35,11 @@ public abstract class FixedAmountSpec implements AmountSpec {
 
     public FixedAmountSpec(long amount) {
         this.amount = amount;
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(amount > 0);
     }
 
     public bisq.offer.protobuf.FixedAmountSpec.Builder getFixedAmountSpecBuilder() {

--- a/offer/src/main/java/bisq/offer/amount/spec/QuoteSideFixedAmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/QuoteSideFixedAmountSpec.java
@@ -30,6 +30,13 @@ import lombok.ToString;
 public final class QuoteSideFixedAmountSpec extends FixedAmountSpec implements QuoteSideAmountSpec {
     public QuoteSideFixedAmountSpec(long amount) {
         super(amount);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/amount/spec/QuoteSideRangeAmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/QuoteSideRangeAmountSpec.java
@@ -27,6 +27,13 @@ import lombok.ToString;
 public final class QuoteSideRangeAmountSpec extends RangeAmountSpec implements QuoteSideAmountSpec {
     public QuoteSideRangeAmountSpec(long minAmount, long maxAmount) {
         super(minAmount, maxAmount);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/amount/spec/RangeAmountSpec.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/RangeAmountSpec.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -32,6 +34,13 @@ public abstract class RangeAmountSpec implements AmountSpec {
     public RangeAmountSpec(long minAmount, long maxAmount) {
         this.minAmount = minAmount;
         this.maxAmount = maxAmount;
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(minAmount > 0);
+        checkArgument(maxAmount > 0);
+        checkArgument(maxAmount >= minAmount);
     }
 
     public bisq.offer.protobuf.RangeAmountSpec.Builder getRangeAmountSpecBuilder() {

--- a/offer/src/main/java/bisq/offer/bisq_easy/BisqEasyOffer.java
+++ b/offer/src/main/java/bisq/offer/bisq_easy/BisqEasyOffer.java
@@ -84,6 +84,13 @@ public final class BisqEasyOffer extends Offer<BitcoinPaymentMethodSpec, FiatPay
         this.supportedLanguageCodes = supportedLanguageCodes;
         Collections.sort(this.supportedLanguageCodes);
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+
         NetworkDataValidation.validateText(supportedLanguageCodes.toString(), 100);
     }
 

--- a/offer/src/main/java/bisq/offer/multisig/MultisigOffer.java
+++ b/offer/src/main/java/bisq/offer/multisig/MultisigOffer.java
@@ -73,6 +73,13 @@ public final class MultisigOffer extends Offer<BitcoinPaymentMethodSpec, FiatPay
                 baseSidePaymentMethodSpecs,
                 quoteSidePaymentMethodSpecs,
                 offerOptions);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/options/CollateralOption.java
+++ b/offer/src/main/java/bisq/offer/options/CollateralOption.java
@@ -31,6 +31,12 @@ public final class CollateralOption implements OfferOption {
     public CollateralOption(long buyerSecurityDeposit, long sellerSecurityDeposit) {
         this.buyerSecurityDeposit = buyerSecurityDeposit;
         this.sellerSecurityDeposit = sellerSecurityDeposit;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     public bisq.offer.protobuf.OfferOption toProto() {

--- a/offer/src/main/java/bisq/offer/options/FeeOption.java
+++ b/offer/src/main/java/bisq/offer/options/FeeOption.java
@@ -51,6 +51,11 @@ public final class FeeOption implements OfferOption {
         this.blockHeightAtFeePayment = blockHeightAtFeePayment;
         this.feeTxId = feeTxId;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateBtcTxId(feeTxId);
     }
 

--- a/offer/src/main/java/bisq/offer/options/FeeOption.java
+++ b/offer/src/main/java/bisq/offer/options/FeeOption.java
@@ -54,6 +54,7 @@ public final class FeeOption implements OfferOption {
         NetworkDataValidation.validateBtcTxId(feeTxId);
     }
 
+    @Override
     public bisq.offer.protobuf.OfferOption toProto() {
         return getOfferOptionBuilder().setFeeOption(bisq.offer.protobuf.FeeOption.newBuilder()
                         .setFeeType(feeType.toProto())

--- a/offer/src/main/java/bisq/offer/options/FiatPaymentOption.java
+++ b/offer/src/main/java/bisq/offer/options/FiatPaymentOption.java
@@ -27,8 +27,6 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public final class FiatPaymentOption implements OfferOption {
-    public final static int MAX_NAME_LENGTH = 50;
-
     private final String countyCodeOfBank;
     private final String bankName;
 
@@ -36,8 +34,13 @@ public final class FiatPaymentOption implements OfferOption {
         this.countyCodeOfBank = countyCodeOfBank;
         this.bankName = bankName;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateCode(countyCodeOfBank);
-        NetworkDataValidation.validateText(bankName, MAX_NAME_LENGTH);
+        NetworkDataValidation.validateText(bankName, 100);
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/options/FiatPaymentOption.java
+++ b/offer/src/main/java/bisq/offer/options/FiatPaymentOption.java
@@ -40,6 +40,7 @@ public final class FiatPaymentOption implements OfferOption {
         NetworkDataValidation.validateText(bankName, MAX_NAME_LENGTH);
     }
 
+    @Override
     public bisq.offer.protobuf.OfferOption toProto() {
         return getOfferOptionBuilder().setFiatPaymentOption(bisq.offer.protobuf.FiatPaymentOption.newBuilder()
                         .setCountyCodeOfBank(countyCodeOfBank)

--- a/offer/src/main/java/bisq/offer/options/OfferOption.java
+++ b/offer/src/main/java/bisq/offer/options/OfferOption.java
@@ -17,10 +17,10 @@
 
 package bisq.offer.options;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 
-public interface OfferOption extends Proto {
+public interface OfferOption extends NetworkProto {
 
     bisq.offer.protobuf.OfferOption toProto();
 

--- a/offer/src/main/java/bisq/offer/options/ReputationOption.java
+++ b/offer/src/main/java/bisq/offer/options/ReputationOption.java
@@ -29,6 +29,12 @@ public final class ReputationOption implements OfferOption {
 
     public ReputationOption(long requiredTotalReputationScore) {
         this.requiredTotalReputationScore = requiredTotalReputationScore;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/options/ReputationOption.java
+++ b/offer/src/main/java/bisq/offer/options/ReputationOption.java
@@ -31,6 +31,7 @@ public final class ReputationOption implements OfferOption {
         this.requiredTotalReputationScore = requiredTotalReputationScore;
     }
 
+    @Override
     public bisq.offer.protobuf.OfferOption toProto() {
         return getOfferOptionBuilder().setReputationOption(
                         bisq.offer.protobuf.ReputationOption.newBuilder()

--- a/offer/src/main/java/bisq/offer/options/TradeTermsOption.java
+++ b/offer/src/main/java/bisq/offer/options/TradeTermsOption.java
@@ -26,13 +26,18 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public final class TradeTermsOption implements OfferOption {
-    public final static int MAX_TERM_LENGTH = 1000;
+    public final static int MAX_TERM_LENGTH = 10_000;
 
     private final String makersTradeTerms;
 
     public TradeTermsOption(String makersTradeTerms) {
         this.makersTradeTerms = makersTradeTerms;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateText(makersTradeTerms, MAX_TERM_LENGTH);
     }
 

--- a/offer/src/main/java/bisq/offer/options/TradeTermsOption.java
+++ b/offer/src/main/java/bisq/offer/options/TradeTermsOption.java
@@ -36,6 +36,7 @@ public final class TradeTermsOption implements OfferOption {
         NetworkDataValidation.validateText(makersTradeTerms, MAX_TERM_LENGTH);
     }
 
+    @Override
     public bisq.offer.protobuf.OfferOption toProto() {
         return getOfferOptionBuilder().setTradeTermsOption(bisq.offer.protobuf.TradeTermsOption.newBuilder()
                         .setMakersTradeTerms(makersTradeTerms))

--- a/offer/src/main/java/bisq/offer/payment_method/BitcoinPaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/BitcoinPaymentMethodSpec.java
@@ -34,6 +34,13 @@ public final class BitcoinPaymentMethodSpec extends PaymentMethodSpec<BitcoinPay
 
     public BitcoinPaymentMethodSpec(BitcoinPaymentMethod paymentMethod, Optional<String> saltedMakerAccountId) {
         super(paymentMethod, saltedMakerAccountId);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/payment_method/BitcoinPaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/BitcoinPaymentMethodSpec.java
@@ -36,6 +36,7 @@ public final class BitcoinPaymentMethodSpec extends PaymentMethodSpec<BitcoinPay
         super(paymentMethod, saltedMakerAccountId);
     }
 
+    @Override
     public bisq.offer.protobuf.PaymentMethodSpec toProto() {
         return getPaymentMethodSpecBuilder().setBitcoinPaymentMethodSpec(bisq.offer.protobuf.BitcoinPaymentMethodSpec.newBuilder()).build();
     }

--- a/offer/src/main/java/bisq/offer/payment_method/FiatPaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/FiatPaymentMethodSpec.java
@@ -36,6 +36,7 @@ public final class FiatPaymentMethodSpec extends PaymentMethodSpec<FiatPaymentMe
         super(paymentMethod, saltedMakerAccountId);
     }
 
+    @Override
     public bisq.offer.protobuf.PaymentMethodSpec toProto() {
         return getPaymentMethodSpecBuilder().setFiatPaymentMethodSpec(bisq.offer.protobuf.FiatPaymentMethodSpec.newBuilder()).build();
     }

--- a/offer/src/main/java/bisq/offer/payment_method/FiatPaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/FiatPaymentMethodSpec.java
@@ -34,6 +34,13 @@ public final class FiatPaymentMethodSpec extends PaymentMethodSpec<FiatPaymentMe
 
     public FiatPaymentMethodSpec(FiatPaymentMethod paymentMethod, Optional<String> saltedMakerAccountId) {
         super(paymentMethod, saltedMakerAccountId);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/payment_method/PaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/PaymentMethodSpec.java
@@ -19,7 +19,7 @@ package bisq.offer.payment_method;
 
 import bisq.account.payment_method.PaymentMethod;
 import bisq.account.payment_method.PaymentRail;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
@@ -31,7 +31,7 @@ import java.util.Optional;
 @ToString
 @Getter
 @EqualsAndHashCode
-public abstract class PaymentMethodSpec<T extends PaymentMethod<? extends PaymentRail>> implements Proto {
+public abstract class PaymentMethodSpec<T extends PaymentMethod<? extends PaymentRail>> implements NetworkProto {
     protected final Optional<String> saltedMakerAccountId;
     protected final T paymentMethod;
 

--- a/offer/src/main/java/bisq/offer/payment_method/PaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/PaymentMethodSpec.java
@@ -55,6 +55,7 @@ public abstract class PaymentMethodSpec<T extends PaymentMethod<? extends Paymen
 
     }
 
+    @Override
     public abstract bisq.offer.protobuf.PaymentMethodSpec toProto();
 
     public bisq.offer.protobuf.PaymentMethodSpec.Builder getPaymentMethodSpecBuilder() {

--- a/offer/src/main/java/bisq/offer/payment_method/PaymentMethodSpec.java
+++ b/offer/src/main/java/bisq/offer/payment_method/PaymentMethodSpec.java
@@ -50,12 +50,15 @@ public abstract class PaymentMethodSpec<T extends PaymentMethod<? extends Paymen
     public PaymentMethodSpec(T paymentMethod, Optional<String> saltedMakerAccountId) {
         this.paymentMethod = paymentMethod;
         this.saltedMakerAccountId = saltedMakerAccountId;
-
-        NetworkDataValidation.validateText(saltedMakerAccountId, 100);
-
     }
 
     @Override
+    public void verify() {
+        NetworkDataValidation.validateText(saltedMakerAccountId, 100);
+    }
+
+    @Override
+
     public abstract bisq.offer.protobuf.PaymentMethodSpec toProto();
 
     public bisq.offer.protobuf.PaymentMethodSpec.Builder getPaymentMethodSpecBuilder() {

--- a/offer/src/main/java/bisq/offer/poc/PocOffer.java
+++ b/offer/src/main/java/bisq/offer/poc/PocOffer.java
@@ -23,9 +23,9 @@ import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.currency.Market;
 import bisq.common.monetary.Monetary;
 import bisq.common.monetary.PriceQuote;
+import bisq.network.identity.NetworkId;
 import bisq.network.p2p.services.data.storage.DistributedData;
 import bisq.network.p2p.services.data.storage.MetaData;
-import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
 import bisq.offer.options.OfferOption;
 import bisq.offer.payment_method.BitcoinPaymentMethodSpec;
@@ -100,6 +100,12 @@ public final class PocOffer implements DistributedData {
         this.baseSidePaymentMethodSpecs = baseSidePaymentMethodSpecs;
         this.quoteSidePaymentMethodSpecs = quoteSidePaymentMethodSpecs;
         this.offerOptions = offerOptions;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/poc/PocOpenOffer.java
+++ b/offer/src/main/java/bisq/offer/poc/PocOpenOffer.java
@@ -17,14 +17,14 @@
 
 package bisq.offer.poc;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.Message;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @EqualsAndHashCode
 @Getter
-public final class PocOpenOffer implements Proto {
+public final class PocOpenOffer implements NetworkProto {
     private final PocOffer offer;
 
     public PocOpenOffer(PocOffer offer) {

--- a/offer/src/main/java/bisq/offer/poc/PocOpenOffer.java
+++ b/offer/src/main/java/bisq/offer/poc/PocOpenOffer.java
@@ -29,8 +29,12 @@ public final class PocOpenOffer implements NetworkProto {
 
     public PocOpenOffer(PocOffer offer) {
         this.offer = offer;
+        verify();
     }
 
+    @Override
+    public void verify() {
+    }
 
     @Override
     public Message toProto() {

--- a/offer/src/main/java/bisq/offer/price/spec/FixPriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/FixPriceSpec.java
@@ -33,6 +33,12 @@ public final class FixPriceSpec implements PriceSpec {
 
     public FixPriceSpec(PriceQuote priceQuote) {
         this.priceQuote = priceQuote;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/price/spec/FloatPriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/FloatPriceSpec.java
@@ -21,6 +21,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * A floating price based on the current market price.
  */
@@ -31,12 +33,19 @@ public final class FloatPriceSpec implements PriceSpec {
     private final double percentage;
 
     /**
-     * @param percentage  The percentage value normalized to 1 (1 = 100%) above or below the market price.
-     *                    Positive value means higher than market price. 
-     *                    E.g. 0.1 means `marketPrice * 1.1`, -0.2 means `marketPrice * 0.8`
+     * @param percentage The percentage value normalized to 1 (1 = 100%) above or below the market price.
+     *                   Positive value means higher than market price.
+     *                   E.g. 0.1 means `marketPrice * 1.1`, -0.2 means `marketPrice * 0.8`
      */
     public FloatPriceSpec(double percentage) {
         this.percentage = percentage;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(percentage >= -1 && percentage <= 1);
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/price/spec/MarketPriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/MarketPriceSpec.java
@@ -30,6 +30,11 @@ import lombok.ToString;
 public final class MarketPriceSpec implements PriceSpec {
 
     public MarketPriceSpec() {
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/price/spec/PriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/PriceSpec.java
@@ -17,10 +17,10 @@
 
 package bisq.offer.price.spec;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 
-public interface PriceSpec extends Proto {
+public interface PriceSpec extends NetworkProto {
 
     bisq.offer.protobuf.PriceSpec toProto();
 

--- a/offer/src/main/java/bisq/offer/submarine/SubmarineOffer.java
+++ b/offer/src/main/java/bisq/offer/submarine/SubmarineOffer.java
@@ -73,6 +73,12 @@ public final class SubmarineOffer extends Offer<BitcoinPaymentMethodSpec, FiatPa
                 baseSidePaymentMethodSpecs,
                 quoteSidePaymentMethodSpecs,
                 offerOptions);
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/persistence/src/main/java/bisq/persistence/PersistableStore.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStore.java
@@ -17,14 +17,14 @@
 
 package bisq.persistence;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.ProtoResolver;
 import com.google.protobuf.Any;
 
 /**
  * Interface for the outside envelope object persisted to disk.
  */
-public interface PersistableStore<T> extends NetworkProto {
+public interface PersistableStore<T> extends PersistableProto {
     static PersistableStore<?> fromAny(Any anyProto) {
         return PersistableStoreResolver.fromAny(anyProto);
     }

--- a/persistence/src/main/java/bisq/persistence/PersistableStore.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStore.java
@@ -17,14 +17,14 @@
 
 package bisq.persistence;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.ProtoResolver;
 import com.google.protobuf.Any;
 
 /**
  * Interface for the outside envelope object persisted to disk.
  */
-public interface PersistableStore<T> extends Proto {
+public interface PersistableStore<T> extends NetworkProto {
     static PersistableStore<?> fromAny(Any anyProto) {
         return PersistableStoreResolver.fromAny(anyProto);
     }

--- a/persistence/src/main/java/bisq/persistence/PersistenceService.java
+++ b/persistence/src/main/java/bisq/persistence/PersistenceService.java
@@ -17,7 +17,7 @@
 
 package bisq.persistence;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.util.CompletableFutureUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +32,8 @@ public class PersistenceService {
     @Getter
     private final String baseDir;
     @Getter
-    protected final List<PersistenceClient<? extends Proto>> clients = new CopyOnWriteArrayList<>();
-    protected final List<Persistence<? extends Proto>> persistenceInstances = new CopyOnWriteArrayList<>();
+    protected final List<PersistenceClient<? extends NetworkProto>> clients = new CopyOnWriteArrayList<>();
+    protected final List<Persistence<? extends NetworkProto>> persistenceInstances = new CopyOnWriteArrayList<>();
 
     public PersistenceService(String baseDir) {
         this.baseDir = baseDir;

--- a/persistence/src/main/java/bisq/persistence/PersistenceService.java
+++ b/persistence/src/main/java/bisq/persistence/PersistenceService.java
@@ -17,7 +17,7 @@
 
 package bisq.persistence;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.util.CompletableFutureUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +32,8 @@ public class PersistenceService {
     @Getter
     private final String baseDir;
     @Getter
-    protected final List<PersistenceClient<? extends NetworkProto>> clients = new CopyOnWriteArrayList<>();
-    protected final List<Persistence<? extends NetworkProto>> persistenceInstances = new CopyOnWriteArrayList<>();
+    protected final List<PersistenceClient<? extends PersistableProto>> clients = new CopyOnWriteArrayList<>();
+    protected final List<Persistence<? extends PersistableProto>> persistenceInstances = new CopyOnWriteArrayList<>();
 
     public PersistenceService(String baseDir) {
         this.baseDir = baseDir;

--- a/security/src/main/java/bisq/security/ConfidentialData.java
+++ b/security/src/main/java/bisq/security/ConfidentialData.java
@@ -55,6 +55,7 @@ public final class ConfidentialData implements NetworkProto {
         NetworkDataValidation.validateECSignature(signature);
     }
 
+    @Override
     public bisq.security.protobuf.ConfidentialData toProto() {
         return bisq.security.protobuf.ConfidentialData.newBuilder()
                 .setSenderPublicKey(ByteString.copyFrom(senderPublicKey))

--- a/security/src/main/java/bisq/security/ConfidentialData.java
+++ b/security/src/main/java/bisq/security/ConfidentialData.java
@@ -48,9 +48,13 @@ public final class ConfidentialData implements NetworkProto {
         this.cipherText = cipherText;
         this.signature = signature;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         checkArgument(iv.length <= 20);
         checkArgument(cipherText.length <= MAX_SIZE_CIPHERTEXT);
-
         NetworkDataValidation.validateECPubKey(senderPublicKey);
         NetworkDataValidation.validateECSignature(signature);
     }

--- a/security/src/main/java/bisq/security/ConfidentialData.java
+++ b/security/src/main/java/bisq/security/ConfidentialData.java
@@ -17,7 +17,7 @@
 
 package bisq.security;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
@@ -31,7 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Getter
 @ToString
 @EqualsAndHashCode
-public final class ConfidentialData implements Proto {
+public final class ConfidentialData implements NetworkProto {
     private static final int MAX_SIZE_CIPHERTEXT = 20_000;
 
     private final byte[] senderPublicKey;

--- a/security/src/main/java/bisq/security/EncryptedData.java
+++ b/security/src/main/java/bisq/security/EncryptedData.java
@@ -18,7 +18,7 @@
 package bisq.security;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -32,7 +32,7 @@ import lombok.Getter;
  */
 @Getter
 @EqualsAndHashCode
-public final class EncryptedData implements Proto {
+public final class EncryptedData implements NetworkProto {
     private final byte[] iv;
     private final byte[] cipherText;
 

--- a/security/src/main/java/bisq/security/EncryptedData.java
+++ b/security/src/main/java/bisq/security/EncryptedData.java
@@ -18,7 +18,7 @@
 package bisq.security;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -32,7 +32,7 @@ import lombok.Getter;
  */
 @Getter
 @EqualsAndHashCode
-public final class EncryptedData implements NetworkProto {
+public final class EncryptedData implements PersistableProto {
     private final byte[] iv;
     private final byte[] cipherText;
 

--- a/security/src/main/java/bisq/security/ScryptParameters.java
+++ b/security/src/main/java/bisq/security/ScryptParameters.java
@@ -17,7 +17,7 @@
 
 package bisq.security;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class ScryptParameters implements Proto {
+public class ScryptParameters implements NetworkProto {
     public static final int KEY_LENGTH = 32; // 256 bits.
 
     private final byte[] salt;

--- a/security/src/main/java/bisq/security/ScryptParameters.java
+++ b/security/src/main/java/bisq/security/ScryptParameters.java
@@ -17,7 +17,7 @@
 
 package bisq.security;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class ScryptParameters implements NetworkProto {
+public class ScryptParameters implements PersistableProto {
     public static final int KEY_LENGTH = 32; // 256 bits.
 
     private final byte[] salt;

--- a/security/src/main/java/bisq/security/ScryptParameters.java
+++ b/security/src/main/java/bisq/security/ScryptParameters.java
@@ -66,6 +66,7 @@ public class ScryptParameters implements PersistableProto {
         }
     }
 
+    @Override
     public bisq.security.protobuf.ScryptParameters toProto() {
         return bisq.security.protobuf.ScryptParameters.newBuilder()
                 .setSalt(ByteString.copyFrom(salt))

--- a/security/src/main/java/bisq/security/keys/I2pKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/I2pKeyPair.java
@@ -1,12 +1,12 @@
 package bisq.security.keys;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-public class I2pKeyPair implements NetworkProto {
+public class I2pKeyPair implements PersistableProto {
     @ToString.Exclude
     private final byte[] privateKey;
     private final byte[] publicKey;

--- a/security/src/main/java/bisq/security/keys/I2pKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/I2pKeyPair.java
@@ -1,12 +1,12 @@
 package bisq.security.keys;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-public class I2pKeyPair implements Proto {
+public class I2pKeyPair implements NetworkProto {
     @ToString.Exclude
     private final byte[] privateKey;
     private final byte[] publicKey;

--- a/security/src/main/java/bisq/security/keys/KeyBundle.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundle.java
@@ -1,6 +1,6 @@
 package bisq.security.keys;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -10,7 +10,7 @@ import java.security.KeyPair;
 @ToString
 @Getter
 @EqualsAndHashCode
-public class KeyBundle implements NetworkProto {
+public class KeyBundle implements PersistableProto {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private final KeyPair keyPair;

--- a/security/src/main/java/bisq/security/keys/KeyBundle.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundle.java
@@ -1,6 +1,6 @@
 package bisq.security.keys;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -10,7 +10,7 @@ import java.security.KeyPair;
 @ToString
 @Getter
 @EqualsAndHashCode
-public class KeyBundle implements Proto {
+public class KeyBundle implements NetworkProto {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private final KeyPair keyPair;

--- a/security/src/main/java/bisq/security/keys/PubKey.java
+++ b/security/src/main/java/bisq/security/keys/PubKey.java
@@ -50,6 +50,12 @@ public final class PubKey implements NetworkProto {
         this.publicKey = publicKey;
         this.keyId = keyId;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateECPubKey(publicKey);
         NetworkDataValidation.validateId(keyId);
     }
 

--- a/security/src/main/java/bisq/security/keys/PubKey.java
+++ b/security/src/main/java/bisq/security/keys/PubKey.java
@@ -53,6 +53,7 @@ public final class PubKey implements NetworkProto {
         NetworkDataValidation.validateId(keyId);
     }
 
+    @Override
     public bisq.security.protobuf.PubKey toProto() {
         return bisq.security.protobuf.PubKey.newBuilder()
                 .setPublicKey(ByteString.copyFrom(publicKey.getEncoded()))

--- a/security/src/main/java/bisq/security/keys/PubKey.java
+++ b/security/src/main/java/bisq/security/keys/PubKey.java
@@ -18,7 +18,7 @@
 package bisq.security.keys;
 
 import bisq.common.encoding.Hex;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.security.DigestUtil;
 import com.google.protobuf.ByteString;
@@ -33,7 +33,7 @@ import java.security.PublicKey;
 @Slf4j
 @EqualsAndHashCode
 @ToString
-public final class PubKey implements Proto {
+public final class PubKey implements NetworkProto {
     // The PublicKey implementation (BCECPublicKey) has an equals and hashCode method implemented.
     // Therefor we can include it for @EqualsAndHashCode.
     @Getter

--- a/security/src/main/java/bisq/security/keys/TorKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyPair.java
@@ -1,6 +1,6 @@
 package bisq.security.keys;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
-public class TorKeyPair implements NetworkProto {
+public class TorKeyPair implements PersistableProto {
     @ToString.Exclude
     private final byte[] privateKey;
     @ToString.Exclude

--- a/security/src/main/java/bisq/security/keys/TorKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyPair.java
@@ -1,6 +1,6 @@
 package bisq.security.keys;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
-public class TorKeyPair implements Proto {
+public class TorKeyPair implements NetworkProto {
     @ToString.Exclude
     private final byte[] privateKey;
     @ToString.Exclude

--- a/security/src/main/java/bisq/security/pow/ProofOfWork.java
+++ b/security/src/main/java/bisq/security/pow/ProofOfWork.java
@@ -17,7 +17,7 @@
 
 package bisq.security.pow;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
@@ -32,7 +32,7 @@ import java.util.Optional;
 @Slf4j
 @Getter
 @EqualsAndHashCode
-public final class ProofOfWork implements Proto {
+public final class ProofOfWork implements NetworkProto {
     // payload is usually the pubKeyHash
     private final byte[] payload;       // message of 1000 chars has about 1300 bytes
     private final long counter;

--- a/security/src/main/java/bisq/security/pow/ProofOfWork.java
+++ b/security/src/main/java/bisq/security/pow/ProofOfWork.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Optional;
 
+// TODO use Optional instead of Nullable
 // Borrowed from: https://github.com/bisq-network/bisq
 @Slf4j
 @Getter
@@ -57,6 +58,16 @@ public final class ProofOfWork implements NetworkProto {
         this.solution = solution;
         this.duration = duration;
 
+        verify();
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void verify() {
         // We have to allow a large size here as InventoryData can be large
         NetworkDataValidation.validateByteArray(payload, 10_000_000);
         if (challenge != null) {
@@ -64,11 +75,6 @@ public final class ProofOfWork implements NetworkProto {
         }
         NetworkDataValidation.validateByteArray(solution, 75);
     }
-
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // PROTO BUFFER
-    ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
     public bisq.security.protobuf.ProofOfWork toProto() {

--- a/settings/src/main/java/bisq/settings/Cookie.java
+++ b/settings/src/main/java/bisq/settings/Cookie.java
@@ -17,7 +17,7 @@
 
 package bisq.settings;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.settings.protobuf.CookieMapEntry;
 
 import java.util.HashMap;
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Should not be over-used for domain specific data where type safety and data integrity is important.
  * Does not support observable properties.
  */
-public final class Cookie implements NetworkProto {
+public final class Cookie implements PersistableProto {
     private final Map<CookieKey, String> map = new HashMap<>();
 
     public Cookie() {

--- a/settings/src/main/java/bisq/settings/Cookie.java
+++ b/settings/src/main/java/bisq/settings/Cookie.java
@@ -17,7 +17,7 @@
 
 package bisq.settings;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.settings.protobuf.CookieMapEntry;
 
 import java.util.HashMap;
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Should not be over-used for domain specific data where type safety and data integrity is important.
  * Does not support observable properties.
  */
-public final class Cookie implements Proto {
+public final class Cookie implements NetworkProto {
     private final Map<CookieKey, String> map = new HashMap<>();
 
     public Cookie() {

--- a/support/src/main/java/bisq/support/mediation/MediationCase.java
+++ b/support/src/main/java/bisq/support/mediation/MediationCase.java
@@ -1,7 +1,7 @@
 package bisq.support.mediation;
 
 import bisq.common.observable.Observable;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -9,7 +9,7 @@ import java.util.Date;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class MediationCase implements Proto {
+public class MediationCase implements NetworkProto {
     @EqualsAndHashCode.Include
     private final MediationRequest mediationRequest;
     private final long requestDate;

--- a/support/src/main/java/bisq/support/mediation/MediationCase.java
+++ b/support/src/main/java/bisq/support/mediation/MediationCase.java
@@ -2,6 +2,7 @@ package bisq.support.mediation;
 
 import bisq.common.observable.Observable;
 import bisq.common.proto.NetworkProto;
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -23,6 +24,13 @@ public class MediationCase implements NetworkProto {
         this.mediationRequest = mediationRequest;
         this.requestDate = requestDate;
         this.isClosed.set(isClosed);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateDate(requestDate);
     }
 
     @Override

--- a/support/src/main/java/bisq/support/mediation/MediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/MediationRequest.java
@@ -20,6 +20,7 @@ package bisq.support.mediation;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeMessage;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.contract.bisq_easy.BisqEasyContract;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
@@ -39,6 +40,7 @@ import java.util.stream.Collectors;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 @Getter
@@ -68,7 +70,13 @@ public final class MediationRequest implements MailboxMessage {
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.chatMessages);
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); // 3729 -> can be much more if lot of messages!
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateTradeId(tradeId);
+        checkArgument(chatMessages.size() < 1000);
     }
 
     @Override

--- a/support/src/main/java/bisq/support/mediation/MediatorsResponse.java
+++ b/support/src/main/java/bisq/support/mediation/MediatorsResponse.java
@@ -19,6 +19,7 @@ package bisq.support.mediation;
 
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
@@ -44,7 +45,12 @@ public final class MediatorsResponse implements MailboxMessage {
     public MediatorsResponse(String tradeId) {
         this.tradeId = tradeId;
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //425
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateTradeId(tradeId);
     }
 
     @Override

--- a/support/src/main/java/bisq/support/moderator/ReportToModeratorMessage.java
+++ b/support/src/main/java/bisq/support/moderator/ReportToModeratorMessage.java
@@ -41,7 +41,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 @ToString
 @EqualsAndHashCode
 public final class ReportToModeratorMessage implements MailboxMessage {
-    public final static int MAX_MESSAGE_LENGTH = 1000;
+    public final static int MAX_MESSAGE_LENGTH = 10_000;
 
     private final MetaData metaData = new MetaData(TTL_10_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
     private final long date;
@@ -61,11 +61,14 @@ public final class ReportToModeratorMessage implements MailboxMessage {
         this.message = message;
         this.chatChannelDomain = chatChannelDomain;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateDate(date);
         NetworkDataValidation.validateProfileId(reporterUserProfileId);
         NetworkDataValidation.validateText(message, MAX_MESSAGE_LENGTH);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//1438
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -19,7 +19,7 @@ package bisq.trade;
 
 import bisq.common.fsm.FsmModel;
 import bisq.common.fsm.State;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.contract.Contract;
 import bisq.identity.Identity;
@@ -40,7 +40,7 @@ import java.util.UUID;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P extends TradeParty> extends FsmModel implements NetworkProto {
+public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P extends TradeParty> extends FsmModel implements PersistableProto {
     public static String createId(String offerId, String takerPubKeyHash) {
         String combined = offerId + takerPubKeyHash;
         return UUID.nameUUIDFromBytes(DigestUtil.hash(combined.getBytes(StandardCharsets.UTF_8))).toString();

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -19,7 +19,7 @@ package bisq.trade;
 
 import bisq.common.fsm.FsmModel;
 import bisq.common.fsm.State;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.contract.Contract;
 import bisq.identity.Identity;
@@ -40,7 +40,7 @@ import java.util.UUID;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P extends TradeParty> extends FsmModel implements Proto {
+public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P extends TradeParty> extends FsmModel implements NetworkProto {
     public static String createId(String offerId, String takerPubKeyHash) {
         String combined = offerId + takerPubKeyHash;
         return UUID.nameUUIDFromBytes(DigestUtil.hash(combined.getBytes(StandardCharsets.UTF_8))).toString();

--- a/trade/src/main/java/bisq/trade/TradeParty.java
+++ b/trade/src/main/java/bisq/trade/TradeParty.java
@@ -18,7 +18,7 @@
 package bisq.trade;
 
 import bisq.common.observable.Observable;
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.contract.ContractSignatureData;
 import bisq.network.identity.NetworkId;
@@ -36,7 +36,7 @@ import java.util.Optional;
 @ToString
 @EqualsAndHashCode
 @Getter
-public abstract class TradeParty implements Proto {
+public abstract class TradeParty implements NetworkProto {
     private final NetworkId networkId;
     private final Observable<ContractSignatureData> contractSignatureData = new Observable<>();
 

--- a/trade/src/main/java/bisq/trade/TradeParty.java
+++ b/trade/src/main/java/bisq/trade/TradeParty.java
@@ -18,7 +18,7 @@
 package bisq.trade;
 
 import bisq.common.observable.Observable;
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.contract.ContractSignatureData;
 import bisq.network.identity.NetworkId;
@@ -36,7 +36,7 @@ import java.util.Optional;
 @ToString
 @EqualsAndHashCode
 @Getter
-public abstract class TradeParty implements NetworkProto {
+public abstract class TradeParty implements PersistableProto {
     private final NetworkId networkId;
     private final Observable<ContractSignatureData> contractSignatureData = new Observable<>();
 

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyAccountDataMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyAccountDataMessage.java
@@ -42,8 +42,13 @@ public final class BisqEasyAccountDataMessage extends BisqEasyTradeMessage {
 
         this.paymentAccountData = paymentAccountData;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
         NetworkDataValidation.validateText(paymentAccountData, MAX_LENGTH);
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //631
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyBtcAddressMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyBtcAddressMessage.java
@@ -40,10 +40,17 @@ public final class BisqEasyBtcAddressMessage extends BisqEasyTradeMessage {
 
         this.btcAddress = btcAddress;
 
-        // We tolerate non-btc address data as well (e.g. LN invoice)
-        NetworkDataValidation.validateText(btcAddress, 200);
+        verify();
+    }
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//338
+    @Override
+    public void verify() {
+        super.verify();
+
+        // We tolerate non-btc address data as well (e.g. LN invoice)
+        // The minimum possible length of an LN invoice is around 190 characters
+        // Max. length depends on optional fields
+        NetworkDataValidation.validateText(btcAddress, 1000);
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyCancelTradeMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyCancelTradeMessage.java
@@ -34,6 +34,13 @@ public final class BisqEasyCancelTradeMessage extends BisqEasyTradeMessage {
                                       NetworkId sender,
                                       NetworkId receiver) {
         super(id, tradeId, sender, receiver);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyConfirmBtcSentMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyConfirmBtcSentMessage.java
@@ -40,10 +40,15 @@ public final class BisqEasyConfirmBtcSentMessage extends BisqEasyTradeMessage {
 
         this.txId = txId;
 
-        // We tolerate non-btc txId data as well 
-        NetworkDataValidation.validateText(txId, 200);
+        verify();
+    }
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //412
+    @Override
+    public void verify() {
+        super.verify();
+
+        // We tolerate non-btc txId data as well
+        NetworkDataValidation.validateText(txId, 1000);
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyConfirmFiatReceiptMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyConfirmFiatReceiptMessage.java
@@ -34,7 +34,12 @@ public final class BisqEasyConfirmFiatReceiptMessage extends BisqEasyTradeMessag
                                              NetworkId receiver) {
         super(id, tradeId, sender, receiver);
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//332
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyConfirmFiatSentMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyConfirmFiatSentMessage.java
@@ -34,7 +34,12 @@ public final class BisqEasyConfirmFiatSentMessage extends BisqEasyTradeMessage {
                                           NetworkId receiver) {
         super(id, tradeId, sender, receiver);
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//332
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyRejectTradeMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyRejectTradeMessage.java
@@ -34,6 +34,13 @@ public final class BisqEasyRejectTradeMessage extends BisqEasyTradeMessage {
                                       NetworkId sender,
                                       NetworkId receiver) {
         super(id, tradeId, sender, receiver);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequest.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequest.java
@@ -44,7 +44,12 @@ public final class BisqEasyTakeOfferRequest extends BisqEasyTradeMessage {
         this.bisqEasyContract = bisqEasyContract;
         this.contractSignatureData = contractSignatureData;
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //1158
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferResponse.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferResponse.java
@@ -40,7 +40,12 @@ public final class BisqEasyTakeOfferResponse extends BisqEasyTradeMessage {
 
         this.contractSignatureData = contractSignatureData;
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //534
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/protocol/messages/TradeMessage.java
+++ b/trade/src/main/java/bisq/trade/protocol/messages/TradeMessage.java
@@ -21,10 +21,10 @@ import bisq.common.fsm.Event;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
+import bisq.network.identity.NetworkId;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
-import bisq.network.identity.NetworkId;
 import bisq.network.protobuf.ExternalNetworkMessage;
 import bisq.trade.bisq_easy.protocol.messages.BisqEasyTradeMessage;
 import bisq.trade.submarine.messages.SubmarineTradeMessage;
@@ -50,8 +50,12 @@ public abstract class TradeMessage implements MailboxMessage, AckRequestingMessa
         this.tradeId = tradeId;
         this.sender = sender;
         this.receiver = receiver;
+    }
 
-        NetworkDataValidation.validateText(tradeId, 200); // For private channels we combine user profile IDs for channelId
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateId(id);
+        NetworkDataValidation.validateTradeId(tradeId);
     }
 
     public bisq.trade.protobuf.TradeMessage.Builder getTradeMessageBuilder() {

--- a/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
+++ b/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
@@ -50,7 +50,11 @@ public final class BannedUserProfileData implements AuthorizedDistributedData {
         this.userProfile = userProfile;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //313
+        verify();
+    }
+
+    @Override
+    public void verify() {
     }
 
     @Override

--- a/user/src/main/java/bisq/user/identity/UserIdentity.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentity.java
@@ -17,7 +17,7 @@
 
 package bisq.user.identity;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import bisq.identity.Identity;
 import bisq.network.identity.NetworkIdWithKeyPair;
 import bisq.user.profile.UserProfile;
@@ -33,7 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode
 @ToString
 @Getter
-public final class UserIdentity implements Proto {
+public final class UserIdentity implements NetworkProto {
     private final Identity identity;
     private final UserProfile userProfile;
 

--- a/user/src/main/java/bisq/user/identity/UserIdentity.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentity.java
@@ -17,7 +17,7 @@
 
 package bisq.user.identity;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import bisq.identity.Identity;
 import bisq.network.identity.NetworkIdWithKeyPair;
 import bisq.user.profile.UserProfile;
@@ -33,7 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode
 @ToString
 @Getter
-public final class UserIdentity implements NetworkProto {
+public final class UserIdentity implements PersistableProto {
     private final Identity identity;
     private final UserProfile userProfile;
 

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -82,11 +82,14 @@ public final class UserProfile implements DistributedData {
         this.terms = terms;
         this.statement = statement;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateText(nickName, MAX_LENGTH_NICK_NAME);
         NetworkDataValidation.validateText(terms, MAX_LENGTH_TERMS);
         NetworkDataValidation.validateText(statement, MAX_LENGTH_STATEMENT);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); // 310
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedAccountAgeData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedAccountAgeData.java
@@ -52,10 +52,13 @@ public final class AuthorizedAccountAgeData implements AuthorizedDistributedData
         this.date = date;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validateDate(date);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//51
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
@@ -57,12 +57,15 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
         this.lockTime = lockTime;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(amount > 0);
         NetworkDataValidation.validateDate(time);
         NetworkDataValidation.validateHash(hash);
-        checkArgument(amount > 0);
         checkArgument(lockTime >= 50_000);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//38
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -55,11 +55,14 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
         this.hash = hash;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateDate(time);
         NetworkDataValidation.validateHash(hash);
         checkArgument(amount > 0);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//34
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedSignedWitnessData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedSignedWitnessData.java
@@ -51,10 +51,13 @@ public final class AuthorizedSignedWitnessData implements AuthorizedDistributedD
         this.witnessSignDate = witnessSignDate;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validateDate(witnessSignDate);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedTimestampData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedTimestampData.java
@@ -50,10 +50,13 @@ public final class AuthorizedTimestampData implements AuthorizedDistributedData 
         this.date = date;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validateDate(date);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//51
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/requests/AuthorizeAccountAgeRequest.java
+++ b/user/src/main/java/bisq/user/reputation/requests/AuthorizeAccountAgeRequest.java
@@ -57,13 +57,16 @@ public final class AuthorizeAccountAgeRequest implements MailboxMessage {
         this.pubKeyBase64 = pubKeyBase64;
         this.signatureBase64 = signatureBase64;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validateHashAsHex(hashAsHex);
         NetworkDataValidation.validateDate(date);
         NetworkDataValidation.validatePubKeyBase64(pubKeyBase64);
         NetworkDataValidation.validateSignatureBase64(signatureBase64);
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());//814
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/requests/AuthorizeSignedWitnessRequest.java
+++ b/user/src/main/java/bisq/user/reputation/requests/AuthorizeSignedWitnessRequest.java
@@ -65,7 +65,6 @@ public final class AuthorizeSignedWitnessRequest implements MailboxMessage {
         NetworkDataValidation.validateDate(accountAgeWitnessDate);
         NetworkDataValidation.validateDate(witnessSignDate);
         NetworkDataValidation.validatePubKeyBase64(pubKeyBase64);
-        ;
         NetworkDataValidation.validateSignatureBase64(signatureBase64);
 
 

--- a/user/src/main/java/bisq/user/reputation/requests/AuthorizeSignedWitnessRequest.java
+++ b/user/src/main/java/bisq/user/reputation/requests/AuthorizeSignedWitnessRequest.java
@@ -60,15 +60,17 @@ public final class AuthorizeSignedWitnessRequest implements MailboxMessage {
         this.pubKeyBase64 = pubKeyBase64;
         this.signatureBase64 = signatureBase64;
 
+        verify();
+    }
+
+    @Override
+    public void verify() {
         NetworkDataValidation.validateProfileId(profileId);
         NetworkDataValidation.validateHashAsHex(hashAsHex);
         NetworkDataValidation.validateDate(accountAgeWitnessDate);
         NetworkDataValidation.validateDate(witnessSignDate);
         NetworkDataValidation.validatePubKeyBase64(pubKeyBase64);
         NetworkDataValidation.validateSignatureBase64(signatureBase64);
-
-
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize());
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/requests/AuthorizeTimestampRequest.java
+++ b/user/src/main/java/bisq/user/reputation/requests/AuthorizeTimestampRequest.java
@@ -44,9 +44,12 @@ public final class AuthorizeTimestampRequest implements MailboxMessage {
     public AuthorizeTimestampRequest(String profileId) {
         this.profileId = profileId;
 
-        NetworkDataValidation.validateProfileId(profileId);
+        verify();
+    }
 
-        // log.error("{} {}", metaData.getClassName(), toProto().getSerializedSize()); //100
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateProfileId(profileId);
     }
 
     @Override

--- a/wallets/json-rpc/src/main/java/bisq/wallets/json_rpc/RpcConfig.java
+++ b/wallets/json-rpc/src/main/java/bisq/wallets/json_rpc/RpcConfig.java
@@ -17,13 +17,13 @@
 
 package bisq.wallets.json_rpc;
 
-import bisq.common.proto.Proto;
+import bisq.common.proto.NetworkProto;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
-public final class RpcConfig implements Proto {
+public final class RpcConfig implements NetworkProto {
     private String hostname;
     private int port;
     private String user;

--- a/wallets/json-rpc/src/main/java/bisq/wallets/json_rpc/RpcConfig.java
+++ b/wallets/json-rpc/src/main/java/bisq/wallets/json_rpc/RpcConfig.java
@@ -17,13 +17,13 @@
 
 package bisq.wallets.json_rpc;
 
-import bisq.common.proto.NetworkProto;
+import bisq.common.proto.PersistableProto;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
-public final class RpcConfig implements NetworkProto {
+public final class RpcConfig implements PersistableProto {
     private String hostname;
     private int port;
     private String user;


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq2/pull/1600

The network message based validation is primarily a protection against dos attacks to set bounds on the size of messages. In some cases we have also specific validation (e.g. amounts to be > 0) but the core validation for domain specific data is up to the domain operating on that data.

We call verify() in all constructors from final classes. Abstract classes do not call validate as it would call the validate method in the extending class which might use fields which are not initialized when the super class's constructor is called.
We could also call the validate from the `fromProto` method, but by using the constructor we verify also the case when the message is not created from network input (e.g. sender user case) so it helps to spot potential bugs in the validation which otherwise would only be thrown at the receiver.

I have not found yet a easy way how to enforce that only NetworkProto instances are used inside network messages. At the moment it is in the responsibility of the developer to check all fields used in a network message. One way to do it would be with reflection, to iterate all nested objects and check for Proto instances and that those are of type NetworkProto. This should be done only once (e.g. use a static flag once validated). But I hope we find a better solution.

We do not validate primitive data as those are bounded anyway. The typical data types we validate are Strings and Collections (lists, maps, arrays, byte arrays).
For common data like public keys or IDs we use the NetworkDataValidation util class.

Encrypted data cannot be validated meaningfully beside a max. data size limit.