### PR TITLE
Stack reputation, take offer button vertically

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1012,8 +1012,10 @@ public class ChatMessagesListView {
                                 reputationLabel.getStyleClass().add("bisq-text-7");
 
                                 reputationScoreDisplay.setReputationScore(item.getReputationScore());
-                                VBox reputationVBox = new VBox(4, reputationLabel, reputationScoreDisplay);
-                                reputationVBox.setAlignment(Pos.CENTER_LEFT);
+                                VBox.setMargin(reputationScoreDisplay, new Insets(0, 0, 10, 0));
+                                reputationScoreDisplay.setAlignment(Pos.CENTER);
+                                VBox reputationTakeOfferVBox = new VBox(4, reputationLabel, reputationScoreDisplay, takeOfferButton);
+                                reputationTakeOfferVBox.setAlignment(Pos.CENTER);
 
                                 BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
                                 takeOfferButton.setOnAction(e -> controller.onTakeOffer(bisqEasyOfferbookMessage, item.isCanTakeOffer()));
@@ -1022,9 +1024,8 @@ public class ChatMessagesListView {
                                 VBox messageVBox = new VBox(quotedMessageVBox, message);
                                 HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
                                 HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
-                                HBox.setMargin(reputationVBox, new Insets(-5, 10, 0, 0));
-                                HBox.setMargin(takeOfferButton, new Insets(0, 10, 0, 0));
-                                messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox, Spacer.fillHBox(), reputationVBox, takeOfferButton);
+                                HBox.setMargin(reputationTakeOfferVBox, new Insets(-5, 10, 0, 0));
+                                messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox, Spacer.fillHBox(), reputationTakeOfferVBox);
 
                                 VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, 5, 10));
                                 mainVBox.getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);


### PR DESCRIPTION
The limited horizontal space makes it hard to show the take offer button label nicely when stacked horizontally.

Before
![image](https://github.com/bisq-network/bisq2/assets/123634778/4fd647ee-7e1a-434c-be8b-7afde1c2cd3a)

After
![image](https://github.com/bisq-network/bisq2/assets/123634778/a2fd1eb7-24a9-4a4a-a7b3-4407dcc76adb)
