### PR TITLE
Fix misaligned offerbook messages

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/MyOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/MyOfferMessage.java
@@ -69,7 +69,7 @@ public final class MyOfferMessage extends BubbleMessage {
         reactionsHBox.getChildren().setAll(Spacer.fillHBox(), supportedLanguages, copyIcon);
         reactionsHBox.setAlignment(Pos.CENTER_RIGHT);
 
-        getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
+        contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
@@ -46,7 +46,7 @@ public final class PeerOfferMessage extends PeerMessage {
         reactionsHBox.getChildren().setAll(replyIcon, pmIcon, moreOptionsIcon, supportedLanguages, Spacer.fillHBox());
 
         VBox.setMargin(userNameAndDateHBox, new Insets(-5, 0, 5, 10));
-        getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);
+        contentVBox.getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);
     }
 
     @Override


### PR DESCRIPTION
In recent changes all the message elements were refactored and now all elements are added in `contentVBox` instead of the component itself. This was missing to update for messages of type offer.