### PR TITLE
Improve margins to align chatbox messages in listView

### DIFF
--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -363,6 +363,16 @@
     -fx-background-color: transparent;
 }
 
+.chat-messages-list-view .chat-message-list-cell-main-vbox-no-margins {
+    -fx-border-width: 0 15 0 30;
+    -fx-border-color: transparent;
+}
+
+.chat-messages-list-view .chat-message-list-cell-main-vbox-with-margins {
+    -fx-border-width: 0 0 0 15;
+    -fx-border-color: transparent;
+}
+
 .chat-messages-list-view .list-cell:filled:hover {
     -fx-background-color: none;
 }


### PR DESCRIPTION
Improves dynamically setting the margins of chat messages.
Prior to this, the solution was aiming to account for whether the scroll bar was showing or not. However, this proved not to be reliable enough and also had to be computed on `runOnNextRenderFrame` which gave a bad UX (it was setting the margins after the first click). Therefore, for now, I am optimising margins to work well only when we have a scrollbar present. 
Will look more into this and follow-up with another PR addressing the situation without scrollbar.