### PR TITLE
Market logo placeholder

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
@@ -3,11 +3,9 @@ package bisq.desktop.main.content.bisq_easy.offerbook;
 import bisq.common.currency.Market;
 import bisq.common.currency.MarketRepository;
 import bisq.desktop.components.controls.BisqTooltip;
-import bisq.desktop.main.content.components.MarketImageComposition;
 import bisq.i18n.Res;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringExpression;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
 import javafx.scene.control.*;
@@ -17,24 +15,9 @@ import javafx.util.Callback;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class BisqEasyOfferbookUtil {
     private static final List<Market> majorMarkets = MarketRepository.getMajorMarkets();
-    private static final Set<String> marketsWithLogos = Stream.of("aed", "afn", "all", "amd", "aoa", "ars", "aud",
-            "awg", "azn", "bam", "bbd", "bdt", "bgn", "bhd", "bif", "bmd", "bnd", "bob", "brl", "bsd", "btn", "bwp",
-            "byn", "bzd", "cad", "chf", "clp", "cny", "cop", "crc", "cup", "cve", "czk", "djf", "dkk", "dop", "dzd",
-            "egp", "ern", "etb", "eur", "fjd", "fkp", "gbp", "gel", "ghs", "gip", "gmd", "gnf", "gtq", "gyd", "hkd",
-            "hnl", "htg", "huf", "idr", "ils", "inr", "iqd", "irr", "isk", "jmd", "jod", "jpy", "kes", "kgs", "khr",
-            "kmf", "kpw", "krw", "kwd", "kyd", "kzt", "lak", "lbp", "lkr", "lrd", "lsl", "lyd", "mad", "mdl", "mga",
-            "mmk", "mnt", "mop", "mru", "mur", "mvr", "mwk", "mxn", "myr", "mzn", "nad", "ngn", "nio", "nok", "npr",
-            "nzd", "omr", "pab", "pen", "pgk", "php", "pkr", "pln", "pyg", "qar", "ron", "rsd", "rub", "rwf", "sar",
-            "sbd", "scr", "sdg", "sek", "sgd", "sle", "sos", "srd", "ssp", "stn", "svc", "syp", "szl", "thb", "tjs",
-            "tmt", "tnd", "top", "try", "ttd", "twd", "tzs", "uah", "ugx", "usd", "uyu", "uzs", "ves", "vnd", "vuv",
-            "wst", "xaf", "yer", "zar", "zmw", "zwl")
-            .collect(Collectors.toUnmodifiableSet());
 
     public static Comparator<MarketChannelItem> SortByNumOffers() {
         return (lhs, rhs) -> Integer.compare(rhs.getNumOffers().get(), lhs.getNumOffers().get());
@@ -116,14 +99,8 @@ public class BisqEasyOfferbookUtil {
             @Override
             protected void updateItem(MarketChannelItem item, boolean empty) {
                 super.updateItem(item, empty);
-                if (item != null && !empty) {
-                    String marketCode = item.getMarket().getQuoteCurrencyCode();
-                    setGraphic(marketsWithLogos.contains(marketCode.toLowerCase())
-                            ? item.getMarketLogo()
-                            : MarketImageComposition.createMarketLogoPlaceholder(marketCode));
-                } else {
-                    setGraphic(null);
-                }
+
+                setGraphic(item != null && !empty ? item.getMarketLogo() : null);
             }
         };
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -21,12 +21,12 @@ import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookChannel;
 import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
 import bisq.common.currency.Market;
 import bisq.desktop.common.threading.UIThread;
-import bisq.desktop.common.utils.ImageUtil;
+import bisq.desktop.main.content.components.MarketImageComposition;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.CacheHint;
+import javafx.scene.Node;
 import javafx.scene.effect.ColorAdjust;
-import javafx.scene.image.ImageView;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -37,16 +37,13 @@ import java.lang.ref.WeakReference;
 public class MarketChannelItem {
     private final BisqEasyOfferbookChannel channel;
     private final Market market;
-    private final ImageView marketLogo;
+    private final Node marketLogo;
     private final IntegerProperty numOffers = new SimpleIntegerProperty(0);
 
     public MarketChannelItem(BisqEasyOfferbookChannel channel) {
         this.channel = channel;
         market = channel.getMarket();
-
-        String marketCode = market.getQuoteCurrencyCode().toLowerCase();
-        String iconId = String.format("market-%s", marketCode);
-        marketLogo = ImageUtil.getImageViewById(iconId);
+        marketLogo = MarketImageComposition.createMarketLogo(market.getQuoteCurrencyCode());
         marketLogo.setCache(true);
         marketLogo.setCacheHint(CacheHint.SPEED);
         ColorAdjust colorAdjust = new ColorAdjust();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/market/TradeWizardMarketView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/market/TradeWizardMarketView.java
@@ -30,10 +30,13 @@ import bisq.desktop.main.content.components.MarketImageComposition;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.CacheHint;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.Tooltip;
+import javafx.scene.effect.ColorAdjust;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
@@ -149,7 +152,7 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
                 super.updateItem(item, empty);
 
                 if (item != null && !empty) {
-                    label.setGraphic(item.getIcon());
+                    label.setGraphic(item.getMarketLogo());
                     String quoteCurrencyName = item.getQuoteCurrencyName();
                     label.setText(quoteCurrencyName);
                     if (quoteCurrencyName.length() > 20) {
@@ -178,7 +181,7 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
         private final String numOffers;
         private final String numUsers;
         @EqualsAndHashCode.Exclude
-        private final StackPane icon;
+        private final Node marketLogo;
 
         MarketListItem(Market market, int numOffersAsInteger, int numUsersAsInteger) {
             this.market = market;
@@ -186,8 +189,13 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
             this.numOffers = String.valueOf(numOffersAsInteger);
             this.numOffersAsInteger = numOffersAsInteger;
             this.numUsers = String.valueOf(numUsersAsInteger);
-            icon = MarketImageComposition.getCurrencyIcon(market.getQuoteCurrencyCode());
             this.numUsersAsInteger = numUsersAsInteger;
+            marketLogo = MarketImageComposition.createMarketLogo(market.getQuoteCurrencyCode());
+            marketLogo.setCache(true);
+            marketLogo.setCacheHint(CacheHint.SPEED);
+            ColorAdjust colorAdjust = new ColorAdjust();
+            colorAdjust.setBrightness(-0.1);
+            marketLogo.setEffect(colorAdjust);
         }
 
         @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
@@ -7,6 +7,7 @@ import bisq.desktop.common.utils.ImageUtil;
 import bisq.security.DigestUtil;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.effect.ColorAdjust;
@@ -20,12 +21,25 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
 public class MarketImageComposition {
     private static final List<String> MARKETS_WITH_IMAGE = List.of("bsq", "btc", "eur", "usd", "xmr", "any-base", "any-quote");
+    private static final Set<String> MARKETS_WITH_LOGOS = Stream.of("aed", "afn", "all", "amd", "aoa", "ars", "aud",
+                    "awg", "azn", "bam", "bbd", "bdt", "bgn", "bhd", "bif", "bmd", "bnd", "bob", "brl", "bsd", "btn", "bwp",
+                    "byn", "bzd", "cad", "chf", "clp", "cny", "cop", "crc", "cup", "cve", "czk", "djf", "dkk", "dop", "dzd",
+                    "egp", "ern", "etb", "eur", "fjd", "fkp", "gbp", "gel", "ghs", "gip", "gmd", "gnf", "gtq", "gyd", "hkd",
+                    "hnl", "htg", "huf", "idr", "ils", "inr", "iqd", "irr", "isk", "jmd", "jod", "jpy", "kes", "kgs", "khr",
+                    "kmf", "kpw", "krw", "kwd", "kyd", "kzt", "lak", "lbp", "lkr", "lrd", "lsl", "lyd", "mad", "mdl", "mga",
+                    "mmk", "mnt", "mop", "mru", "mur", "mvr", "mwk", "mxn", "myr", "mzn", "nad", "ngn", "nio", "nok", "npr",
+                    "nzd", "omr", "pab", "pen", "pgk", "php", "pkr", "pln", "pyg", "qar", "ron", "rsd", "rub", "rwf", "sar",
+                    "sbd", "scr", "sdg", "sek", "sgd", "sle", "sos", "srd", "ssp", "stn", "svc", "syp", "szl", "thb", "tjs",
+                    "tmt", "tnd", "top", "try", "ttd", "twd", "tzs", "uah", "ugx", "usd", "uyu", "uzs", "ves", "vnd", "vuv",
+                    "wst", "xaf", "yer", "zar", "zmw", "zwl")
+            .collect(Collectors.toUnmodifiableSet());
 
     public static Pair<StackPane, List<ImageView>> imageBoxForMarket(String baseCurrencyCode, String quoteCurrencyCode) {
         StackPane pane = new StackPane();
@@ -130,7 +144,15 @@ public class MarketImageComposition {
         return pane;
     }
 
-    public static Label createMarketLogoPlaceholder(String marketCode) {
+    public static Node createMarketLogo(String marketCode) {
+        String market = marketCode.toLowerCase();
+        String iconId = String.format("market-%s", market);
+        return MARKETS_WITH_LOGOS.contains(market)
+                ? ImageUtil.getImageViewById(iconId)
+                : createMarketLogoPlaceholder(marketCode);
+    }
+
+    private static Label createMarketLogoPlaceholder(String marketCode) {
         Circle circle = new Circle(15);
         circle.setFill(Paint.valueOf("#FF0000"));
         circle.setEffect(createColorAdjust(marketCode));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
@@ -153,16 +153,15 @@ public class MarketImageComposition {
     }
 
     private static Label createMarketLogoPlaceholder(String marketCode) {
-        Circle circle = new Circle(15);
+        Circle circle = new Circle(16);
         circle.setFill(Paint.valueOf("#FF0000"));
         circle.setEffect(createColorAdjust(marketCode));
 
         Text text = new Text(marketCode.substring(0, Math.min(3, marketCode.length())));
-        text.getStyleClass().setAll("fiat-code");
-
-        Label label = new Label("", new Circle(15, Color.LIGHTGRAY));
+        Label label = new Label(text.getText(), new Circle(16, Color.TRANSPARENT));
+        label.getStyleClass().add("fiat-code");
+        label.setAlignment(Pos.CENTER);
         label.setGraphic(circle);
-        label.setText(text.getText());
         label.setContentDisplay(ContentDisplay.CENTER);
         return label;
     }

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -24,21 +24,22 @@
     -fx-font-family: "IBM Plex Sans";
 }
 
-.fiat-code {
-    -fx-font-size: 8;
-    -fx-text-fill: -fx-light-text-color !important;;
-    -fx-font-family: "IBM Plex Sans Medium";
+.fiat-code > .text {
+    -fx-font-size: 12;
+    -fx-fill: -bisq-white !important;
+    -fx-text-fill: -bisq-white !important;
+    -fx-font-family: "IBM Plex Sans SemiBold";
 }
 
 .fiat-symbol {
     -fx-font-size: 13;
-    -fx-text-fill: -fx-light-text-color !important;;
+    -fx-text-fill: -fx-light-text-color !important;
     -fx-font-family: "IBM Plex Sans Medium";
 }
 
 .fiat-symbol-2 {
     -fx-font-size: 11;
-    -fx-text-fill: -fx-light-text-color !important;;
+    -fx-text-fill: -fx-light-text-color !important;
     -fx-font-family: "IBM Plex Sans Medium";
 }
 


### PR DESCRIPTION
Based on #1668

Fix market logo placeholder (markets without country flag):
* Make placeholder the same size as the logos.
* Change the text colour to be visible.

![image](https://github.com/bisq-network/bisq2/assets/145597137/b9ad7589-a872-42f8-88fa-727898119cc1)
