### PR TITLE
Introduce auxiliary colours and clean-up existing ones 

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/MaterialTextField.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/MaterialTextField.java
@@ -80,7 +80,7 @@ public class MaterialTextField extends Pane {
         bg.getStyleClass().add("material-text-field-bg");
 
         line.setPrefHeight(1);
-        line.setStyle("-fx-background-color: -bisq-mid-grey-30");
+        line.setStyle("-fx-background-color: -bisq-mid-grey-20");
         line.setMouseTransparent(true);
 
         selectionLine.setPrefWidth(0);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/AmountComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/AmountComponent.java
@@ -533,7 +533,7 @@ public class AmountComponent {
             line.setLayoutY(121);
             line.setPrefHeight(1);
             line.setPrefWidth(AMOUNT_BOX_WIDTH);
-            line.setStyle("-fx-background-color: -bisq-mid-grey-30");
+            line.setStyle("-fx-background-color: -bisq-mid-grey-20");
             line.setMouseTransparent(true);
 
             selectionLine = new Region();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1366,8 +1366,8 @@ public class ChatMessagesListView {
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CIRCLE_ARROW_RIGHT);
                                                 break;
                                             case ACK_RECEIVED:
-                                                // -bisq2-green-dim-50: #2b5624;
-                                                messageDeliveryStatusIconColor = Optional.of("#2b5624");
+                                                // -bisq2-green-dim-50: #2b5724;
+                                                messageDeliveryStatusIconColor = Optional.of("#2b5724");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.OK_SIGN);
                                                 break;
                                             case TRY_ADD_TO_MAILBOX:
@@ -1381,8 +1381,8 @@ public class ChatMessagesListView {
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_UPLOAD);
                                                 break;
                                             case MAILBOX_MSG_RECEIVED:
-                                                // -bisq2-green-dim-50: #2b5624;
-                                                messageDeliveryStatusIconColor = Optional.of("#2b5624");
+                                                // -bisq2-green-dim-50: #2b5724;
+                                                messageDeliveryStatusIconColor = Optional.of("#2b5724");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_DOWNLOAD);
                                                 break;
                                             case FAILED:

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1371,12 +1371,12 @@ public class ChatMessagesListView {
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.OK_SIGN);
                                                 break;
                                             case TRY_ADD_TO_MAILBOX:
-                                                // -bisq-warning: #d0831f;
+                                                // -bisq2-yellow: #d0831f;
                                                 messageDeliveryStatusIconColor = Optional.of("#d0831f");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.SHARE_SIGN);
                                                 break;
                                             case ADDED_TO_MAILBOX:
-                                                // -bisq-warning: #d0831f;
+                                                // -bisq2-yellow: #d0831f;
                                                 messageDeliveryStatusIconColor = Optional.of("#d0831f");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_UPLOAD);
                                                 break;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1356,7 +1356,7 @@ public class ChatMessagesListView {
                                         messageDeliveryStatusTooltip.set(Res.get("chat.message.deliveryState." + status.name()));
                                         switch (status) {
                                             case CONNECTING:
-                                                // -bisq-mid-grey-30: #808080;
+                                                // -bisq-mid-grey-20: #808080;
                                                 messageDeliveryStatusIconColor = Optional.of("#808080");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.SPINNER);
                                                 break;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1371,13 +1371,13 @@ public class ChatMessagesListView {
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.OK_SIGN);
                                                 break;
                                             case TRY_ADD_TO_MAILBOX:
-                                                // -bisq-yellow: #e5a500;
-                                                messageDeliveryStatusIconColor = Optional.of("#e5a500");
+                                                // -bisq-warning: #d0831f;
+                                                messageDeliveryStatusIconColor = Optional.of("#d0831f");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.SHARE_SIGN);
                                                 break;
                                             case ADDED_TO_MAILBOX:
-                                                // -bisq-yellow: #e5a500;
-                                                messageDeliveryStatusIconColor = Optional.of("#e5a500");
+                                                // -bisq-warning: #d0831f;
+                                                messageDeliveryStatusIconColor = Optional.of("#d0831f");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_UPLOAD);
                                                 break;
                                             case MAILBOX_MSG_RECEIVED:

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1218,7 +1218,7 @@ public class ChatMessagesListView {
                                     quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
                                     Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
                                     userName.getStyleClass().add("font-medium");
-                                    userName.setStyle("-fx-text-fill: -bisq-mid-grey-40");
+                                    userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
                                     quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
                                 }
                             } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -1386,7 +1386,7 @@ public class ChatMessagesListView {
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_DOWNLOAD);
                                                 break;
                                             case FAILED:
-                                                // -bisq-red: #d02c1f;
+                                                // -bisq2-red: #d02c1f;
                                                 messageDeliveryStatusIconColor = Optional.of("#d02c1f");
                                                 messageDeliveryStatusIcon.set(AwesomeIcon.EXCLAMATION_SIGN);
                                                 break;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
@@ -140,7 +140,7 @@ public class CitationBlock {
             root.setPadding(new Insets(0, 15, 0, 20));
 
             Label headline = new Label(Res.get("chat.message.citation.headline"));
-            headline.setStyle("-fx-text-fill: -bisq-mid-grey-40");
+            headline.setStyle("-fx-text-fill: -bisq-mid-grey-30");
             headline.getStyleClass().addAll("font-light", "font-size-11");
 
             closeButton = BisqIconButton.createDeleteIconButton();
@@ -154,7 +154,7 @@ public class CitationBlock {
             userName = new Label();
             userName.setPadding(new Insets(3, 0, 0, -3));
             userName.getStyleClass().add("font-medium");
-            userName.setStyle("-fx-text-fill: -bisq-mid-grey-40");
+            userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
 
             roboIconImageView = new ImageView();
             roboIconImageView.setFitWidth(25);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MaterialUserProfileSelection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MaterialUserProfileSelection.java
@@ -60,7 +60,7 @@ public class MaterialUserProfileSelection extends Pane {
         bg.getStyleClass().add("material-text-field-bg");
 
         line.setPrefHeight(1);
-        line.setStyle("-fx-background-color: -bisq-mid-grey-30");
+        line.setStyle("-fx-background-color: -bisq-mid-grey-20");
         line.setMouseTransparent(true);
 
         selectionLine.setPrefWidth(0);

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -17,7 +17,7 @@
 .splash-bootstrap-details {
     -fx-font-size: 1em;
     -fx-font-family: "IBM Plex Sans Light";
-    -fx-text-fill: -bisq-mid-grey-30;
+    -fx-text-fill: -bisq-mid-grey-20;
 }
 
 .splash-bootstrap-progress {

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -130,7 +130,7 @@
 }
 
 .notification-box {
-    -fx-background-color: -bisq-warning;
+    -fx-background-color: -bisq2-yellow;
     -fx-background-radius: 8;
     -fx-border-color: transparent;
 }

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -130,7 +130,7 @@
 }
 
 .notification-box {
-    -fx-background-color: -bisq-yellow;
+    -fx-background-color: -bisq-warning;
     -fx-background-radius: 8;
     -fx-border-color: transparent;
 }

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -151,7 +151,7 @@
 
 .notification-hyperlink:hover,
 .notification-hyperlink:visited:hover {
-    -fx-text-fill: -bisq-white-10;
+    -fx-text-fill: -bisq-white-dim;
 }
 .notification-hyperlink:visited,
 .notification-hyperlink:armed:visited,

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -144,7 +144,7 @@
 
 .notification-hyperlink,
 .notification-hyperlink:visited {
-    -fx-text-fill: -bisq-black-20;
+    -fx-text-fill: -bisq-black-lit;
     -fx-font-size: 1.15em;
     -fx-font-family: "IBM Plex Sans";
 }

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -80,7 +80,8 @@
     -bisq-light-grey-30: #dbdbdb;
     -bisq-light-grey-40: #e3e3e3;
     -bisq-light-grey-50: #eaeaea;
-    -bisq-white-10: #f2f2f2;
+
+    -bisq-white-dim: #f2f2f2;
     -bisq-white-20: #fafafa;
 
     /* Background colors */

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -64,7 +64,7 @@
     -bisq2-red-dim-50: #68160f;
 
     /* Bisq Grey Palette */
-    -bisq-black-10: #050505;
+    -bisq-black: #050505;
     -bisq-black-20: #0d0d0d;
     -bisq-dark-grey-10: #151515;
     -bisq-dark-grey-20: #1c1c1c;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -38,7 +38,6 @@
     -fx-font-size: 13;
 
     /* Colors */
-    -bisq-sell: #660000;
     -bisq-red: #d02c1f;
     -bisq-warning: #d0831f;
     -bisq-yellow: #e5a500;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -38,7 +38,6 @@
     -fx-font-size: 13;
 
     /* Colors */
-    -bisq-buy: #006600;
     -bisq-sell: #660000;
     -bisq-red: #d02c1f;
     -bisq-warning: #d0831f;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -38,7 +38,6 @@
     -fx-font-size: 13;
 
     /* Colors */
-    -bisq2-red: #d02c1f;
     -you-tube-red: #fc0d1b;
 
     /* Bisq 2 Colors */
@@ -56,6 +55,13 @@
     -bisq2-yellow-dim-30: #915b15;
     -bisq2-yellow-dim-40: #7c4e12;
     -bisq2-yellow-dim-50: #68410f;
+
+    -bisq2-red: #d02c1f;
+    -bisq2-red-dim-10: #a62318;
+    -bisq2-red-dim-20: #a62318;
+    -bisq2-red-dim-30: #911e15;
+    -bisq2-red-dim-40: #7c1a12;
+    -bisq2-red-dim-50: #68160f;
 
     /* Bisq Grey Palette */
     -bisq-black-10: #050505;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -51,6 +51,7 @@
     -bisq2-green-dim-10: #4d9c40;
     -bisq2-green-dim-20: #448b39;
     -bisq2-green-dim-30: #3c7932;
+    -bisq2-green-dim-40: #33682b;
     -bisq2-green-dim-50: #2b5624;
 
     /* Bisq Grey Palette */

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -37,11 +37,11 @@
     -fx-font-family: "IBM Plex Sans";
     -fx-font-size: 13;
 
-    /* Colors */
+    /* External Colors */
+    -bisq-green-logo: #25b135;
     -you-tube-red: #fc0d1b;
 
-    /* Bisq 2 Colors */
-    -bisq-green-logo: #25b135;
+    /* Bisq2 App Colors */
     -bisq2-green: #56ae48; /* rgb(86, 174, 72) */
     -bisq2-green-dim-10: #4d9c40;
     -bisq2-green-dim-20: #448b39;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -73,7 +73,7 @@
     -bisq-dark-grey-40: #2b2b2b;
     -bisq-dark-grey-50: #383838;
     -bisq-mid-grey-10: #4d4d4d;
-    -bisq-mid-grey-30: #808080;
+    -bisq-mid-grey-20: #808080;
     -bisq-mid-grey-40: #b2b2b2;
     -bisq-light-grey-10: #c7c7c7;
     -bisq-light-grey-20: #d4d4d4;
@@ -109,7 +109,7 @@
     -bisq-green-pressed: -bisq2-green-dim-30;
 
     -fx-dark-text-color: -bisq-black-10;
-    -fx-mid-text-color: -bisq-mid-grey-30;
+    -fx-mid-text-color: -bisq-mid-grey-20;
     -fx-light-text-color: -bisq-white-20;
 
     -bisq-error: -bisq2-red;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -52,7 +52,7 @@
     -bisq2-green-dim-20: #448b39;
     -bisq2-green-dim-30: #3c7932;
     -bisq2-green-dim-40: #33682b;
-    -bisq2-green-dim-50: #2b5624;
+    -bisq2-green-dim-50: #2b5724;
 
     /* Bisq Grey Palette */
     -bisq-black-10: #050505;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -74,7 +74,7 @@
     -bisq-dark-grey-50: #383838;
     -bisq-mid-grey-10: #4d4d4d;
     -bisq-mid-grey-20: #808080;
-    -bisq-mid-grey-40: #b2b2b2;
+    -bisq-mid-grey-30: #b2b2b2;
     -bisq-light-grey-10: #c7c7c7;
     -bisq-light-grey-20: #d4d4d4;
     -bisq-light-grey-30: #dbdbdb;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -39,7 +39,7 @@
 
     /* Colors */
     -bisq-red: #d02c1f;
-    -bisq-warning: #d0831f;
+    -bisq2-yellow: #d0831f;
     -you-tube-red: #fc0d1b;
 
     /* Bisq 2 Colors */

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -82,7 +82,7 @@
     -bisq-light-grey-50: #eaeaea;
 
     -bisq-white-dim: #f2f2f2;
-    -bisq-white-20: #fafafa;
+    -bisq-white: #fafafa;
 
     /* Background colors */
     -bisq-darker-grey: -bisq-dark-grey-20;
@@ -111,7 +111,7 @@
 
     -fx-dark-text-color: -bisq-black-10;
     -fx-mid-text-color: -bisq-mid-grey-20;
-    -fx-light-text-color: -bisq-white-20;
+    -fx-light-text-color: -bisq-white;
 
     -bisq-error: -bisq2-red;
 

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -65,7 +65,8 @@
 
     /* Bisq Grey Palette */
     -bisq-black: #050505;
-    -bisq-black-20: #0d0d0d;
+    -bisq-black-lit: #0d0d0d;
+
     -bisq-dark-grey-10: #151515;
     -bisq-dark-grey-20: #1c1c1c;
     -bisq-dark-grey-30: #242424;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -38,7 +38,7 @@
     -fx-font-size: 13;
 
     /* Colors */
-    -bisq-red: #d02c1f;
+    -bisq2-red: #d02c1f;
     -you-tube-red: #fc0d1b;
 
     /* Bisq 2 Colors */
@@ -105,7 +105,7 @@
     -fx-mid-text-color: -bisq-mid-grey-30;
     -fx-light-text-color: -bisq-white-20;
 
-    -bisq-error: -bisq-red;
+    -bisq-error: -bisq2-red;
 
     -fx-text-background-color: ladder(
                 -fx-background,

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -40,7 +40,6 @@
     /* Colors */
     -bisq-red: #d02c1f;
     -bisq-warning: #d0831f;
-    -bisq-yellow: #e5a500;
     -you-tube-red: #fc0d1b;
 
     /* Bisq 2 Colors */

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -39,7 +39,6 @@
 
     /* Colors */
     -bisq-red: #d02c1f;
-    -bisq2-yellow: #d0831f;
     -you-tube-red: #fc0d1b;
 
     /* Bisq 2 Colors */
@@ -50,6 +49,13 @@
     -bisq2-green-dim-30: #3c7932;
     -bisq2-green-dim-40: #33682b;
     -bisq2-green-dim-50: #2b5724;
+
+    -bisq2-yellow: #d0831f;
+    -bisq2-yellow-dim-10: #bb751b;
+    -bisq2-yellow-dim-20: #a66818;
+    -bisq2-yellow-dim-30: #915b15;
+    -bisq2-yellow-dim-40: #7c4e12;
+    -bisq2-yellow-dim-50: #68410f;
 
     /* Bisq Grey Palette */
     -bisq-black-10: #050505;

--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -72,7 +72,7 @@
     -bisq-dark-grey-30: #242424;
     -bisq-dark-grey-40: #2b2b2b;
     -bisq-dark-grey-50: #383838;
-    -bisq-mid-grey-20: #4d4d4d;
+    -bisq-mid-grey-10: #4d4d4d;
     -bisq-mid-grey-30: #808080;
     -bisq-mid-grey-40: #b2b2b2;
     -bisq-light-grey-10: #c7c7c7;
@@ -90,7 +90,7 @@
     -bisq-popup-bg-grey: -bisq-dark-grey-40;
 
     /* Border colors */
-    -bisq-border-color-grey: -bisq-mid-grey-20;
+    -bisq-border-color-grey: -bisq-mid-grey-10;
     -bisq-border-color-grey-hover: -bisq-light-grey-10;
 
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -263,8 +263,8 @@
 }
 
 .bisq-easy-trade-state-phase-inactive {
-    -fx-fill: -bisq-mid-grey-30;
-    -fx-text-fill: -bisq-mid-grey-30;
+    -fx-fill: -bisq-mid-grey-20;
+    -fx-text-fill: -bisq-mid-grey-20;
     -fx-font-family: "IBM Plex Sans Light";
 }
 
@@ -669,7 +669,7 @@
 #bisq-easy-next-button {
     -fx-background-color: transparent;
     -fx-background-radius: 4;
-    -fx-border-color: -bisq-mid-grey-30;
+    -fx-border-color: -bisq-mid-grey-20;
     -fx-border-width: 0.75;
     -fx-border-radius: 2.5;
     -fx-text-fill: -fx-light-text-color;

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -20,8 +20,8 @@
 }
 
 .bisq-easy-trade-interrupted-headline {
-    -fx-fill: -bisq-yellow;
-    -fx-text-fill: -bisq-yellow;
+    -fx-fill: -bisq-warning;
+    -fx-text-fill: -bisq-warning;
     -fx-font-size: 1.15em;
     -fx-font-family: "IBM Plex Sans";
 }
@@ -41,7 +41,7 @@
 }
 
 .bisq-easy-trade-isInMediation-bg {
-    -fx-background-color: -bisq-yellow;
+    -fx-background-color: -bisq-warning;
     -fx-background-radius: 8;
     -fx-border-color: transparent;
 }
@@ -146,7 +146,7 @@
 
 
 .open-trades-badge.bisq-badge .badge-pane {
-    -fx-background-color: -bisq-yellow;
+    -fx-background-color: -bisq-warning;
 }
 
 .open-trades-badge.bisq-badge .badge-pane .label {

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -20,8 +20,8 @@
 }
 
 .bisq-easy-trade-interrupted-headline {
-    -fx-fill: -bisq-warning;
-    -fx-text-fill: -bisq-warning;
+    -fx-fill: -bisq2-yellow;
+    -fx-text-fill: -bisq2-yellow;
     -fx-font-size: 1.15em;
     -fx-font-family: "IBM Plex Sans";
 }
@@ -41,7 +41,7 @@
 }
 
 .bisq-easy-trade-isInMediation-bg {
-    -fx-background-color: -bisq-warning;
+    -fx-background-color: -bisq2-yellow;
     -fx-background-radius: 8;
     -fx-border-color: transparent;
 }
@@ -146,7 +146,7 @@
 
 
 .open-trades-badge.bisq-badge .badge-pane {
-    -fx-background-color: -bisq-warning;
+    -fx-background-color: -bisq2-yellow;
 }
 
 .open-trades-badge.bisq-badge .badge-pane .label {

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -174,12 +174,6 @@
     -fx-background-radius: 0 0 16 16;
 }
 
-#buy-button {
-    -fx-background-color: -bisq-buy;
-    -fx-text-fill: -fx-light-text-color;
-    -fx-background-insets: 0 0 0 0;
-}
-
 #sell-button {
     -fx-background-color: -bisq-sell;
     -fx-text-fill: -fx-light-text-color;

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -174,12 +174,6 @@
     -fx-background-radius: 0 0 16 16;
 }
 
-#sell-button {
-    -fx-background-color: -bisq-sell;
-    -fx-text-fill: -fx-light-text-color;
-    -fx-background-insets: 0 0 0 0;
-}
-
 #button-inactive {
     -fx-background-color: -bisq-dark-grey-50;
     -fx-text-fill: -fx-light-text-color;

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -54,7 +54,7 @@
 }
 
 #chat-filter-box {
-    -fx-border-color: -bisq-mid-grey-20;
+    -fx-border-color: -bisq-mid-grey-10;
     -fx-border-width: 0 0 1 0;
     -fx-border-insets: 0 0 -1 0;
 }
@@ -351,7 +351,7 @@
 }
 
 .chat-messages-badge.bisq-badge .badge-pane {
-    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-color: -bisq-mid-grey-10;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -49,7 +49,7 @@
 }
 
 .close-sidebar-button {
-    -fx-background-color: -bisq-mid-grey-30;
+    -fx-background-color: -bisq-mid-grey-20;
     -fx-text-fill: -bisq-dark-grey-40;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -634,7 +634,7 @@
 }
 
 .overlay-headline-warning {
-    -fx-text-fill: -bisq-warning;
+    -fx-text-fill: -bisq2-yellow;
 }
 
 .overlay-headline-error {
@@ -646,7 +646,7 @@
 }
 
 .overlay-icon-warning {
-    -fx-text-fill: -bisq-warning;
+    -fx-text-fill: -bisq2-yellow;
 }
 
 .overlay-icon-error {

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -553,7 +553,7 @@
     -fx-background-radius: 0 8 8 0;
     -fx-border-radius: 0;
     -fx-border-width: 0 0 0 3;
-    -fx-border-color: -bisq-mid-grey-30;
+    -fx-border-color: -bisq-mid-grey-20;
     -fx-padding: 10 10 10 15;
 }
 
@@ -562,7 +562,7 @@
     -fx-background-radius: 0 8 8 0;
     -fx-border-radius: 0;
     -fx-border-width: 0 0 0 3;
-    -fx-border-color: -bisq-mid-grey-30;
+    -fx-border-color: -bisq-mid-grey-20;
     -fx-padding: 10 10 10 15;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -370,13 +370,13 @@
 }
 
 .titled-pane > .title > .arrow-button > .arrow {
-    -fx-background-color: -bisq-white-20;
+    -fx-background-color: -bisq-white;
     -fx-background-insets: 2.5;
     -fx-shape: "M 0 0 h 7 l -3.5 4 z";
 }
 
 .titled-pane:focused > .title > .arrow-button > .arrow {
-    -fx-background-color: -bisq-white-20;
+    -fx-background-color: -bisq-white;
     -fx-effect: null;
 }
 
@@ -541,7 +541,7 @@
 }
 
 .bisq-white-bg {
-    -fx-background-color: -bisq-white-20;
+    -fx-background-color: -bisq-white;
 }
 
 .bisq-content-bg {

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -120,12 +120,12 @@
 }
 
 .scroll-bar > .thumb {
-    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-color: -bisq-mid-grey-10;
 }
 
 .scroll-bar > .increment-button,
 .scroll-bar > .decrement-button {
-    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-color: -bisq-mid-grey-10;
 }
 
 
@@ -269,8 +269,8 @@
 
 /* disabled */
 .table-view .table-row-cell:disabled .table-cell .text {
-    -fx-text-fill: -bisq-mid-grey-20;
-    -fx-fill: -bisq-mid-grey-20;
+    -fx-text-fill: -bisq-mid-grey-10;
+    -fx-fill: -bisq-mid-grey-10;
 }
 
 
@@ -496,7 +496,7 @@
 }
 
 .tab-view-line {
-    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-color: -bisq-mid-grey-10;
 }
 
 .tab-view-selection {
@@ -533,7 +533,7 @@
 }
 
 .bisq-mid-grey {
-    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-color: -bisq-mid-grey-10;
 }
 
 .bisq-green-line {

--- a/apps/desktop/desktop/src/main/resources/css/containers.css
+++ b/apps/desktop/desktop/src/main/resources/css/containers.css
@@ -638,7 +638,7 @@
 }
 
 .overlay-headline-error {
-    -fx-text-fill: -bisq-red;
+    -fx-text-fill: -bisq2-red;
 }
 
 .overlay-icon-information {
@@ -650,7 +650,7 @@
 }
 
 .overlay-icon-error {
-    -fx-text-fill: -bisq-red;
+    -fx-text-fill: -bisq2-red;
 }
 
 .overlay-message {

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -61,15 +61,15 @@
 }
 
 .red-button {
-    -fx-background-color: -bisq-red;
+    -fx-background-color: -bisq2-red;
 }
 
 .red-button:hover {
-    -fx-background-color: derive(-bisq-red, 10%);
+    -fx-background-color: derive(-bisq2-red, 10%);
 }
 
 .red-button:pressed {
-    -fx-background-color: derive(-bisq-red, -10%);
+    -fx-background-color: derive(-bisq2-red, -10%);
 }
 
 .button.icon-button {
@@ -235,39 +235,39 @@
 
 .red-outlined-button {
     -fx-background-color: transparent;
-    -fx-border-color: -bisq-red;
-    -fx-text-fill: -bisq-red;
+    -fx-border-color: -bisq2-red;
+    -fx-text-fill: -bisq2-red;
 }
 
 .red-outlined-button:hover {
-    -fx-border-color: derive(-bisq-red, 10%);
-    -fx-text-fill: derive(-bisq-red, 10%);
+    -fx-border-color: derive(-bisq2-red, 10%);
+    -fx-text-fill: derive(-bisq2-red, 10%);
 }
 
 .red-outlined-button:pressed {
-    -fx-border-color: derive(-bisq-red, -10%);
-    -fx-text-fill: derive(-bisq-red, -10%);
+    -fx-border-color: derive(-bisq2-red, -10%);
+    -fx-text-fill: derive(-bisq2-red, -10%);
 }
 
 
 .red-small-button {
     -fx-background-color: transparent;
-    -fx-border-color: -bisq-red;
+    -fx-border-color: -bisq2-red;
     -fx-border-width: 1;
     -fx-border-radius: 2;
-    -fx-text-fill: -bisq-red;
+    -fx-text-fill: -bisq2-red;
     -fx-font-size: 0.8em;
     -fx-padding: 2.5 16 2.5 16;
 }
 
 .red-small-button:hover {
-    -fx-border-color: derive(-bisq-red, 10%);
-    -fx-text-fill: derive(-bisq-red, 10%);
+    -fx-border-color: derive(-bisq2-red, 10%);
+    -fx-text-fill: derive(-bisq2-red, 10%);
 }
 
 .red-small-button:pressed {
-    -fx-border-color: derive(-bisq-red, -10%);
-    -fx-text-fill: derive(-bisq-red, -10%);
+    -fx-border-color: derive(-bisq2-red, -10%);
+    -fx-text-fill: derive(-bisq2-red, -10%);
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -81,7 +81,7 @@
 
 
 .white-button {
-    -fx-background-color: -bisq-white-20;
+    -fx-background-color: -bisq-white;
     -fx-fill: -bisq-black-10 !important;
     -fx-text-fill: -bisq-black-10 !important;
 }
@@ -106,8 +106,8 @@
 .dark-grey-button {
     -fx-background-color: -bisq-dark-grey-40;
     -fx-border-color: transparent;
-    -fx-fill: -bisq-white-20;
-    -fx-text-fill: -bisq-white-20;
+    -fx-fill: -bisq-white;
+    -fx-text-fill: -bisq-white;
 }
 
 .dark-grey-button:hover {
@@ -210,8 +210,8 @@
 
 .white-transparent-outlined-button {
     -fx-background-color: transparent;
-    -fx-border-color: -bisq-white-20;
-    -fx-text-fill: -bisq-white-20;
+    -fx-border-color: -bisq-white;
+    -fx-text-fill: -bisq-white;
 }
 
 .white-transparent-outlined-button:hover {
@@ -471,7 +471,7 @@
     -fx-background-insets: 0px;
     -fx-padding: 2px;
     -bisq-toggle-color: -fx-default-button;
-    -bisq-un-toggle-color: -bisq-white-20;
+    -bisq-un-toggle-color: -bisq-white;
     -bisq-toggle-line-color: derive(-bisq-toggle-color, 65%);
     -bisq-un-toggle-line-color: -bisq-mid-grey-20;
     -bisq-size: 8;
@@ -554,17 +554,17 @@
 
 .card-button-border {
     -fx-background-color: transparent;
-    -fx-border-color: derive(-bisq-white-20, -25%);
+    -fx-border-color: derive(-bisq-white, -25%);
 }
 
 .card-button-border:hover {
     -fx-background-color: rgba(0, 0, 0, 0.15);
-    -fx-border-color: derive(-bisq-white-20, -15%);
+    -fx-border-color: derive(-bisq-white, -15%);
 }
 
 .card-button-border:pressed {
     -fx-background-color: rgba(0, 0, 0, 0.2);
-    -fx-border-color: derive(-bisq-white-20, -10%);
+    -fx-border-color: derive(-bisq-white, -10%);
 }
 
 .card-button-border:default {
@@ -667,7 +667,7 @@
 
 .check-box:selected > .box > .mark,
 .check-box:indeterminate > .box > .mark {
-    -fx-background-color: -bisq-white-20;
+    -fx-background-color: -bisq-white;
     -fx-background-insets: 1 0 -1 0, 0;
     -fx-border-color: transparent;
 }
@@ -857,7 +857,7 @@
 }
 
 .radio-button:selected .radio .dot {
-    -fx-background-color: -bisq-white-20;
+    -fx-background-color: -bisq-white;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -473,7 +473,7 @@
     -bisq-toggle-color: -fx-default-button;
     -bisq-un-toggle-color: -bisq-white-20;
     -bisq-toggle-line-color: derive(-bisq-toggle-color, 65%);
-    -bisq-un-toggle-line-color: -bisq-mid-grey-30;
+    -bisq-un-toggle-line-color: -bisq-mid-grey-20;
     -bisq-size: 8;
 }
 
@@ -637,12 +637,12 @@
 .check-box > .box {
     -fx-background-color: transparent;
     -fx-background-radius: 0;
-    -fx-border-color: -bisq-mid-grey-30;
+    -fx-border-color: -bisq-mid-grey-20;
     -fx-border-width: 1;
 }
 
 .check-box:hover > .box {
-    -fx-border-color: derive(-bisq-mid-grey-30, 20%);
+    -fx-border-color: derive(-bisq-mid-grey-20, 20%);
 }
 
 .check-box > .box > .mark {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -516,7 +516,7 @@
 }
 
 .bisq-text-yellow {
-    -fx-text-fill: -bisq-yellow !important;
+    -fx-text-fill: -bisq-warning !important;
 }
 
 .bisq-text-error {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -137,8 +137,8 @@
 }
 
 .bisq-text-2 {
-    -fx-fill: -bisq-mid-grey-30;
-    -fx-text-fill: -bisq-mid-grey-30;
+    -fx-fill: -bisq-mid-grey-20;
+    -fx-text-fill: -bisq-mid-grey-20;
     -fx-font-size: 1.2em;
 }
 
@@ -472,7 +472,7 @@
 .bisq-small-light-label-dimmed {
     -fx-font-size: 0.9em;
     -fx-font-family: "IBM Plex Sans Light";
-    -fx-text-fill: -bisq-mid-grey-30;
+    -fx-text-fill: -bisq-mid-grey-20;
 }
 
 .bisq-content-headline-label {
@@ -504,7 +504,7 @@
 }
 
 .bisq-grey-dimmed {
-    -fx-text-fill: -bisq-mid-grey-30;
+    -fx-text-fill: -bisq-mid-grey-20;
 }
 
 .bisq-text-white {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -588,7 +588,7 @@
 }
 
 .material-text-field-selection-line:error {
-    -fx-background-color: -bisq-red;
+    -fx-background-color: -bisq2-red;
 }
 
 .material-text-field-bg {
@@ -617,7 +617,7 @@
 }
 
 .material-text-field-description-selected:error {
-    -fx-text-fill: -bisq-red;
+    -fx-text-fill: -bisq2-red;
 }
 
 .material-text-field-description-deselected {
@@ -640,7 +640,7 @@
 
 .material-text-field-help:error {
     -fx-font-size: 0.95em;
-    -fx-text-fill: -bisq-red;
+    -fx-text-fill: -bisq2-red;
     -fx-font-family: "IBM Plex Sans Light";
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -516,7 +516,7 @@
 }
 
 .bisq-text-yellow {
-    -fx-text-fill: -bisq-warning !important;
+    -fx-text-fill: -bisq2-yellow !important;
 }
 
 .bisq-text-error {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -433,7 +433,7 @@
 #quote-amount-text-field {
     -fx-background-color: transparent;
     -fx-border-style: none;
-    -fx-text-fill: -bisq-mid-grey-40;
+    -fx-text-fill: -bisq-mid-grey-30;
     -fx-font-size: 1.1em;
     -fx-font-family: "IBM Plex Sans Light";
 }
@@ -528,7 +528,7 @@
 }
 
 .bisq-text-grey-10 {
-    -fx-text-fill: -bisq-mid-grey-40;
+    -fx-text-fill: -bisq-mid-grey-30;
 }
 
 .font-medium {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -458,7 +458,7 @@
 }
 
 .bisq-large-profile-id-label {
-    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-color: -bisq-mid-grey-10;
     -fx-text-fill: -fx-light-text-color;
     -fx-font-size: 1em;
 }
@@ -578,7 +578,7 @@
     -fx-faint-focus-color: transparent;
     -fx-background-color: transparent;
     -fx-text-fill: -fx-light-text-color;
-    -fx-prompt-text-fill: -bisq-mid-grey-20;
+    -fx-prompt-text-fill: -bisq-mid-grey-10;
     -fx-font-size: 1.25em;
     -fx-font-family: "IBM Plex Sans Light";
 }
@@ -671,7 +671,7 @@
     -fx-faint-focus-color: transparent;
     -fx-background-color: transparent;
     -fx-text-fill: -fx-light-text-color;
-    -fx-prompt-text-fill: -bisq-mid-grey-20;
+    -fx-prompt-text-fill: -bisq-mid-grey-10;
     -fx-font-size: 1.25em;
     -fx-font-family: "IBM Plex Sans Light";
 }


### PR DESCRIPTION
Introducing a static set of yellows and red shades for message status icons and upcomming minor needs.
Grouped the old yellow with the warning yellow as it seemed reductant to have two similar tones. I opted for the warning yellow as it fitted best with the background and the bisq2 green.

Yellow shades:


<img width="300" alt="bisq2-yellow" src="https://github.com/bisq-network/bisq2/assets/145597137/e68f3cbb-b30e-4d95-ab39-e1da38d48131">

<br>
<br>

Red shades:


<img width="300" alt="bisq2-red" src="https://github.com/bisq-network/bisq2/assets/145597137/dee4856c-1b22-458f-956d-cf94f8f483f6">

<br>
<br>

Fixed from #1603 some naming errors. Changed black and white naming for better clarity.


![bisq-greys_3-H650](https://github.com/bisq-network/bisq2/assets/145597137/ff0bd3ca-ea8e-4ee5-83a3-c72a55c6b27c)


Towards #1211
