### PR TITLE
Revisit styles of Bisq Easy offer messages

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
@@ -493,7 +493,7 @@ public class ChatMessagesComponent {
 
         private HBox createAndGetSendMessageBox() {
             inputField.setPromptText(Res.get("chat.message.input.prompt"));
-            inputField.getStyleClass().addAll("chat-input-field", "normal-text");
+            inputField.getStyleClass().addAll("chat-input-field", "medium-text");
             inputField.setPadding(new Insets(5, 0, 5, 5));
             HBox.setMargin(inputField, new Insets(0, 0, 1.5, 0));
             HBox.setHgrow(inputField, Priority.ALWAYS);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/MyOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/MyOfferMessage.java
@@ -29,6 +29,7 @@ import bisq.i18n.Res;
 import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.HBox;
@@ -44,32 +45,30 @@ public final class MyOfferMessage extends BubbleMessage {
         super(item, list, controller, model);
 
         // Message
-        message.setAlignment(Pos.CENTER_RIGHT);
-        message.maxWidthProperty().bind(list.widthProperty().subtract(160));
-        VBox messageVBox = new VBox(message);
-        HBox.setMargin(messageVBox, new Insets(0, -10, 0, 0));
+        message.getStyleClass().add("chat-my-offer-message");
 
         // User profile icon
-        userProfileIcon.setSize(60);
-        userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
-        HBox.setMargin(userProfileIconVbox, new Insets(0, 0, 10, 0));
+        userProfileIcon.setSize(70);
 
         // Dropdown menu
         DropdownMenu dropdownMenu = createAndGetDropdownMenu();
 
+        // Wrappers
+        HBox hBox = new HBox(15, message, userProfileIconVbox);
+        hBox.setAlignment(Pos.CENTER);
+        VBox vBox = new VBox(hBox, dropdownMenu);
+        vBox.setAlignment(Pos.CENTER_RIGHT);
+
         // Message background
-        HBox hBox = new HBox(15, messageVBox, userProfileIconVbox);
-        HBox dropdownMenuHBox = new HBox(Spacer.fillHBox(), dropdownMenu);
-        VBox vBox = new VBox(hBox, dropdownMenuHBox);
+        messageBgHBox.getStyleClass().add("chat-my-offer-message-bg");
         messageBgHBox.getChildren().setAll(vBox);
-        messageBgHBox.getStyleClass().add("chat-message-bg-my-message");
-        messageHBox.getChildren().setAll(Spacer.fillHBox(), messageBgHBox);
+        messageBgHBox.setMaxWidth(Control.USE_PREF_SIZE);
 
         // Reactions
         reactionsHBox.getChildren().setAll(Spacer.fillHBox(), supportedLanguages, copyIcon);
-        reactionsHBox.setAlignment(Pos.CENTER_RIGHT);
 
-        contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, reactionsHBox);
+        contentVBox.setAlignment(Pos.CENTER_RIGHT);
+        contentVBox.getChildren().setAll(userNameAndDateHBox, messageBgHBox, reactionsHBox);
     }
 
     @Override
@@ -78,7 +77,7 @@ public final class MyOfferMessage extends BubbleMessage {
 
         userNameAndDateHBox = new HBox(10, dateTime, userName);
         userNameAndDateHBox.setAlignment(Pos.CENTER_RIGHT);
-        VBox.setMargin(userNameAndDateHBox, new Insets(-5, 10, -5, 0));
+        VBox.setMargin(userNameAndDateHBox, new Insets(0, 10, 5, 0));
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
@@ -52,8 +52,7 @@ public final class PeerOfferMessage extends PeerMessage {
     @Override
     protected void setUpPeerMessage() {
         // User profile icon
-        userProfileIcon.setSize(80);
-        userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
+        userProfileIcon.setSize(70);
 
         // Reputation
         Label reputationLabel = new Label(Res.get("chat.message.reputation").toUpperCase());
@@ -70,10 +69,12 @@ public final class PeerOfferMessage extends PeerMessage {
         takeOfferButton.setDefaultButton(!item.isOfferAlreadyTaken());
         takeOfferButton.getStyleClass().add("take-offer-button");
 
-        HBox hBox = new HBox(15, userProfileIconVbox, reputationVBox, message);
-        hBox.setAlignment(Pos.CENTER);
+        // Message
         message.getStyleClass().add("chat-peer-offer-message");
 
+        // Wrappers
+        HBox hBox = new HBox(15, userProfileIconVbox, reputationVBox, message);
+        hBox.setAlignment(Pos.CENTER);
         VBox vBox = new VBox(5, hBox, takeOfferButton);
         vBox.setAlignment(Pos.CENTER_RIGHT);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
@@ -51,37 +51,37 @@ public final class PeerOfferMessage extends PeerMessage {
 
     @Override
     protected void setUpPeerMessage() {
-        super.setUpPeerMessage();
-
         // User profile icon
-        userProfileIcon.setSize(60);
+        userProfileIcon.setSize(80);
         userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
-        HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
-
-        // Message
-        message.maxWidthProperty().bind(list.widthProperty().subtract(430));
-        VBox messageVBox = new VBox(quotedMessageVBox, message);
-        HBox.setMargin(messageVBox, new Insets(0, 0, 0, -10));
 
         // Reputation
         Label reputationLabel = new Label(Res.get("chat.message.reputation").toUpperCase());
-        reputationLabel.getStyleClass().add("bisq-text-7");
         ReputationScoreDisplay reputationScoreDisplay = new ReputationScoreDisplay();
         reputationScoreDisplay.setReputationScore(item.getReputationScore());
         VBox reputationVBox = new VBox(4, reputationLabel, reputationScoreDisplay);
-        reputationVBox.setAlignment(Pos.CENTER_LEFT);
-        HBox.setMargin(reputationVBox, new Insets(-5, 10, 0, 0));
+        reputationVBox.setAlignment(Pos.CENTER);
+        reputationVBox.getStyleClass().add("reputation");
 
         // Take offer button
         takeOfferButton = new Button(Res.get("offer.takeOffer"));
         BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) item.getChatMessage();
         takeOfferButton.setOnAction(e -> controller.onTakeOffer(bisqEasyOfferbookMessage));
         takeOfferButton.setDefaultButton(!item.isOfferAlreadyTaken());
-        takeOfferButton.setMinWidth(Control.USE_PREF_SIZE);
-        HBox.setMargin(takeOfferButton, new Insets(0, 10, 0, 0));
+        takeOfferButton.getStyleClass().add("take-offer-button");
+
+        HBox hBox = new HBox(15, userProfileIconVbox, reputationVBox, message);
+        hBox.setAlignment(Pos.CENTER);
+        message.getStyleClass().add("chat-peer-offer-message");
+
+        VBox vBox = new VBox(5, hBox, takeOfferButton);
+        vBox.setAlignment(Pos.CENTER_RIGHT);
 
         // Message background
-        messageBgHBox.getChildren().setAll(userProfileIconVbox, messageVBox, Spacer.fillHBox(), reputationVBox, takeOfferButton);
+        messageBgHBox.getStyleClass().add("chat-peer-offer-message-bg");
+        messageBgHBox.getChildren().setAll(vBox);
+        messageBgHBox.setAlignment(Pos.CENTER_LEFT);
+        messageBgHBox.setMaxWidth(Control.USE_PREF_SIZE);
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
@@ -54,6 +54,7 @@ public final class PeerOfferMessage extends PeerMessage {
         super.setUpPeerMessage();
 
         // User profile icon
+        userProfileIcon.setSize(60);
         userProfileIconVbox.setAlignment(Pos.CENTER_LEFT);
         HBox.setMargin(userProfileIconVbox, new Insets(-5, 0, -5, 0));
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BubbleMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BubbleMessage.java
@@ -182,7 +182,7 @@ public abstract class BubbleMessage extends Message {
         label.maxWidthProperty().unbind();
         label.setWrapText(true);
         label.setPadding(new Insets(10));
-        label.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
+        label.getStyleClass().addAll("text-fill-white", "medium-text", "font-default");
         label.setText(item.getMessage());
         return label;
     }

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -155,12 +155,7 @@
     -fx-font-family: "IBM Plex Sans Light";
 }
 
-.chat-message-bg-my-message {
-    -fx-background-color: -bisq-dark-grey-40;
-    -fx-background-radius: 8;
-}
-
-/* Peer Message */
+/* Peer Message Background */
 .chat-message-bg-peer-message,
 .chat-peer-offer-message-bg {
     -fx-background-color: -bisq-dark-grey-40;
@@ -169,7 +164,7 @@
 
 /* Peer Offer Message */
 .chat-peer-offer-message-bg {
-    -fx-padding: 30 30 20 20;
+    -fx-padding: 20 30 20 20;
 }
 
 .chat-peer-offer-message-bg .reputation .label {
@@ -178,17 +173,35 @@
 
 .chat-peer-offer-message {
     -fx-padding: 0 0 0 7;
-    -fx-line-spacing: 10px;
+    -fx-line-spacing: 7px;
 }
 
 .chat-peer-offer-message-bg .take-offer-button {
     -fx-padding: 5 30 5 30;
 }
-/* ... */
 
 .chat-peer-offer-message-bg .take-offer-button .text {
     -fx-font-size: 0.8em;
 }
+/* ... */
+
+/* My Message Background */
+.chat-message-bg-my-message,
+.chat-my-offer-message-bg {
+    -fx-background-color: #2c372b; /* -bisq2-green; saturation -70; lightness -60 */
+    -fx-background-radius: 8;
+}
+
+/* My Offer Message */
+.chat-my-offer-message {
+    -fx-padding: 0;
+    -fx-line-spacing: 7px;
+}
+
+.chat-my-offer-message-bg {
+    -fx-padding: 20 20 15 30;
+}
+/* ... */
 
 .create-offer-message-my-offer {
     -fx-background-color: -bisq-dark-grey-10;

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -160,9 +160,34 @@
     -fx-background-radius: 8;
 }
 
-.chat-message-bg-peer-message {
+/* Peer Message */
+.chat-message-bg-peer-message,
+.chat-peer-offer-message-bg {
     -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 8;
+}
+
+/* Peer Offer Message */
+.chat-peer-offer-message-bg {
+    -fx-padding: 30 30 20 20;
+}
+
+.chat-peer-offer-message-bg .reputation .label {
+    -fx-font-size: 0.9em;
+}
+
+.chat-peer-offer-message {
+    -fx-padding: 0 0 0 7;
+    -fx-line-spacing: 10px;
+}
+
+.chat-peer-offer-message-bg .take-offer-button {
+    -fx-padding: 5 30 5 30;
+}
+/* ... */
+
+.chat-peer-offer-message-bg .take-offer-button .text {
+    -fx-font-size: 0.8em;
 }
 
 .create-offer-message-my-offer {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -12,6 +12,10 @@
     -fx-font-size: 0.769em;
 }
 
+.medium-text {
+    -fx-font-size: 1.05em !important;
+}
+
 .normal-text {
     -fx-font-size: 1.1em !important;
 }

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -13,7 +13,7 @@
 }
 
 .medium-text {
-    -fx-font-size: 1.05em !important;
+    -fx-font-size: 1.02em !important;
 }
 
 .normal-text {


### PR DESCRIPTION
Towards #1718

* Relocate `reputation` to be nearer and alongside the user avatar.
* Reduce size of `takeOfferButton` size and moved it closer to the offer text details.
* Decrease font size of the message bubble and increase line spacing.
* Change colour of the my message bubble to a dark desaturated green. 

![image](https://github.com/bisq-network/bisq2/assets/145597137/98291634-bdf2-4d01-9383-3e33df7ffbb3)
