### PR TITLE
Fix Oracle Node Docs

### DIFF
--- a/docs/bonded_roles/nodes/oracle_node.md
+++ b/docs/bonded_roles/nodes/oracle_node.md
@@ -123,11 +123,11 @@ cd bisq-daonode
   -jar [PATH TO bisq-daonode]/build/libs/bisq-daonode-1.9.14-SNAPSHOT-all.jar \
   --appName=daonode \
   --daoNodeApiPort=[DAO-NODE PORT] \
-  --fullDaoNode=true
-  --rpcPort=[RPC PORT]  
-  --rpcUser=[RPC USER]
-  --rpcPassword=[RPC PW]
-  --rpcBlockNotificationPort=5120
+  --fullDaoNode=true \
+  --rpcPort=[RPC PORT] \  
+  --rpcUser=[RPC USER] \
+  --rpcPassword=[RPC PW] \
+  --rpcBlockNotificationPort=5120 \
   --maxMemory=5000
   ```
 


### PR DESCRIPTION
- [Add JDK 11 installation to oracle_node docs](https://github.com/bisq-network/bisq2/commit/d748293bc3359109070acae9c567fe9bbe336e7d)
- [oracle_node docs: Don't start Gradle Daemon for builds](https://github.com/bisq-network/bisq2/commit/4dac9525babb6dc144c31db7973ea45888c688a8)
- [oracle_node docs: Add missing backslashes in run_daonode.sh](https://github.com/bisq-network/bisq2/commit/4291bdf09f1a064b592b169b36bc430f7bc22987)