### PR TITLE
Fix margins for full width chat messages

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesListView.java
@@ -978,13 +978,20 @@ public class ChatMessagesListView {
                                 if (width == null) {
                                     return;
                                 }
-
                                 mainVBox.getStyleClass().clear();
+
+                                // List cell has no padding, so it must have the same width as list view (no scrollbar)
+                                if (width.doubleValue() == listView.widthProperty().doubleValue()) {
+                                    mainVBox.getStyleClass().add("chat-message-list-cell-wo-scrollbar");
+                                    return;
+                                }
+
                                 if (width.doubleValue() < CHAT_BOX_MAX_WIDTH) {
-                                    // FIXME (low prio): This should also be dependent of whether there's a scrollbar
-                                    mainVBox.getStyleClass().add("chat-message-list-cell-main-vbox-with-margins");
+                                    // List cell has different size as list view, therefore there's a scrollbar
+                                    mainVBox.getStyleClass().add("chat-message-list-cell-w-scrollbar-full-width");
                                 } else {
-                                    mainVBox.getStyleClass().add("chat-message-list-cell-main-vbox-no-margins");
+                                    // FIXME (low prio): needs to take into account whether there's scrollbar
+                                    mainVBox.getStyleClass().add("chat-message-list-cell-w-scrollbar-max-width");
                                 }
                             }));
 

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -361,15 +361,25 @@
 
 .chat-messages-list-view {
     -fx-background-color: transparent;
+    -fx-padding: 0;
 }
 
-.chat-messages-list-view .chat-message-list-cell-main-vbox-no-margins {
-    -fx-border-width: 0 15 0 30;
+.chat-messages-list-view .list-cell {
+    -fx-padding: 5 0 5 0;
+}
+
+.chat-messages-list-view .chat-message-list-cell-wo-scrollbar {
+    -fx-border-width: 0 20 0 20;
     -fx-border-color: transparent;
 }
 
-.chat-messages-list-view .chat-message-list-cell-main-vbox-with-margins {
-    -fx-border-width: 0 0 0 15;
+.chat-messages-list-view .chat-message-list-cell-w-scrollbar-max-width {
+    -fx-border-width: 0 12 0 28;
+    -fx-border-color: transparent;
+}
+
+.chat-messages-list-view .chat-message-list-cell-w-scrollbar-full-width {
+    -fx-border-width: 0 6 0 20;
     -fx-border-color: transparent;
 }
 
@@ -388,7 +398,6 @@
 .chat-messages-badge.bisq-badge .badge-pane .label {
     -fx-text-fill: -fx-mid-text-color !important;
 }
-
 
 /*******************************************************************************
  * Chat guide                                                                  *


### PR DESCRIPTION
Introduce handling margins considering scrollbar for full width chat messages.
The following heuristic is used: since chat messages (list cell items) are full width, then they must be the same size as the list view. Otherwise, the scrollbar is present.

There's still one case missing: when the list cells have a max-width applied, then this doesn't hold. I will follow-up regarding this case.