### PR TITLE
Complete refactor of chat messages for better handling of different message types

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediatorController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediatorController.java
@@ -28,7 +28,7 @@ import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
-import bisq.desktop.main.content.components.ChatMessagesComponent;
+import bisq.desktop.main.content.components.chatMessages.ChatMessagesComponent;
 import bisq.support.mediation.MediationCase;
 import bisq.support.mediation.MediationRequest;
 import bisq.support.mediation.MediatorService;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/BaseChatController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/BaseChatController.java
@@ -34,7 +34,7 @@ import bisq.desktop.components.controls.BisqIconButton;
 import bisq.desktop.components.robohash.RoboHash;
 import bisq.desktop.main.content.chat.sidebar.ChannelSidebar;
 import bisq.desktop.main.content.chat.sidebar.UserProfileSidebar;
-import bisq.desktop.main.content.components.ChatMessagesComponent;
+import bisq.desktop.main.content.components.chatMessages.ChatMessagesComponent;
 import bisq.i18n.Res;
 import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ChatMessagesComponent.java
@@ -40,6 +40,7 @@ import bisq.desktop.components.controls.BisqTextArea;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.chat.ChatUtil;
+import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
 import bisq.i18n.Res;
 import bisq.offer.Direction;
 import bisq.offer.bisq_easy.BisqEasyOffer;
@@ -98,7 +99,7 @@ public class ChatMessagesComponent {
         controller.mentionUserHandler(userProfile);
     }
 
-    public void setSearchPredicate(Predicate<? super ChatMessagesListView.ChatMessageListItem<? extends ChatMessage>> predicate) {
+    public void setSearchPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage>> predicate) {
         controller.chatMessagesListView.setSearchPredicate(predicate);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListCellFactory.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListCellFactory.java
@@ -1,0 +1,552 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.components.chatMessages;
+
+import bisq.chat.ChatMessage;
+import bisq.chat.Citation;
+import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
+import bisq.chat.pub.PublicChatMessage;
+import bisq.desktop.common.Icons;
+import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.BisqTextArea;
+import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.main.content.components.ReputationScoreDisplay;
+import bisq.desktop.main.content.components.UserProfileIcon;
+import bisq.i18n.Res;
+import de.jensd.fx.fontawesome.AwesomeDude;
+import de.jensd.fx.fontawesome.AwesomeIcon;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.Node;
+import javafx.scene.control.*;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.util.Callback;
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.Subscription;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+final class ChatMessageListCellFactory implements Callback<ListView<ChatMessageListItem<? extends ChatMessage>>, ListCell<ChatMessageListItem<? extends ChatMessage>>> {
+    private final ChatMessagesListView.Controller controller;
+    private final ChatMessagesListView.Model model;
+
+    public ChatMessageListCellFactory(ChatMessagesListView.Controller controller, ChatMessagesListView.Model model) {
+        this.controller = controller;
+        this.model = model;
+    }
+
+    @Override
+    public ListCell<ChatMessageListItem<? extends ChatMessage>> call(ListView<ChatMessageListItem<? extends ChatMessage>> list) {
+        return new ListCell<>() {
+            private final static double CHAT_BOX_MAX_WIDTH = 1200;
+            private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
+            private final String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
+
+            private final ReputationScoreDisplay reputationScoreDisplay;
+            private final Button takeOfferButton, removeOfferButton;
+            private final Label message, userName, dateTime, replyIcon, pmIcon, editIcon, deleteIcon, copyIcon,
+                    moreOptionsIcon, supportedLanguages;
+            private final Label deliveryState;
+            private final Label quotedMessageField = new Label();
+            private final BisqTextArea editInputField;
+            private final Button saveEditButton, cancelEditButton;
+            private final VBox mainVBox, quotedMessageVBox;
+            private final HBox cellHBox, messageHBox, messageBgHBox, reactionsHBox, editButtonsHBox;
+            private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
+            private final Set<Subscription> subscriptions = new HashSet<>();
+
+            {
+                userName = new Label();
+                userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
+
+                deliveryState = new Label();
+                deliveryState.setCursor(Cursor.HAND);
+                deliveryState.setTooltip(new BisqTooltip(true));
+
+                dateTime = new Label();
+                dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
+
+                reputationScoreDisplay = new ReputationScoreDisplay();
+                takeOfferButton = new Button(Res.get("offer.takeOffer"));
+
+                removeOfferButton = new Button(Res.get("offer.deleteOffer"));
+                removeOfferButton.getStyleClass().addAll("red-small-button", "no-background");
+
+                // quoted message
+                quotedMessageField.setWrapText(true);
+                quotedMessageVBox = new VBox(5);
+                quotedMessageVBox.setVisible(false);
+                quotedMessageVBox.setManaged(false);
+
+                // HBox for message reputation vBox and action button
+                message = new Label();
+                message.setWrapText(true);
+                message.setPadding(new Insets(10));
+                message.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
+
+
+                // edit
+                editInputField = new BisqTextArea();
+                //editInputField.getStyleClass().addAll("text-fill-white", "font-size-13", "font-default");
+                editInputField.setId("chat-messages-edit-text-area");
+                editInputField.setMinWidth(150);
+                editInputField.setVisible(false);
+                editInputField.setManaged(false);
+
+                // edit buttons
+                saveEditButton = new Button(Res.get("action.save"));
+                saveEditButton.setDefaultButton(true);
+                cancelEditButton = new Button(Res.get("action.cancel"));
+
+                editButtonsHBox = new HBox(15, Spacer.fillHBox(), cancelEditButton, saveEditButton);
+                editButtonsHBox.setVisible(false);
+                editButtonsHBox.setManaged(false);
+
+                messageBgHBox = new HBox(15);
+                messageBgHBox.setAlignment(Pos.CENTER_LEFT);
+                messageBgHBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
+
+                // Reactions box
+                replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
+                pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
+                editIcon = getIconWithToolTip(AwesomeIcon.EDIT, Res.get("action.edit"));
+                HBox.setMargin(editIcon, new Insets(1, 0, 0, 0));
+                copyIcon = getIconWithToolTip(AwesomeIcon.COPY, Res.get("action.copyToClipboard"));
+                deleteIcon = getIconWithToolTip(AwesomeIcon.REMOVE_SIGN, Res.get("action.delete"));
+                moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
+                supportedLanguages = new Label();
+
+                reactionsHBox = new HBox(20);
+
+                reactionsHBox.setVisible(false);
+
+                HBox.setHgrow(messageBgHBox, Priority.SOMETIMES);
+                messageHBox = new HBox();
+
+                VBox.setMargin(quotedMessageVBox, new Insets(15, 0, 10, 5));
+                VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
+                VBox.setMargin(editButtonsHBox, new Insets(10, 25, -15, 0));
+                mainVBox = new VBox();
+                mainVBox.setFillWidth(true);
+                HBox.setHgrow(mainVBox, Priority.ALWAYS);
+                cellHBox = new HBox(15);
+                cellHBox.setMaxWidth(CHAT_BOX_MAX_WIDTH);
+                cellHBox.setAlignment(Pos.CENTER);
+            }
+
+
+            private void hideReactionsBox() {
+                reactionsHBox.setVisible(false);
+            }
+
+            @Override
+            public void updateItem(final ChatMessageListItem<? extends ChatMessage> item, boolean empty) {
+                super.updateItem(item, empty);
+                if (item == null || empty) {
+                    cleanup();
+                    return;
+                }
+
+                subscriptions.clear();
+                ChatMessage chatMessage = item.getChatMessage();
+
+                Node flow = this.getListView().lookup(".virtual-flow");
+                if (flow != null && !flow.isVisible()) {
+                    return;
+                }
+
+                boolean hasTradeChatOffer = model.hasTradeChatOffer(chatMessage);
+                boolean isBisqEasyPublicChatMessageWithOffer = chatMessage instanceof BisqEasyOfferbookMessage && hasTradeChatOffer;
+                boolean isMyMessage = model.isMyMessage(chatMessage);
+
+                if (isBisqEasyPublicChatMessageWithOffer) {
+                    supportedLanguages.setText(controller.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) chatMessage)));
+                    supportedLanguages.setTooltip(new BisqTooltip(controller.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) chatMessage))));
+                }
+
+                dateTime.setVisible(false);
+
+                cellHBox.getChildren().setAll(mainVBox);
+
+                message.maxWidthProperty().unbind();
+                if (hasTradeChatOffer) {
+                    messageBgHBox.setPadding(new Insets(15));
+                } else {
+                    messageBgHBox.setPadding(new Insets(5, 15, 5, 15));
+                }
+                messageBgHBox.getStyleClass().removeAll("chat-message-bg-my-message", "chat-message-bg-peer-message");
+                VBox userProfileIconVbox = new VBox(userProfileIcon);
+                if (isMyMessage) {
+                    buildMyMessage(isBisqEasyPublicChatMessageWithOffer, userProfileIconVbox, chatMessage);
+                } else {
+                    buildPeerMessage(item, isBisqEasyPublicChatMessageWithOffer, userProfileIconVbox, chatMessage);
+                }
+
+                handleQuoteMessageBox(item);
+                handleReactionsBox(item);
+                handleEditBox(chatMessage);
+
+                message.setText(item.getMessage());
+                dateTime.setText(item.getDate());
+
+                item.getSenderUserProfile().ifPresent(author -> {
+                    userName.setText(author.getUserName());
+                    userName.setOnMouseClicked(e -> controller.onMention(author));
+
+                    userProfileIcon.setUserProfile(author);
+                    userProfileIcon.setCursor(Cursor.HAND);
+                    Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
+                    userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(chatMessage));
+                });
+
+                subscriptions.add(EasyBind.subscribe(item.getMessageDeliveryStatusIcon(), icon -> {
+                            deliveryState.setManaged(icon != null);
+                            deliveryState.setVisible(icon != null);
+                            if (icon != null) {
+                                AwesomeDude.setIcon(deliveryState, icon, AwesomeDude.DEFAULT_ICON_SIZE);
+                                item.getMessageDeliveryStatusIconColor().ifPresent(color ->
+                                        Icons.setAwesomeIconColor(deliveryState, color));
+                            }
+                        }
+                ));
+                deliveryState.getTooltip().textProperty().bind(item.getMessageDeliveryStatusTooltip());
+                editInputField.maxWidthProperty().bind(message.widthProperty());
+
+                subscriptions.add(EasyBind.subscribe(mainVBox.widthProperty(), width -> {
+                    if (width == null) {
+                        return;
+                    }
+                    mainVBox.getStyleClass().clear();
+
+                    // List cell has no padding, so it must have the same width as list view (no scrollbar)
+                    if (width.doubleValue() == list.widthProperty().doubleValue()) {
+                        mainVBox.getStyleClass().add("chat-message-list-cell-wo-scrollbar");
+                        return;
+                    }
+
+                    if (width.doubleValue() < CHAT_BOX_MAX_WIDTH) {
+                        // List cell has different size as list view, therefore there's a scrollbar
+                        mainVBox.getStyleClass().add("chat-message-list-cell-w-scrollbar-full-width");
+                    } else {
+                        // FIXME (low prio): needs to take into account whether there's scrollbar
+                        mainVBox.getStyleClass().add("chat-message-list-cell-w-scrollbar-max-width");
+                    }
+                }));
+
+                setGraphic(cellHBox);
+                setAlignment(Pos.CENTER);
+            }
+
+            private void buildPeerMessage(ChatMessageListItem<? extends ChatMessage> item, boolean isBisqEasyPublicChatMessageWithOffer, VBox userProfileIconVbox, ChatMessage chatMessage) {
+                // Peer
+                HBox userNameAndDateHBox = new HBox(10, userName, dateTime);
+                message.setAlignment(Pos.CENTER_LEFT);
+                userNameAndDateHBox.setAlignment(Pos.CENTER_LEFT);
+
+                userProfileIcon.setSize(60);
+                HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
+                HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
+                HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
+
+
+                quotedMessageVBox.setId("chat-message-quote-box-peer-msg");
+
+                messageBgHBox.getStyleClass().add("chat-message-bg-peer-message");
+                if (isBisqEasyPublicChatMessageWithOffer) {
+                    reactionsHBox.getChildren().setAll(replyIcon, pmIcon, editIcon, deleteIcon, moreOptionsIcon, supportedLanguages, Spacer.fillHBox());
+                    message.maxWidthProperty().bind(list.widthProperty().subtract(430));
+                    userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
+
+                    Label reputationLabel = new Label(Res.get("chat.message.reputation").toUpperCase());
+                    reputationLabel.getStyleClass().add("bisq-text-7");
+
+                    reputationScoreDisplay.setReputationScore(item.getReputationScore());
+                    VBox reputationVBox = new VBox(4, reputationLabel, reputationScoreDisplay);
+                    reputationVBox.setAlignment(Pos.CENTER_LEFT);
+
+                    BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
+                    takeOfferButton.setOnAction(e -> controller.onTakeOffer(bisqEasyOfferbookMessage, item.isCanTakeOffer()));
+                    takeOfferButton.setDefaultButton(item.isCanTakeOffer());
+                    takeOfferButton.setMinWidth(Control.USE_PREF_SIZE);
+
+                    VBox messageVBox = new VBox(quotedMessageVBox, message);
+                    HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
+                    HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
+                    HBox.setMargin(reputationVBox, new Insets(-5, 10, 0, 0));
+                    HBox.setMargin(takeOfferButton, new Insets(0, 10, 0, 0));
+                    messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox, Spacer.fillHBox(), reputationVBox, takeOfferButton);
+
+                    VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, 5, 10));
+                    mainVBox.getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);
+                } else {
+                    reactionsHBox.getChildren().setAll(replyIcon, pmIcon, editIcon, deleteIcon, moreOptionsIcon, Spacer.fillHBox());
+                    message.maxWidthProperty().bind(list.widthProperty().subtract(140));//165
+                    userProfileIcon.setSize(30);
+                    userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
+
+                    VBox messageVBox = new VBox(quotedMessageVBox, message);
+                    HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
+                    HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
+                    messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox);
+                    messageHBox.getChildren().setAll(messageBgHBox, Spacer.fillHBox());
+
+                    VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, -5, 10));
+                    mainVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
+                }
+            }
+
+            private void buildMyMessage(boolean isBisqEasyPublicChatMessageWithOffer, VBox userProfileIconVbox, ChatMessage chatMessage) {
+                HBox userNameAndDateHBox = new HBox(10, dateTime, userName);
+                userNameAndDateHBox.setAlignment(Pos.CENTER_RIGHT);
+                message.setAlignment(Pos.CENTER_RIGHT);
+
+                quotedMessageVBox.setId("chat-message-quote-box-my-msg");
+
+                messageBgHBox.getStyleClass().add("chat-message-bg-my-message");
+                VBox.setMargin(userNameAndDateHBox, new Insets(-5, 10, -5, 0));
+
+                VBox messageVBox = new VBox(quotedMessageVBox, message, editInputField);
+                if (isBisqEasyPublicChatMessageWithOffer) {
+                    message.maxWidthProperty().bind(list.widthProperty().subtract(160));
+                    userProfileIcon.setSize(60);
+                    userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
+                    HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
+                    HBox.setMargin(editInputField, new Insets(-4, -10, -15, 0));
+                    HBox.setMargin(messageVBox, new Insets(0, -10, 0, 0));
+
+                    removeOfferButton.setOnAction(e -> controller.onDeleteMessage(chatMessage));
+                    reactionsHBox.getChildren().setAll(Spacer.fillHBox(), replyIcon, pmIcon, editIcon, supportedLanguages, copyIcon);
+                    reactionsHBox.setAlignment(Pos.CENTER_RIGHT);
+
+                    HBox.setMargin(userProfileIconVbox, new Insets(0, 0, 10, 0));
+                    HBox hBox = new HBox(15, messageVBox, userProfileIconVbox);
+                    HBox removeOfferButtonHBox = new HBox(Spacer.fillHBox(), removeOfferButton);
+                    VBox vBox = new VBox(hBox, removeOfferButtonHBox);
+                    messageBgHBox.getChildren().setAll(vBox);
+                } else {
+                    message.maxWidthProperty().bind(list.widthProperty().subtract(140));
+                    userProfileIcon.setSize(30);
+                    userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
+                    HBox.setMargin(deleteIcon, new Insets(0, 10, 0, 0));
+                    reactionsHBox.getChildren().setAll(Spacer.fillHBox(), replyIcon, pmIcon, editIcon, copyIcon, deleteIcon);
+                    HBox.setMargin(messageVBox, new Insets(0, -15, 0, 0));
+                    HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
+                    HBox.setMargin(editInputField, new Insets(6, -10, -25, 0));
+                    messageBgHBox.getChildren().setAll(messageVBox, userProfileIconVbox);
+                }
+
+                HBox.setMargin(deliveryState, new Insets(0, 10, 0, 0));
+                HBox deliveryStateHBox = new HBox(Spacer.fillHBox(), reactionsHBox);
+
+                subscriptions.add(EasyBind.subscribe(reactionsHBox.visibleProperty(), v -> {
+                    if (v) {
+                        deliveryStateHBox.getChildren().remove(deliveryState);
+                        if (!reactionsHBox.getChildren().contains(deliveryState)) {
+                            reactionsHBox.getChildren().add(deliveryState);
+                        }
+                    } else {
+                        reactionsHBox.getChildren().remove(deliveryState);
+                        if (!deliveryStateHBox.getChildren().contains(deliveryState)) {
+                            deliveryStateHBox.getChildren().add(deliveryState);
+                        }
+                    }
+                }));
+
+                VBox.setMargin(deliveryStateHBox, new Insets(4, 0, -3, 0));
+                mainVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, deliveryStateHBox);
+
+                messageHBox.getChildren().setAll(Spacer.fillHBox(), messageBgHBox);
+            }
+
+
+            private void cleanup() {
+                message.maxWidthProperty().unbind();
+                editInputField.maxWidthProperty().unbind();
+
+                editInputField.maxWidthProperty().unbind();
+                removeOfferButton.setOnAction(null);
+                takeOfferButton.setOnAction(null);
+
+                saveEditButton.setOnAction(null);
+                cancelEditButton.setOnAction(null);
+
+                userName.setOnMouseClicked(null);
+                userProfileIcon.setOnMouseClicked(null);
+                replyIcon.setOnMouseClicked(null);
+                pmIcon.setOnMouseClicked(null);
+                editIcon.setOnMouseClicked(null);
+                copyIcon.setOnMouseClicked(null);
+                deleteIcon.setOnMouseClicked(null);
+                moreOptionsIcon.setOnMouseClicked(null);
+
+                editInputField.setOnKeyPressed(null);
+
+                cellHBox.setOnMouseEntered(null);
+                cellHBox.setOnMouseExited(null);
+
+                userProfileIcon.releaseResources();
+
+                subscriptions.forEach(Subscription::unsubscribe);
+                subscriptions.clear();
+
+                setGraphic(null);
+            }
+
+            private void handleEditBox(ChatMessage chatMessage) {
+                saveEditButton.setOnAction(e -> {
+                    controller.onSaveEditedMessage(chatMessage, editInputField.getText());
+                    onCloseEditMessage();
+                });
+                cancelEditButton.setOnAction(e -> onCloseEditMessage());
+            }
+
+            private void handleReactionsBox(ChatMessageListItem<? extends ChatMessage> item) {
+                ChatMessage chatMessage = item.getChatMessage();
+                boolean isMyMessage = model.isMyMessage(chatMessage);
+
+                boolean isPublicChannel = model.getIsPublicChannel().get();
+                boolean allowEditing = isPublicChannel;
+                if (chatMessage instanceof BisqEasyOfferbookMessage) {
+                    BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
+                    allowEditing = allowEditing && bisqEasyOfferbookMessage.getBisqEasyOffer().isEmpty();
+                }
+                if (isMyMessage) {
+                    copyIcon.setOnMouseClicked(e -> controller.onCopyMessage(chatMessage));
+                    if (allowEditing) {
+                        editIcon.setOnMouseClicked(e -> onEditMessage(item));
+                    }
+                    if (isPublicChannel) {
+                        deleteIcon.setOnMouseClicked(e -> controller.onDeleteMessage(chatMessage));
+                    }
+                } else {
+                    moreOptionsIcon.setOnMouseClicked(e -> controller.onOpenMoreOptions(pmIcon, chatMessage, () -> {
+                        hideReactionsBox();
+                        model.getSelectedChatMessageForMoreOptionsPopup().set(null);
+                    }));
+                    replyIcon.setOnMouseClicked(e -> controller.onReply(chatMessage));
+                    pmIcon.setOnMouseClicked(e -> controller.onOpenPrivateChannel(chatMessage));
+                }
+
+                replyIcon.setVisible(!isMyMessage);
+                replyIcon.setManaged(!isMyMessage);
+
+                pmIcon.setVisible(!isMyMessage && chatMessage instanceof PublicChatMessage);
+                pmIcon.setManaged(!isMyMessage && chatMessage instanceof PublicChatMessage);
+
+                editIcon.setVisible(isMyMessage && allowEditing);
+                editIcon.setManaged(isMyMessage && allowEditing);
+                deleteIcon.setVisible(isMyMessage && isPublicChannel);
+                deleteIcon.setManaged(isMyMessage && isPublicChannel);
+                removeOfferButton.setVisible(isMyMessage && isPublicChannel);
+                removeOfferButton.setManaged(isMyMessage && isPublicChannel);
+
+                setOnMouseEntered(e -> {
+                    if (model.getSelectedChatMessageForMoreOptionsPopup().get() != null || editInputField.isVisible()) {
+                        return;
+                    }
+                    dateTime.setVisible(true);
+                    reactionsHBox.setVisible(true);
+                });
+
+                setOnMouseExited(e -> {
+                    if (model.getSelectedChatMessageForMoreOptionsPopup().get() == null) {
+                        hideReactionsBox();
+                        dateTime.setVisible(false);
+                        reactionsHBox.setVisible(false);
+                    }
+                });
+            }
+
+            private void handleQuoteMessageBox(ChatMessageListItem<? extends ChatMessage> item) {
+                Optional<Citation> optionalCitation = item.getCitation();
+                if (optionalCitation.isPresent()) {
+                    Citation citation = optionalCitation.get();
+                    if (citation.isValid()) {
+                        quotedMessageVBox.setVisible(true);
+                        quotedMessageVBox.setManaged(true);
+                        quotedMessageField.setText(citation.getText());
+                        quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
+                        Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
+                        userName.getStyleClass().add("font-medium");
+                        userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
+                        quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
+                    }
+                } else {
+                    quotedMessageVBox.getChildren().clear();
+                    quotedMessageVBox.setVisible(false);
+                    quotedMessageVBox.setManaged(false);
+                }
+            }
+
+            private void onEditMessage(ChatMessageListItem<? extends ChatMessage> item) {
+                reactionsHBox.setVisible(false);
+                editInputField.setVisible(true);
+                editInputField.setManaged(true);
+                editInputField.setInitialHeight(message.getBoundsInLocal().getHeight());
+                editInputField.setText(message.getText().replace(EDITED_POST_FIX, ""));
+                editInputField.requestFocus();
+                editInputField.positionCaret(message.getText().length());
+                editButtonsHBox.setVisible(true);
+                editButtonsHBox.setManaged(true);
+                removeOfferButton.setVisible(false);
+                removeOfferButton.setManaged(false);
+
+                message.setVisible(false);
+                message.setManaged(false);
+
+                editInputField.setOnKeyPressed(event -> {
+                    if (event.getCode() == KeyCode.ENTER) {
+                        event.consume();
+                        if (event.isShiftDown()) {
+                            editInputField.appendText(System.getProperty("line.separator"));
+                        } else if (!editInputField.getText().isEmpty()) {
+                            controller.onSaveEditedMessage(item.getChatMessage(), editInputField.getText().trim());
+                            onCloseEditMessage();
+                        }
+                    }
+                });
+            }
+
+            private void onCloseEditMessage() {
+                editInputField.setVisible(false);
+                editInputField.setManaged(false);
+                editButtonsHBox.setVisible(false);
+                editButtonsHBox.setManaged(false);
+                removeOfferButton.setVisible(true);
+                removeOfferButton.setManaged(true);
+
+                message.setVisible(true);
+                message.setManaged(true);
+                editInputField.setOnKeyPressed(null);
+            }
+        };
+    }
+
+    private Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
+        Label iconLabel = Icons.getIcon(icon);
+        iconLabel.setCursor(Cursor.HAND);
+        iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
+        return iconLabel;
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListCellFactory.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListCellFactory.java
@@ -19,34 +19,18 @@ package bisq.desktop.main.content.components.chatMessages;
 
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
-import bisq.chat.Citation;
-import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
-import bisq.chat.pub.PublicChatMessage;
-import bisq.desktop.common.Icons;
-import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTextArea;
-import bisq.desktop.components.controls.BisqTooltip;
-import bisq.desktop.main.content.components.ReputationScoreDisplay;
-import bisq.desktop.main.content.components.UserProfileIcon;
+import bisq.desktop.main.content.components.chatMessages.messages.Message;
+import bisq.desktop.main.content.components.chatMessages.messages.MyMessage;
 import bisq.desktop.main.content.components.chatMessages.messages.PeerMessage;
-import bisq.i18n.Res;
-import de.jensd.fx.fontawesome.AwesomeDude;
-import de.jensd.fx.fontawesome.AwesomeIcon;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.*;
-import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 final class ChatMessageListCellFactory implements Callback<ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>,
@@ -63,99 +47,15 @@ final class ChatMessageListCellFactory implements Callback<ListView<ChatMessageL
     public ListCell<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> call(ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list) {
         return new ListCell<>() {
             private final static double CHAT_BOX_MAX_WIDTH = 1200;
-            private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
-            private final String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
 
-            private final Button takeOfferButton, removeOfferButton;
-            private final Label message, userName, dateTime, replyIcon, pmIcon, editIcon, deleteIcon, copyIcon,
-                    moreOptionsIcon, supportedLanguages;
-            private final Label deliveryState;
-            private final Label quotedMessageField = new Label();
-            private final BisqTextArea editInputField;
-            private final Button saveEditButton, cancelEditButton;
-            private VBox mainVBox, quotedMessageVBox;
-            private final HBox cellHBox, messageHBox, messageBgHBox, reactionsHBox, editButtonsHBox;
-            private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
+            private Message mainVBox;
+            private final HBox cellHBox;
             private final Set<Subscription> subscriptions = new HashSet<>();
 
             {
-                userName = new Label();
-                userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
-
-                deliveryState = new Label();
-                deliveryState.setCursor(Cursor.HAND);
-                deliveryState.setTooltip(new BisqTooltip(true));
-
-                dateTime = new Label();
-                dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
-
-                takeOfferButton = new Button(Res.get("offer.takeOffer"));
-
-                removeOfferButton = new Button(Res.get("offer.deleteOffer"));
-                removeOfferButton.getStyleClass().addAll("red-small-button", "no-background");
-
-                // quoted message
-                quotedMessageField.setWrapText(true);
-                quotedMessageVBox = new VBox(5);
-                quotedMessageVBox.setVisible(false);
-                quotedMessageVBox.setManaged(false);
-
-                // HBox for message reputation vBox and action button
-                message = new Label();
-                message.setWrapText(true);
-                message.setPadding(new Insets(10));
-                message.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
-
-
-                // edit
-                editInputField = new BisqTextArea();
-                //editInputField.getStyleClass().addAll("text-fill-white", "font-size-13", "font-default");
-                editInputField.setId("chat-messages-edit-text-area");
-                editInputField.setMinWidth(150);
-                editInputField.setVisible(false);
-                editInputField.setManaged(false);
-
-                // edit buttons
-                saveEditButton = new Button(Res.get("action.save"));
-                saveEditButton.setDefaultButton(true);
-                cancelEditButton = new Button(Res.get("action.cancel"));
-
-                editButtonsHBox = new HBox(15, Spacer.fillHBox(), cancelEditButton, saveEditButton);
-                editButtonsHBox.setVisible(false);
-                editButtonsHBox.setManaged(false);
-
-                messageBgHBox = new HBox(15);
-                messageBgHBox.setAlignment(Pos.CENTER_LEFT);
-                messageBgHBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
-
-                // Reactions box
-                replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
-                pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
-                editIcon = getIconWithToolTip(AwesomeIcon.EDIT, Res.get("action.edit"));
-                HBox.setMargin(editIcon, new Insets(1, 0, 0, 0));
-                copyIcon = getIconWithToolTip(AwesomeIcon.COPY, Res.get("action.copyToClipboard"));
-                deleteIcon = getIconWithToolTip(AwesomeIcon.REMOVE_SIGN, Res.get("action.delete"));
-                moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
-                supportedLanguages = new Label();
-
-                reactionsHBox = new HBox(20);
-
-                reactionsHBox.setVisible(false);
-
-                HBox.setHgrow(messageBgHBox, Priority.SOMETIMES);
-                messageHBox = new HBox();
-
-                VBox.setMargin(quotedMessageVBox, new Insets(15, 0, 10, 5));
-                VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
-                VBox.setMargin(editButtonsHBox, new Insets(10, 25, -15, 0));
-
                 cellHBox = new HBox(15);
                 cellHBox.setMaxWidth(CHAT_BOX_MAX_WIDTH);
                 cellHBox.setAlignment(Pos.CENTER);
-            }
-
-            private void hideReactionsBox() {
-                reactionsHBox.setVisible(false);
             }
 
             @Override
@@ -174,67 +74,13 @@ final class ChatMessageListCellFactory implements Callback<ListView<ChatMessageL
                     return;
                 }
 
-                boolean hasTradeChatOffer = item.hasTradeChatOffer();
-                boolean isBisqEasyPublicChatMessageWithOffer = item.isBisqEasyPublicChatMessageWithOffer();
                 boolean isMyMessage = model.isMyMessage(chatMessage);
-
-//                if (isBisqEasyPublicChatMessageWithOffer) {
-//                    supportedLanguages.setText(controller.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) chatMessage)));
-//                    supportedLanguages.setTooltip(new BisqTooltip(controller.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) chatMessage))));
-//                }
-
-                dateTime.setVisible(false);
-
-
-                message.maxWidthProperty().unbind();
-                if (hasTradeChatOffer) {
-                    messageBgHBox.setPadding(new Insets(15));
-                } else {
-                    messageBgHBox.setPadding(new Insets(5, 15, 5, 15));
-                }
-                messageBgHBox.getStyleClass().removeAll("chat-message-bg-my-message", "chat-message-bg-peer-message");
-                VBox userProfileIconVbox = new VBox(userProfileIcon);
                 if (isMyMessage) {
-                    mainVBox = new VBox();
-                    mainVBox.setFillWidth(true);
-                    HBox.setHgrow(mainVBox, Priority.ALWAYS);
-                    buildMyMessage(isBisqEasyPublicChatMessageWithOffer, userProfileIconVbox, chatMessage);
+                    mainVBox = new MyMessage(item, list, controller, model, subscriptions);
                 } else {
                     mainVBox = new PeerMessage(item, list, controller, model);
-                    //buildPeerMessage(item, isBisqEasyPublicChatMessageWithOffer, userProfileIconVbox, chatMessage);
                 }
-
                 cellHBox.getChildren().setAll(mainVBox);
-
-                handleQuoteMessageBox(item);
-                handleReactionsBox(item);
-                handleEditBox(chatMessage);
-
-                message.setText(item.getMessage());
-                dateTime.setText(item.getDate());
-
-                item.getSenderUserProfile().ifPresent(author -> {
-                    userName.setText(author.getUserName());
-                    userName.setOnMouseClicked(e -> controller.onMention(author));
-
-                    userProfileIcon.setUserProfile(author);
-                    userProfileIcon.setCursor(Cursor.HAND);
-                    Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
-                    userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(chatMessage));
-                });
-
-                subscriptions.add(EasyBind.subscribe(item.getMessageDeliveryStatusIcon(), icon -> {
-                            deliveryState.setManaged(icon != null);
-                            deliveryState.setVisible(icon != null);
-                            if (icon != null) {
-                                AwesomeDude.setIcon(deliveryState, icon, AwesomeDude.DEFAULT_ICON_SIZE);
-                                item.getMessageDeliveryStatusIconColor().ifPresent(color ->
-                                        Icons.setAwesomeIconColor(deliveryState, color));
-                            }
-                        }
-                ));
-                deliveryState.getTooltip().textProperty().bind(item.getMessageDeliveryStatusTooltip());
-                editInputField.maxWidthProperty().bind(message.widthProperty());
 
                 subscriptions.add(EasyBind.subscribe(mainVBox.widthProperty(), width -> {
                     if (width == null) {
@@ -261,237 +107,20 @@ final class ChatMessageListCellFactory implements Callback<ListView<ChatMessageL
                 setAlignment(Pos.CENTER);
             }
 
-            private void buildMyMessage(boolean isBisqEasyPublicChatMessageWithOffer, VBox userProfileIconVbox, ChatMessage chatMessage) {
-                HBox userNameAndDateHBox = new HBox(10, dateTime, userName);
-                userNameAndDateHBox.setAlignment(Pos.CENTER_RIGHT);
-                message.setAlignment(Pos.CENTER_RIGHT);
-
-                quotedMessageVBox.setId("chat-message-quote-box-my-msg");
-
-                messageBgHBox.getStyleClass().add("chat-message-bg-my-message");
-                VBox.setMargin(userNameAndDateHBox, new Insets(-5, 10, -5, 0));
-
-                VBox messageVBox = new VBox(quotedMessageVBox, message, editInputField);
-                if (isBisqEasyPublicChatMessageWithOffer) {
-                    message.maxWidthProperty().bind(list.widthProperty().subtract(160));
-                    userProfileIcon.setSize(60);
-                    userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
-                    HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
-                    HBox.setMargin(editInputField, new Insets(-4, -10, -15, 0));
-                    HBox.setMargin(messageVBox, new Insets(0, -10, 0, 0));
-
-                    removeOfferButton.setOnAction(e -> controller.onDeleteMessage(chatMessage));
-                    reactionsHBox.getChildren().setAll(Spacer.fillHBox(), replyIcon, pmIcon, editIcon, supportedLanguages, copyIcon);
-                    reactionsHBox.setAlignment(Pos.CENTER_RIGHT);
-
-                    HBox.setMargin(userProfileIconVbox, new Insets(0, 0, 10, 0));
-                    HBox hBox = new HBox(15, messageVBox, userProfileIconVbox);
-                    HBox removeOfferButtonHBox = new HBox(Spacer.fillHBox(), removeOfferButton);
-                    VBox vBox = new VBox(hBox, removeOfferButtonHBox);
-                    messageBgHBox.getChildren().setAll(vBox);
-                } else {
-                    message.maxWidthProperty().bind(list.widthProperty().subtract(140));
-                    userProfileIcon.setSize(30);
-                    userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
-                    HBox.setMargin(deleteIcon, new Insets(0, 10, 0, 0));
-                    reactionsHBox.getChildren().setAll(Spacer.fillHBox(), replyIcon, pmIcon, editIcon, copyIcon, deleteIcon);
-                    HBox.setMargin(messageVBox, new Insets(0, -15, 0, 0));
-                    HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
-                    HBox.setMargin(editInputField, new Insets(6, -10, -25, 0));
-                    messageBgHBox.getChildren().setAll(messageVBox, userProfileIconVbox);
-                }
-
-                HBox.setMargin(deliveryState, new Insets(0, 10, 0, 0));
-                HBox deliveryStateHBox = new HBox(Spacer.fillHBox(), reactionsHBox);
-
-                subscriptions.add(EasyBind.subscribe(reactionsHBox.visibleProperty(), v -> {
-                    if (v) {
-                        deliveryStateHBox.getChildren().remove(deliveryState);
-                        if (!reactionsHBox.getChildren().contains(deliveryState)) {
-                            reactionsHBox.getChildren().add(deliveryState);
-                        }
-                    } else {
-                        reactionsHBox.getChildren().remove(deliveryState);
-                        if (!deliveryStateHBox.getChildren().contains(deliveryState)) {
-                            deliveryStateHBox.getChildren().add(deliveryState);
-                        }
-                    }
-                }));
-
-                VBox.setMargin(deliveryStateHBox, new Insets(4, 0, -3, 0));
-                mainVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, deliveryStateHBox);
-
-                messageHBox.getChildren().setAll(Spacer.fillHBox(), messageBgHBox);
-            }
-
 
             private void cleanup() {
-                message.maxWidthProperty().unbind();
-                editInputField.maxWidthProperty().unbind();
-
-                editInputField.maxWidthProperty().unbind();
-                removeOfferButton.setOnAction(null);
-                takeOfferButton.setOnAction(null);
-
-                saveEditButton.setOnAction(null);
-                cancelEditButton.setOnAction(null);
-
-                userName.setOnMouseClicked(null);
-                userProfileIcon.setOnMouseClicked(null);
-                replyIcon.setOnMouseClicked(null);
-                pmIcon.setOnMouseClicked(null);
-                editIcon.setOnMouseClicked(null);
-                copyIcon.setOnMouseClicked(null);
-                deleteIcon.setOnMouseClicked(null);
-                moreOptionsIcon.setOnMouseClicked(null);
-
-                editInputField.setOnKeyPressed(null);
+                if (mainVBox != null) {
+                    mainVBox.cleanup();
+                }
 
                 cellHBox.setOnMouseEntered(null);
                 cellHBox.setOnMouseExited(null);
-
-                userProfileIcon.releaseResources();
 
                 subscriptions.forEach(Subscription::unsubscribe);
                 subscriptions.clear();
 
                 setGraphic(null);
             }
-
-            private void handleEditBox(ChatMessage chatMessage) {
-                saveEditButton.setOnAction(e -> {
-                    controller.onSaveEditedMessage(chatMessage, editInputField.getText());
-                    onCloseEditMessage();
-                });
-                cancelEditButton.setOnAction(e -> onCloseEditMessage());
-            }
-
-            private void handleReactionsBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
-                ChatMessage chatMessage = item.getChatMessage();
-                boolean isMyMessage = model.isMyMessage(chatMessage);
-
-                boolean isPublicChannel = model.getIsPublicChannel().get();
-                boolean allowEditing = isPublicChannel;
-                if (chatMessage instanceof BisqEasyOfferbookMessage) {
-                    BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
-                    allowEditing = allowEditing && bisqEasyOfferbookMessage.getBisqEasyOffer().isEmpty();
-                }
-                if (isMyMessage) {
-                    copyIcon.setOnMouseClicked(e -> controller.onCopyMessage(chatMessage));
-                    if (allowEditing) {
-                        editIcon.setOnMouseClicked(e -> onEditMessage(item));
-                    }
-                    if (isPublicChannel) {
-                        deleteIcon.setOnMouseClicked(e -> controller.onDeleteMessage(chatMessage));
-                    }
-                } else {
-                    moreOptionsIcon.setOnMouseClicked(e -> controller.onOpenMoreOptions(pmIcon, chatMessage, () -> {
-                        hideReactionsBox();
-                        model.getSelectedChatMessageForMoreOptionsPopup().set(null);
-                    }));
-                    replyIcon.setOnMouseClicked(e -> controller.onReply(chatMessage));
-                    pmIcon.setOnMouseClicked(e -> controller.onOpenPrivateChannel(chatMessage));
-                }
-
-                replyIcon.setVisible(!isMyMessage);
-                replyIcon.setManaged(!isMyMessage);
-
-                pmIcon.setVisible(!isMyMessage && chatMessage instanceof PublicChatMessage);
-                pmIcon.setManaged(!isMyMessage && chatMessage instanceof PublicChatMessage);
-
-                editIcon.setVisible(isMyMessage && allowEditing);
-                editIcon.setManaged(isMyMessage && allowEditing);
-                deleteIcon.setVisible(isMyMessage && isPublicChannel);
-                deleteIcon.setManaged(isMyMessage && isPublicChannel);
-                removeOfferButton.setVisible(isMyMessage && isPublicChannel);
-                removeOfferButton.setManaged(isMyMessage && isPublicChannel);
-
-                setOnMouseEntered(e -> {
-                    if (model.getSelectedChatMessageForMoreOptionsPopup().get() != null || editInputField.isVisible()) {
-                        return;
-                    }
-                    dateTime.setVisible(true);
-                    reactionsHBox.setVisible(true);
-                });
-
-                setOnMouseExited(e -> {
-                    if (model.getSelectedChatMessageForMoreOptionsPopup().get() == null) {
-                        hideReactionsBox();
-                        dateTime.setVisible(false);
-                        reactionsHBox.setVisible(false);
-                    }
-                });
-            }
-
-            private void handleQuoteMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
-                Optional<Citation> optionalCitation = item.getCitation();
-                if (optionalCitation.isPresent()) {
-                    Citation citation = optionalCitation.get();
-                    if (citation.isValid()) {
-                        quotedMessageVBox.setVisible(true);
-                        quotedMessageVBox.setManaged(true);
-                        quotedMessageField.setText(citation.getText());
-                        quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
-                        Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
-                        userName.getStyleClass().add("font-medium");
-                        userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
-                        quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
-                    }
-                } else {
-                    quotedMessageVBox.getChildren().clear();
-                    quotedMessageVBox.setVisible(false);
-                    quotedMessageVBox.setManaged(false);
-                }
-            }
-
-            private void onEditMessage(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
-                reactionsHBox.setVisible(false);
-                editInputField.setVisible(true);
-                editInputField.setManaged(true);
-                editInputField.setInitialHeight(message.getBoundsInLocal().getHeight());
-                editInputField.setText(message.getText().replace(EDITED_POST_FIX, ""));
-                editInputField.requestFocus();
-                editInputField.positionCaret(message.getText().length());
-                editButtonsHBox.setVisible(true);
-                editButtonsHBox.setManaged(true);
-                removeOfferButton.setVisible(false);
-                removeOfferButton.setManaged(false);
-
-                message.setVisible(false);
-                message.setManaged(false);
-
-                editInputField.setOnKeyPressed(event -> {
-                    if (event.getCode() == KeyCode.ENTER) {
-                        event.consume();
-                        if (event.isShiftDown()) {
-                            editInputField.appendText(System.getProperty("line.separator"));
-                        } else if (!editInputField.getText().isEmpty()) {
-                            controller.onSaveEditedMessage(item.getChatMessage(), editInputField.getText().trim());
-                            onCloseEditMessage();
-                        }
-                    }
-                });
-            }
-
-            private void onCloseEditMessage() {
-                editInputField.setVisible(false);
-                editInputField.setManaged(false);
-                editButtonsHBox.setVisible(false);
-                editButtonsHBox.setManaged(false);
-                removeOfferButton.setVisible(true);
-                removeOfferButton.setManaged(true);
-
-                message.setVisible(true);
-                message.setManaged(true);
-                editInputField.setOnKeyPressed(null);
-            }
         };
-    }
-
-    private static Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
-        Label iconLabel = Icons.getIcon(icon);
-        iconLabel.setCursor(Cursor.HAND);
-        iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
-        return iconLabel;
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
@@ -1,0 +1,208 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.components.chatMessages;
+
+import bisq.chat.ChatMessage;
+import bisq.chat.Citation;
+import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
+import bisq.chat.priv.PrivateChatMessage;
+import bisq.common.observable.Observable;
+import bisq.common.observable.Pin;
+import bisq.common.observable.map.HashMapObserver;
+import bisq.common.util.StringUtils;
+import bisq.desktop.common.threading.UIThread;
+import bisq.i18n.Res;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.services.confidential.ack.MessageDeliveryStatus;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.presentation.formatters.DateFormatter;
+import bisq.trade.Trade;
+import bisq.trade.bisq_easy.BisqEasyTradeService;
+import bisq.user.identity.UserIdentityService;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+import de.jensd.fx.fontawesome.AwesomeIcon;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.text.DateFormat;
+import java.util.*;
+
+import static bisq.desktop.main.content.components.ChatMessagesComponent.View.EDITED_POST_FIX;
+
+@Slf4j
+@Getter
+@EqualsAndHashCode
+public final class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessageListItem<T>> {
+    private final T chatMessage;
+    private final String message;
+    private final String date;
+    private final Optional<Citation> citation;
+    private final Optional<UserProfile> senderUserProfile;
+    private final String nym;
+    private final String nickName;
+    @EqualsAndHashCode.Exclude
+    private final ReputationScore reputationScore;
+    private final boolean canTakeOffer;
+    @EqualsAndHashCode.Exclude
+    private final StringProperty messageDeliveryStatusTooltip = new SimpleStringProperty();
+    @EqualsAndHashCode.Exclude
+    private final ObjectProperty<AwesomeIcon> messageDeliveryStatusIcon = new SimpleObjectProperty<>();
+    @EqualsAndHashCode.Exclude
+    private Optional<String> messageDeliveryStatusIconColor = Optional.empty();
+    @EqualsAndHashCode.Exclude
+    private final Set<Pin> mapPins = new HashSet<>();
+    @EqualsAndHashCode.Exclude
+    private final Set<Pin> statusPins = new HashSet<>();
+
+    public ChatMessageListItem(T chatMessage,
+                               UserProfileService userProfileService,
+                               ReputationService reputationService,
+                               BisqEasyTradeService bisqEasyTradeService,
+                               UserIdentityService userIdentityService,
+                               NetworkService networkService) {
+        this.chatMessage = chatMessage;
+
+        if (chatMessage instanceof PrivateChatMessage) {
+            senderUserProfile = Optional.of(((PrivateChatMessage) chatMessage).getSenderUserProfile());
+        } else {
+            senderUserProfile = userProfileService.findUserProfile(chatMessage.getAuthorUserProfileId());
+        }
+        String editPostFix = chatMessage.isWasEdited() ? EDITED_POST_FIX : "";
+        message = chatMessage.getText() + editPostFix;
+        citation = chatMessage.getCitation();
+        date = DateFormatter.formatDateTime(new Date(chatMessage.getDate()), DateFormat.MEDIUM, DateFormat.SHORT,
+                true, " " + Res.get("temporal.at") + " ");
+
+        nym = senderUserProfile.map(UserProfile::getNym).orElse("");
+        nickName = senderUserProfile.map(UserProfile::getNickName).orElse("");
+
+        reputationScore = senderUserProfile.flatMap(reputationService::findReputationScore).orElse(ReputationScore.NONE);
+
+        if (chatMessage instanceof BisqEasyOfferbookMessage) {
+            BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
+            if (userIdentityService.getSelectedUserIdentity() != null && bisqEasyOfferbookMessage.getBisqEasyOffer().isPresent()) {
+                UserProfile userProfile = userIdentityService.getSelectedUserIdentity().getUserProfile();
+                NetworkId takerNetworkId = userProfile.getNetworkId();
+                BisqEasyOffer bisqEasyOffer = bisqEasyOfferbookMessage.getBisqEasyOffer().get();
+                String tradeId = Trade.createId(bisqEasyOffer.getId(), takerNetworkId.getId());
+                canTakeOffer = !bisqEasyTradeService.tradeExists(tradeId);
+            } else {
+                canTakeOffer = false;
+            }
+        } else {
+            canTakeOffer = false;
+        }
+
+        mapPins.add(networkService.getMessageDeliveryStatusByMessageId().addObserver(new HashMapObserver<>() {
+            @Override
+            public void put(String key, Observable<MessageDeliveryStatus> value) {
+                if (key.equals(chatMessage.getId())) {
+                    // Delay to avoid ConcurrentModificationException
+                    UIThread.runOnNextRenderFrame(() -> {
+                        statusPins.add(value.addObserver(status -> {
+                            UIThread.run(() -> {
+                                if (status != null) {
+                                    messageDeliveryStatusIconColor = Optional.empty();
+                                    messageDeliveryStatusTooltip.set(Res.get("chat.message.deliveryState." + status.name()));
+                                    switch (status) {
+                                        case CONNECTING:
+                                            // -bisq-mid-grey-20: #808080;
+                                            messageDeliveryStatusIconColor = Optional.of("#808080");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.SPINNER);
+                                            break;
+                                        case SENT:
+                                            // -bisq-light-grey-50: #eaeaea;
+                                            messageDeliveryStatusIconColor = Optional.of("#eaeaea");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.CIRCLE_ARROW_RIGHT);
+                                            break;
+                                        case ACK_RECEIVED:
+                                            // -bisq2-green-dim-50: #2b5724;
+                                            messageDeliveryStatusIconColor = Optional.of("#2b5724");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.OK_SIGN);
+                                            break;
+                                        case TRY_ADD_TO_MAILBOX:
+                                            // -bisq2-yellow: #d0831f;
+                                            messageDeliveryStatusIconColor = Optional.of("#d0831f");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.SHARE_SIGN);
+                                            break;
+                                        case ADDED_TO_MAILBOX:
+                                            // -bisq2-yellow: #d0831f;
+                                            messageDeliveryStatusIconColor = Optional.of("#d0831f");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_UPLOAD);
+                                            break;
+                                        case MAILBOX_MSG_RECEIVED:
+                                            // -bisq2-green-dim-50: #2b5724;
+                                            messageDeliveryStatusIconColor = Optional.of("#2b5724");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.CLOUD_DOWNLOAD);
+                                            break;
+                                        case FAILED:
+                                            // -bisq2-red: #d02c1f;
+                                            messageDeliveryStatusIconColor = Optional.of("#d02c1f");
+                                            messageDeliveryStatusIcon.set(AwesomeIcon.EXCLAMATION_SIGN);
+                                            break;
+                                    }
+                                }
+                            });
+                        }));
+                    });
+                }
+            }
+
+            @Override
+            public void putAll(Map<? extends String, ? extends Observable<MessageDeliveryStatus>> map) {
+                map.forEach(this::put);
+            }
+
+            @Override
+            public void remove(Object key) {
+            }
+
+            @Override
+            public void clear() {
+            }
+        }));
+    }
+
+    @Override
+    public int compareTo(ChatMessageListItem o) {
+        return Comparator.comparingLong(ChatMessage::getDate).compare(this.getChatMessage(), o.getChatMessage());
+    }
+
+    public boolean match(String filterString) {
+        return filterString == null
+                || filterString.isEmpty()
+                || StringUtils.containsIgnoreCase(message, filterString)
+                || StringUtils.containsIgnoreCase(nym, filterString)
+                || StringUtils.containsIgnoreCase(nickName, filterString)
+                || StringUtils.containsIgnoreCase(date, filterString);
+    }
+
+    public void dispose() {
+        mapPins.forEach(Pin::unbind);
+        statusPins.forEach(Pin::unbind);
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
@@ -51,12 +51,12 @@ import lombok.extern.slf4j.Slf4j;
 import java.text.DateFormat;
 import java.util.*;
 
-import static bisq.desktop.main.content.components.ChatMessagesComponent.View.EDITED_POST_FIX;
+import static bisq.desktop.main.content.components.chatMessages.ChatMessagesComponent.View.EDITED_POST_FIX;
 
 @Slf4j
 @Getter
 @EqualsAndHashCode
-public final class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessageListItem<T>> {
+final class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessageListItem<T>> {
     private final T chatMessage;
     private final String message;
     private final String date;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
@@ -56,7 +56,7 @@ import static bisq.desktop.main.content.components.chatMessages.ChatMessagesComp
 @Slf4j
 @Getter
 @EqualsAndHashCode
-final class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessageListItem<T>> {
+public final class ChatMessageListItem<T extends ChatMessage> implements Comparable<ChatMessageListItem<T>> {
     private final T chatMessage;
     private final String message;
     private final String date;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
@@ -103,7 +103,7 @@ public class ChatMessagesComponent {
         controller.mentionUserHandler(userProfile);
     }
 
-    public void setSearchPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage>> predicate) {
+    public void setSearchPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
         controller.chatMessagesListView.setSearchPredicate(predicate);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.main.content.components;
+package bisq.desktop.main.content.components.chatMessages;
 
 import bisq.account.AccountService;
 import bisq.account.accounts.Account;
@@ -40,7 +40,11 @@ import bisq.desktop.components.controls.BisqTextArea;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.chat.ChatUtil;
+import bisq.desktop.main.content.components.ChatMentionPopupMenu;
+import bisq.desktop.main.content.components.CitationBlock;
+import bisq.desktop.main.content.components.UserProfileSelection;
 import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
+import bisq.desktop.main.content.components.chatMessages.ChatMessagesListView;
 import bisq.i18n.Res;
 import bisq.offer.Direction;
 import bisq.offer.bisq_easy.BisqEasyOffer;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
@@ -30,10 +30,8 @@ import bisq.chat.priv.PrivateChatMessage;
 import bisq.chat.pub.PublicChatChannel;
 import bisq.chat.pub.PublicChatMessage;
 import bisq.chat.two_party.TwoPartyPrivateChatChannel;
-import bisq.common.locale.LanguageRepository;
 import bisq.common.observable.Pin;
 import bisq.common.observable.collection.CollectionObserver;
-import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Transitions;
 import bisq.desktop.common.observable.FxBindings;
@@ -59,7 +57,6 @@ import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationService;
-import com.google.common.base.Joiner;
 import com.sun.javafx.scene.control.VirtualScrollBar;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
@@ -88,7 +85,6 @@ import org.fxmisc.easybind.Subscription;
 
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -324,7 +320,7 @@ public class ChatMessagesListView {
             Navigation.navigateTo(NavigationTarget.TAKE_OFFER, new TakeOfferController.InitData(bisqEasyOffer));
         }
 
-        void onDeleteMessage(ChatMessage chatMessage) {
+        public void onDeleteMessage(ChatMessage chatMessage) {
             String authorUserProfileId = chatMessage.getAuthorUserProfileId();
             userIdentityService.findUserIdentity(authorUserProfileId)
                     .ifPresent(authorUserIdentity -> {
@@ -369,7 +365,7 @@ public class ChatMessagesListView {
                     .ifPresent(this::createAndSelectTwoPartyPrivateChatChannel);
         }
 
-        void onSaveEditedMessage(ChatMessage chatMessage, String editedText) {
+        public void onSaveEditedMessage(ChatMessage chatMessage, String editedText) {
             checkArgument(chatMessage instanceof PublicChatMessage);
             checkArgument(model.isMyMessage(chatMessage));
 
@@ -429,7 +425,7 @@ public class ChatMessagesListView {
                     .ifPresent(userProfileService::ignoreUserProfile);
         }
 
-        void onCopyMessage(ChatMessage chatMessage) {
+        public void onCopyMessage(ChatMessage chatMessage) {
             ClipboardUtil.copyToClipboard(chatMessage.getText());
         }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.desktop.main.content.components;
+package bisq.desktop.main.content.components.chatMessages;
 
 import bisq.bisq_easy.NavigationTarget;
 import bisq.chat.*;
@@ -50,6 +50,9 @@ import bisq.desktop.components.list_view.NoSelectionModel;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.take_offer.TakeOfferController;
 import bisq.desktop.main.content.chat.ChatUtil;
+import bisq.desktop.main.content.components.ReportToModeratorWindow;
+import bisq.desktop.main.content.components.ReputationScoreDisplay;
+import bisq.desktop.main.content.components.UserProfileIcon;
 import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
 import bisq.i18n.Res;
 import bisq.network.NetworkService;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
@@ -36,14 +36,12 @@ import bisq.common.observable.Pin;
 import bisq.common.observable.collection.CollectionObserver;
 import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
-import bisq.desktop.common.Icons;
 import bisq.desktop.common.Transitions;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.view.Navigation;
-import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.*;
 import bisq.desktop.components.list_view.ListViewUtil;
 import bisq.desktop.components.list_view.NoSelectionModel;
@@ -51,9 +49,6 @@ import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.take_offer.TakeOfferController;
 import bisq.desktop.main.content.chat.ChatUtil;
 import bisq.desktop.main.content.components.ReportToModeratorWindow;
-import bisq.desktop.main.content.components.ReputationScoreDisplay;
-import bisq.desktop.main.content.components.UserProfileIcon;
-import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
 import bisq.i18n.Res;
 import bisq.network.NetworkService;
 import bisq.offer.bisq_easy.BisqEasyOffer;
@@ -67,8 +62,6 @@ import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationService;
 import com.google.common.base.Joiner;
 import com.sun.javafx.scene.control.VirtualScrollBar;
-import de.jensd.fx.fontawesome.AwesomeDude;
-import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
@@ -86,9 +79,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.KeyCode;
 import javafx.scene.layout.*;
-import javafx.util.Callback;
 import javafx.util.Duration;
 import lombok.Getter;
 import lombok.Setter;
@@ -133,7 +124,7 @@ public class ChatMessagesListView {
         controller.refreshMessages();
     }
 
-    private static class Controller implements bisq.desktop.common.view.Controller {
+    static class Controller implements bisq.desktop.common.view.Controller {
         private final ChatService chatService;
         private final UserIdentityService userIdentityService;
         private final UserProfileService userProfileService;
@@ -299,15 +290,15 @@ public class ChatMessagesListView {
         // UI - delegate to client
         ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-        private void onMention(UserProfile userProfile) {
+        void onMention(UserProfile userProfile) {
             mentionUserHandler.accept(userProfile);
         }
 
-        private void onShowChatUserDetails(ChatMessage chatMessage) {
+        void onShowChatUserDetails(ChatMessage chatMessage) {
             showChatUserDetailsHandler.accept(chatMessage);
         }
 
-        private void onReply(ChatMessage chatMessage) {
+        void onReply(ChatMessage chatMessage) {
             replyHandler.accept(chatMessage);
         }
 
@@ -316,7 +307,7 @@ public class ChatMessagesListView {
         // UI - handler
         ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-        private void onTakeOffer(BisqEasyOfferbookMessage chatMessage, boolean canTakeOffer) {
+        void onTakeOffer(BisqEasyOfferbookMessage chatMessage, boolean canTakeOffer) {
             if (userIdentityService.getSelectedUserIdentity() == null ||
                     bannedUserService.isUserProfileBanned(chatMessage.getAuthorUserProfileId()) ||
                     bannedUserService.isUserProfileBanned(userIdentityService.getSelectedUserIdentity().getUserProfile())) {
@@ -334,7 +325,7 @@ public class ChatMessagesListView {
             Navigation.navigateTo(NavigationTarget.TAKE_OFFER, new TakeOfferController.InitData(bisqEasyOffer));
         }
 
-        private void onDeleteMessage(ChatMessage chatMessage) {
+        void onDeleteMessage(ChatMessage chatMessage) {
             String authorUserProfileId = chatMessage.getAuthorUserProfileId();
             userIdentityService.findUserIdentity(authorUserProfileId)
                     .ifPresent(authorUserIdentity -> {
@@ -372,14 +363,14 @@ public class ChatMessagesListView {
             }
         }
 
-        private void onOpenPrivateChannel(ChatMessage chatMessage) {
+        void onOpenPrivateChannel(ChatMessage chatMessage) {
             checkArgument(!model.isMyMessage(chatMessage));
 
             userProfileService.findUserProfile(chatMessage.getAuthorUserProfileId())
                     .ifPresent(this::createAndSelectTwoPartyPrivateChatChannel);
         }
 
-        private void onSaveEditedMessage(ChatMessage chatMessage, String editedText) {
+        void onSaveEditedMessage(ChatMessage chatMessage, String editedText) {
             checkArgument(chatMessage instanceof PublicChatMessage);
             checkArgument(model.isMyMessage(chatMessage));
 
@@ -398,7 +389,7 @@ public class ChatMessagesListView {
             }
         }
 
-        private void onOpenMoreOptions(Node owner, ChatMessage chatMessage, Runnable onClose) {
+        void onOpenMoreOptions(Node owner, ChatMessage chatMessage, Runnable onClose) {
             if (chatMessage.equals(model.selectedChatMessageForMoreOptionsPopup.get())) {
                 return;
             }
@@ -439,7 +430,7 @@ public class ChatMessagesListView {
                     .ifPresent(userProfileService::ignoreUserProfile);
         }
 
-        private void onCopyMessage(ChatMessage chatMessage) {
+        void onCopyMessage(ChatMessage chatMessage) {
             ClipboardUtil.copyToClipboard(chatMessage.getText());
         }
 
@@ -515,7 +506,7 @@ public class ChatMessagesListView {
                     BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) item.getChatMessage();
                     offerOnlyPredicate = !offerOnly || bisqEasyOfferbookMessage.hasBisqEasyOffer();
                 }
-                // We do not display the take offer message as it has no text and is used only for sending the offer 
+                // We do not display the take offer message as it has no text and is used only for sending the offer
                 // to the peer and signalling the take offer event.
                 if (item.getChatMessage().getChatMessageType() == ChatMessageType.TAKE_BISQ_EASY_OFFER) {
                     return false;
@@ -582,18 +573,18 @@ public class ChatMessagesListView {
             });
         }
 
-        private String getUserName(String userProfileId) {
+        String getUserName(String userProfileId) {
             return userProfileService.findUserProfile(userProfileId)
                     .map(UserProfile::getUserName)
                     .orElse(Res.get("data.na"));
         }
 
-        private String getSupportedLanguageCodes(BisqEasyOfferbookMessage chatMessage) {
+        String getSupportedLanguageCodes(BisqEasyOfferbookMessage chatMessage) {
             String result = getSupportedLanguageCodes(chatMessage, ", ", LanguageRepository::getDisplayLanguage);
             return result.isEmpty() ? "" : Res.get("chat.message.supportedLanguages") + " " + StringUtils.truncate(result, 100);
         }
 
-        private String getSupportedLanguageCodesForTooltip(BisqEasyOfferbookMessage chatMessage) {
+        String getSupportedLanguageCodesForTooltip(BisqEasyOfferbookMessage chatMessage) {
             String result = getSupportedLanguageCodes(chatMessage, "\n", LanguageRepository::getDisplayString);
             return result.isEmpty() ? "" : Res.get("chat.message.supportedLanguages") + "\n" + result;
         }
@@ -610,7 +601,7 @@ public class ChatMessagesListView {
     }
 
     @Getter
-    private static class Model implements bisq.desktop.common.view.Model {
+    static class Model implements bisq.desktop.common.view.Model {
         private final UserIdentityService userIdentityService;
         private final ObjectProperty<ChatChannel<?>> selectedChannel = new SimpleObjectProperty<>();
         private final ObservableList<ChatMessageListItem<? extends ChatMessage>> chatMessages = FXCollections.observableArrayList();
@@ -649,8 +640,6 @@ public class ChatMessagesListView {
 
     @Slf4j
     private static class View extends bisq.desktop.common.view.View<StackPane, Model, Controller> {
-        private static final String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
-
         private final ListView<ChatMessageListItem<? extends ChatMessage>> listView;
         private final ImageView scrollDownImageView;
         private final Badge scrollDownBadge;
@@ -670,7 +659,7 @@ public class ChatMessagesListView {
             VBox placeholder = ChatUtil.createEmptyChatPlaceholder(placeholderTitle, placeholderDescription);
             listView.setPlaceholder(placeholder);
 
-            listView.setCellFactory(getCellFactory());
+            listView.setCellFactory(new ChatMessageListCellFactory(controller, model));
 
             // https://stackoverflow.com/questions/20621752/javafx-make-listview-not-selectable-via-mouse
             listView.setSelectionModel(new NoSelectionModel<>());
@@ -788,503 +777,6 @@ public class ChatMessagesListView {
                     new KeyValue(scrollDownBadge.opacityProperty(), 1, Interpolator.EASE_OUT)
             ));
             fadeInScrollDownBadgeTimeline.play();
-        }
-
-        public Callback<ListView<ChatMessageListItem<? extends ChatMessage>>, ListCell<ChatMessageListItem<? extends ChatMessage>>> getCellFactory() {
-            return new Callback<>() {
-                @Override
-                public ListCell<ChatMessageListItem<? extends ChatMessage>> call(ListView<ChatMessageListItem<? extends ChatMessage>> list) {
-                    return new ListCell<>() {
-                        private final static double CHAT_BOX_MAX_WIDTH = 1200;
-                        private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
-
-                        private final ReputationScoreDisplay reputationScoreDisplay;
-                        private final Button takeOfferButton, removeOfferButton;
-                        private final Label message, userName, dateTime, replyIcon, pmIcon, editIcon, deleteIcon, copyIcon,
-                                moreOptionsIcon, supportedLanguages;
-                        private final Label deliveryState;
-                        private final Label quotedMessageField = new Label();
-                        private final BisqTextArea editInputField;
-                        private final Button saveEditButton, cancelEditButton;
-                        private final VBox mainVBox, quotedMessageVBox;
-                        private final HBox cellHBox, messageHBox, messageBgHBox, reactionsHBox, editButtonsHBox;
-                        private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
-                        private final Set<Subscription> subscriptions = new HashSet<>();
-
-                        {
-                            userName = new Label();
-                            userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
-
-                            deliveryState = new Label();
-                            deliveryState.setCursor(Cursor.HAND);
-                            deliveryState.setTooltip(new BisqTooltip(true));
-
-                            dateTime = new Label();
-                            dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
-
-                            reputationScoreDisplay = new ReputationScoreDisplay();
-                            takeOfferButton = new Button(Res.get("offer.takeOffer"));
-
-                            removeOfferButton = new Button(Res.get("offer.deleteOffer"));
-                            removeOfferButton.getStyleClass().addAll("red-small-button", "no-background");
-
-                            // quoted message
-                            quotedMessageField.setWrapText(true);
-                            quotedMessageVBox = new VBox(5);
-                            quotedMessageVBox.setVisible(false);
-                            quotedMessageVBox.setManaged(false);
-
-                            // HBox for message reputation vBox and action button
-                            message = new Label();
-                            message.setWrapText(true);
-                            message.setPadding(new Insets(10));
-                            message.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
-
-
-                            // edit
-                            editInputField = new BisqTextArea();
-                            //editInputField.getStyleClass().addAll("text-fill-white", "font-size-13", "font-default");
-                            editInputField.setId("chat-messages-edit-text-area");
-                            editInputField.setMinWidth(150);
-                            editInputField.setVisible(false);
-                            editInputField.setManaged(false);
-
-                            // edit buttons
-                            saveEditButton = new Button(Res.get("action.save"));
-                            saveEditButton.setDefaultButton(true);
-                            cancelEditButton = new Button(Res.get("action.cancel"));
-
-                            editButtonsHBox = new HBox(15, Spacer.fillHBox(), cancelEditButton, saveEditButton);
-                            editButtonsHBox.setVisible(false);
-                            editButtonsHBox.setManaged(false);
-
-                            messageBgHBox = new HBox(15);
-                            messageBgHBox.setAlignment(Pos.CENTER_LEFT);
-                            messageBgHBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
-
-                            // Reactions box
-                            replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
-                            pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
-                            editIcon = getIconWithToolTip(AwesomeIcon.EDIT, Res.get("action.edit"));
-                            HBox.setMargin(editIcon, new Insets(1, 0, 0, 0));
-                            copyIcon = getIconWithToolTip(AwesomeIcon.COPY, Res.get("action.copyToClipboard"));
-                            deleteIcon = getIconWithToolTip(AwesomeIcon.REMOVE_SIGN, Res.get("action.delete"));
-                            moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
-                            supportedLanguages = new Label();
-
-                            reactionsHBox = new HBox(20);
-
-                            reactionsHBox.setVisible(false);
-
-                            HBox.setHgrow(messageBgHBox, Priority.SOMETIMES);
-                            messageHBox = new HBox();
-
-                            VBox.setMargin(quotedMessageVBox, new Insets(15, 0, 10, 5));
-                            VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
-                            VBox.setMargin(editButtonsHBox, new Insets(10, 25, -15, 0));
-                            mainVBox = new VBox();
-                            mainVBox.setFillWidth(true);
-                            HBox.setHgrow(mainVBox, Priority.ALWAYS);
-                            cellHBox = new HBox(15);
-                            cellHBox.setMaxWidth(CHAT_BOX_MAX_WIDTH);
-                            cellHBox.setAlignment(Pos.CENTER);
-                        }
-
-
-                        private void hideReactionsBox() {
-                            reactionsHBox.setVisible(false);
-                        }
-
-                        @Override
-                        public void updateItem(final ChatMessageListItem<? extends ChatMessage> item, boolean empty) {
-                            super.updateItem(item, empty);
-                            if (item == null || empty) {
-                                cleanup();
-                                return;
-                            }
-
-                            subscriptions.clear();
-                            ChatMessage chatMessage = item.getChatMessage();
-
-                            Node flow = this.getListView().lookup(".virtual-flow");
-                            if (flow != null && !flow.isVisible()) {
-                                return;
-                            }
-
-                            boolean hasTradeChatOffer = model.hasTradeChatOffer(chatMessage);
-                            boolean isBisqEasyPublicChatMessageWithOffer = chatMessage instanceof BisqEasyOfferbookMessage && hasTradeChatOffer;
-                            boolean isMyMessage = model.isMyMessage(chatMessage);
-
-                            if (isBisqEasyPublicChatMessageWithOffer) {
-                                supportedLanguages.setText(controller.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) chatMessage)));
-                                supportedLanguages.setTooltip(new BisqTooltip(controller.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) chatMessage))));
-                            }
-
-                            dateTime.setVisible(false);
-
-                            cellHBox.getChildren().setAll(mainVBox);
-
-                            message.maxWidthProperty().unbind();
-                            if (hasTradeChatOffer) {
-                                messageBgHBox.setPadding(new Insets(15));
-                            } else {
-                                messageBgHBox.setPadding(new Insets(5, 15, 5, 15));
-                            }
-                            messageBgHBox.getStyleClass().removeAll("chat-message-bg-my-message", "chat-message-bg-peer-message");
-                            VBox userProfileIconVbox = new VBox(userProfileIcon);
-                            if (isMyMessage) {
-                                buildMyMessage(isBisqEasyPublicChatMessageWithOffer, userProfileIconVbox, chatMessage);
-                            } else {
-                                buildPeerMessage(item, isBisqEasyPublicChatMessageWithOffer, userProfileIconVbox, chatMessage);
-                            }
-
-                            handleQuoteMessageBox(item);
-                            handleReactionsBox(item);
-                            handleEditBox(chatMessage);
-
-                            message.setText(item.getMessage());
-                            dateTime.setText(item.getDate());
-
-                            item.getSenderUserProfile().ifPresent(author -> {
-                                userName.setText(author.getUserName());
-                                userName.setOnMouseClicked(e -> controller.onMention(author));
-
-                                userProfileIcon.setUserProfile(author);
-                                userProfileIcon.setCursor(Cursor.HAND);
-                                Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
-                                userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(chatMessage));
-                            });
-
-                            subscriptions.add(EasyBind.subscribe(item.getMessageDeliveryStatusIcon(), icon -> {
-                                        deliveryState.setManaged(icon != null);
-                                        deliveryState.setVisible(icon != null);
-                                        if (icon != null) {
-                                            AwesomeDude.setIcon(deliveryState, icon, AwesomeDude.DEFAULT_ICON_SIZE);
-                                            item.getMessageDeliveryStatusIconColor().ifPresent(color ->
-                                                    Icons.setAwesomeIconColor(deliveryState, color));
-                                        }
-                                    }
-                            ));
-                            deliveryState.getTooltip().textProperty().bind(item.getMessageDeliveryStatusTooltip());
-                            editInputField.maxWidthProperty().bind(message.widthProperty());
-
-                            subscriptions.add(EasyBind.subscribe(mainVBox.widthProperty(), width -> {
-                                if (width == null) {
-                                    return;
-                                }
-                                mainVBox.getStyleClass().clear();
-
-                                // List cell has no padding, so it must have the same width as list view (no scrollbar)
-                                if (width.doubleValue() == listView.widthProperty().doubleValue()) {
-                                    mainVBox.getStyleClass().add("chat-message-list-cell-wo-scrollbar");
-                                    return;
-                                }
-
-                                if (width.doubleValue() < CHAT_BOX_MAX_WIDTH) {
-                                    // List cell has different size as list view, therefore there's a scrollbar
-                                    mainVBox.getStyleClass().add("chat-message-list-cell-w-scrollbar-full-width");
-                                } else {
-                                    // FIXME (low prio): needs to take into account whether there's scrollbar
-                                    mainVBox.getStyleClass().add("chat-message-list-cell-w-scrollbar-max-width");
-                                }
-                            }));
-
-                            setGraphic(cellHBox);
-                            setAlignment(Pos.CENTER);
-                        }
-
-                        private void buildPeerMessage(ChatMessageListItem<? extends ChatMessage> item, boolean isBisqEasyPublicChatMessageWithOffer, VBox userProfileIconVbox, ChatMessage chatMessage) {
-                            // Peer
-                            HBox userNameAndDateHBox = new HBox(10, userName, dateTime);
-                            message.setAlignment(Pos.CENTER_LEFT);
-                            userNameAndDateHBox.setAlignment(Pos.CENTER_LEFT);
-
-                            userProfileIcon.setSize(60);
-                            HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
-                            HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
-                            HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
-
-
-                            quotedMessageVBox.setId("chat-message-quote-box-peer-msg");
-
-                            messageBgHBox.getStyleClass().add("chat-message-bg-peer-message");
-                            if (isBisqEasyPublicChatMessageWithOffer) {
-                                reactionsHBox.getChildren().setAll(replyIcon, pmIcon, editIcon, deleteIcon, moreOptionsIcon, supportedLanguages, Spacer.fillHBox());
-                                message.maxWidthProperty().bind(root.widthProperty().subtract(430));
-                                userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
-
-                                Label reputationLabel = new Label(Res.get("chat.message.reputation").toUpperCase());
-                                reputationLabel.getStyleClass().add("bisq-text-7");
-
-                                reputationScoreDisplay.setReputationScore(item.getReputationScore());
-                                VBox reputationVBox = new VBox(4, reputationLabel, reputationScoreDisplay);
-                                reputationVBox.setAlignment(Pos.CENTER_LEFT);
-
-                                BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
-                                takeOfferButton.setOnAction(e -> controller.onTakeOffer(bisqEasyOfferbookMessage, item.isCanTakeOffer()));
-                                takeOfferButton.setDefaultButton(item.isCanTakeOffer());
-                                takeOfferButton.setMinWidth(Control.USE_PREF_SIZE);
-
-                                VBox messageVBox = new VBox(quotedMessageVBox, message);
-                                HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
-                                HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
-                                HBox.setMargin(reputationVBox, new Insets(-5, 10, 0, 0));
-                                HBox.setMargin(takeOfferButton, new Insets(0, 10, 0, 0));
-                                messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox, Spacer.fillHBox(), reputationVBox, takeOfferButton);
-
-                                VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, 5, 10));
-                                mainVBox.getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);
-                            } else {
-                                reactionsHBox.getChildren().setAll(replyIcon, pmIcon, editIcon, deleteIcon, moreOptionsIcon, Spacer.fillHBox());
-                                message.maxWidthProperty().bind(root.widthProperty().subtract(140));//165
-                                userProfileIcon.setSize(30);
-                                userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
-
-                                VBox messageVBox = new VBox(quotedMessageVBox, message);
-                                HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
-                                HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
-                                messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox);
-                                messageHBox.getChildren().setAll(messageBgHBox, Spacer.fillHBox());
-
-                                VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, -5, 10));
-                                mainVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
-                            }
-                        }
-
-                        private void buildMyMessage(boolean isBisqEasyPublicChatMessageWithOffer, VBox userProfileIconVbox, ChatMessage chatMessage) {
-                            HBox userNameAndDateHBox = new HBox(10, dateTime, userName);
-                            userNameAndDateHBox.setAlignment(Pos.CENTER_RIGHT);
-                            message.setAlignment(Pos.CENTER_RIGHT);
-
-                            quotedMessageVBox.setId("chat-message-quote-box-my-msg");
-
-                            messageBgHBox.getStyleClass().add("chat-message-bg-my-message");
-                            VBox.setMargin(userNameAndDateHBox, new Insets(-5, 10, -5, 0));
-
-                            VBox messageVBox = new VBox(quotedMessageVBox, message, editInputField);
-                            if (isBisqEasyPublicChatMessageWithOffer) {
-                                message.maxWidthProperty().bind(root.widthProperty().subtract(160));
-                                userProfileIcon.setSize(60);
-                                userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
-                                HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
-                                HBox.setMargin(editInputField, new Insets(-4, -10, -15, 0));
-                                HBox.setMargin(messageVBox, new Insets(0, -10, 0, 0));
-
-                                removeOfferButton.setOnAction(e -> controller.onDeleteMessage(chatMessage));
-                                reactionsHBox.getChildren().setAll(Spacer.fillHBox(), replyIcon, pmIcon, editIcon, supportedLanguages, copyIcon);
-                                reactionsHBox.setAlignment(Pos.CENTER_RIGHT);
-
-                                HBox.setMargin(userProfileIconVbox, new Insets(0, 0, 10, 0));
-                                HBox hBox = new HBox(15, messageVBox, userProfileIconVbox);
-                                HBox removeOfferButtonHBox = new HBox(Spacer.fillHBox(), removeOfferButton);
-                                VBox vBox = new VBox(hBox, removeOfferButtonHBox);
-                                messageBgHBox.getChildren().setAll(vBox);
-                            } else {
-                                message.maxWidthProperty().bind(root.widthProperty().subtract(140));
-                                userProfileIcon.setSize(30);
-                                userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
-                                HBox.setMargin(deleteIcon, new Insets(0, 10, 0, 0));
-                                reactionsHBox.getChildren().setAll(Spacer.fillHBox(), replyIcon, pmIcon, editIcon, copyIcon, deleteIcon);
-                                HBox.setMargin(messageVBox, new Insets(0, -15, 0, 0));
-                                HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
-                                HBox.setMargin(editInputField, new Insets(6, -10, -25, 0));
-                                messageBgHBox.getChildren().setAll(messageVBox, userProfileIconVbox);
-                            }
-
-                            HBox.setMargin(deliveryState, new Insets(0, 10, 0, 0));
-                            HBox deliveryStateHBox = new HBox(Spacer.fillHBox(), reactionsHBox);
-
-                            subscriptions.add(EasyBind.subscribe(reactionsHBox.visibleProperty(), v -> {
-                                if (v) {
-                                    deliveryStateHBox.getChildren().remove(deliveryState);
-                                    if (!reactionsHBox.getChildren().contains(deliveryState)) {
-                                        reactionsHBox.getChildren().add(deliveryState);
-                                    }
-                                } else {
-                                    reactionsHBox.getChildren().remove(deliveryState);
-                                    if (!deliveryStateHBox.getChildren().contains(deliveryState)) {
-                                        deliveryStateHBox.getChildren().add(deliveryState);
-                                    }
-                                }
-                            }));
-
-                            VBox.setMargin(deliveryStateHBox, new Insets(4, 0, -3, 0));
-                            mainVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, deliveryStateHBox);
-
-                            messageHBox.getChildren().setAll(Spacer.fillHBox(), messageBgHBox);
-                        }
-
-
-                        private void cleanup() {
-                            message.maxWidthProperty().unbind();
-                            editInputField.maxWidthProperty().unbind();
-
-                            editInputField.maxWidthProperty().unbind();
-                            removeOfferButton.setOnAction(null);
-                            takeOfferButton.setOnAction(null);
-
-                            saveEditButton.setOnAction(null);
-                            cancelEditButton.setOnAction(null);
-
-                            userName.setOnMouseClicked(null);
-                            userProfileIcon.setOnMouseClicked(null);
-                            replyIcon.setOnMouseClicked(null);
-                            pmIcon.setOnMouseClicked(null);
-                            editIcon.setOnMouseClicked(null);
-                            copyIcon.setOnMouseClicked(null);
-                            deleteIcon.setOnMouseClicked(null);
-                            moreOptionsIcon.setOnMouseClicked(null);
-
-                            editInputField.setOnKeyPressed(null);
-
-                            cellHBox.setOnMouseEntered(null);
-                            cellHBox.setOnMouseExited(null);
-
-                            userProfileIcon.releaseResources();
-
-                            subscriptions.forEach(Subscription::unsubscribe);
-                            subscriptions.clear();
-
-                            setGraphic(null);
-                        }
-
-                        private void handleEditBox(ChatMessage chatMessage) {
-                            saveEditButton.setOnAction(e -> {
-                                controller.onSaveEditedMessage(chatMessage, editInputField.getText());
-                                onCloseEditMessage();
-                            });
-                            cancelEditButton.setOnAction(e -> onCloseEditMessage());
-                        }
-
-                        private void handleReactionsBox(ChatMessageListItem<? extends ChatMessage> item) {
-                            ChatMessage chatMessage = item.getChatMessage();
-                            boolean isMyMessage = model.isMyMessage(chatMessage);
-
-                            boolean isPublicChannel = model.isPublicChannel.get();
-                            boolean allowEditing = isPublicChannel;
-                            if (chatMessage instanceof BisqEasyOfferbookMessage) {
-                                BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
-                                allowEditing = allowEditing && bisqEasyOfferbookMessage.getBisqEasyOffer().isEmpty();
-                            }
-                            if (isMyMessage) {
-                                copyIcon.setOnMouseClicked(e -> controller.onCopyMessage(chatMessage));
-                                if (allowEditing) {
-                                    editIcon.setOnMouseClicked(e -> onEditMessage(item));
-                                }
-                                if (isPublicChannel) {
-                                    deleteIcon.setOnMouseClicked(e -> controller.onDeleteMessage(chatMessage));
-                                }
-                            } else {
-                                moreOptionsIcon.setOnMouseClicked(e -> controller.onOpenMoreOptions(pmIcon, chatMessage, () -> {
-                                    hideReactionsBox();
-                                    model.selectedChatMessageForMoreOptionsPopup.set(null);
-                                }));
-                                replyIcon.setOnMouseClicked(e -> controller.onReply(chatMessage));
-                                pmIcon.setOnMouseClicked(e -> controller.onOpenPrivateChannel(chatMessage));
-                            }
-
-                            replyIcon.setVisible(!isMyMessage);
-                            replyIcon.setManaged(!isMyMessage);
-
-                            pmIcon.setVisible(!isMyMessage && chatMessage instanceof PublicChatMessage);
-                            pmIcon.setManaged(!isMyMessage && chatMessage instanceof PublicChatMessage);
-
-                            editIcon.setVisible(isMyMessage && allowEditing);
-                            editIcon.setManaged(isMyMessage && allowEditing);
-                            deleteIcon.setVisible(isMyMessage && isPublicChannel);
-                            deleteIcon.setManaged(isMyMessage && isPublicChannel);
-                            removeOfferButton.setVisible(isMyMessage && isPublicChannel);
-                            removeOfferButton.setManaged(isMyMessage && isPublicChannel);
-
-                            setOnMouseEntered(e -> {
-                                if (model.selectedChatMessageForMoreOptionsPopup.get() != null || editInputField.isVisible()) {
-                                    return;
-                                }
-                                dateTime.setVisible(true);
-                                reactionsHBox.setVisible(true);
-                            });
-
-                            setOnMouseExited(e -> {
-                                if (model.selectedChatMessageForMoreOptionsPopup.get() == null) {
-                                    hideReactionsBox();
-                                    dateTime.setVisible(false);
-                                    reactionsHBox.setVisible(false);
-                                }
-                            });
-                        }
-
-                        private void handleQuoteMessageBox(ChatMessageListItem<? extends ChatMessage> item) {
-                            Optional<Citation> optionalCitation = item.getCitation();
-                            if (optionalCitation.isPresent()) {
-                                Citation citation = optionalCitation.get();
-                                if (citation.isValid()) {
-                                    quotedMessageVBox.setVisible(true);
-                                    quotedMessageVBox.setManaged(true);
-                                    quotedMessageField.setText(citation.getText());
-                                    quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
-                                    Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
-                                    userName.getStyleClass().add("font-medium");
-                                    userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
-                                    quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
-                                }
-                            } else {
-                                quotedMessageVBox.getChildren().clear();
-                                quotedMessageVBox.setVisible(false);
-                                quotedMessageVBox.setManaged(false);
-                            }
-                        }
-
-                        private void onEditMessage(ChatMessageListItem<? extends ChatMessage> item) {
-                            reactionsHBox.setVisible(false);
-                            editInputField.setVisible(true);
-                            editInputField.setManaged(true);
-                            editInputField.setInitialHeight(message.getBoundsInLocal().getHeight());
-                            editInputField.setText(message.getText().replace(EDITED_POST_FIX, ""));
-                            editInputField.requestFocus();
-                            editInputField.positionCaret(message.getText().length());
-                            editButtonsHBox.setVisible(true);
-                            editButtonsHBox.setManaged(true);
-                            removeOfferButton.setVisible(false);
-                            removeOfferButton.setManaged(false);
-
-                            message.setVisible(false);
-                            message.setManaged(false);
-
-                            editInputField.setOnKeyPressed(event -> {
-                                if (event.getCode() == KeyCode.ENTER) {
-                                    event.consume();
-                                    if (event.isShiftDown()) {
-                                        editInputField.appendText(System.getProperty("line.separator"));
-                                    } else if (!editInputField.getText().isEmpty()) {
-                                        controller.onSaveEditedMessage(item.getChatMessage(), editInputField.getText().trim());
-                                        onCloseEditMessage();
-                                    }
-                                }
-                            });
-                        }
-
-                        private void onCloseEditMessage() {
-                            editInputField.setVisible(false);
-                            editInputField.setManaged(false);
-                            editButtonsHBox.setVisible(false);
-                            editButtonsHBox.setManaged(false);
-                            removeOfferButton.setVisible(true);
-                            removeOfferButton.setManaged(true);
-
-                            message.setVisible(true);
-                            message.setManaged(true);
-                            editInputField.setOnKeyPressed(null);
-                        }
-                    };
-                }
-
-                private Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
-                    Label iconLabel = Icons.getIcon(icon);
-                    iconLabel.setCursor(Cursor.HAND);
-                    iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
-                    return iconLabel;
-                }
-            };
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BubbleMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BubbleMessage.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.desktop.main.content.components.chatMessages.messages;
 
 import bisq.chat.ChatChannel;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BubbleMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BubbleMessage.java
@@ -1,0 +1,197 @@
+package bisq.desktop.main.content.components.chatMessages.messages;
+
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatMessage;
+import bisq.chat.Citation;
+import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
+import bisq.desktop.common.Icons;
+import bisq.desktop.common.utils.ClipboardUtil;
+import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.main.content.components.UserProfileIcon;
+import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
+import bisq.desktop.main.content.components.chatMessages.ChatMessagesListView;
+import de.jensd.fx.fontawesome.AwesomeIcon;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+import java.util.Optional;
+
+public abstract class BubbleMessage extends Message {
+    protected final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
+
+    protected final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item;
+    protected final ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list;
+    protected final ChatMessagesListView.Controller controller;
+    protected final ChatMessagesListView.Model model;
+    protected Label supportedLanguages, userName, dateTime, message;
+    protected HBox userNameAndDateHBox, messageBgHBox, messageHBox;
+    protected final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
+    protected VBox userProfileIconVbox;
+    protected final HBox reactionsHBox = new HBox(20);
+    protected final VBox quotedMessageVBox;
+
+    public BubbleMessage(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
+                         ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
+                         ChatMessagesListView.Controller controller, ChatMessagesListView.Model model) {
+        this.item = item;
+        this.list = list;
+        this.controller = controller;
+        this.model = model;
+
+        setUpUserNameAndDateTime();
+        setUpUserProfileIcon();
+        setUpReactions();
+        addReactionsHandlers();
+        addOnMouseEventHandlers();
+
+        supportedLanguages = createAndGetSupportedLanguagesLabel();
+        quotedMessageVBox = createAndGetQuotedMessageVBox();
+        handleQuoteMessageBox();
+        message = createAndGetMessage();
+        messageBgHBox = createAndGetMessageBackground();
+        messageHBox = createAndGetMessageBox();
+
+        setFillWidth(true);
+        HBox.setHgrow(this, Priority.ALWAYS);
+    }
+
+    protected void setUpUserNameAndDateTime() {
+        userName = new Label();
+        userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
+        dateTime = new Label();
+        dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
+        dateTime.setVisible(false);
+        dateTime.setText(item.getDate());
+    }
+
+    private void setUpUserProfileIcon() {
+        userProfileIcon.setSize(60);
+        userProfileIconVbox = new VBox(userProfileIcon);
+
+        item.getSenderUserProfile().ifPresent(author -> {
+            userName.setText(author.getUserName());
+            userName.setOnMouseClicked(e -> controller.onMention(author));
+
+            userProfileIcon.setUserProfile(author);
+            userProfileIcon.setCursor(Cursor.HAND);
+            Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
+            userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(item.getChatMessage()));
+        });
+    }
+
+    protected void setUpReactions() {
+    }
+
+    protected void addReactionsHandlers() {
+    }
+
+    protected void hideReactionsBox() {
+        reactionsHBox.setVisible(false);
+    }
+
+    private void addOnMouseEventHandlers() {
+        setOnMouseEntered(e -> {
+            if (model.getSelectedChatMessageForMoreOptionsPopup().get() != null) {
+                return;
+            }
+            dateTime.setVisible(true);
+            reactionsHBox.setVisible(true);
+        });
+
+        setOnMouseExited(e -> {
+            if (model.getSelectedChatMessageForMoreOptionsPopup().get() == null) {
+                hideReactionsBox();
+                dateTime.setVisible(false);
+                reactionsHBox.setVisible(false);
+            }
+        });
+    }
+
+    private Label createAndGetSupportedLanguagesLabel() {
+        Label label = new Label();
+        if (item.isBisqEasyPublicChatMessageWithOffer()) {
+            BisqEasyOfferbookMessage chatMessage = (BisqEasyOfferbookMessage) item.getChatMessage();
+            label.setText(item.getSupportedLanguageCodes(chatMessage));
+            label.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(chatMessage)));
+        }
+        return label;
+    }
+
+    private VBox createAndGetQuotedMessageVBox() {
+        VBox vBox = new VBox(5);
+        vBox.setVisible(false);
+        vBox.setManaged(false);
+        VBox.setMargin(vBox, new Insets(15, 0, 10, 5));
+        return vBox;
+    }
+
+    private void handleQuoteMessageBox() {
+        Optional<Citation> optionalCitation = item.getCitation();
+        if (optionalCitation.isPresent()) {
+            Citation citation = optionalCitation.get();
+            if (citation.isValid()) {
+                quotedMessageVBox.setVisible(true);
+                quotedMessageVBox.setManaged(true);
+                Label quotedMessageField = new Label();
+                quotedMessageField.setWrapText(true);
+                quotedMessageField.setText(citation.getText());
+                quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
+                Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
+                userName.getStyleClass().add("font-medium");
+                userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
+                quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
+            }
+        } else {
+            quotedMessageVBox.getChildren().clear();
+            quotedMessageVBox.setVisible(false);
+            quotedMessageVBox.setManaged(false);
+        }
+    }
+
+    private Label createAndGetMessage() {
+        Label label = new Label();
+        label.maxWidthProperty().unbind();
+        label.setWrapText(true);
+        label.setPadding(new Insets(10));
+        label.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
+        label.setText(item.getMessage());
+        return label;
+    }
+
+    private HBox createAndGetMessageBackground() {
+        HBox hBox = new HBox(15);
+        hBox.setAlignment(Pos.CENTER_LEFT);
+        hBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
+        HBox.setHgrow(hBox, Priority.SOMETIMES);
+        if (item.hasTradeChatOffer()) {
+            hBox.setPadding(new Insets(15));
+        } else {
+            hBox.setPadding(new Insets(5, 15, 5, 15));
+        }
+        return hBox;
+    }
+
+    private HBox createAndGetMessageBox() {
+        HBox hBox = new HBox();
+        VBox.setMargin(hBox, new Insets(10, 0, 0, 0));
+        return hBox;
+    }
+
+    protected static Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
+        Label iconLabel = Icons.getIcon(icon);
+        iconLabel.setCursor(Cursor.HAND);
+        iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
+        return iconLabel;
+    }
+
+    protected static void onCopyMessage(ChatMessage chatMessage) {
+        ClipboardUtil.copyToClipboard(chatMessage.getText());
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/Message.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/Message.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.components.chatMessages.messages;
+
+import javafx.scene.layout.VBox;
+
+public abstract class Message extends VBox {
+    public abstract void cleanup();
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/MyMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/MyMessage.java
@@ -49,14 +49,14 @@ import java.util.Optional;
 
 public final class MyMessage extends Message {
     private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
-    private final String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
+    private final static String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
 
     private final ChatMessagesListView.Controller controller;
     private final ChatMessagesListView.Model model;
     private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
-    private final Label message, userName, dateTime, editIcon, deleteIcon, copyIcon, moreOptionsIcon;
+    private final Label message, userName, dateTime, editIcon, deleteIcon, copyIcon;
     private final Label quotedMessageField = new Label();
-    private VBox quotedMessageVBox;
+    private final VBox quotedMessageVBox;
     private final HBox messageHBox, messageBgHBox;
     private final Button removeOfferButton;
     private final Label deliveryState;
@@ -64,7 +64,6 @@ public final class MyMessage extends Message {
     private final Button saveEditButton, cancelEditButton;
     private final HBox reactionsHBox, editButtonsHBox;
     private Subscription reactionsVisiblePropertyPin, messageDeliveryStatusIconPin;
-
 
     public MyMessage(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                      ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
@@ -106,13 +105,17 @@ public final class MyMessage extends Message {
         editIcon = getIconWithToolTip(AwesomeIcon.EDIT, Res.get("action.edit"));
         copyIcon = getIconWithToolTip(AwesomeIcon.COPY, Res.get("action.copyToClipboard"));
         deleteIcon = getIconWithToolTip(AwesomeIcon.REMOVE_SIGN, Res.get("action.delete"));
-        moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
-        Label supportedLanguages = new Label();
         HBox.setMargin(editIcon, new Insets(1, 0, 0, 0));
-        HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
         reactionsHBox = new HBox(20);
         reactionsHBox.setVisible(false);
         handleReactionsBox(item);
+
+        // supportedLanguages
+        Label supportedLanguages = new Label();
+        if (item.isBisqEasyPublicChatMessageWithOffer()) {
+            supportedLanguages.setText(item.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) item.getChatMessage())));
+            supportedLanguages.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) item.getChatMessage()))));
+        }
 
         // edit
         editInputField = new BisqTextArea();
@@ -381,7 +384,6 @@ public final class MyMessage extends Message {
         editIcon.setOnMouseClicked(null);
         copyIcon.setOnMouseClicked(null);
         deleteIcon.setOnMouseClicked(null);
-        moreOptionsIcon.setOnMouseClicked(null);
 
         editInputField.setOnKeyPressed(null);
         userProfileIcon.releaseResources();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/MyMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/MyMessage.java
@@ -1,12 +1,389 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.desktop.main.content.components.chatMessages.messages;
 
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatMessage;
+import bisq.chat.Citation;
+import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
+import bisq.desktop.common.Icons;
+import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.BisqTextArea;
+import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.main.content.components.UserProfileIcon;
+import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
+import bisq.desktop.main.content.components.chatMessages.ChatMessagesListView;
+import bisq.i18n.Res;
+import de.jensd.fx.fontawesome.AwesomeDude;
+import de.jensd.fx.fontawesome.AwesomeIcon;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.Tooltip;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.Subscription;
 
-public class MyMessage extends VBox {
+import java.util.Optional;
+import java.util.Set;
 
-    public MyMessage() {
-        super();
+public final class MyMessage extends Message {
+    private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
+    private final String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
+
+    private final ChatMessagesListView.Controller controller;
+    private final ChatMessagesListView.Model model;
+    private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
+    private final Label message, userName, dateTime, editIcon, deleteIcon, copyIcon, moreOptionsIcon;
+    private final Label quotedMessageField = new Label();
+    private VBox quotedMessageVBox;
+    private final HBox messageHBox, messageBgHBox;
+    private final Button removeOfferButton;
+    private final Label deliveryState;
+    private final BisqTextArea editInputField;
+    private final Button saveEditButton, cancelEditButton;
+    private final HBox reactionsHBox, editButtonsHBox;
+
+
+    public MyMessage(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
+                     ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
+                     ChatMessagesListView.Controller controller, ChatMessagesListView.Model model,
+                     Set<Subscription> subscriptions) {
+        this.controller = controller;
+        this.model = model;
+
+        // userName and DateTime
+        userName = new Label();
+        userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
+        dateTime = new Label();
+        dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
+        dateTime.setVisible(false);
+        dateTime.setText(item.getDate());
+
+        HBox userNameAndDateHBox = new HBox(10, dateTime, userName);
+        userNameAndDateHBox.setAlignment(Pos.CENTER_RIGHT);
+        VBox.setMargin(userNameAndDateHBox, new Insets(-5, 10, -5, 0));
+
+        // userProfileIcon
+        userProfileIcon.setSize(60);
+        VBox userProfileIconVbox = new VBox(userProfileIcon);
+
+        item.getSenderUserProfile().ifPresent(author -> {
+            userName.setText(author.getUserName());
+            userName.setOnMouseClicked(e -> controller.onMention(author));
+
+            userProfileIcon.setUserProfile(author);
+            userProfileIcon.setCursor(Cursor.HAND);
+            Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
+            userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(item.getChatMessage()));
+        });
+
+        // removeOfferButton
+        removeOfferButton = new Button(Res.get("offer.deleteOffer"));
+        removeOfferButton.getStyleClass().addAll("red-small-button", "no-background");
+
+        // reactions
+        editIcon = getIconWithToolTip(AwesomeIcon.EDIT, Res.get("action.edit"));
+        copyIcon = getIconWithToolTip(AwesomeIcon.COPY, Res.get("action.copyToClipboard"));
+        deleteIcon = getIconWithToolTip(AwesomeIcon.REMOVE_SIGN, Res.get("action.delete"));
+        moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
+        Label supportedLanguages = new Label();
+        HBox.setMargin(editIcon, new Insets(1, 0, 0, 0));
+        HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
+        reactionsHBox = new HBox(20);
+        reactionsHBox.setVisible(false);
+        handleReactionsBox(item);
+
+        // edit
+        editInputField = new BisqTextArea();
+        editInputField.setId("chat-messages-edit-text-area");
+        editInputField.setMinWidth(150);
+        editInputField.setVisible(false);
+        editInputField.setManaged(false);
+
+        // edit buttons
+        saveEditButton = new Button(Res.get("action.save"));
+        saveEditButton.setDefaultButton(true);
+        cancelEditButton = new Button(Res.get("action.cancel"));
+        editButtonsHBox = new HBox(15, Spacer.fillHBox(), cancelEditButton, saveEditButton);
+        editButtonsHBox.setVisible(false);
+        editButtonsHBox.setManaged(false);
+        VBox.setMargin(editButtonsHBox, new Insets(10, 25, -15, 0));
+        handleEditBox(item.getChatMessage());
+
+        // quoted message
+        quotedMessageVBox = new VBox(5);
+        quotedMessageVBox.setVisible(false);
+        quotedMessageVBox.setManaged(false);
+        quotedMessageVBox.setId("chat-message-quote-box-my-msg");
+        VBox.setMargin(quotedMessageVBox, new Insets(15, 0, 10, 5));
+        quotedMessageField.setWrapText(true);
+        handleQuoteMessageBox(item);
+
+        // HBox for message reputation vBox and action button
+        message = new Label();
+        message.maxWidthProperty().unbind();
+        message.setWrapText(true);
+        message.setPadding(new Insets(10));
+        message.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
+        message.setAlignment(Pos.CENTER_RIGHT);
+        message.setText(item.getMessage());
+
+        // message background
+        messageBgHBox = new HBox(15);
+        messageBgHBox.setAlignment(Pos.CENTER_LEFT);
+        messageBgHBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
+        messageBgHBox.getStyleClass().add("chat-message-bg-my-message");
+        HBox.setHgrow(messageBgHBox, Priority.SOMETIMES);
+        if (item.hasTradeChatOffer()) {
+            messageBgHBox.setPadding(new Insets(15));
+        } else {
+            messageBgHBox.setPadding(new Insets(5, 15, 5, 15));
+        }
+
+        // messageHBox
+        messageHBox = new HBox();
+        VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
+
+        // deliveryState
+        deliveryState = new Label();
+        deliveryState.setCursor(Cursor.HAND);
+        deliveryState.setTooltip(new BisqTooltip(true));
+
+        VBox messageVBox = new VBox(quotedMessageVBox, message, editInputField);
+        if (item.isBisqEasyPublicChatMessageWithOffer()) {
+            message.maxWidthProperty().bind(list.widthProperty().subtract(160));
+            userProfileIcon.setSize(60);
+            userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
+            HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
+            HBox.setMargin(editInputField, new Insets(-4, -10, -15, 0));
+            HBox.setMargin(messageVBox, new Insets(0, -10, 0, 0));
+
+            removeOfferButton.setOnAction(e -> controller.onDeleteMessage(item.getChatMessage()));
+            reactionsHBox.getChildren().setAll(Spacer.fillHBox(), editIcon, supportedLanguages, copyIcon);
+            reactionsHBox.setAlignment(Pos.CENTER_RIGHT);
+
+            HBox.setMargin(userProfileIconVbox, new Insets(0, 0, 10, 0));
+            HBox hBox = new HBox(15, messageVBox, userProfileIconVbox);
+            HBox removeOfferButtonHBox = new HBox(Spacer.fillHBox(), removeOfferButton);
+            VBox vBox = new VBox(hBox, removeOfferButtonHBox);
+            messageBgHBox.getChildren().setAll(vBox);
+        } else {
+            message.maxWidthProperty().bind(list.widthProperty().subtract(140));
+            userProfileIcon.setSize(30);
+            userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
+            HBox.setMargin(deleteIcon, new Insets(0, 10, 0, 0));
+            reactionsHBox.getChildren().setAll(Spacer.fillHBox(), editIcon, copyIcon, deleteIcon);
+            HBox.setMargin(messageVBox, new Insets(0, -15, 0, 0));
+            HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
+            HBox.setMargin(editInputField, new Insets(6, -10, -25, 0));
+            messageBgHBox.getChildren().setAll(messageVBox, userProfileIconVbox);
+        }
+
+        HBox.setMargin(deliveryState, new Insets(0, 10, 0, 0));
+        HBox deliveryStateHBox = new HBox(Spacer.fillHBox(), reactionsHBox);
+
+        subscriptions.add(EasyBind.subscribe(reactionsHBox.visibleProperty(), v -> {
+            if (v) {
+                deliveryStateHBox.getChildren().remove(deliveryState);
+                if (!reactionsHBox.getChildren().contains(deliveryState)) {
+                    reactionsHBox.getChildren().add(deliveryState);
+                }
+            } else {
+                reactionsHBox.getChildren().remove(deliveryState);
+                if (!deliveryStateHBox.getChildren().contains(deliveryState)) {
+                    deliveryStateHBox.getChildren().add(deliveryState);
+                }
+            }
+        }));
+
+        subscriptions.add(EasyBind.subscribe(item.getMessageDeliveryStatusIcon(), icon -> {
+                    deliveryState.setManaged(icon != null);
+                    deliveryState.setVisible(icon != null);
+                    if (icon != null) {
+                        AwesomeDude.setIcon(deliveryState, icon, AwesomeDude.DEFAULT_ICON_SIZE);
+                        item.getMessageDeliveryStatusIconColor().ifPresent(color ->
+                                Icons.setAwesomeIconColor(deliveryState, color));
+                    }
+                }
+        ));
+
+        deliveryState.getTooltip().textProperty().bind(item.getMessageDeliveryStatusTooltip());
+        editInputField.maxWidthProperty().bind(message.widthProperty());
+
+        VBox.setMargin(deliveryStateHBox, new Insets(4, 0, -3, 0));
+        messageHBox.getChildren().setAll(Spacer.fillHBox(), messageBgHBox);
+        getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, deliveryStateHBox);
+        setFillWidth(true);
+        HBox.setHgrow(this, Priority.ALWAYS);
     }
 
+    // TODO: move outside
+    private static Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
+        Label iconLabel = Icons.getIcon(icon);
+        iconLabel.setCursor(Cursor.HAND);
+        iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
+        return iconLabel;
+    }
 
+    private void handleEditBox(ChatMessage chatMessage) {
+        saveEditButton.setOnAction(e -> {
+            controller.onSaveEditedMessage(chatMessage, editInputField.getText());
+            onCloseEditMessage();
+        });
+        cancelEditButton.setOnAction(e -> onCloseEditMessage());
+    }
+
+    private void handleReactionsBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
+        ChatMessage chatMessage = item.getChatMessage();
+        boolean isPublicChannel = item.isPublicChannel();
+        boolean allowEditing = isPublicChannel;
+        if (chatMessage instanceof BisqEasyOfferbookMessage) {
+            BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
+            allowEditing = allowEditing && bisqEasyOfferbookMessage.getBisqEasyOffer().isEmpty();
+        }
+
+        // myMessage
+        copyIcon.setOnMouseClicked(e -> controller.onCopyMessage(chatMessage));
+        if (allowEditing) {
+            editIcon.setOnMouseClicked(e -> onEditMessage(item));
+        }
+        if (isPublicChannel) {
+            deleteIcon.setOnMouseClicked(e -> controller.onDeleteMessage(chatMessage));
+        }
+
+        editIcon.setVisible(allowEditing);
+        editIcon.setManaged(allowEditing);
+        deleteIcon.setVisible(isPublicChannel);
+        deleteIcon.setManaged(isPublicChannel);
+        removeOfferButton.setVisible(isPublicChannel);
+        removeOfferButton.setManaged(isPublicChannel);
+
+        setOnMouseEntered(e -> {
+            if (model.getSelectedChatMessageForMoreOptionsPopup().get() != null || editInputField.isVisible()) {
+                return;
+            }
+            dateTime.setVisible(true);
+            reactionsHBox.setVisible(true);
+        });
+
+        setOnMouseExited(e -> {
+            if (model.getSelectedChatMessageForMoreOptionsPopup().get() == null) {
+                hideReactionsBox();
+                dateTime.setVisible(false);
+                reactionsHBox.setVisible(false);
+            }
+        });
+    }
+
+    private void hideReactionsBox() {
+        reactionsHBox.setVisible(false);
+    }
+
+    private void handleQuoteMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
+        Optional<Citation> optionalCitation = item.getCitation();
+        if (optionalCitation.isPresent()) {
+            Citation citation = optionalCitation.get();
+            if (citation.isValid()) {
+                quotedMessageVBox.setVisible(true);
+                quotedMessageVBox.setManaged(true);
+                quotedMessageField.setText(citation.getText());
+                quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
+                Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
+                userName.getStyleClass().add("font-medium");
+                userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
+                quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
+            }
+        } else {
+            quotedMessageVBox.getChildren().clear();
+            quotedMessageVBox.setVisible(false);
+            quotedMessageVBox.setManaged(false);
+        }
+    }
+
+    private void onEditMessage(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
+        reactionsHBox.setVisible(false);
+        editInputField.setVisible(true);
+        editInputField.setManaged(true);
+        editInputField.setInitialHeight(message.getBoundsInLocal().getHeight());
+        editInputField.setText(message.getText().replace(EDITED_POST_FIX, ""));
+        editInputField.requestFocus();
+        editInputField.positionCaret(message.getText().length());
+        editButtonsHBox.setVisible(true);
+        editButtonsHBox.setManaged(true);
+        removeOfferButton.setVisible(false);
+        removeOfferButton.setManaged(false);
+
+        message.setVisible(false);
+        message.setManaged(false);
+
+        editInputField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                event.consume();
+                if (event.isShiftDown()) {
+                    editInputField.appendText(System.getProperty("line.separator"));
+                } else if (!editInputField.getText().isEmpty()) {
+                    controller.onSaveEditedMessage(item.getChatMessage(), editInputField.getText().trim());
+                    onCloseEditMessage();
+                }
+            }
+        });
+    }
+
+    private void onCloseEditMessage() {
+        editInputField.setVisible(false);
+        editInputField.setManaged(false);
+        editButtonsHBox.setVisible(false);
+        editButtonsHBox.setManaged(false);
+        removeOfferButton.setVisible(true);
+        removeOfferButton.setManaged(true);
+
+        message.setVisible(true);
+        message.setManaged(true);
+        editInputField.setOnKeyPressed(null);
+    }
+
+    @Override
+    public void cleanup() {
+        message.maxWidthProperty().unbind();
+        editInputField.maxWidthProperty().unbind();
+
+        editInputField.maxWidthProperty().unbind();
+        removeOfferButton.setOnAction(null);
+
+        saveEditButton.setOnAction(null);
+        cancelEditButton.setOnAction(null);
+
+        userName.setOnMouseClicked(null);
+        userProfileIcon.setOnMouseClicked(null);
+
+        editIcon.setOnMouseClicked(null);
+        copyIcon.setOnMouseClicked(null);
+        deleteIcon.setOnMouseClicked(null);
+        moreOptionsIcon.setOnMouseClicked(null);
+
+        editInputField.setOnKeyPressed(null);
+        userProfileIcon.releaseResources();
+    }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/MyMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/MyMessage.java
@@ -1,0 +1,12 @@
+package bisq.desktop.main.content.components.chatMessages.messages;
+
+import javafx.scene.layout.VBox;
+
+public class MyMessage extends VBox {
+
+    public MyMessage() {
+        super();
+    }
+
+
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
@@ -1,0 +1,279 @@
+package bisq.desktop.main.content.components.chatMessages.messages;
+
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatMessage;
+import bisq.chat.Citation;
+import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
+import bisq.chat.pub.PublicChatMessage;
+import bisq.desktop.common.Icons;
+import bisq.desktop.common.utils.ClipboardUtil;
+import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.BisqPopup;
+import bisq.desktop.components.controls.BisqPopupMenu;
+import bisq.desktop.components.controls.BisqPopupMenuItem;
+import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.main.content.components.ReputationScoreDisplay;
+import bisq.desktop.main.content.components.UserProfileIcon;
+import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
+import bisq.desktop.main.content.components.chatMessages.ChatMessagesListView;
+import bisq.i18n.Res;
+import de.jensd.fx.fontawesome.AwesomeIcon;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
+import javafx.scene.Node;
+import javafx.scene.control.*;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+// Represents mainVBox
+public class PeerMessage extends VBox {
+    private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
+
+    private final ChatMessagesListView.Controller controller;
+    private final ChatMessagesListView.Model model;
+    private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
+    private final VBox quotedMessageVBox;
+    private final Label message, userName, dateTime, replyIcon, pmIcon, moreOptionsIcon, supportedLanguages;
+    private final HBox messageHBox, messageBgHBox;
+    private final HBox reactionsHBox;
+    private final ReputationScoreDisplay reputationScoreDisplay;
+    private final Button takeOfferButton;
+    private final Label quotedMessageField = new Label();
+
+    public PeerMessage(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
+                       ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
+                       ChatMessagesListView.Controller controller, ChatMessagesListView.Model model) {
+        this.controller = controller;
+        this.model = model;
+
+        // userName and DateTime
+        userName = new Label();
+        userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
+        dateTime = new Label();
+        dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
+        dateTime.setVisible(false);
+        dateTime.setText(item.getDate());
+        HBox userNameAndDateHBox = new HBox(10, userName, dateTime);
+        userNameAndDateHBox.setAlignment(Pos.CENTER_LEFT);
+
+        // userProfileIcon
+        userProfileIcon.setSize(60);
+        VBox userProfileIconVbox = new VBox(userProfileIcon);
+
+        item.getSenderUserProfile().ifPresent(author -> {
+            userName.setText(author.getUserName());
+            userName.setOnMouseClicked(e -> controller.onMention(author));
+
+            userProfileIcon.setUserProfile(author);
+            userProfileIcon.setCursor(Cursor.HAND);
+            Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
+            userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(item.getChatMessage()));
+        });
+
+        // reactions
+        replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
+        pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
+        moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
+        supportedLanguages = new Label();
+        HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
+        HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
+        HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
+        reactionsHBox = new HBox(20);
+        reactionsHBox.setVisible(false);
+        handleReactionsBox(item);
+
+        // quoted message
+        quotedMessageVBox = new VBox(5);
+        quotedMessageVBox.setVisible(false);
+        quotedMessageVBox.setManaged(false);
+        quotedMessageVBox.setId("chat-message-quote-box-peer-msg");
+        VBox.setMargin(quotedMessageVBox, new Insets(15, 0, 10, 5));
+        quotedMessageField.setWrapText(true);
+        handleQuoteMessageBox(item);
+
+        // HBox for message reputation vBox and action button
+        message = new Label();
+        message.maxWidthProperty().unbind();
+        message.setWrapText(true);
+        message.setPadding(new Insets(10));
+        message.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
+        message.setAlignment(Pos.CENTER_LEFT);
+        message.setText(item.getMessage());
+
+        // message background
+        messageBgHBox = new HBox(15);
+        messageBgHBox.setAlignment(Pos.CENTER_LEFT);
+        messageBgHBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
+        messageBgHBox.getStyleClass().add("chat-message-bg-peer-message");
+        HBox.setHgrow(messageBgHBox, Priority.SOMETIMES);
+        if (item.hasTradeChatOffer()) {
+            messageBgHBox.setPadding(new Insets(15));
+        } else {
+            messageBgHBox.setPadding(new Insets(5, 15, 5, 15));
+        }
+
+        // reputation
+        reputationScoreDisplay = new ReputationScoreDisplay();
+
+        // takeOfferButton
+        takeOfferButton = new Button(Res.get("offer.takeOffer"));
+
+        // messageHBox
+        messageHBox = new HBox();
+        VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
+
+        if (item.isBisqEasyPublicChatMessageWithOffer()) {
+            supportedLanguages.setText(item.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) item.getChatMessage())));
+            supportedLanguages.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) item.getChatMessage()))));
+
+            reactionsHBox.getChildren().setAll(replyIcon, pmIcon, moreOptionsIcon, supportedLanguages, Spacer.fillHBox());
+            message.maxWidthProperty().bind(list.widthProperty().subtract(430));
+            userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
+
+            Label reputationLabel = new Label(Res.get("chat.message.reputation").toUpperCase());
+            reputationLabel.getStyleClass().add("bisq-text-7");
+
+            reputationScoreDisplay.setReputationScore(item.getReputationScore());
+            VBox reputationVBox = new VBox(4, reputationLabel, reputationScoreDisplay);
+            reputationVBox.setAlignment(Pos.CENTER_LEFT);
+
+            BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) item.getChatMessage();
+            takeOfferButton.setOnAction(e -> controller.onTakeOffer(bisqEasyOfferbookMessage, item.isCanTakeOffer()));
+            takeOfferButton.setDefaultButton(item.isCanTakeOffer());
+            takeOfferButton.setMinWidth(Control.USE_PREF_SIZE);
+
+            VBox messageVBox = new VBox(quotedMessageVBox, message);
+            HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
+            HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
+            HBox.setMargin(reputationVBox, new Insets(-5, 10, 0, 0));
+            HBox.setMargin(takeOfferButton, new Insets(0, 10, 0, 0));
+            messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox, Spacer.fillHBox(), reputationVBox, takeOfferButton);
+
+            VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, 5, 10));
+            getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);
+        } else {
+            reactionsHBox.getChildren().setAll(replyIcon, pmIcon, moreOptionsIcon, Spacer.fillHBox());
+            message.maxWidthProperty().bind(list.widthProperty().subtract(140));//165
+            userProfileIcon.setSize(30);
+            userProfileIconVbox.setAlignment(Pos.TOP_LEFT);
+
+            VBox messageVBox = new VBox(quotedMessageVBox, message);
+            HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
+            HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
+            messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox);
+            messageHBox.getChildren().setAll(messageBgHBox, Spacer.fillHBox());
+
+            VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, -5, 10));
+
+            getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
+        }
+        setFillWidth(true);
+        HBox.setHgrow(this, Priority.ALWAYS);
+    }
+
+    // TODO: move outside
+    private static Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
+        Label iconLabel = Icons.getIcon(icon);
+        iconLabel.setCursor(Cursor.HAND);
+        iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
+        return iconLabel;
+    }
+
+    // TODO: move outside
+    private void handleQuoteMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
+        Optional<Citation> optionalCitation = item.getCitation();
+        if (optionalCitation.isPresent()) {
+            Citation citation = optionalCitation.get();
+            if (citation.isValid()) {
+                quotedMessageVBox.setVisible(true);
+                quotedMessageVBox.setManaged(true);
+                quotedMessageField.setText(citation.getText());
+                quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
+                Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
+                userName.getStyleClass().add("font-medium");
+                userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
+                quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
+            }
+        } else {
+            quotedMessageVBox.getChildren().clear();
+            quotedMessageVBox.setVisible(false);
+            quotedMessageVBox.setManaged(false);
+        }
+    }
+
+    // TODO: move outside
+    private void handleReactionsBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
+        ChatMessage chatMessage = item.getChatMessage();
+
+        // !isMyMessage
+        moreOptionsIcon.setOnMouseClicked(e -> onOpenMoreOptions(pmIcon, chatMessage, () -> {
+            hideReactionsBox();
+            model.getSelectedChatMessageForMoreOptionsPopup().set(null);
+        }));
+        replyIcon.setOnMouseClicked(e -> controller.onReply(chatMessage));
+        pmIcon.setOnMouseClicked(e -> controller.onOpenPrivateChannel(chatMessage));
+
+        replyIcon.setVisible(true);
+        replyIcon.setManaged(true);
+
+        pmIcon.setVisible(chatMessage instanceof PublicChatMessage);
+        pmIcon.setManaged(chatMessage instanceof PublicChatMessage);
+
+        setOnMouseEntered(e -> {
+            if (model.getSelectedChatMessageForMoreOptionsPopup().get() != null) {
+                return;
+            }
+            dateTime.setVisible(true);
+            reactionsHBox.setVisible(true);
+        });
+
+        setOnMouseExited(e -> {
+            if (model.getSelectedChatMessageForMoreOptionsPopup().get() == null) {
+                hideReactionsBox();
+                dateTime.setVisible(false);
+                reactionsHBox.setVisible(false);
+            }
+        });
+    }
+
+    // TODO: can be reused
+    private void hideReactionsBox() {
+        reactionsHBox.setVisible(false);
+    }
+
+    // TODO: reuse
+    void onOpenMoreOptions(Node owner, ChatMessage chatMessage, Runnable onClose) {
+        if (chatMessage.equals(model.getSelectedChatMessageForMoreOptionsPopup().get())) {
+            return;
+        }
+        model.getSelectedChatMessageForMoreOptionsPopup().set(chatMessage);
+
+        List<BisqPopupMenuItem> items = new ArrayList<>();
+        items.add(new BisqPopupMenuItem(Res.get("chat.message.contextMenu.copyMessage"),
+                () -> onCopyMessage(chatMessage)));
+
+        // !myMessage
+        if (chatMessage instanceof PublicChatMessage) {
+            items.add(new BisqPopupMenuItem(Res.get("chat.message.contextMenu.ignoreUser"),
+                    () -> controller.onIgnoreUser(chatMessage)));
+        }
+        items.add(new BisqPopupMenuItem(Res.get("chat.message.contextMenu.reportUser"),
+                () -> controller.onReportUser(chatMessage)));
+
+        BisqPopupMenu menu = new BisqPopupMenu(items, onClose);
+        menu.setAlignment(BisqPopup.Alignment.LEFT);
+        menu.show(owner);
+    }
+
+    void onCopyMessage(ChatMessage chatMessage) {
+        ClipboardUtil.copyToClipboard(chatMessage.getText());
+    }
+
+    // TODO: Add clean-up function
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
@@ -19,136 +19,41 @@ package bisq.desktop.main.content.components.chatMessages.messages;
 
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
-import bisq.chat.Citation;
 import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
 import bisq.chat.pub.PublicChatMessage;
-import bisq.desktop.common.Icons;
-import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqPopup;
 import bisq.desktop.components.controls.BisqPopupMenu;
 import bisq.desktop.components.controls.BisqPopupMenuItem;
-import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.main.content.components.ReputationScoreDisplay;
-import bisq.desktop.main.content.components.UserProfileIcon;
 import bisq.desktop.main.content.components.chatMessages.ChatMessageListItem;
 import bisq.desktop.main.content.components.chatMessages.ChatMessagesListView;
 import bisq.i18n.Res;
 import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-public final class PeerMessage extends Message {
-    private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
-
-    private final ChatMessagesListView.Controller controller;
-    private final ChatMessagesListView.Model model;
-    private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
-    private final VBox quotedMessageVBox;
-    private final Label message, userName, dateTime, replyIcon, pmIcon, moreOptionsIcon;
-    private final HBox messageHBox, messageBgHBox;
-    private final HBox reactionsHBox;
-    private final ReputationScoreDisplay reputationScoreDisplay;
+public final class PeerMessage extends BubbleMessage {
     private final Button takeOfferButton;
-    private final Label quotedMessageField = new Label();
+    private Label replyIcon, pmIcon, moreOptionsIcon;
 
-    public PeerMessage(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
+    public PeerMessage(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                        ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
                        ChatMessagesListView.Controller controller, ChatMessagesListView.Model model) {
-        this.controller = controller;
-        this.model = model;
+        super(item, list, controller, model);
 
-        // userName and DateTime
-        userName = new Label();
-        userName.getStyleClass().addAll("text-fill-white", "font-size-09", "font-default");
-        dateTime = new Label();
-        dateTime.getStyleClass().addAll("text-fill-grey-dimmed", "font-size-09", "font-light");
-        dateTime.setVisible(false);
-        dateTime.setText(item.getDate());
-        HBox userNameAndDateHBox = new HBox(10, userName, dateTime);
-        userNameAndDateHBox.setAlignment(Pos.CENTER_LEFT);
-
-        // userProfileIcon
-        userProfileIcon.setSize(60);
-        VBox userProfileIconVbox = new VBox(userProfileIcon);
-
-        item.getSenderUserProfile().ifPresent(author -> {
-            userName.setText(author.getUserName());
-            userName.setOnMouseClicked(e -> controller.onMention(author));
-
-            userProfileIcon.setUserProfile(author);
-            userProfileIcon.setCursor(Cursor.HAND);
-            Tooltip.install(userProfileIcon, new BisqTooltip(author.getTooltipString()));
-            userProfileIcon.setOnMouseClicked(e -> controller.onShowChatUserDetails(item.getChatMessage()));
-        });
-
-        // reactions
-        replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
-        pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
-        moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
-        HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
-        HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
-        HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
-        reactionsHBox = new HBox(20);
-        reactionsHBox.setVisible(false);
-        handleReactionsBox(item);
-
-        // supportedLanguages
-        Label supportedLanguages = new Label();
-        if (item.isBisqEasyPublicChatMessageWithOffer()) {
-            supportedLanguages.setText(item.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) item.getChatMessage())));
-            supportedLanguages.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) item.getChatMessage()))));
-        }
-
-        // quoted message
-        quotedMessageVBox = new VBox(5);
-        quotedMessageVBox.setVisible(false);
-        quotedMessageVBox.setManaged(false);
         quotedMessageVBox.setId("chat-message-quote-box-peer-msg");
-        VBox.setMargin(quotedMessageVBox, new Insets(15, 0, 10, 5));
-        quotedMessageField.setWrapText(true);
-        handleQuoteMessageBox(item);
-
-        // HBox for message reputation vBox and action button
-        message = new Label();
-        message.maxWidthProperty().unbind();
-        message.setWrapText(true);
-        message.setPadding(new Insets(10));
-        message.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
         message.setAlignment(Pos.CENTER_LEFT);
-        message.setText(item.getMessage());
-
-        // message background
-        messageBgHBox = new HBox(15);
-        messageBgHBox.setAlignment(Pos.CENTER_LEFT);
-        messageBgHBox.setMaxWidth(CHAT_MESSAGE_BOX_MAX_WIDTH);
         messageBgHBox.getStyleClass().add("chat-message-bg-peer-message");
-        HBox.setHgrow(messageBgHBox, Priority.SOMETIMES);
-        if (item.hasTradeChatOffer()) {
-            messageBgHBox.setPadding(new Insets(15));
-        } else {
-            messageBgHBox.setPadding(new Insets(5, 15, 5, 15));
-        }
-
-        // reputation
-        reputationScoreDisplay = new ReputationScoreDisplay();
-
-        // takeOfferButton
+        ReputationScoreDisplay reputationScoreDisplay = new ReputationScoreDisplay();
         takeOfferButton = new Button(Res.get("offer.takeOffer"));
-
-        // messageHBox
-        messageHBox = new HBox();
-        VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
 
         // TODO (refactor): Move this logic to BisqEasy package
         if (item.isBisqEasyPublicChatMessageWithOffer()) {
@@ -190,48 +95,32 @@ public final class PeerMessage extends Message {
             messageHBox.getChildren().setAll(messageBgHBox, Spacer.fillHBox());
 
             VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, -5, 10));
-
             getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
         }
-        setFillWidth(true);
-        HBox.setHgrow(this, Priority.ALWAYS);
     }
 
-    // TODO: move outside
-    private static Label getIconWithToolTip(AwesomeIcon icon, String tooltipString) {
-        Label iconLabel = Icons.getIcon(icon);
-        iconLabel.setCursor(Cursor.HAND);
-        iconLabel.setTooltip(new BisqTooltip(tooltipString, true));
-        return iconLabel;
+    @Override
+    protected void setUpUserNameAndDateTime() {
+        super.setUpUserNameAndDateTime();
+
+        userNameAndDateHBox = new HBox(10, userName, dateTime);
+        userNameAndDateHBox.setAlignment(Pos.CENTER_LEFT);
     }
 
-    // TODO: move outside
-    private void handleQuoteMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
-        Optional<Citation> optionalCitation = item.getCitation();
-        if (optionalCitation.isPresent()) {
-            Citation citation = optionalCitation.get();
-            if (citation.isValid()) {
-                quotedMessageVBox.setVisible(true);
-                quotedMessageVBox.setManaged(true);
-                quotedMessageField.setText(citation.getText());
-                quotedMessageField.setStyle("-fx-fill: -fx-mid-text-color");
-                Label userName = new Label(controller.getUserName(citation.getAuthorUserProfileId()));
-                userName.getStyleClass().add("font-medium");
-                userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
-                quotedMessageVBox.getChildren().setAll(userName, quotedMessageField);
-            }
-        } else {
-            quotedMessageVBox.getChildren().clear();
-            quotedMessageVBox.setVisible(false);
-            quotedMessageVBox.setManaged(false);
-        }
+    @Override
+    protected void setUpReactions() {
+        replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
+        pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
+        moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
+        HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
+        HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
+        HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
+        reactionsHBox.setVisible(false);
     }
 
-    // TODO: move outside
-    private void handleReactionsBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) {
+    @Override
+    protected void addReactionsHandlers() {
         ChatMessage chatMessage = item.getChatMessage();
-
-        // !isMyMessage
         moreOptionsIcon.setOnMouseClicked(e -> onOpenMoreOptions(pmIcon, chatMessage, () -> {
             hideReactionsBox();
             model.getSelectedChatMessageForMoreOptionsPopup().set(null);
@@ -244,31 +133,9 @@ public final class PeerMessage extends Message {
 
         pmIcon.setVisible(chatMessage instanceof PublicChatMessage);
         pmIcon.setManaged(chatMessage instanceof PublicChatMessage);
-
-        setOnMouseEntered(e -> {
-            if (model.getSelectedChatMessageForMoreOptionsPopup().get() != null) {
-                return;
-            }
-            dateTime.setVisible(true);
-            reactionsHBox.setVisible(true);
-        });
-
-        setOnMouseExited(e -> {
-            if (model.getSelectedChatMessageForMoreOptionsPopup().get() == null) {
-                hideReactionsBox();
-                dateTime.setVisible(false);
-                reactionsHBox.setVisible(false);
-            }
-        });
     }
 
-    // TODO: can be reused
-    private void hideReactionsBox() {
-        reactionsHBox.setVisible(false);
-    }
-
-    // TODO: reuse
-    void onOpenMoreOptions(Node owner, ChatMessage chatMessage, Runnable onClose) {
+    private void onOpenMoreOptions(Node owner, ChatMessage chatMessage, Runnable onClose) {
         if (chatMessage.equals(model.getSelectedChatMessageForMoreOptionsPopup().get())) {
             return;
         }
@@ -289,10 +156,6 @@ public final class PeerMessage extends Message {
         BisqPopupMenu menu = new BisqPopupMenu(items, onClose);
         menu.setAlignment(BisqPopup.Alignment.LEFT);
         menu.show(owner);
-    }
-
-    void onCopyMessage(ChatMessage chatMessage) {
-        ClipboardUtil.copyToClipboard(chatMessage.getText());
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
@@ -144,6 +144,7 @@ public final class PeerMessage extends Message {
         messageHBox = new HBox();
         VBox.setMargin(messageHBox, new Insets(10, 0, 0, 0));
 
+        // TODO (refactor): Move this logic to BisqEasy package
         if (item.isBisqEasyPublicChatMessageWithOffer()) {
             supportedLanguages.setText(item.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) item.getChatMessage())));
             supportedLanguages.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) item.getChatMessage()))));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
@@ -96,13 +96,19 @@ public final class PeerMessage extends Message {
         replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
         pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
         moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
-        Label supportedLanguages = new Label();
         HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
         HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
         HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
         reactionsHBox = new HBox(20);
         reactionsHBox.setVisible(false);
         handleReactionsBox(item);
+
+        // supportedLanguages
+        Label supportedLanguages = new Label();
+        if (item.isBisqEasyPublicChatMessageWithOffer()) {
+            supportedLanguages.setText(item.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) item.getChatMessage())));
+            supportedLanguages.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) item.getChatMessage()))));
+        }
 
         // quoted message
         quotedMessageVBox = new VBox(5);
@@ -146,9 +152,6 @@ public final class PeerMessage extends Message {
 
         // TODO (refactor): Move this logic to BisqEasy package
         if (item.isBisqEasyPublicChatMessageWithOffer()) {
-            supportedLanguages.setText(item.getSupportedLanguageCodes(((BisqEasyOfferbookMessage) item.getChatMessage())));
-            supportedLanguages.setTooltip(new BisqTooltip(item.getSupportedLanguageCodesForTooltip(((BisqEasyOfferbookMessage) item.getChatMessage()))));
-
             reactionsHBox.getChildren().setAll(replyIcon, pmIcon, moreOptionsIcon, supportedLanguages, Spacer.fillHBox());
             message.maxWidthProperty().bind(list.widthProperty().subtract(430));
             userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/PeerMessage.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package bisq.desktop.main.content.components.chatMessages.messages;
 
 import bisq.chat.ChatChannel;
@@ -31,15 +48,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-// Represents mainVBox
-public class PeerMessage extends VBox {
+public final class PeerMessage extends Message {
     private final static double CHAT_MESSAGE_BOX_MAX_WIDTH = 630;
 
     private final ChatMessagesListView.Controller controller;
     private final ChatMessagesListView.Model model;
     private final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
     private final VBox quotedMessageVBox;
-    private final Label message, userName, dateTime, replyIcon, pmIcon, moreOptionsIcon, supportedLanguages;
+    private final Label message, userName, dateTime, replyIcon, pmIcon, moreOptionsIcon;
     private final HBox messageHBox, messageBgHBox;
     private final HBox reactionsHBox;
     private final ReputationScoreDisplay reputationScoreDisplay;
@@ -80,7 +96,7 @@ public class PeerMessage extends VBox {
         replyIcon = getIconWithToolTip(AwesomeIcon.REPLY, Res.get("chat.message.reply"));
         pmIcon = getIconWithToolTip(AwesomeIcon.COMMENT_ALT, Res.get("chat.message.privateMessage"));
         moreOptionsIcon = getIconWithToolTip(AwesomeIcon.ELLIPSIS_HORIZONTAL, Res.get("chat.message.moreOptions"));
-        supportedLanguages = new Label();
+        Label supportedLanguages = new Label();
         HBox.setMargin(replyIcon, new Insets(4, 0, -4, 10));
         HBox.setMargin(pmIcon, new Insets(4, 0, -4, 0));
         HBox.setMargin(moreOptionsIcon, new Insets(6, 0, -6, 0));
@@ -275,5 +291,18 @@ public class PeerMessage extends VBox {
         ClipboardUtil.copyToClipboard(chatMessage.getText());
     }
 
-    // TODO: Add clean-up function
+    @Override
+    public void cleanup() {
+        message.maxWidthProperty().unbind();
+
+        takeOfferButton.setOnAction(null);
+
+        userName.setOnMouseClicked(null);
+        userProfileIcon.setOnMouseClicked(null);
+        replyIcon.setOnMouseClicked(null);
+        pmIcon.setOnMouseClicked(null);
+        moreOptionsIcon.setOnMouseClicked(null);
+
+        userProfileIcon.releaseResources();
+    }
 }


### PR DESCRIPTION
Since there multiple types of chat messages that can appear in the chat box (text messages, system messages, offerbook messages, leave chat, and potentially more), I am decoupling the logic so that they are well-defined and other types can be introduced easily.

I will follow-up with another PR decoupling more, especially the logic inside the `Controller` and `Model` of the `ChatMessagesListView`.