### PR TITLE
Fix zombie private channel

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/common/CommonChatTabController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/common/CommonChatTabController.java
@@ -170,7 +170,7 @@ public final class CommonChatTabController extends ContentTabController<CommonCh
 
     void onSelected(NavigationTarget navigationTarget) {
         if (navigationTarget == model.getPrivateChatsNavigationTarget()) {
-            chatChannelSelectionService.getLastSelectedPrivateChannel().ifPresent(chatChannelSelectionService::selectChannel);
+            chatChannelSelectionService.selectChannel(chatChannelSelectionService.getLastSelectedPrivateChannel().orElse(null));
         } else {
             model.channelTabButtonModelByChannelId.values().stream()
                     .filter(Objects::nonNull)

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsController.java
@@ -90,6 +90,10 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
         UIThread.run(() -> {
             if (chatChannel == null) {
                 model.getSelectedItem().set(null);
+                model.setMyUserReputationScore(null);
+                model.getMyUserProfile().set(null);
+                model.setPeersReputationScore(null);
+                model.getPeersUserProfile().set(null);
                 maybeSelectFirst();
             }
 
@@ -122,7 +126,9 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
         //todo (Critical) add popup
         if (model.getSelectedChannel() != null) {
             channelService.leaveChannel(model.getSelectedChannel().getId());
-            selectionService.getSelectedChannel().set(null);
+            if (channelService.getChannels().isEmpty()) {
+                selectionService.selectChannel(null);
+            }
         }
     }
 
@@ -137,7 +143,7 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
         if (selectionService.getSelectedChannel().get() == null &&
                 !channelService.getChannels().isEmpty() &&
                 !model.getSortedList().isEmpty()) {
-            selectionService.getSelectedChannel().set(model.getSortedList().get(0).getChannel());
+            selectionService.selectChannel(model.getSortedList().get(0).getChannel());
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -557,7 +557,8 @@ public class ChatMessagesListView {
                         ChatMessageListItem<M> item = new ChatMessageListItem<>(chatMessage, userProfileService, reputationService,
                                 bisqEasyTradeService, userIdentityService, networkService);
                         // As long as we use runOnNextRenderFrame we need to check to avoid adding duplicates
-                        if (!model.chatMessages.contains(item)) {
+                        // The model is updated async in stages, verify that messages belong to the selected channel
+                        if (!model.chatMessages.contains(item) && channel.equals(model.selectedChannel.get())) {
                             model.chatMessages.add(item);
                             maybeScrollDownOnNewItemAdded();
                         }

--- a/chat/src/main/java/bisq/chat/common/CommonChannelSelectionService.java
+++ b/chat/src/main/java/bisq/chat/common/CommonChannelSelectionService.java
@@ -69,10 +69,14 @@ public class CommonChannelSelectionService extends ChatChannelSelectionService {
 
     @Override
     public void selectChannel(ChatChannel<? extends ChatMessage> chatChannel) {
-        if (chatChannel instanceof PublicChatChannel) {
+        // Assume only private channels can be set to null
+        if (chatChannel == null) {
+            lastSelectedPrivateChannel = Optional.empty();
+        } else if (chatChannel instanceof PublicChatChannel) {
             publicChatChannelService.removeExpiredMessages(chatChannel);
         } else if (chatChannel instanceof TwoPartyPrivateChatChannel) {
             TwoPartyPrivateChatChannel privateChatChannel = (TwoPartyPrivateChatChannel) chatChannel;
+
             lastSelectedPrivateChannel = Optional.of(privateChatChannel);
             userIdentityService.selectChatUserIdentity(privateChatChannel.getMyUserIdentity());
         }


### PR DESCRIPTION
When a user left the last private chat channel no new channel was selected so the lastSelectedPrivateChannel still kept the closed channel alive. This caused strange issues, such as private chat messages ending up in public channels and private chat messages not being delivered to the correct private channel.