### PR TITLE
New revision of grey colours

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/MaterialTextField.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/MaterialTextField.java
@@ -80,7 +80,7 @@ public class MaterialTextField extends Pane {
         bg.getStyleClass().add("material-text-field-bg");
 
         line.setPrefHeight(1);
-        line.setStyle("-fx-background-color: -bisq-medium-grey-mid");
+        line.setStyle("-fx-background-color: -bisq-mid-grey-30");
         line.setMouseTransparent(true);
 
         selectionLine.setPrefWidth(0);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/AmountComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/AmountComponent.java
@@ -533,7 +533,7 @@ public class AmountComponent {
             line.setLayoutY(121);
             line.setPrefHeight(1);
             line.setPrefWidth(AMOUNT_BOX_WIDTH);
-            line.setStyle("-fx-background-color: -bisq-medium-grey-mid");
+            line.setStyle("-fx-background-color: -bisq-mid-grey-30");
             line.setMouseTransparent(true);
 
             selectionLine = new Region();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/TakeOfferView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/TakeOfferView.java
@@ -82,7 +82,7 @@ public class TakeOfferView extends NavigationView<VBox, TakeOfferModel, TakeOffe
 
         HBox hBox = new HBox();
         hBox.setAlignment(Pos.CENTER);
-        hBox.setStyle("-fx-background-color: -bisq-dark-grey-dim");
+        hBox.setStyle("-fx-background-color: -bisq-dark-grey-20");
         hBox.setMinHeight(TOP_PANE_HEIGHT);
         hBox.setMaxHeight(TOP_PANE_HEIGHT);
         hBox.setPadding(new Insets(0, 20, 0, 50));
@@ -189,7 +189,7 @@ public class TakeOfferView extends NavigationView<VBox, TakeOfferModel, TakeOffe
            /* if (showProgressBox) {
                 // VBox.setMargin(content, new Insets(0, 0, 0, 0));
                 Transitions.fadeIn(progressBox, 200);
-                topPane.setStyle("-fx-background-color: -bisq-dark-grey-dim");
+                topPane.setStyle("-fx-background-color: -bisq-dark-grey-20");
             } else {
                 // VBox.setMargin(content, new Insets(0, 40, 0, 40));
                 Transitions.fadeOut(progressBox, 200);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
@@ -237,7 +237,7 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
                         int size = 20;
                         roboIcon.setFitWidth(size);
                         roboIcon.setFitHeight(size);
-                        StackPane roboIconWithRing = ImageUtil.addRingToNode(roboIcon, size, 1.5, "-bisq-dark-grey-lit");
+                        StackPane roboIconWithRing = ImageUtil.addRingToNode(roboIcon, size, 1.5, "-bisq-dark-grey-50");
                         hBox = new HBox(10, roboIconWithRing, userName);
                         hBox.setAlignment(Pos.CENTER_LEFT);
                     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1356,7 +1356,7 @@ public class ChatMessagesListView {
                                         messageDeliveryStatusTooltip.set(Res.get("chat.message.deliveryState." + status.name()));
                                         switch (status) {
                                             case CONNECTING:
-                                                // -bisq-medium-grey-mid: #808080;
+                                                // -bisq-mid-grey-30: #808080;
                                                 messageDeliveryStatusIconColor = Optional.of("#808080");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.SPINNER);
                                                 break;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1218,7 +1218,7 @@ public class ChatMessagesListView {
                                     quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
                                     Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
                                     userName.getStyleClass().add("font-medium");
-                                    userName.setStyle("-fx-text-fill: -bisq-medium-grey-lit");
+                                    userName.setStyle("-fx-text-fill: -bisq-mid-grey-40");
                                     quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
                                 }
                             } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1361,7 +1361,7 @@ public class ChatMessagesListView {
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.SPINNER);
                                                 break;
                                             case SENT:
-                                                // -bisq-white-dim: #eaeaea;
+                                                // -bisq-light-grey-50: #eaeaea;
                                                 messageDeliveryStatusIconColor = Optional.of("#eaeaea");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CIRCLE_ARROW_RIGHT);
                                                 break;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
@@ -140,7 +140,7 @@ public class CitationBlock {
             root.setPadding(new Insets(0, 15, 0, 20));
 
             Label headline = new Label(Res.get("chat.message.citation.headline"));
-            headline.setStyle("-fx-text-fill: -bisq-medium-grey-lit");
+            headline.setStyle("-fx-text-fill: -bisq-mid-grey-40");
             headline.getStyleClass().addAll("font-light", "font-size-11");
 
             closeButton = BisqIconButton.createDeleteIconButton();
@@ -154,7 +154,7 @@ public class CitationBlock {
             userName = new Label();
             userName.setPadding(new Insets(3, 0, 0, -3));
             userName.getStyleClass().add("font-medium");
-            userName.setStyle("-fx-text-fill: -bisq-medium-grey-lit");
+            userName.setStyle("-fx-text-fill: -bisq-mid-grey-40");
 
             roboIconImageView = new ImageView();
             roboIconImageView.setFitWidth(25);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
@@ -136,7 +136,7 @@ public class CitationBlock {
             super(new VBox(), model, controller);
             root.setSpacing(10);
             root.setAlignment(Pos.CENTER_LEFT);
-            root.setStyle("-fx-background-color: -bisq-black-lit;");
+            root.setStyle("-fx-background-color: -bisq-dark-grey-10;");
             root.setPadding(new Insets(0, 15, 0, 20));
 
             Label headline = new Label(Res.get("chat.message.citation.headline"));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MaterialUserProfileSelection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MaterialUserProfileSelection.java
@@ -60,7 +60,7 @@ public class MaterialUserProfileSelection extends Pane {
         bg.getStyleClass().add("material-text-field-bg");
 
         line.setPrefHeight(1);
-        line.setStyle("-fx-background-color: -bisq-medium-grey-mid");
+        line.setStyle("-fx-background-color: -bisq-mid-grey-30");
         line.setMouseTransparent(true);
 
         selectionLine.setPrefWidth(0);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ReputationScoreDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ReputationScoreDisplay.java
@@ -50,7 +50,7 @@ public class ReputationScoreDisplay extends HBox {
         super(SPACING);
         setAlignment(Pos.CENTER_LEFT);
 
-        tooltip.setStyle("-fx-text-fill: black; -fx-background-color: -bisq-light-grey-dim;");
+        tooltip.setStyle("-fx-text-fill: black; -fx-background-color: -bisq-light-grey-10;");
         tooltip.setMaxWidth(300);
         tooltip.setWrapText(true);
         Tooltip.install(this, tooltip);

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -188,7 +188,7 @@
  ******************************************************************************/
 
 .video-bg {
-    -fx-background-color: -bisq-black-dim;
+    -fx-background-color: -bisq-black-10;
 }
 
 .video-control-bg {

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -122,7 +122,7 @@
  ******************************************************************************/
 
 .notification-pane {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
 }
 
 .notification-pane-dark {

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -17,7 +17,7 @@
 .splash-bootstrap-details {
     -fx-font-size: 1em;
     -fx-font-family: "IBM Plex Sans Light";
-    -fx-text-fill: -bisq-medium-grey-mid;
+    -fx-text-fill: -bisq-mid-grey-30;
 }
 
 .splash-bootstrap-progress {

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -97,12 +97,12 @@
 
 .updater-release-notes .content {
     -fx-padding: 1.0em;
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 .updater-release-notes:focused .content {
     -fx-padding: 1.0em;
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 .updater-text {
@@ -113,7 +113,7 @@
 }
 
 .updater-table-view {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 
@@ -126,7 +126,7 @@
 }
 
 .notification-pane-dark {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 .notification-box {

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -151,7 +151,7 @@
 
 .notification-hyperlink:hover,
 .notification-hyperlink:visited:hover {
-    -fx-text-fill: -bisq-white-mid;
+    -fx-text-fill: -bisq-white-10;
 }
 .notification-hyperlink:visited,
 .notification-hyperlink:armed:visited,

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -136,8 +136,8 @@
 }
 
 .notification-headline {
-    -fx-fill: -bisq-dark-grey-lit;
-    -fx-text-fill: -bisq-dark-grey-lit;
+    -fx-fill: -bisq-dark-grey-50;
+    -fx-text-fill: -bisq-dark-grey-50;
     -fx-font-size: 1.15em;
     -fx-font-family: "IBM Plex Sans";
 }
@@ -156,7 +156,7 @@
 .notification-hyperlink:visited,
 .notification-hyperlink:armed:visited,
 .notification-hyperlink:hover:armed {
-    -fx-text-fill: -bisq-dark-grey-lit;
+    -fx-text-fill: -bisq-dark-grey-50;
 }
 
 /*******************************************************************************

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -144,7 +144,7 @@
 
 .notification-hyperlink,
 .notification-hyperlink:visited {
-    -fx-text-fill: -bisq-black-mid;
+    -fx-text-fill: -bisq-black-20;
     -fx-font-size: 1.15em;
     -fx-font-family: "IBM Plex Sans";
 }

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -54,7 +54,7 @@
     -bisq2-green-dim-50: #2b5624;
 
     /* Bisq Grey Palette */
-    -bisq-black-dim: #050505;
+    -bisq-black-10: #050505;
     -bisq-black-mid: #0d0d0d;
     -bisq-black-lit: #151515;
     -bisq-dark-grey-dim: #1e1e1e;
@@ -95,7 +95,7 @@
     -bisq-green-hover: -bisq2-green-dim-10;
     -bisq-green-pressed: -bisq2-green-dim-30;
 
-    -fx-dark-text-color: -bisq-black-dim;
+    -fx-dark-text-color: -bisq-black-10;
     -fx-mid-text-color: -bisq-medium-grey-mid;
     -fx-light-text-color: -bisq-white-lit;
 

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -57,7 +57,7 @@
     -bisq-black-10: #050505;
     -bisq-black-20: #0d0d0d;
     -bisq-dark-grey-10: #151515;
-    -bisq-dark-grey-dim: #1e1e1e;
+    -bisq-dark-grey-20: #1e1e1e;
     -bisq-dark-grey-mid: #2b2b2b;
     -bisq-dark-grey-lit: #383838;
     -bisq-medium-grey-dim: #4d4d4d;
@@ -71,8 +71,8 @@
     -bisq-white-lit: #fafafa;
 
     /* Background colors */
-    -bisq-darker-grey: -bisq-dark-grey-dim;
-    -bisq-dark-grey: -bisq-dark-grey-dim;
+    -bisq-darker-grey: -bisq-dark-grey-20;
+    -bisq-dark-grey: -bisq-dark-grey-20;
     -bisq-content-bg-grey: -bisq-dark-grey-mid;
     -bisq-popup-bg-grey: -bisq-dark-grey-mid;
 

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -60,7 +60,7 @@
     -bisq-dark-grey-20: #1c1c1c;
     -bisq-dark-grey-30: #242424;
     -bisq-dark-grey-40: #2b2b2b;
-    -bisq-dark-grey-lit: #383838;
+    -bisq-dark-grey-50: #383838;
     -bisq-medium-grey-dim: #4d4d4d;
     -bisq-medium-grey-mid: #808080;
     -bisq-medium-grey-lit: #b2b2b2;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -67,7 +67,7 @@
     -bisq-light-grey-10: #c7c7c7;
     -bisq-light-grey-20: #d4d4d4;
     -bisq-light-grey-30: #dbdbdb;
-    -bisq-light-grey-lit: #e1e1e1;
+    -bisq-light-grey-40: #e1e1e1;
     -bisq-white-dim: #eaeaea;
     -bisq-white-mid: #f2f2f2;
     -bisq-white-lit: #fafafa;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -70,7 +70,7 @@
     -bisq-light-grey-40: #e3e3e3;
     -bisq-light-grey-50: #eaeaea;
     -bisq-white-10: #f2f2f2;
-    -bisq-white-lit: #fafafa;
+    -bisq-white-20: #fafafa;
 
     /* Background colors */
     -bisq-darker-grey: -bisq-dark-grey-20;
@@ -99,7 +99,7 @@
 
     -fx-dark-text-color: -bisq-black-10;
     -fx-mid-text-color: -bisq-mid-grey-30;
-    -fx-light-text-color: -bisq-white-lit;
+    -fx-light-text-color: -bisq-white-20;
 
     -bisq-error: -bisq-red;
 

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -56,7 +56,7 @@
     /* Bisq Grey Palette */
     -bisq-black-10: #050505;
     -bisq-black-20: #0d0d0d;
-    -bisq-black-lit: #151515;
+    -bisq-dark-grey-10: #151515;
     -bisq-dark-grey-dim: #1e1e1e;
     -bisq-dark-grey-mid: #2b2b2b;
     -bisq-dark-grey-lit: #383838;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -63,7 +63,7 @@
     -bisq-dark-grey-50: #383838;
     -bisq-mid-grey-20: #4d4d4d;
     -bisq-mid-grey-30: #808080;
-    -bisq-medium-grey-lit: #b2b2b2;
+    -bisq-mid-grey-40: #b2b2b2;
     -bisq-light-grey-dim: #c7c7c7;
     -bisq-light-grey-mid: #d4d4d4;
     -bisq-light-grey-lit: #e1e1e1;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -55,7 +55,7 @@
 
     /* Bisq Grey Palette */
     -bisq-black-10: #050505;
-    -bisq-black-mid: #0d0d0d;
+    -bisq-black-20: #0d0d0d;
     -bisq-black-lit: #151515;
     -bisq-dark-grey-dim: #1e1e1e;
     -bisq-dark-grey-mid: #2b2b2b;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -67,7 +67,7 @@
     -bisq-light-grey-10: #c7c7c7;
     -bisq-light-grey-20: #d4d4d4;
     -bisq-light-grey-30: #dbdbdb;
-    -bisq-light-grey-40: #e1e1e1;
+    -bisq-light-grey-40: #e3e3e3;
     -bisq-white-dim: #eaeaea;
     -bisq-white-mid: #f2f2f2;
     -bisq-white-lit: #fafafa;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -65,7 +65,7 @@
     -bisq-mid-grey-30: #808080;
     -bisq-mid-grey-40: #b2b2b2;
     -bisq-light-grey-10: #c7c7c7;
-    -bisq-light-grey-mid: #d4d4d4;
+    -bisq-light-grey-20: #d4d4d4;
     -bisq-light-grey-lit: #e1e1e1;
     -bisq-white-dim: #eaeaea;
     -bisq-white-mid: #f2f2f2;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -61,7 +61,7 @@
     -bisq-dark-grey-30: #242424;
     -bisq-dark-grey-40: #2b2b2b;
     -bisq-dark-grey-50: #383838;
-    -bisq-medium-grey-dim: #4d4d4d;
+    -bisq-mid-grey-20: #4d4d4d;
     -bisq-medium-grey-mid: #808080;
     -bisq-medium-grey-lit: #b2b2b2;
     -bisq-light-grey-dim: #c7c7c7;
@@ -78,7 +78,7 @@
     -bisq-popup-bg-grey: -bisq-dark-grey-40;
 
     /* Border colors */
-    -bisq-border-color-grey: -bisq-medium-grey-dim;
+    -bisq-border-color-grey: -bisq-mid-grey-20;
     -bisq-border-color-grey-hover: -bisq-light-grey-dim;
 
 

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -68,7 +68,7 @@
     -bisq-light-grey-20: #d4d4d4;
     -bisq-light-grey-30: #dbdbdb;
     -bisq-light-grey-40: #e3e3e3;
-    -bisq-white-dim: #eaeaea;
+    -bisq-light-grey-50: #eaeaea;
     -bisq-white-mid: #f2f2f2;
     -bisq-white-lit: #fafafa;
 

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -57,7 +57,7 @@
     -bisq-black-10: #050505;
     -bisq-black-20: #0d0d0d;
     -bisq-dark-grey-10: #151515;
-    -bisq-dark-grey-20: #1e1e1e;
+    -bisq-dark-grey-20: #1c1c1c;
     -bisq-dark-grey-mid: #2b2b2b;
     -bisq-dark-grey-lit: #383838;
     -bisq-medium-grey-dim: #4d4d4d;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -62,7 +62,7 @@
     -bisq-dark-grey-40: #2b2b2b;
     -bisq-dark-grey-50: #383838;
     -bisq-mid-grey-20: #4d4d4d;
-    -bisq-medium-grey-mid: #808080;
+    -bisq-mid-grey-30: #808080;
     -bisq-medium-grey-lit: #b2b2b2;
     -bisq-light-grey-dim: #c7c7c7;
     -bisq-light-grey-mid: #d4d4d4;
@@ -97,7 +97,7 @@
     -bisq-green-pressed: -bisq2-green-dim-30;
 
     -fx-dark-text-color: -bisq-black-10;
-    -fx-mid-text-color: -bisq-medium-grey-mid;
+    -fx-mid-text-color: -bisq-mid-grey-30;
     -fx-light-text-color: -bisq-white-lit;
 
     -bisq-error: -bisq-red;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -58,7 +58,8 @@
     -bisq-black-20: #0d0d0d;
     -bisq-dark-grey-10: #151515;
     -bisq-dark-grey-20: #1c1c1c;
-    -bisq-dark-grey-mid: #2b2b2b;
+    -bisq-dark-grey-30: #242424;
+    -bisq-dark-grey-40: #2b2b2b;
     -bisq-dark-grey-lit: #383838;
     -bisq-medium-grey-dim: #4d4d4d;
     -bisq-medium-grey-mid: #808080;
@@ -73,8 +74,8 @@
     /* Background colors */
     -bisq-darker-grey: -bisq-dark-grey-20;
     -bisq-dark-grey: -bisq-dark-grey-20;
-    -bisq-content-bg-grey: -bisq-dark-grey-mid;
-    -bisq-popup-bg-grey: -bisq-dark-grey-mid;
+    -bisq-content-bg-grey: -bisq-dark-grey-40;
+    -bisq-popup-bg-grey: -bisq-dark-grey-40;
 
     /* Border colors */
     -bisq-border-color-grey: -bisq-medium-grey-dim;
@@ -85,7 +86,7 @@
     -fx-accent: -bisq2-green;
     -fx-background: -bisq-content-bg-grey;
 
-    -fx-color: -bisq-dark-grey-mid;
+    -fx-color: -bisq-dark-grey-40;
     -fx-body-color: -fx-color;
 
     -fx-box-border: transparent;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -69,7 +69,7 @@
     -bisq-light-grey-30: #dbdbdb;
     -bisq-light-grey-40: #e3e3e3;
     -bisq-light-grey-50: #eaeaea;
-    -bisq-white-mid: #f2f2f2;
+    -bisq-white-10: #f2f2f2;
     -bisq-white-lit: #fafafa;
 
     /* Background colors */

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -66,6 +66,7 @@
     -bisq-mid-grey-40: #b2b2b2;
     -bisq-light-grey-10: #c7c7c7;
     -bisq-light-grey-20: #d4d4d4;
+    -bisq-light-grey-30: #dbdbdb;
     -bisq-light-grey-lit: #e1e1e1;
     -bisq-white-dim: #eaeaea;
     -bisq-white-mid: #f2f2f2;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -64,7 +64,7 @@
     -bisq-mid-grey-20: #4d4d4d;
     -bisq-mid-grey-30: #808080;
     -bisq-mid-grey-40: #b2b2b2;
-    -bisq-light-grey-dim: #c7c7c7;
+    -bisq-light-grey-10: #c7c7c7;
     -bisq-light-grey-mid: #d4d4d4;
     -bisq-light-grey-lit: #e1e1e1;
     -bisq-white-dim: #eaeaea;
@@ -79,7 +79,7 @@
 
     /* Border colors */
     -bisq-border-color-grey: -bisq-mid-grey-20;
-    -bisq-border-color-grey-hover: -bisq-light-grey-dim;
+    -bisq-border-color-grey-hover: -bisq-light-grey-10;
 
 
     -fx-base: -bisq-content-bg-grey;

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -3,12 +3,12 @@
  ******************************************************************************/
 
 .bisq-easy-container {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8;
 }
 
 .bisq-easy-container-header {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8 8 0 0;
 }
 
@@ -64,7 +64,7 @@
  ******************************************************************************/
 
 .bisq-easy-onboarding-big-box {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8;
 }
 
@@ -154,7 +154,7 @@
  ******************************************************************************/
 
 .bisq-easy-open-trades-welcome-bg {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8;
 }
 
@@ -603,7 +603,7 @@
  ******************************************************************************/
 
 .bisq-easy-chat-sidebar-bg {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8 8 0 0;
 }
 
@@ -692,7 +692,7 @@
  ******************************************************************************/
 
 .bisq-easy-private-chats-table-view {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 /*******************************************************************************

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -509,7 +509,7 @@
 }
 
 .bisq-easy-trade-wizard-market.table-view .table-row-cell .table-cell {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
 }
 
 .bisq-easy-trade-wizard-market.table-view .table-row-cell:hover .table-cell {
@@ -538,7 +538,7 @@
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell .table-cell {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:hover .table-cell {
@@ -550,15 +550,15 @@
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty {
-    -fx-border-color: derive(-bisq-dark-grey-mid, -30%);
+    -fx-border-color: derive(-bisq-dark-grey-40, -30%);
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty .table-cell {
-    -fx-background-color: derive(-bisq-dark-grey-mid, -15%);
+    -fx-background-color: derive(-bisq-dark-grey-40, -15%);
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty:hover .table-cell {
-    -fx-background-color: derive(-bisq-dark-grey-mid, -15%);
+    -fx-background-color: derive(-bisq-dark-grey-40, -15%);
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:selected .button.white-button .text {

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -189,7 +189,7 @@
 }
 
 .bisq-easy-open-trades.table-view .table-row-cell:filled:selected .table-cell {
-    -fx-background-color: -bisq-black-lit;
+    -fx-background-color: -bisq-dark-grey-10;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -27,8 +27,8 @@
 }
 
 .bisq-easy-trade-isInMediation-headline {
-    -fx-fill: -bisq-dark-grey-lit;
-    -fx-text-fill: -bisq-dark-grey-lit;
+    -fx-fill: -bisq-dark-grey-50;
+    -fx-text-fill: -bisq-dark-grey-50;
     -fx-font-size: 1.15em;
     -fx-font-family: "IBM Plex Sans";
 }
@@ -278,7 +278,7 @@
 }
 
 .bisq-easy-trade-state-phase-badge-inactive .badge-pane {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .bisq-easy-trade-state-phase-badge-active .badge-pane {
@@ -483,7 +483,7 @@
 
 
 .trade-wizard-review-payment-combo-box {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-background-insets: 6 0 6 0;
     -fx-fill: -fx-light-text-color;
     -fx-text-fill: -fx-light-text-color;

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -562,7 +562,7 @@
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:selected .button.white-button .text {
-    -fx-fill: -bisq-black-dim !important;
+    -fx-fill: -bisq-black-10 !important;
     -fx-font-family: "IBM Plex Sans Medium" !important;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -256,8 +256,8 @@
 }
 
 .bisq-easy-trade-state-phase-inactive {
-    -fx-fill: -bisq-medium-grey-mid;
-    -fx-text-fill: -bisq-medium-grey-mid;
+    -fx-fill: -bisq-mid-grey-30;
+    -fx-text-fill: -bisq-mid-grey-30;
     -fx-font-family: "IBM Plex Sans Light";
 }
 
@@ -662,7 +662,7 @@
 #bisq-easy-next-button {
     -fx-background-color: transparent;
     -fx-background-radius: 4;
-    -fx-border-color: -bisq-medium-grey-mid;
+    -fx-border-color: -bisq-mid-grey-30;
     -fx-border-width: 0.75;
     -fx-border-radius: 2.5;
     -fx-text-fill: -fx-light-text-color;

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -50,7 +50,7 @@
 
 .close-sidebar-button {
     -fx-background-color: -bisq-medium-grey-mid;
-    -fx-text-fill: -bisq-dark-grey-mid;
+    -fx-text-fill: -bisq-dark-grey-40;
 }
 
 #chat-filter-box {
@@ -60,7 +60,7 @@
 }
 
 #chat-user-profile-bg {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-background-insets: 1 20 1 9;
     -fx-background-radius: 8;
 }
@@ -73,10 +73,10 @@
 }
 
 .chat-send-message-box {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 8;
     -fx-background-insets: 0;
-    -fx-border-color: -bisq-dark-grey-mid;
+    -fx-border-color: -bisq-dark-grey-40;
     -fx-border-radius: 8;
     -fx-border-width: 1;
     -fx-border-insets: 0;
@@ -166,7 +166,7 @@
 }
 
 .create-offer-box-my-offer {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
 }
 
 .trade-wizard-feedback-bg {

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -151,7 +151,7 @@
 }
 
 .chat-message-bg-my-message {
-    -fx-background-color: -bisq-black-lit;
+    -fx-background-color: -bisq-dark-grey-10;
     -fx-background-radius: 8;
 }
 
@@ -161,7 +161,7 @@
 }
 
 .create-offer-message-my-offer {
-    -fx-background-color: -bisq-black-lit;
+    -fx-background-color: -bisq-dark-grey-10;
     -fx-background-radius: 8;
 }
 
@@ -170,7 +170,7 @@
 }
 
 .trade-wizard-feedback-bg {
-    -fx-background-color: -bisq-black-lit;
+    -fx-background-color: -bisq-dark-grey-10;
     -fx-background-radius: 0 0 16 16;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -49,7 +49,7 @@
 }
 
 .close-sidebar-button {
-    -fx-background-color: -bisq-medium-grey-mid;
+    -fx-background-color: -bisq-mid-grey-30;
     -fx-text-fill: -bisq-dark-grey-40;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -54,7 +54,7 @@
 }
 
 #chat-filter-box {
-    -fx-border-color: -bisq-medium-grey-dim;
+    -fx-border-color: -bisq-mid-grey-20;
     -fx-border-width: 0 0 1 0;
     -fx-border-insets: 0 0 -1 0;
 }
@@ -363,7 +363,7 @@
 }
 
 .chat-messages-badge.bisq-badge .badge-pane {
-    -fx-background-color: -bisq-medium-grey-dim;
+    -fx-background-color: -bisq-mid-grey-20;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -15,7 +15,7 @@
 
 .channel-large-thin-headline {
     -fx-font-size: 1.692em;
-    -fx-text-fill: -bisq-dark-grey-lit;
+    -fx-text-fill: -bisq-dark-grey-50;
 }
 
 .market-fiat-label {
@@ -156,7 +156,7 @@
 }
 
 .chat-message-bg-peer-message {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-background-radius: 8;
 }
 
@@ -187,13 +187,13 @@
 }
 
 #button-inactive {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-text-fill: -fx-light-text-color;
     -fx-background-insets: 0;
 }
 
 #bisq-combo-box-list-view {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-border-color: -bisq-dark-grey;;
     -fx-border-width: 1;
     -fx-border-insets: 0;
@@ -228,7 +228,7 @@
 }
 
 #chat-message-reactions-separator {
-    -fx-text-fill: -bisq-dark-grey-lit;
+    -fx-text-fill: -bisq-dark-grey-50;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -237,7 +237,7 @@
 }
 
 .chat-mention-popup-menu-item {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-text-fill: -fx-light-text-color;
     -fx-alignment: center-left;
     -fx-padding: 8 14 8 14;
@@ -254,7 +254,7 @@
 }
 
 #onboarding-top-panel {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 /*******************************************************************************
@@ -300,7 +300,7 @@
 }
 
 .chat-container {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8 8 0 0;
 }
 
@@ -334,7 +334,7 @@
 }
 
 .channel-selection-list-view .list-cell:selected {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-fill: -fx-dark-text-color;
     -fx-text-fill: -fx-dark-text-color;
 }

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 .bisq-popup {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 /*******************************************************************************
@@ -515,7 +515,7 @@
 }
 
 .bisq-box-2 {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8;
 }
 
@@ -549,7 +549,7 @@
 }
 
 #chat-message-quote-box-peer-msg {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 0 8 8 0;
     -fx-border-radius: 0;
     -fx-border-width: 0 0 0 3;

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -553,7 +553,7 @@
     -fx-background-radius: 0 8 8 0;
     -fx-border-radius: 0;
     -fx-border-width: 0 0 0 3;
-    -fx-border-color: -bisq-medium-grey-mid;
+    -fx-border-color: -bisq-mid-grey-30;
     -fx-padding: 10 10 10 15;
 }
 
@@ -562,7 +562,7 @@
     -fx-background-radius: 0 8 8 0;
     -fx-border-radius: 0;
     -fx-border-width: 0 0 0 3;
-    -fx-border-color: -bisq-medium-grey-mid;
+    -fx-border-color: -bisq-mid-grey-30;
     -fx-padding: 10 10 10 15;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -529,7 +529,7 @@
 }
 
 .bisq-grey-2-bg {
-    -fx-background-color: -bisq-black-lit;
+    -fx-background-color: -bisq-dark-grey-10;
 }
 
 .bisq-mid-grey {

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -15,7 +15,7 @@
  ******************************************************************************/
 
 .bisq-popup-menu {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 6px;
     -fx-padding: 0.667em 0.75em 0.667em 0.75em; /* 10px */
     -fx-effect: dropshadow(three-pass-box, rgba(0, 0, 0, 0.5), 10, 0.0, 5, 5);
@@ -85,12 +85,12 @@
  ******************************************************************************/
 
 .separator:horizontal .line {
-    -fx-border-color: -bisq-dark-grey-mid;
+    -fx-border-color: -bisq-dark-grey-40;
     -fx-border-width: 0.5;
 }
 
 .separator:vertical .line {
-    -fx-border-color: -bisq-dark-grey-mid;
+    -fx-border-color: -bisq-dark-grey-40;
     -fx-border-width: 0.5;
 }
 
@@ -105,7 +105,7 @@
 }
 
 .popup-bg {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
 }
 
 
@@ -246,7 +246,7 @@
 }
 
 .table-view .table-row-cell:selected .table-cell {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
 }
 
 /* Custom style used in selection column for vertical green bar */
@@ -520,7 +520,7 @@
 }
 
 .bisq-dual-amount-bg {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 8 8 0 0;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -120,12 +120,12 @@
 }
 
 .scroll-bar > .thumb {
-    -fx-background-color: -bisq-medium-grey-dim;
+    -fx-background-color: -bisq-mid-grey-20;
 }
 
 .scroll-bar > .increment-button,
 .scroll-bar > .decrement-button {
-    -fx-background-color: -bisq-medium-grey-dim;
+    -fx-background-color: -bisq-mid-grey-20;
 }
 
 
@@ -269,8 +269,8 @@
 
 /* disabled */
 .table-view .table-row-cell:disabled .table-cell .text {
-    -fx-text-fill: -bisq-medium-grey-dim;
-    -fx-fill: -bisq-medium-grey-dim;
+    -fx-text-fill: -bisq-mid-grey-20;
+    -fx-fill: -bisq-mid-grey-20;
 }
 
 
@@ -496,7 +496,7 @@
 }
 
 .tab-view-line {
-    -fx-background-color: -bisq-medium-grey-dim;
+    -fx-background-color: -bisq-mid-grey-20;
 }
 
 .tab-view-selection {
@@ -533,7 +533,7 @@
 }
 
 .bisq-mid-grey {
-    -fx-background-color: -bisq-medium-grey-dim;
+    -fx-background-color: -bisq-mid-grey-20;
 }
 
 .bisq-green-line {

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -370,13 +370,13 @@
 }
 
 .titled-pane > .title > .arrow-button > .arrow {
-    -fx-background-color: -bisq-white-lit;
+    -fx-background-color: -bisq-white-20;
     -fx-background-insets: 2.5;
     -fx-shape: "M 0 0 h 7 l -3.5 4 z";
 }
 
 .titled-pane:focused > .title > .arrow-button > .arrow {
-    -fx-background-color: -bisq-white-lit;
+    -fx-background-color: -bisq-white-20;
     -fx-effect: null;
 }
 
@@ -541,7 +541,7 @@
 }
 
 .bisq-white-bg {
-    -fx-background-color: -bisq-white-lit;
+    -fx-background-color: -bisq-white-20;
 }
 
 .bisq-content-bg {

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -68,12 +68,12 @@
  ******************************************************************************/
 
 .h-line {
-    -fx-border-color: -bisq-dark-grey-lit;
+    -fx-border-color: -bisq-dark-grey-50;
     -fx-border-width: 1 0 0 0;
 }
 
 .v-line {
-    -fx-border-color: -bisq-dark-grey-lit;
+    -fx-border-color: -bisq-dark-grey-50;
     -fx-border-width: 0 1 0 0;
 }
 
@@ -101,7 +101,7 @@
  ******************************************************************************/
 
 .bg-grey-5 {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .popup-bg {
@@ -242,7 +242,7 @@
 }
 
 .table-view .table-row-cell:hover .table-cell {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .table-view .table-row-cell:selected .table-cell {
@@ -456,12 +456,12 @@
 
 .scroll-bar:horizontal .thumb:hover,
 .scroll-bar:vertical .thumb:hover {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .scroll-bar:horizontal .thumb:pressed,
 .scroll-bar:vertical .thumb:pressed {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .scroll-bar:vertical:focused,
@@ -558,7 +558,7 @@
 }
 
 #chat-message-quote-box-my-msg {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-background-radius: 0 8 8 0;
     -fx-border-radius: 0;
     -fx-border-width: 0 0 0 3;

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -104,7 +104,7 @@
 }
 
 .dark-grey-button {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-border-color: transparent;
     -fx-fill: -bisq-white-lit;
     -fx-text-fill: -bisq-white-lit;
@@ -868,7 +868,7 @@
  ******************************************************************************/
 
 .search-box {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 6;
     -fx-border-color: transparent;
     -fx-border-width: 0;

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -82,13 +82,13 @@
 
 .white-button {
     -fx-background-color: -bisq-white-lit;
-    -fx-fill: -bisq-black-dim !important;
-    -fx-text-fill: -bisq-black-dim !important;
+    -fx-fill: -bisq-black-10 !important;
+    -fx-text-fill: -bisq-black-10 !important;
 }
 
 .white-button > .text {
-    -fx-fill: -bisq-black-dim !important;
-    -fx-text-fill: -bisq-black-dim !important;
+    -fx-fill: -bisq-black-10 !important;
+    -fx-text-fill: -bisq-black-10 !important;
 }
 
 .white-button:hover {

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -695,7 +695,7 @@
 
 .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:filled:hover,
 .combo-box-popup > .list-view > .virtual-flow > .clipped-container > .sheet > .list-cell:filled:selected:hover {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-background: transparent;
 }
 
@@ -738,9 +738,9 @@
 }
 
 .tooltip .medium-dark-tooltip {
-    -fx-background: -bisq-dark-grey-lit;
+    -fx-background: -bisq-dark-grey-50;
     -fx-text-fill: -fx-light-text-color;
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-font-size: 0.85em;
 }
 
@@ -756,7 +756,7 @@
 }
 
 .progress-bar > .track {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .progress-bar > .bar,
@@ -802,7 +802,7 @@
  ******************************************************************************/
 
 .slider .track {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-pref-height: 2px;
 }
 
@@ -826,7 +826,7 @@
 }
 
 .radio-button .radio {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-padding: 1px;
     -fx-border-radius: 15px;
     -fx-border-width: 2px;
@@ -842,18 +842,18 @@
 }
 
 .radio-button .radio .dot {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
     -fx-background-insets: 0;
     -fx-padding: 5px
 }
 
 .radio-button:armed .radio {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .radio-button:armed .radio .dot,
 .radio-button:hover .radio .dot {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .radio-button:selected .radio .dot {
@@ -877,7 +877,7 @@
 }
 
 .search-box-active {
-    -fx-background-color: -bisq-dark-grey-lit;
+    -fx-background-color: -bisq-dark-grey-50;
 }
 
 .search-text-field {

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -473,7 +473,7 @@
     -bisq-toggle-color: -fx-default-button;
     -bisq-un-toggle-color: -bisq-white-lit;
     -bisq-toggle-line-color: derive(-bisq-toggle-color, 65%);
-    -bisq-un-toggle-line-color: -bisq-medium-grey-mid;
+    -bisq-un-toggle-line-color: -bisq-mid-grey-30;
     -bisq-size: 8;
 }
 
@@ -637,12 +637,12 @@
 .check-box > .box {
     -fx-background-color: transparent;
     -fx-background-radius: 0;
-    -fx-border-color: -bisq-medium-grey-mid;
+    -fx-border-color: -bisq-mid-grey-30;
     -fx-border-width: 1;
 }
 
 .check-box:hover > .box {
-    -fx-border-color: derive(-bisq-medium-grey-mid, 20%);
+    -fx-border-color: derive(-bisq-mid-grey-30, 20%);
 }
 
 .check-box > .box > .mark {

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -111,13 +111,13 @@
 }
 
 .dark-grey-button:hover {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-text-fill: rgba(255, 255, 255, 0.9);
     -fx-effect: none;
 }
 
 .dark-grey-button:pressed {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-text-fill: rgba(255, 255, 255, 0.85);
     -fx-effect: none;
 }
@@ -521,7 +521,7 @@
  ******************************************************************************/
 
 .card-button {
-    -fx-background-color: derive(-bisq-dark-grey-dim, -20%);
+    -fx-background-color: derive(-bisq-dark-grey-20, -20%);
     -fx-text-fill: -fx-light-text-color;
     -fx-font-size: 1.55em;
     -fx-background-radius: 4;
@@ -529,11 +529,11 @@
 }
 
 .card-button:hover {
-    -fx-background-color: derive(-bisq-dark-grey-dim, -30%);
+    -fx-background-color: derive(-bisq-dark-grey-20, -30%);
 }
 
 .card-button:pressed {
-    -fx-background-color: derive(-bisq-dark-grey-dim, -40%);
+    -fx-background-color: derive(-bisq-dark-grey-20, -40%);
 }
 
 .card-button:default {
@@ -733,7 +733,7 @@
 
 .tooltip .dark-tooltip {
     -fx-text-fill: -bisq-light-grey-dim;
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-font-size: 0.85em;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -81,7 +81,7 @@
 
 
 .white-button {
-    -fx-background-color: -bisq-white-lit;
+    -fx-background-color: -bisq-white-20;
     -fx-fill: -bisq-black-10 !important;
     -fx-text-fill: -bisq-black-10 !important;
 }
@@ -106,8 +106,8 @@
 .dark-grey-button {
     -fx-background-color: -bisq-dark-grey-40;
     -fx-border-color: transparent;
-    -fx-fill: -bisq-white-lit;
-    -fx-text-fill: -bisq-white-lit;
+    -fx-fill: -bisq-white-20;
+    -fx-text-fill: -bisq-white-20;
 }
 
 .dark-grey-button:hover {
@@ -210,8 +210,8 @@
 
 .white-transparent-outlined-button {
     -fx-background-color: transparent;
-    -fx-border-color: -bisq-white-lit;
-    -fx-text-fill: -bisq-white-lit;
+    -fx-border-color: -bisq-white-20;
+    -fx-text-fill: -bisq-white-20;
 }
 
 .white-transparent-outlined-button:hover {
@@ -471,7 +471,7 @@
     -fx-background-insets: 0px;
     -fx-padding: 2px;
     -bisq-toggle-color: -fx-default-button;
-    -bisq-un-toggle-color: -bisq-white-lit;
+    -bisq-un-toggle-color: -bisq-white-20;
     -bisq-toggle-line-color: derive(-bisq-toggle-color, 65%);
     -bisq-un-toggle-line-color: -bisq-mid-grey-30;
     -bisq-size: 8;
@@ -554,17 +554,17 @@
 
 .card-button-border {
     -fx-background-color: transparent;
-    -fx-border-color: derive(-bisq-white-lit, -25%);
+    -fx-border-color: derive(-bisq-white-20, -25%);
 }
 
 .card-button-border:hover {
     -fx-background-color: rgba(0, 0, 0, 0.15);
-    -fx-border-color: derive(-bisq-white-lit, -15%);
+    -fx-border-color: derive(-bisq-white-20, -15%);
 }
 
 .card-button-border:pressed {
     -fx-background-color: rgba(0, 0, 0, 0.2);
-    -fx-border-color: derive(-bisq-white-lit, -10%);
+    -fx-border-color: derive(-bisq-white-20, -10%);
 }
 
 .card-button-border:default {
@@ -667,7 +667,7 @@
 
 .check-box:selected > .box > .mark,
 .check-box:indeterminate > .box > .mark {
-    -fx-background-color: -bisq-white-lit;
+    -fx-background-color: -bisq-white-20;
     -fx-background-insets: 1 0 -1 0, 0;
     -fx-border-color: transparent;
 }
@@ -857,7 +857,7 @@
 }
 
 .radio-button:selected .radio .dot {
-    -fx-background-color: -bisq-white-lit;
+    -fx-background-color: -bisq-white-20;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -721,9 +721,9 @@
     -fx-show-delay: 100ms;
     -fx-hide-delay: 100ms;
     -fx-show-duration: 20000ms;
-    -fx-background: -bisq-light-grey-dim;
+    -fx-background: -bisq-light-grey-10;
     -fx-text-fill: -fx-dark-text-color;
-    -fx-background-color: -bisq-light-grey-dim;
+    -fx-background-color: -bisq-light-grey-10;
     -fx-background-radius: 6px;
     -fx-background-insets: 0;
     -fx-padding: 0.667em 0.75em 0.667em 0.75em; /* 10px */
@@ -732,7 +732,7 @@
 }
 
 .tooltip .dark-tooltip {
-    -fx-text-fill: -bisq-light-grey-dim;
+    -fx-text-fill: -bisq-light-grey-10;
     -fx-background-color: -bisq-dark-grey-20;
     -fx-font-size: 0.85em;
 }

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -653,7 +653,7 @@
  ******************************************************************************/
 
 .bisq-input-box-top-pane {
-    -fx-background-color: -bisq-dark-grey-mid;
+    -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 4 4 0 0;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -458,7 +458,7 @@
 }
 
 .bisq-large-profile-id-label {
-    -fx-background-color: -bisq-medium-grey-dim;
+    -fx-background-color: -bisq-mid-grey-20;
     -fx-text-fill: -fx-light-text-color;
     -fx-font-size: 1em;
 }
@@ -574,7 +574,7 @@
     -fx-faint-focus-color: transparent;
     -fx-background-color: transparent;
     -fx-text-fill: -fx-light-text-color;
-    -fx-prompt-text-fill: -bisq-medium-grey-dim;
+    -fx-prompt-text-fill: -bisq-mid-grey-20;
     -fx-font-size: 1.25em;
     -fx-font-family: "IBM Plex Sans Light";
 }
@@ -667,7 +667,7 @@
     -fx-faint-focus-color: transparent;
     -fx-background-color: transparent;
     -fx-text-fill: -fx-light-text-color;
-    -fx-prompt-text-fill: -bisq-medium-grey-dim;
+    -fx-prompt-text-fill: -bisq-mid-grey-20;
     -fx-font-size: 1.25em;
     -fx-font-family: "IBM Plex Sans Light";
 }

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -137,8 +137,8 @@
 }
 
 .bisq-text-2 {
-    -fx-fill: -bisq-medium-grey-mid;
-    -fx-text-fill: -bisq-medium-grey-mid;
+    -fx-fill: -bisq-mid-grey-30;
+    -fx-text-fill: -bisq-mid-grey-30;
     -fx-font-size: 1.2em;
 }
 
@@ -472,7 +472,7 @@
 .bisq-small-light-label-dimmed {
     -fx-font-size: 0.9em;
     -fx-font-family: "IBM Plex Sans Light";
-    -fx-text-fill: -bisq-medium-grey-mid;
+    -fx-text-fill: -bisq-mid-grey-30;
 }
 
 .bisq-content-headline-label {
@@ -504,7 +504,7 @@
 }
 
 .bisq-grey-dimmed {
-    -fx-text-fill: -bisq-medium-grey-mid;
+    -fx-text-fill: -bisq-mid-grey-30;
 }
 
 .bisq-text-white {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -433,7 +433,7 @@
 #quote-amount-text-field {
     -fx-background-color: transparent;
     -fx-border-style: none;
-    -fx-text-fill: -bisq-medium-grey-lit;
+    -fx-text-fill: -bisq-mid-grey-40;
     -fx-font-size: 1.1em;
     -fx-font-family: "IBM Plex Sans Light";
 }
@@ -524,7 +524,7 @@
 }
 
 .bisq-text-grey-10 {
-    -fx-text-fill: -bisq-medium-grey-lit;
+    -fx-text-fill: -bisq-mid-grey-40;
 }
 
 .font-medium {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -280,7 +280,7 @@
 }
 
 .text-fill-light-dimmed {
-    -fx-text-fill: -bisq-light-grey-dim !Important;
+    -fx-text-fill: -bisq-light-grey-10 !Important;
 }
 
 .text-fill-grey-dimmed {

--- a/apps/desktop/desktop/src/main/resources/css/user.css
+++ b/apps/desktop/desktop/src/main/resources/css/user.css
@@ -28,7 +28,7 @@
  ******************************************************************************/
 
 .user-reputation-table-view {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 /*******************************************************************************
@@ -61,10 +61,10 @@
 }
 
 .user-bonded-roles-table-view {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
 }
 
 .user-bonded-roles-tab-view {
-    -fx-background-color: -bisq-dark-grey-dim;
+    -fx-background-color: -bisq-dark-grey-20;
     -fx-background-radius: 8;
 }


### PR DESCRIPTION
* Change grey naming convention to a more consistent, readable and flexible format. After working for a while with the Bisq greys introduced previously, although logically named, they were not easy to remember/pronounce nor quantify. This also aligns with the green naming convention we currently have.
* Update two shade of greys, for better cohesion in the application.
* Introduce two new more shades of grey, to be used for the new subheader bar in chats.

Summary of the changes:
![bisq-greys_2](https://github.com/bisq-network/bisq2/assets/145597137/7ac49031-1c2e-4edd-99df-b9e2c9a5e972)

