### PR TITLE
Add additional filter in Bisq Easy Offerbook to filter offers by peer reputation

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenu.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenu.java
@@ -18,6 +18,7 @@
 package bisq.desktop.components.controls;
 
 import bisq.desktop.common.utils.ImageUtil;
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ObservableList;
 import javafx.geometry.Bounds;
@@ -36,6 +37,7 @@ public class DropdownMenu extends HBox {
     private final ImageView defaultIcon, activeIcon;
     private final ContextMenu contextMenu = new ContextMenu();
     private ImageView buttonIcon;
+    private ChangeListener<Number> widthPropertyChangeListener;
     private boolean isFirstRun = false;
 
     public DropdownMenu(String defaultIconId, String activeIconId, boolean useIconOnly) {
@@ -129,7 +131,7 @@ public class DropdownMenu extends HBox {
             updateIcon(defaultIcon);
         });
 
-        contextMenu.widthProperty().addListener(new WeakChangeListener<Number>((observable, oldValue, newValue) -> {
+        widthPropertyChangeListener = (observable, oldValue, newValue) -> {
             if (newValue.doubleValue() > INITIAL_WIDTH && !isFirstRun) {
                 isFirstRun = true;
                 // Once the contextMenu has calculated the width on the first render time we update the items
@@ -141,7 +143,8 @@ public class DropdownMenu extends HBox {
                     }
                 }
             }
-        }));
+        };
+        contextMenu.widthProperty().addListener(new WeakChangeListener<>(widthPropertyChangeListener));
     }
 
     private void updateIcon(ImageView newIcon) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenuItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenuItem.java
@@ -18,7 +18,6 @@
 package bisq.desktop.components.controls;
 
 import bisq.desktop.common.utils.ImageUtil;
-import javafx.geometry.Pos;
 import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
@@ -35,7 +34,6 @@ public class DropdownMenuItem extends CustomMenuItem {
         label = new Label(text);
         content = new HBox(8, label);
         content.getStyleClass().add("dropdown-menu-item-content");
-        content.setAlignment(Pos.CENTER_LEFT);
         setContent(content);
 
         if (defaultIconId != null && activeIconId != null) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenuItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenuItem.java
@@ -18,6 +18,7 @@
 package bisq.desktop.components.controls;
 
 import bisq.desktop.common.utils.ImageUtil;
+import javafx.geometry.Pos;
 import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
@@ -34,6 +35,7 @@ public class DropdownMenuItem extends CustomMenuItem {
         label = new Label(text);
         content = new HBox(8, label);
         content.getStyleClass().add("dropdown-menu-item-content");
+        content.setAlignment(Pos.CENTER_LEFT);
         setContent(content);
 
         if (defaultIconId != null && activeIconId != null) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownTitleMenuItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownTitleMenuItem.java
@@ -21,10 +21,15 @@ import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Label;
 
 public class DropdownTitleMenuItem extends CustomMenuItem {
+    private final Label label;
 
     public DropdownTitleMenuItem(String text) {
-        Label label = new Label(text);
+        label = new Label(text);
         setContent(label);
         getStyleClass().add("dropdown-title-menu-item");
+    }
+
+    public String getLabelText() {
+        return label.getText();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -57,7 +57,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     private final BisqEasyOfferbookModel bisqEasyOfferbookModel;
     private Pin offerOnlySettingsPin, bisqEasyPrivateTradeChatChannelsPin, selectedChannelPin, marketPriceByCurrencyMapPin;
     private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOffersFilterPin, selectedMarketSortTypePin,
-            selectedReputationsFilterPin;
+            selectedPeerReputationFilterPin;
 
     public BisqEasyOfferbookController(ServiceProvider serviceProvider) {
         super(serviceProvider, ChatChannelDomain.BISQ_EASY_OFFERBOOK, NavigationTarget.BISQ_EASY_OFFERBOOK);
@@ -142,13 +142,13 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
             }
         });
 
-        selectedReputationsFilterPin = EasyBind.subscribe(model.getSelectedReputationsFilter(), filter -> {
+        selectedPeerReputationFilterPin = EasyBind.subscribe(model.getSelectedPeerReputationFilter(), filter -> {
             if (filter == null) {
                 // By default, show all offers (with any reputation)
-                model.getSelectedReputationsFilter().set(Filters.OfferReputations.ALL);
-                chatMessagesComponent.setBisqEasyReputationsFilterPredicate(model.getSelectedReputationsFilter().get().getPredicate());
+                model.getSelectedPeerReputationFilter().set(Filters.PeerReputation.ALL);
+                chatMessagesComponent.setBisqEasyPeerReputationFilterPredicate(model.getSelectedPeerReputationFilter().get().getPredicate());
             } else {
-                chatMessagesComponent.setBisqEasyReputationsFilterPredicate(filter.getPredicate());
+                chatMessagesComponent.setBisqEasyPeerReputationFilterPredicate(filter.getPredicate());
             }
         });
 
@@ -177,7 +177,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         marketSelectorSearchPin.unsubscribe();
         selectedMarketFilterPin.unsubscribe();
         selectedOffersFilterPin.unsubscribe();
-        selectedReputationsFilterPin.unsubscribe();
+        selectedPeerReputationFilterPin.unsubscribe();
         marketPriceByCurrencyMapPin.unbind();
         selectedMarketSortTypePin.unsubscribe();
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -56,7 +56,8 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     private final BisqEasyOfferbookChannelService bisqEasyOfferbookChannelService;
     private final BisqEasyOfferbookModel bisqEasyOfferbookModel;
     private Pin offerOnlySettingsPin, bisqEasyPrivateTradeChatChannelsPin, selectedChannelPin, marketPriceByCurrencyMapPin;
-    private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOffersFilterPin, selectedMarketSortTypePin;
+    private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOffersFilterPin, selectedMarketSortTypePin,
+            selectedReputationsFilterPin;
 
     public BisqEasyOfferbookController(ServiceProvider serviceProvider) {
         super(serviceProvider, ChatChannelDomain.BISQ_EASY_OFFERBOOK, NavigationTarget.BISQ_EASY_OFFERBOOK);
@@ -141,6 +142,16 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
             }
         });
 
+        selectedReputationsFilterPin = EasyBind.subscribe(model.getSelectedReputationsFilter(), filter -> {
+            if (filter == null) {
+                // By default, show all offers
+                model.getSelectedReputationsFilter().set(Filters.Reputations.ALL);
+                chatMessagesComponent.setBisqEasyReputationsFilterPredicate(model.getSelectedReputationsFilter().get().getPredicate());
+            } else {
+                chatMessagesComponent.setBisqEasyReputationsFilterPredicate(filter.getPredicate());
+            }
+        });
+
         MarketSortType persistedMarketSortType = settingsService.getCookie().asString(CookieKey.MARKET_SORT_TYPE).map(name ->
                         ProtobufUtils.enumFromProto(MarketSortType.class, name, MarketSortType.NUM_OFFERS))
                 .orElse(MarketSortType.NUM_OFFERS);
@@ -166,6 +177,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         marketSelectorSearchPin.unsubscribe();
         selectedMarketFilterPin.unsubscribe();
         selectedOffersFilterPin.unsubscribe();
+        selectedReputationsFilterPin.unsubscribe();
         marketPriceByCurrencyMapPin.unbind();
         selectedMarketSortTypePin.unsubscribe();
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -56,8 +56,8 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     private final BisqEasyOfferbookChannelService bisqEasyOfferbookChannelService;
     private final BisqEasyOfferbookModel bisqEasyOfferbookModel;
     private Pin offerOnlySettingsPin, bisqEasyPrivateTradeChatChannelsPin, selectedChannelPin, marketPriceByCurrencyMapPin;
-    private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOffersFilterPin, selectedMarketSortTypePin,
-            selectedPeerReputationFilterPin;
+    private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOfferDirectionOrOwnerFilterPin,
+            selectedPeerReputationFilterPin, selectedMarketSortTypePin;
 
     public BisqEasyOfferbookController(ServiceProvider serviceProvider) {
         super(serviceProvider, ChatChannelDomain.BISQ_EASY_OFFERBOOK, NavigationTarget.BISQ_EASY_OFFERBOOK);
@@ -132,13 +132,13 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
             });
         });
 
-        selectedOffersFilterPin = EasyBind.subscribe(model.getSelectedOfferTypeFilter(), filter -> {
+        selectedOfferDirectionOrOwnerFilterPin = EasyBind.subscribe(model.getSelectedOfferDirectionOrOwnerFilter(), filter -> {
             if (filter == null) {
-                // By default, show all offers
-                model.getSelectedOfferTypeFilter().set(Filters.OfferType.ALL);
-                chatMessagesComponent.setBisqEasyOffersFilerPredicate(model.getSelectedOfferTypeFilter().get().getPredicate());
+                // By default, show all offers (any direction or owner)
+                model.getSelectedOfferDirectionOrOwnerFilter().set(Filters.OfferDirectionOrOwner.ALL);
+                chatMessagesComponent.setBisqEasyOfferDirectionOrOwnerFilterPredicate(model.getSelectedOfferDirectionOrOwnerFilter().get().getPredicate());
             } else {
-                chatMessagesComponent.setBisqEasyOffersFilerPredicate(filter.getPredicate());
+                chatMessagesComponent.setBisqEasyOfferDirectionOrOwnerFilterPredicate(filter.getPredicate());
             }
         });
 
@@ -176,7 +176,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         selectedChannelPin.unbind();
         marketSelectorSearchPin.unsubscribe();
         selectedMarketFilterPin.unsubscribe();
-        selectedOffersFilterPin.unsubscribe();
+        selectedOfferDirectionOrOwnerFilterPin.unsubscribe();
         selectedPeerReputationFilterPin.unsubscribe();
         marketPriceByCurrencyMapPin.unbind();
         selectedMarketSortTypePin.unsubscribe();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -132,11 +132,11 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
             });
         });
 
-        selectedOffersFilterPin = EasyBind.subscribe(model.getSelectedOffersFilter(), filter -> {
+        selectedOffersFilterPin = EasyBind.subscribe(model.getSelectedOfferTypeFilter(), filter -> {
             if (filter == null) {
                 // By default, show all offers
-                model.getSelectedOffersFilter().set(Filters.Offers.ALL);
-                chatMessagesComponent.setBisqEasyOffersFilerPredicate(model.getSelectedOffersFilter().get().getPredicate());
+                model.getSelectedOfferTypeFilter().set(Filters.OfferType.ALL);
+                chatMessagesComponent.setBisqEasyOffersFilerPredicate(model.getSelectedOfferTypeFilter().get().getPredicate());
             } else {
                 chatMessagesComponent.setBisqEasyOffersFilerPredicate(filter.getPredicate());
             }
@@ -144,8 +144,8 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
 
         selectedReputationsFilterPin = EasyBind.subscribe(model.getSelectedReputationsFilter(), filter -> {
             if (filter == null) {
-                // By default, show all offers
-                model.getSelectedReputationsFilter().set(Filters.Reputations.ALL);
+                // By default, show all offers (with any reputation)
+                model.getSelectedReputationsFilter().set(Filters.OfferReputations.ALL);
                 chatMessagesComponent.setBisqEasyReputationsFilterPredicate(model.getSelectedReputationsFilter().get().getPredicate());
             } else {
                 chatMessagesComponent.setBisqEasyReputationsFilterPredicate(filter.getPredicate());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -42,7 +42,7 @@ public final class BisqEasyOfferbookModel extends ChatModel {
     private final ObjectProperty<MarketChannelItem> selectedMarketChannelItem = new SimpleObjectProperty<>();
     private final StringProperty marketSelectorSearchText = new SimpleStringProperty();
     private final ObjectProperty<Filters.Markets> selectedMarketsFilter = new SimpleObjectProperty<>();
-    private final ObjectProperty<Filters.OfferType> selectedOfferTypeFilter = new SimpleObjectProperty<>();
+    private final ObjectProperty<Filters.OfferDirectionOrOwner> selectedOfferDirectionOrOwnerFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<Filters.PeerReputation> selectedPeerReputationFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<MarketSortType> selectedMarketSortType = new SimpleObjectProperty<>(MarketSortType.NUM_OFFERS);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -35,7 +35,7 @@ import java.util.function.Predicate;
 public final class BisqEasyOfferbookModel extends ChatModel {
     private final BooleanProperty offerOnly = new SimpleBooleanProperty();
     private final BooleanProperty isTradeChannelVisible = new SimpleBooleanProperty();
-    private final BooleanProperty showFilterOverlay = new SimpleBooleanProperty();
+    private final BooleanProperty showFilterOverlay = new SimpleBooleanProperty(); // TODO: remove this
     private final ObservableList<MarketChannelItem> marketChannelItems = FXCollections.observableArrayList();
     private final FilteredList<MarketChannelItem> filteredMarketChannelItems = new FilteredList<>(marketChannelItems);
     private final SortedList<MarketChannelItem> sortedMarketChannelItems = new SortedList<>(filteredMarketChannelItems);
@@ -43,6 +43,7 @@ public final class BisqEasyOfferbookModel extends ChatModel {
     private final StringProperty marketSelectorSearchText = new SimpleStringProperty();
     private final ObjectProperty<Filters.Markets> selectedMarketsFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<Filters.Offers> selectedOffersFilter = new SimpleObjectProperty<>();
+    private final ObjectProperty<Filters.Reputations> selectedReputationsFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<MarketSortType> selectedMarketSortType = new SimpleObjectProperty<>(MarketSortType.NUM_OFFERS);
 
     @Setter

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -42,8 +42,8 @@ public final class BisqEasyOfferbookModel extends ChatModel {
     private final ObjectProperty<MarketChannelItem> selectedMarketChannelItem = new SimpleObjectProperty<>();
     private final StringProperty marketSelectorSearchText = new SimpleStringProperty();
     private final ObjectProperty<Filters.Markets> selectedMarketsFilter = new SimpleObjectProperty<>();
-    private final ObjectProperty<Filters.Offers> selectedOffersFilter = new SimpleObjectProperty<>();
-    private final ObjectProperty<Filters.Reputations> selectedReputationsFilter = new SimpleObjectProperty<>();
+    private final ObjectProperty<Filters.OfferType> selectedOfferTypeFilter = new SimpleObjectProperty<>();
+    private final ObjectProperty<Filters.OfferReputations> selectedReputationsFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<MarketSortType> selectedMarketSortType = new SimpleObjectProperty<>(MarketSortType.NUM_OFFERS);
 
     @Setter

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -43,7 +43,7 @@ public final class BisqEasyOfferbookModel extends ChatModel {
     private final StringProperty marketSelectorSearchText = new SimpleStringProperty();
     private final ObjectProperty<Filters.Markets> selectedMarketsFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<Filters.OfferType> selectedOfferTypeFilter = new SimpleObjectProperty<>();
-    private final ObjectProperty<Filters.OfferReputations> selectedReputationsFilter = new SimpleObjectProperty<>();
+    private final ObjectProperty<Filters.PeerReputation> selectedPeerReputationFilter = new SimpleObjectProperty<>();
     private final ObjectProperty<MarketSortType> selectedMarketSortType = new SimpleObjectProperty<>(MarketSortType.NUM_OFFERS);
 
     @Setter

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -53,9 +53,9 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     private BisqTableView<MarketChannelItem> tableView;
     private VBox marketSelectionList;
     private Subscription tableViewSelectionPin, selectedModelItemPin, marketSelectorHeaderIconPin,
-            selectedMarketFilterPin, selectedOfferTypeFilterPin, selectedOfferReputationsFilterPin, selectedMarketSortTypePin;
+            selectedMarketFilterPin, selectedOfferTypeFilterPin, selectedPeerReputationFilterPin, selectedMarketSortTypePin;
     private Button createOfferButton;
-    private DropdownMenu sortAndFilterMarketsMenu, filterOffersByTypeMenu, filterOffersByReputationMenu;
+    private DropdownMenu sortAndFilterMarketsMenu, filterOffersByTypeMenu, filterOffersByPeerReputationMenu;
     private DropdownSortByMenuItem sortByMostOffers, sortByNameAZ, sortByNameZA;
     private DropdownFilterMenuItem<MarketChannelItem> filterShowAll, filterWithOffers;
     private DropdownFilterMenuItem<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>
@@ -118,8 +118,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         selectedMarketFilterPin = EasyBind.subscribe(getModel().getSelectedMarketsFilter(), this::updateSelectedMarketFilter);
         selectedOfferTypeFilterPin = EasyBind.subscribe(getModel().getSelectedOfferTypeFilter(), filter ->
                 updateSelectedFilterInDropdownMenu(filter, filterOffersByTypeMenu));
-        selectedOfferReputationsFilterPin = EasyBind.subscribe(getModel().getSelectedReputationsFilter(), filter ->
-                updateSelectedFilterInDropdownMenu(filter, filterOffersByReputationMenu));
+        selectedPeerReputationFilterPin = EasyBind.subscribe(getModel().getSelectedPeerReputationFilter(), filter ->
+                updateSelectedFilterInDropdownMenu(filter, filterOffersByPeerReputationMenu));
         selectedMarketSortTypePin = EasyBind.subscribe(getModel().getSelectedMarketSortType(), this::updateMarketSortType);
 
         sortByMostOffers.setOnAction(e -> getController().onSortMarkets(MarketSortType.NUM_OFFERS));
@@ -134,12 +134,12 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         buyOffers.setOnAction(e -> setOffersFilter(buyOffers));
         sellOffers.setOnAction(e -> setOffersFilter(sellOffers));
 
-        allReputations.setOnAction(e -> setReputationsFilter(allReputations));
-        fiveStars.setOnAction(e -> setReputationsFilter(fiveStars));
-        atLeastFourStars.setOnAction(e -> setReputationsFilter(atLeastFourStars));
-        atLeastThreeStars.setOnAction(e -> setReputationsFilter(atLeastThreeStars));
-        atLeastTwoStars.setOnAction(e -> setReputationsFilter(atLeastTwoStars));
-        atLeastOneStar.setOnAction(e -> setReputationsFilter(atLeastOneStar));
+        allReputations.setOnAction(e -> setPeerReputationFilter(allReputations));
+        fiveStars.setOnAction(e -> setPeerReputationFilter(fiveStars));
+        atLeastFourStars.setOnAction(e -> setPeerReputationFilter(atLeastFourStars));
+        atLeastThreeStars.setOnAction(e -> setPeerReputationFilter(atLeastThreeStars));
+        atLeastTwoStars.setOnAction(e -> setPeerReputationFilter(atLeastTwoStars));
+        atLeastOneStar.setOnAction(e -> setPeerReputationFilter(atLeastOneStar));
 
         createOfferButton.setOnAction(e -> getController().onCreateOffer());
     }
@@ -148,8 +148,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         getModel().getSelectedOfferTypeFilter().set((Filters.OfferType) filterMenuItem.getFilter());
     }
 
-    private void setReputationsFilter(DropdownFilterMenuItem<?> filterMenuItem) {
-        getModel().getSelectedReputationsFilter().set((Filters.OfferReputations) filterMenuItem.getFilter());
+    private void setPeerReputationFilter(DropdownFilterMenuItem<?> filterMenuItem) {
+        getModel().getSelectedPeerReputationFilter().set((Filters.PeerReputation) filterMenuItem.getFilter());
     }
 
     @Override
@@ -164,7 +164,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         marketSelectorHeaderIconPin.unsubscribe();
         selectedMarketFilterPin.unsubscribe();
         selectedOfferTypeFilterPin.unsubscribe();
-        selectedOfferReputationsFilterPin.unsubscribe();
+        selectedPeerReputationFilterPin.unsubscribe();
         selectedMarketSortTypePin.unsubscribe();
 
         sortByMostOffers.setOnAction(null);
@@ -176,6 +176,12 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         myOffers.setOnAction(null);
         buyOffers.setOnAction(null);
         sellOffers.setOnAction(null);
+        allReputations.setOnAction(null);
+        fiveStars.setOnAction(null);
+        atLeastFourStars.setOnAction(null);
+        atLeastThreeStars.setOnAction(null);
+        atLeastTwoStars.setOnAction(null);
+        atLeastOneStar.setOnAction(null);
         createOfferButton.setOnAction(null);
     }
 
@@ -298,10 +304,10 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         checkbox.getStyleClass().add("offerbook-subheader-checkbox");
         checkbox.setAlignment(Pos.CENTER);
 
-        filterOffersByReputationMenu = createAndGetReputationFilterMenu();
+        filterOffersByPeerReputationMenu = createAndGetPeerReputationFilterMenu();
         filterOffersByTypeMenu = createAndGetOffersFilterMenu();
         
-        HBox subheaderContent = new HBox(30, checkbox, filterOffersByReputationMenu, filterOffersByTypeMenu);
+        HBox subheaderContent = new HBox(30, checkbox, filterOffersByPeerReputationMenu, filterOffersByTypeMenu);
         subheaderContent.getStyleClass().add("offerbook-subheader-content");
         HBox.setHgrow(subheaderContent, Priority.ALWAYS);
 
@@ -330,31 +336,33 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.buyOffers"), Filters.OfferType.BUY);
         sellOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.sellOffers"), Filters.OfferType.SELL);
+
         dropdownMenu.addMenuItems(allOffers, myOffers, buyOffers, sellOffers);
         return dropdownMenu;
     }
 
-    private DropdownMenu createAndGetReputationFilterMenu() {
+    private DropdownMenu createAndGetPeerReputationFilterMenu() {
         DropdownMenu dropdownMenu = new DropdownMenu("arrow-down", "arrow-down", false);
-        dropdownMenu.setTooltip(Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.tooltip"));
+        dropdownMenu.setTooltip(Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip"));
         dropdownMenu.getStyleClass().add("dropdown-offers-filter-menu");
 
         allReputations = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.allReputations"), Filters.OfferReputations.ALL);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations"), Filters.PeerReputation.ALL);
         fiveStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.fiveStars"), Filters.OfferReputations.FIVE_STARS);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars"), Filters.PeerReputation.FIVE_STARS);
         atLeastFourStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastFourStars"),
-                Filters.OfferReputations.AT_LEAST_FOUR_STARS);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars"),
+                Filters.PeerReputation.AT_LEAST_FOUR_STARS);
         atLeastThreeStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastThreeStars"),
-                Filters.OfferReputations.AT_LEAST_THREE_STARS);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastThreeStars"),
+                Filters.PeerReputation.AT_LEAST_THREE_STARS);
         atLeastTwoStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastTwoStars"),
-                Filters.OfferReputations.AT_LEAST_TWO_STARS);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTwoStars"),
+                Filters.PeerReputation.AT_LEAST_TWO_STARS);
         atLeastOneStar = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastOneStar"),
-                Filters.OfferReputations.AT_LEAST_ONE_STAR);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastOneStar"),
+                Filters.PeerReputation.AT_LEAST_ONE_STAR);
+
         dropdownMenu.addMenuItems(allReputations, fiveStars, atLeastFourStars, atLeastThreeStars, atLeastTwoStars,
                 atLeastOneStar);
         return dropdownMenu;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -61,6 +61,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     private DropdownFilterMenuItem<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>
             allOffers, myOffers, buyOffers, sellOffers, allReputations, fiveStars, atLeastFourStars, atLeastThreeStars,
             atLeastTwoStars, atLeastOneStar;
+    private DropdownTitleMenuItem atLeastTitle;
     private CheckBox hideUserMessagesCheckbox;
 
     public BisqEasyOfferbookView(BisqEasyOfferbookModel model,
@@ -353,6 +354,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         fiveStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars"),
                 Filters.PeerReputation.FIVE_STARS);
+        atLeastTitle = new DropdownTitleMenuItem(
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTitle"));
         atLeastFourStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars"),
                 Filters.PeerReputation.AT_LEAST_FOUR_STARS);
@@ -366,8 +369,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastOneStar"),
                 Filters.PeerReputation.AT_LEAST_ONE_STAR);
 
-        dropdownMenu.addMenuItems(allReputations, fiveStars, atLeastFourStars, atLeastThreeStars, atLeastTwoStars,
-                atLeastOneStar);
+        dropdownMenu.addMenuItems(fiveStars, atLeastTitle, atLeastFourStars, atLeastThreeStars, atLeastTwoStars,
+                atLeastOneStar, allReputations);
         return dropdownMenu;
     }
 
@@ -408,9 +411,27 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                     DropdownFilterMenuItem<?> filterMenuItem = (DropdownFilterMenuItem<?>) menuItem;
                     filterMenuItem.updateSelection(selectedFilter == filterMenuItem.getFilter());
                     if (selectedFilter == filterMenuItem.getFilter()) {
-                        dropdownMenu.setLabel(((DropdownFilterMenuItem<?>) menuItem).getLabelText());
+                        String menuItemLabel = ((DropdownFilterMenuItem<?>) menuItem).getLabelText();
+                        if (selectedFilter instanceof Filters.PeerReputation) {
+                            menuItemLabel = createPeerReputationLabel((Filters.PeerReputation) selectedFilter, menuItemLabel);
+                        }
+                        dropdownMenu.setLabel(menuItemLabel);
                     }
                 });
+    }
+
+    private String createPeerReputationLabel(Filters.PeerReputation filter, String label) {
+        switch (filter) {
+            case AT_LEAST_FOUR_STARS:
+            case AT_LEAST_THREE_STARS:
+            case AT_LEAST_TWO_STARS:
+            case AT_LEAST_ONE_STAR:
+                return String.format("%s %s", atLeastTitle.getLabelText().replace(":", ""), label);
+            case FIVE_STARS:
+            case ALL:
+            default:
+                return label;
+        }
     }
 
     private static final class DropdownFilterMenuItem<T> extends DropdownMenuItem {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -52,10 +52,10 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     private SearchBox marketSelectorSearchBox;
     private BisqTableView<MarketChannelItem> tableView;
     private VBox marketSelectionList;
-    private Subscription tableViewSelectionPin, selectedModelItemPin, marketSelectorHeaderIconPin,
-            selectedMarketFilterPin, selectedOfferTypeFilterPin, selectedPeerReputationFilterPin, selectedMarketSortTypePin;
+    private Subscription tableViewSelectionPin, selectedModelItemPin, marketSelectorHeaderIconPin, selectedMarketFilterPin,
+            selectedOfferDirectionOrOwnerFilterPin, selectedPeerReputationFilterPin, selectedMarketSortTypePin;
     private Button createOfferButton;
-    private DropdownMenu sortAndFilterMarketsMenu, filterOffersByTypeMenu, filterOffersByPeerReputationMenu;
+    private DropdownMenu sortAndFilterMarketsMenu, filterOffersByDirectionOrOwnerMenu, filterOffersByPeerReputationMenu;
     private DropdownSortByMenuItem sortByMostOffers, sortByNameAZ, sortByNameZA;
     private DropdownFilterMenuItem<MarketChannelItem> filterShowAll, filterWithOffers;
     private DropdownFilterMenuItem<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>
@@ -68,7 +68,6 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                                  VBox chatMessagesComponent,
                                  Pane channelSidebar) {
         super(model, controller, chatMessagesComponent, channelSidebar);
-
     }
 
     @Override
@@ -116,8 +115,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         });
         marketSelectorHeaderIconPin = EasyBind.subscribe(model.getChannelIconNode(), this::updateMarketSelectorHeaderIcon);
         selectedMarketFilterPin = EasyBind.subscribe(getModel().getSelectedMarketsFilter(), this::updateSelectedMarketFilter);
-        selectedOfferTypeFilterPin = EasyBind.subscribe(getModel().getSelectedOfferTypeFilter(), filter ->
-                updateSelectedFilterInDropdownMenu(filter, filterOffersByTypeMenu));
+        selectedOfferDirectionOrOwnerFilterPin = EasyBind.subscribe(getModel().getSelectedOfferDirectionOrOwnerFilter(), filter ->
+                updateSelectedFilterInDropdownMenu(filter, filterOffersByDirectionOrOwnerMenu));
         selectedPeerReputationFilterPin = EasyBind.subscribe(getModel().getSelectedPeerReputationFilter(), filter ->
                 updateSelectedFilterInDropdownMenu(filter, filterOffersByPeerReputationMenu));
         selectedMarketSortTypePin = EasyBind.subscribe(getModel().getSelectedMarketSortType(), this::updateMarketSortType);
@@ -129,10 +128,10 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         filterWithOffers.setOnAction(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.WITH_OFFERS));
         filterShowAll.setOnAction(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.ALL));
 
-        allOffers.setOnAction(e -> setOffersFilter(allOffers));
-        myOffers.setOnAction(e -> setOffersFilter(myOffers));
-        buyOffers.setOnAction(e -> setOffersFilter(buyOffers));
-        sellOffers.setOnAction(e -> setOffersFilter(sellOffers));
+        allOffers.setOnAction(e -> setOfferDirectionOrOwnerFilter(allOffers));
+        myOffers.setOnAction(e -> setOfferDirectionOrOwnerFilter(myOffers));
+        buyOffers.setOnAction(e -> setOfferDirectionOrOwnerFilter(buyOffers));
+        sellOffers.setOnAction(e -> setOfferDirectionOrOwnerFilter(sellOffers));
 
         allReputations.setOnAction(e -> setPeerReputationFilter(allReputations));
         fiveStars.setOnAction(e -> setPeerReputationFilter(fiveStars));
@@ -144,8 +143,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         createOfferButton.setOnAction(e -> getController().onCreateOffer());
     }
 
-    private void setOffersFilter(DropdownFilterMenuItem<?> filterMenuItem) {
-        getModel().getSelectedOfferTypeFilter().set((Filters.OfferType) filterMenuItem.getFilter());
+    private void setOfferDirectionOrOwnerFilter(DropdownFilterMenuItem<?> filterMenuItem) {
+        getModel().getSelectedOfferDirectionOrOwnerFilter().set((Filters.OfferDirectionOrOwner) filterMenuItem.getFilter());
     }
 
     private void setPeerReputationFilter(DropdownFilterMenuItem<?> filterMenuItem) {
@@ -163,7 +162,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         tableViewSelectionPin.unsubscribe();
         marketSelectorHeaderIconPin.unsubscribe();
         selectedMarketFilterPin.unsubscribe();
-        selectedOfferTypeFilterPin.unsubscribe();
+        selectedOfferDirectionOrOwnerFilterPin.unsubscribe();
         selectedPeerReputationFilterPin.unsubscribe();
         selectedMarketSortTypePin.unsubscribe();
 
@@ -235,7 +234,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         dropdownMenu.getStyleClass().add("market-selection-dropdown-menu");
 
         // Sorting options
-        DropdownTitleMenuItem sortTitle = new DropdownTitleMenuItem(Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.sortTitle"));
+        DropdownTitleMenuItem sortTitle = new DropdownTitleMenuItem(
+                Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.sortTitle"));
         sortByMostOffers = new DropdownSortByMenuItem("check-grey",
                 "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.mostOffers"),
@@ -253,14 +253,15 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         SeparatorMenuItem separator = new SeparatorMenuItem();
 
         // Filter options
-        DropdownTitleMenuItem filterTitle = new DropdownTitleMenuItem(Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.filterTitle"));
+        DropdownTitleMenuItem filterTitle = new DropdownTitleMenuItem(
+                Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.filterTitle"));
         filterWithOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers"), Filters.Markets.WITH_OFFERS);
         filterShowAll = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all"), Filters.Markets.ALL);
 
-        dropdownMenu.addMenuItems(sortTitle, sortByMostOffers, sortByNameAZ, sortByNameZA, separator,
-                filterTitle, filterWithOffers, filterShowAll);
+        dropdownMenu.addMenuItems(sortTitle, sortByMostOffers, sortByNameAZ, sortByNameZA, separator, filterTitle,
+                filterWithOffers, filterShowAll);
         return dropdownMenu;
     }
 
@@ -305,9 +306,9 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         checkbox.setAlignment(Pos.CENTER);
 
         filterOffersByPeerReputationMenu = createAndGetPeerReputationFilterMenu();
-        filterOffersByTypeMenu = createAndGetOffersFilterMenu();
+        filterOffersByDirectionOrOwnerMenu = createAndGetOfferDirectionOrOwnerFilterMenu();
         
-        HBox subheaderContent = new HBox(30, checkbox, filterOffersByPeerReputationMenu, filterOffersByTypeMenu);
+        HBox subheaderContent = new HBox(30, checkbox, filterOffersByPeerReputationMenu, filterOffersByDirectionOrOwnerMenu);
         subheaderContent.getStyleClass().add("offerbook-subheader-content");
         HBox.setHgrow(subheaderContent, Priority.ALWAYS);
 
@@ -323,19 +324,19 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         centerVBox.setAlignment(Pos.CENTER);
     }
 
-    private DropdownMenu createAndGetOffersFilterMenu() {
+    private DropdownMenu createAndGetOfferDirectionOrOwnerFilterMenu() {
         DropdownMenu dropdownMenu = new DropdownMenu("arrow-down", "arrow-down", false);
-        dropdownMenu.setTooltip(Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.tooltip"));
+        dropdownMenu.setTooltip(Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.tooltip"));
         dropdownMenu.getStyleClass().add("dropdown-offers-filter-menu");
 
         allOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.allOffers"), Filters.OfferType.ALL);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.allOffers"), Filters.OfferDirectionOrOwner.ALL);
         myOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.myOffers"), Filters.OfferType.MINE);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.myOffers"), Filters.OfferDirectionOrOwner.MINE);
         buyOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.buyOffers"), Filters.OfferType.BUY);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers"), Filters.OfferDirectionOrOwner.BUY);
         sellOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByType.sellOffers"), Filters.OfferType.SELL);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers"), Filters.OfferDirectionOrOwner.SELL);
 
         dropdownMenu.addMenuItems(allOffers, myOffers, buyOffers, sellOffers);
         return dropdownMenu;
@@ -347,9 +348,11 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         dropdownMenu.getStyleClass().add("dropdown-offers-filter-menu");
 
         allReputations = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations"), Filters.PeerReputation.ALL);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations"),
+                Filters.PeerReputation.ALL);
         fiveStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
-                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars"), Filters.PeerReputation.FIVE_STARS);
+                Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars"),
+                Filters.PeerReputation.FIVE_STARS);
         atLeastFourStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars"),
                 Filters.PeerReputation.AT_LEAST_FOUR_STARS);
@@ -412,10 +415,14 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
 
     private static final class DropdownFilterMenuItem<T> extends DropdownMenuItem {
         private static final PseudoClass SELECTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("selected");
+
         @Getter
         private final Filters.FilterPredicate<T> filter;
 
-        DropdownFilterMenuItem(String defaultIconId, String activeIconId, String text, Filters.FilterPredicate<T> filter) {
+        DropdownFilterMenuItem(String defaultIconId,
+                               String activeIconId,
+                               String text,
+                               Filters.FilterPredicate<T> filter) {
             super(defaultIconId, activeIconId, text);
 
             this.filter = filter;
@@ -430,6 +437,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
 
     private static final class DropdownSortByMenuItem extends DropdownMenuItem {
         private static final PseudoClass SELECTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("selected");
+
         @Getter
         private final MarketSortType marketSortType;
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -338,7 +338,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         sellOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers"), Filters.OfferDirectionOrOwner.SELL);
 
-        dropdownMenu.addMenuItems(allOffers, myOffers, buyOffers, sellOffers);
+        dropdownMenu.addMenuItems(sellOffers, buyOffers, myOffers, allOffers);
         return dropdownMenu;
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
@@ -42,7 +42,7 @@ class Filters {
     }
 
     @Getter
-    enum Offers implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
+    enum OfferType implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
         ALL(item -> true),
         MINE(item -> !item.isBisqEasyPublicChatMessageWithOffer() || item.isBisqEasyPublicChatMessageWithMyOffer()),
         BUY(item -> !item.isBisqEasyPublicChatMessageWithOffer() || item.isBisqEasyPublicChatMessageWithPeerBuyOffer()),
@@ -50,23 +50,28 @@ class Filters {
 
         private final Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate;
 
-        Offers(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        OfferType(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
             this.predicate = predicate;
         }
     }
 
     @Getter
-    enum Reputations implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
+    enum OfferReputations implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
         ALL(item -> true),
-        FIVE_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() == 5),
-        AT_LEAST_FOUR_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 4),
-        AT_LEAST_THREE_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 3),
-        AT_LEAST_TWO_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 2),
-        AT_LEAST_ONE_STAR(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 1);
+        FIVE_STARS(item -> !item.isBisqEasyPublicChatMessageWithOffer()
+                || (item.isPeerMessage() && item.getReputationStarCount() == 5)),
+        AT_LEAST_FOUR_STARS(item -> !item.isBisqEasyPublicChatMessageWithOffer()
+                || (item.isPeerMessage() && item.getReputationStarCount() >= 4)),
+        AT_LEAST_THREE_STARS(item -> !item.isBisqEasyPublicChatMessageWithOffer()
+                || (item.isPeerMessage() && item.getReputationStarCount() >= 3)),
+        AT_LEAST_TWO_STARS(item -> !item.isBisqEasyPublicChatMessageWithOffer()
+                || (item.isPeerMessage() && item.getReputationStarCount() >= 2)),
+        AT_LEAST_ONE_STAR(item -> !item.isBisqEasyPublicChatMessageWithOffer()
+                || (item.isPeerMessage() && item.getReputationStarCount() >= 1));
 
         private final Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate;
 
-        Reputations(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        OfferReputations(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
             this.predicate = predicate;
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
@@ -49,8 +49,9 @@ class Filters {
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     // OFFERS' FILTERS
     ///////////////////////////////////////////////////////////////////////////////////////////////////
+
     @Getter
-    enum OfferType implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
+    enum OfferDirectionOrOwner implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
         ALL(item -> true),
         MINE(item -> !item.isBisqEasyPublicChatMessageWithOffer() || item.isBisqEasyPublicChatMessageWithMyOffer()),
         BUY(item -> !item.isBisqEasyPublicChatMessageWithOffer() || item.isBisqEasyPublicChatMessageWithPeerBuyOffer()),
@@ -58,7 +59,7 @@ class Filters {
 
         private final Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate;
 
-        OfferType(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        OfferDirectionOrOwner(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
             this.predicate = predicate;
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
@@ -54,4 +54,20 @@ class Filters {
             this.predicate = predicate;
         }
     }
+
+    @Getter
+    enum Reputations implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
+        ALL(item -> true),
+        FIVE_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() == 5),
+        AT_LEAST_FOUR_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 4),
+        AT_LEAST_THREE_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 3),
+        AT_LEAST_TWO_STARS(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 2),
+        AT_LEAST_ONE_STAR(item -> !item.isBisqEasyPublicChatMessageWithPeerOffer() || item.getReputationStarCount() >= 1);
+
+        private final Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate;
+
+        Reputations(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+            this.predicate = predicate;
+        }
+    }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/Filters.java
@@ -29,6 +29,10 @@ class Filters {
         Predicate<T> getPredicate();
     }
 
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // MARKETS' FILTERS
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+
     @Getter
     enum Markets implements FilterPredicate<MarketChannelItem> {
         ALL(item -> true),
@@ -41,6 +45,10 @@ class Filters {
         }
     }
 
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
+    // OFFERS' FILTERS
+    ///////////////////////////////////////////////////////////////////////////////////////////////////
     @Getter
     enum OfferType implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
         ALL(item -> true),
@@ -56,7 +64,7 @@ class Filters {
     }
 
     @Getter
-    enum OfferReputations implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
+    enum PeerReputation implements FilterPredicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
         ALL(item -> true),
         FIVE_STARS(item -> !item.isBisqEasyPublicChatMessageWithOffer()
                 || (item.isPeerMessage() && item.getReputationStarCount() == 5)),
@@ -71,7 +79,7 @@ class Filters {
 
         private final Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate;
 
-        OfferReputations(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        PeerReputation(Predicate<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
             this.predicate = predicate;
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketSortType.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketSortType.java
@@ -27,7 +27,6 @@ enum MarketSortType {
     ASC(BisqEasyOfferbookUtil.sortByMarketNameAsc()),
     DESC(BisqEasyOfferbookUtil.sortByMarketNameDesc());
 
-    @Getter
     private final Comparator<MarketChannelItem> comparator;
 
     MarketSortType(Comparator<MarketChannelItem> comparator) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
@@ -229,16 +229,16 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
             public TableCell<ListItem, ListItem> call(TableColumn<ListItem, ListItem> column) {
                 return new TableCell<>() {
                     private final Label userName = new Label();
-                    private final ImageView roboIcon = new ImageView();
+                    private final ImageView catIcon = new ImageView();
                     private final HBox hBox;
 
                     {
                         userName.setId("chat-user-name");
                         int size = 20;
-                        roboIcon.setFitWidth(size);
-                        roboIcon.setFitHeight(size);
-                        StackPane roboIconWithRing = ImageUtil.addRingToNode(roboIcon, size, 1.5, "-bisq-dark-grey-50");
-                        hBox = new HBox(10, roboIconWithRing, userName);
+                        catIcon.setFitWidth(size);
+                        catIcon.setFitHeight(size);
+                        StackPane catIconWithRing = ImageUtil.addRingToNode(catIcon, size, 1.5, "-bisq-dark-grey-50");
+                        hBox = new HBox(10, catIconWithRing, userName);
                         hBox.setAlignment(Pos.CENTER_LEFT);
                     }
 
@@ -249,7 +249,7 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
                         if (item != null && !empty) {
                             userName.setText(item.getMakerUserName());
                             item.getAuthorUserProfile().ifPresent(userProfile ->
-                                    roboIcon.setImage(CatHash.getImage(userProfile)));
+                                    catIcon.setImage(CatHash.getImage(userProfile)));
                             setGraphic(hBox);
                         } else {
                             setGraphic(null);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/ChannelSidebar.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/ChannelSidebar.java
@@ -296,7 +296,7 @@ public class ChannelSidebar {
                 public ListCell<ChannelSidebarUserProfile> call(ListView<ChannelSidebarUserProfile> list) {
                     return new ListCell<>() {
                         Pane chatUser;
-                        private ImageView roboIcon;
+                        private ImageView catIcon;
                         final Hyperlink undoIgnoreUserButton = new Hyperlink(Res.get("chat.sideBar.userProfile.undoIgnore"));
                         final HBox hBox = new HBox(10);
 
@@ -323,8 +323,8 @@ public class ChannelSidebar {
                                 // With setOnMouseClicked or released it does not work well (prob. due handlers inside the components)
                                 chatUser.setOnMousePressed(e -> controller.onOpenUserProfileSidebar(channelSidebarUserProfile.getUserProfile()));
 
-                                roboIcon = channelSidebarUserProfile.getRoboIcon();
-                                roboIcon.setOnMousePressed(e -> controller.onOpenUserProfileSidebar(channelSidebarUserProfile.getUserProfile()));
+                                catIcon = channelSidebarUserProfile.getCatIcon();
+                                catIcon.setOnMousePressed(e -> controller.onOpenUserProfileSidebar(channelSidebarUserProfile.getUserProfile()));
 
                                 hBox.getChildren().setAll(chatUser, Spacer.fillHBox(), undoIgnoreUserButton);
 
@@ -335,9 +335,9 @@ public class ChannelSidebar {
                                     chatUser.setOnMousePressed(null);
                                     chatUser = null;
                                 }
-                                if (roboIcon != null) {
-                                    roboIcon.setOnMousePressed(null);
-                                    roboIcon = null;
+                                if (catIcon != null) {
+                                    catIcon.setOnMousePressed(null);
+                                    catIcon = null;
                                 }
                                 setGraphic(null);
                             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/ChannelSidebarUserProfile.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/ChannelSidebarUserProfile.java
@@ -55,8 +55,8 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
         return controller.view.getRoot();
     }
 
-    public ImageView getRoboIcon() {
-        return controller.view.getRoboIcon();
+    public ImageView getCatIcon() {
+        return controller.view.getCatIcon();
     }
 
     public boolean isIgnored() {
@@ -93,7 +93,7 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
 
             String userName = userProfile.getUserName();
             model.userName.set(isUserProfileBanned() ? Res.get("user.userProfile.userName.banned", userName) : userName);
-            model.roboHashImage.set(CatHash.getImage(userProfile));
+            model.catHashImage.set(CatHash.getImage(userProfile));
         }
 
         @Override
@@ -108,7 +108,7 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
     private static class Model implements bisq.desktop.common.view.Model {
         private final UserProfile userProfile;
         private boolean ignored;
-        private final ObjectProperty<Image> roboHashImage = new SimpleObjectProperty<>();
+        private final ObjectProperty<Image> catHashImage = new SimpleObjectProperty<>();
         private final StringProperty userName = new SimpleStringProperty();
 
         private Model(UserProfile userProfile) {
@@ -119,9 +119,9 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
     @Slf4j
     public static class View extends bisq.desktop.common.view.View<HBox, Model, Controller> {
         @Getter
-        private final ImageView roboIcon;
+        private final ImageView catIcon;
         private final Label userName;
-        private Subscription roboHashNodeSubscription;
+        private Subscription catHashNodeSubscription;
 
         private View(Model model, Controller controller) {
             super(new HBox(10), model, controller);
@@ -141,10 +141,10 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
             String tooltipString = banPrefix + model.userProfile.getTooltipString();
             Tooltip.install(userName, new BisqTooltip(tooltipString));
 
-            roboIcon = new ImageView();
-            roboIcon.setFitWidth(37.5);
-            roboIcon.setFitHeight(37.5);
-            Tooltip.install(roboIcon, new BisqTooltip(tooltipString));
+            catIcon = new ImageView();
+            catIcon.setFitWidth(37.5);
+            catIcon.setFitHeight(37.5);
+            Tooltip.install(catIcon, new BisqTooltip(tooltipString));
             if (isUserProfileBanned) {
                 // coloring icon red
                 /*Blend blush = new Blend(BlendMode.MULTIPLY,
@@ -154,19 +154,19 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
                                 37.5,
                                 37.5,
                                 Color.RED));
-                roboIcon.setClip(new Circle(18.75, 18.75, 18.75));
-                roboIcon.setEffect(blush);*/
+                catIcon.setClip(new Circle(18.75, 18.75, 18.75));
+                catIcon.setEffect(blush);*/
             }
 
-            root.getChildren().addAll(roboIcon, userName);
+            root.getChildren().addAll(catIcon, userName);
         }
 
         @Override
         protected void onViewAttached() {
             userName.textProperty().bind(model.userName);
-            roboHashNodeSubscription = EasyBind.subscribe(model.roboHashImage, image -> {
+            catHashNodeSubscription = EasyBind.subscribe(model.catHashImage, image -> {
                 if (image != null) {
-                    this.roboIcon.setImage(image);
+                    this.catIcon.setImage(image);
                 }
             });
         }
@@ -174,7 +174,7 @@ public class ChannelSidebarUserProfile implements Comparable<ChannelSidebarUserP
         @Override
         protected void onViewDetached() {
             userName.textProperty().unbind();
-            roboHashNodeSubscription.unsubscribe();
+            catHashNodeSubscription.unsubscribe();
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/UserProfileSidebar.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/UserProfileSidebar.java
@@ -129,7 +129,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             model.nickName.set(isUserProfileBanned() ? Res.get("user.userProfile.userName.banned", nickName) : nickName);
             model.nym.set(Res.get("chat.sideBar.userProfile.nym", userProfile.getNym()));
             model.userProfileIdString.set(Res.get("chat.sideBar.userProfile.id", userProfile.getId()));
-            model.roboHashNode.set(CatHash.getImage(userProfile));
+            model.catHashNode.set(CatHash.getImage(userProfile));
 
             model.addressByTransport.set(userProfile.getAddressByTransportDisplayString(26));
             model.addressByTransportTooltip.set(userProfile.getAddressByTransportDisplayString());
@@ -195,7 +195,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
         private Optional<Consumer<UserProfile>> mentionUserHandler = Optional.empty();
         private Optional<Consumer<UserProfile>> sendPrivateMessageHandler = Optional.empty();
         private Optional<Runnable> ignoreUserStateHandler = Optional.empty();
-        private final ObjectProperty<Image> roboHashNode = new SimpleObjectProperty<>();
+        private final ObjectProperty<Image> catHashNode = new SimpleObjectProperty<>();
         private final StringProperty nickName = new SimpleStringProperty();
         private final StringProperty nym = new SimpleStringProperty();
         private final StringProperty addressByTransport = new SimpleStringProperty();
@@ -218,14 +218,14 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
 
     @Slf4j
     public static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
-        private final ImageView roboIconImageView;
+        private final ImageView catIconImageView;
         private final Label nickName, botId, userProfileId, addressByTransport, statement, totalReputationScore, profileAge;
         private final Hyperlink privateMsg, mention, ignore, report;
         private final VBox statementBox, termsBox, optionsVBox;
         private final ReputationScoreDisplay reputationScoreDisplay;
         private final TextArea terms;
         private final Button closeButton;
-        private Subscription roboHashNodeSubscription;
+        private Subscription catHashNodeSubscription;
 
         private View(Model model, Controller controller) {
             super(new VBox(15), model, controller);
@@ -249,9 +249,9 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
                 nickName.getStyleClass().add("error");
             }
 
-            roboIconImageView = new ImageView();
-            roboIconImageView.setFitWidth(100);
-            roboIconImageView.setFitHeight(100);
+            catIconImageView = new ImageView();
+            catIconImageView.setFitWidth(100);
+            catIconImageView.setFitHeight(100);
 
             botId = new Label();
             botId.getStyleClass().add("chat-side-bar-user-profile-details");
@@ -316,7 +316,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             VBox.setMargin(addressByTransport, new Insets(-10, 0, 0, 0));
             VBox.setMargin(reputationBox, new Insets(4, 0, 0, 0));
             root.getChildren().addAll(header,
-                    nickName, roboIconImageView, botId, userProfileId, addressByTransport,
+                    nickName, catIconImageView, botId, userProfileId, addressByTransport,
                     reputationBox, totalReputationScoreBox, profileAgeBox, statementBox, termsBox,
                     optionsVBox);
         }
@@ -343,13 +343,13 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             privateMsg.visibleProperty().bind(model.isPeer);
             privateMsg.managedProperty().bind(model.isPeer);
 
-            roboHashNodeSubscription = EasyBind.subscribe(model.roboHashNode, roboIcon -> {
-                if (roboIcon != null) {
-                    roboIconImageView.setImage(roboIcon);
+            catHashNodeSubscription = EasyBind.subscribe(model.catHashNode, catIcon -> {
+                if (catIcon != null) {
+                    catIconImageView.setImage(catIcon);
                 }
             });
 
-            roboHashNodeSubscription = EasyBind.subscribe(model.reputationScore, reputationScore -> {
+            catHashNodeSubscription = EasyBind.subscribe(model.reputationScore, reputationScore -> {
                 if (reputationScore != null) {
                     reputationScoreDisplay.setReputationScore(reputationScore);
                     totalReputationScore.setText(String.valueOf(reputationScore.getTotalScore()));
@@ -385,7 +385,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             privateMsg.visibleProperty().unbind();
             privateMsg.managedProperty().unbind();
 
-            roboHashNodeSubscription.unsubscribe();
+            catHashNodeSubscription.unsubscribe();
 
             privateMsg.setOnAction(null);
             mention.setOnAction(null);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/CitationBlock.java
@@ -92,7 +92,7 @@ public class CitationBlock {
             userProfileService.findUserProfile(chatMessage.getAuthorUserProfileId()).ifPresent(author -> {
                 model.author = author;
                 model.userName.set(author.getUserName());
-                model.roboHashNode.set(CatHash.getImage(author));
+                model.catHashNode.set(CatHash.getImage(author));
                 model.citation.set(chatMessage.getText());
                 model.visible.set(true);
             });
@@ -115,7 +115,7 @@ public class CitationBlock {
     private static class Model implements bisq.desktop.common.view.Model {
         private final BooleanProperty visible = new SimpleBooleanProperty();
         private final StringProperty citation = new SimpleStringProperty("");
-        private final ObjectProperty<Image> roboHashNode = new SimpleObjectProperty<>();
+        private final ObjectProperty<Image> catHashNode = new SimpleObjectProperty<>();
         private final StringProperty userName = new SimpleStringProperty();
         private UserProfile author;
 
@@ -125,11 +125,11 @@ public class CitationBlock {
 
     @Slf4j
     public static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
-        private final ImageView roboIconImageView;
+        private final ImageView catIconImageView;
         private final Label userName;
         private final Button closeButton;
         private final Label citation;
-        private Subscription roboHashNodeSubscription;
+        private Subscription catHashNodeSubscription;
 
         private View(Model model, Controller controller) {
             super(new VBox(), model, controller);
@@ -155,10 +155,10 @@ public class CitationBlock {
             userName.getStyleClass().add("font-medium");
             userName.setStyle("-fx-text-fill: -bisq-mid-grey-30");
 
-            roboIconImageView = new ImageView();
-            roboIconImageView.setFitWidth(25);
-            roboIconImageView.setFitHeight(25);
-            HBox userBox = new HBox(15, roboIconImageView, userName);
+            catIconImageView = new ImageView();
+            catIconImageView.setFitWidth(25);
+            catIconImageView.setFitHeight(25);
+            HBox userBox = new HBox(15, catIconImageView, userName);
             VBox.setMargin(userBox, new Insets(0, 0, 0, 0));
             citation = new Label();
             citation.setWrapText(true);
@@ -173,9 +173,9 @@ public class CitationBlock {
             root.managedProperty().bind(model.visible);
             userName.textProperty().bind(model.userName);
             citation.textProperty().bind(model.citation);
-            roboHashNodeSubscription = EasyBind.subscribe(model.roboHashNode, roboIcon -> {
-                if (roboIcon != null) {
-                    roboIconImageView.setImage(roboIcon);
+            catHashNodeSubscription = EasyBind.subscribe(model.catHashNode, catIcon -> {
+                if (catIcon != null) {
+                    catIconImageView.setImage(catIcon);
                 }
             });
 
@@ -186,7 +186,7 @@ public class CitationBlock {
         protected void onViewDetached() {
             userName.textProperty().unbind();
             citation.textProperty().unbind();
-            roboHashNodeSubscription.unsubscribe();
+            catHashNodeSubscription.unsubscribe();
             closeButton.setOnAction(null);
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ReputationScoreDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/ReputationScoreDisplay.java
@@ -28,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Slf4j
 public class ReputationScoreDisplay extends HBox {
@@ -36,7 +38,9 @@ public class ReputationScoreDisplay extends HBox {
     private static final double STAR_HEIGHT = 11;
     private static final double OPACITY = 0.2;
     private static final String DEFAULT_ACCEPT_STAR_ID = "star-green";
-    private final List<ImageView> stars;
+    private static final int STAR_SYSTEM = 5; // 5-star system
+
+    private final List<ImageView> stars = IntStream.range(0, STAR_SYSTEM).mapToObj(i -> getDefaultStar()).collect(Collectors.toList());
     private final Tooltip tooltip = new BisqTooltip();
     private ReputationScore reputationScore;
     private String acceptStarId = DEFAULT_ACCEPT_STAR_ID;
@@ -55,7 +59,6 @@ public class ReputationScoreDisplay extends HBox {
         tooltip.setWrapText(true);
         Tooltip.install(this, tooltip);
 
-        stars = List.of(getDefaultStar(), getDefaultStar(), getDefaultStar(), getDefaultStar(), getDefaultStar());
         getChildren().addAll(stars);
     }
 
@@ -83,11 +86,10 @@ public class ReputationScoreDisplay extends HBox {
     }
 
     private void applyReputationScore() {
-        double relativeScore = reputationScore != null ? reputationScore.getRelativeScore() : 0;
-        int target = (int) Math.floor(stars.size() * relativeScore);
-        for (int i = 0; i < stars.size(); i++) {
+        int starsToFill = calculateStars();
+        for (int i = 0; i < STAR_SYSTEM; i++) {
             ImageView imageView = stars.get(i);
-            if (i < target) {
+            if (i < starsToFill) {
                 imageView.setOpacity(1);
                 imageView.setId(acceptStarId);
             } else {
@@ -102,10 +104,18 @@ public class ReputationScoreDisplay extends HBox {
         return reputationScore != null ? reputationScore.getTooltipString() : "";
     }
 
+    public int getNumberOfStars() {
+        return calculateStars();
+    }
+
     private ImageView getDefaultStar() {
         ImageView imageView = ImageUtil.getImageViewById("star-white");
         imageView.setOpacity(OPACITY);
         return imageView;
     }
 
+    private int calculateStars() {
+        double relativeScore = reputationScore != null ? reputationScore.getRelativeScore() : 0;
+        return (int) Math.floor(STAR_SYSTEM * relativeScore);
+    }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
@@ -30,6 +30,7 @@ import bisq.common.observable.Pin;
 import bisq.common.observable.map.HashMapObserver;
 import bisq.common.util.StringUtils;
 import bisq.desktop.common.threading.UIThread;
+import bisq.desktop.main.content.components.ReputationScoreDisplay;
 import bisq.i18n.Res;
 import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
@@ -77,6 +78,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
     private final String nickName;
     @EqualsAndHashCode.Exclude
     private final ReputationScore reputationScore;
+    private final ReputationScoreDisplay reputationScoreDisplay = new ReputationScoreDisplay();
     private final boolean offerAlreadyTaken;
     @EqualsAndHashCode.Exclude
     private final StringProperty messageDeliveryStatusTooltip = new SimpleStringProperty();
@@ -116,6 +118,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
         nickName = senderUserProfile.map(UserProfile::getNickName).orElse("");
 
         reputationScore = senderUserProfile.flatMap(reputationService::findReputationScore).orElse(ReputationScore.NONE);
+        reputationScoreDisplay.setReputationScore(reputationScore);
 
         if (chatMessage instanceof BisqEasyOfferbookMessage) {
             BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
@@ -260,12 +263,20 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
         return isBisqEasyPublicChatMessageWithOffer() && isMyMessage();
     }
 
+    public boolean isBisqEasyPublicChatMessageWithPeerOffer() {
+        return isBisqEasyPublicChatMessageWithOffer() && !isMyMessage();
+    }
+
     public boolean isBisqEasyPublicChatMessageWithPeerBuyOffer() {
-        return isBisqEasyPublicChatMessageWithOffer() && !isMyMessage() && hasBisqEasyOfferWithDirection(Direction.BUY);
+        return isBisqEasyPublicChatMessageWithPeerOffer() && hasBisqEasyOfferWithDirection(Direction.BUY);
     }
 
     public boolean isBisqEasyPublicChatMessageWithPeerSellOffer() {
-        return isBisqEasyPublicChatMessageWithOffer() && !isMyMessage() && hasBisqEasyOfferWithDirection(Direction.SELL);
+        return isBisqEasyPublicChatMessageWithPeerOffer() && hasBisqEasyOfferWithDirection(Direction.SELL);
+    }
+
+    public int getReputationStarCount() {
+        return reputationScoreDisplay.getNumberOfStars();
     }
 
     private boolean hasBisqEasyOfferWithDirection(Direction direction) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessageListItem.java
@@ -259,6 +259,10 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
         return chatMessage.isMyMessage(userIdentityService);
     }
 
+    public boolean isPeerMessage() {
+        return !isMyMessage();
+    }
+
     public boolean isBisqEasyPublicChatMessageWithMyOffer() {
         return isBisqEasyPublicChatMessageWithOffer() && isMyMessage();
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
@@ -98,6 +98,10 @@ public class ChatMessagesComponent {
         controller.chatMessagesListView.setBisqEasyOffersFilerPredicate(predicate);
     }
 
+    public void setBisqEasyReputationsFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        controller.chatMessagesListView.setBisqEasyReputationsFilerPredicate(predicate);
+    }
+
     public void resetSelectedChatMessage() {
         controller.model.selectedChatMessage = null;
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
@@ -94,8 +94,8 @@ public class ChatMessagesComponent {
         controller.chatMessagesListView.setSearchPredicate(predicate);
     }
 
-    public void setBisqEasyOffersFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
-        controller.chatMessagesListView.setBisqEasyOffersFilerPredicate(predicate);
+    public void setBisqEasyOfferDirectionOrOwnerFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        controller.chatMessagesListView.setBisqEasyOfferDirectionOrOwnerFilterPredicate(predicate);
     }
 
     public void setBisqEasyPeerReputationFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesComponent.java
@@ -98,8 +98,8 @@ public class ChatMessagesComponent {
         controller.chatMessagesListView.setBisqEasyOffersFilerPredicate(predicate);
     }
 
-    public void setBisqEasyReputationsFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
-        controller.chatMessagesListView.setBisqEasyReputationsFilerPredicate(predicate);
+    public void setBisqEasyPeerReputationFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        controller.chatMessagesListView.setBisqEasyPeerReputationFilterPredicate(predicate);
     }
 
     public void resetSelectedChatMessage() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
@@ -135,6 +135,10 @@ public class ChatMessagesListView {
         controller.setBisqEasyOffersFilerPredicate(predicate);
     }
 
+    public void setBisqEasyReputationsFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        controller.setBisqEasyReputationsFilerPredicate(predicate);
+    }
+
     public void refreshMessages() {
         controller.refreshMessages();
     }
@@ -302,6 +306,11 @@ public class ChatMessagesListView {
 
         private void setBisqEasyOffersFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
             model.setBisqEasyOffersFilerPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
+            applyPredicate();
+        }
+
+        private void setBisqEasyReputationsFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+            model.setBisqEasyReputationsFilerPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
             applyPredicate();
         }
 
@@ -610,7 +619,9 @@ public class ChatMessagesListView {
                         userProfileService.findUserProfile(senderUserProfile.get().getId()).isPresent();
             };
             model.filteredChatMessages.setPredicate(item -> model.getSearchPredicate().test(item)
-                    && model.getBisqEasyOffersFilerPredicate().test(item) && predicate.test(item));
+                    && model.getBisqEasyOffersFilerPredicate().test(item)
+                    && model.getBisqEasyReputationsFilerPredicate().test(item)
+                    && predicate.test(item));
         }
 
         private <M extends ChatMessage, C extends ChatChannel<M>> Pin bindChatMessages(C channel) {
@@ -689,6 +700,8 @@ public class ChatMessagesListView {
         private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> searchPredicate = e -> true;
         @Setter
         private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyOffersFilerPredicate = e -> true;
+        @Setter
+        private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyReputationsFilerPredicate = e -> true;
 
         private boolean autoScrollToBottom;
         private int numReadMessages;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
@@ -135,8 +135,8 @@ public class ChatMessagesListView {
         controller.setBisqEasyOffersFilerPredicate(predicate);
     }
 
-    public void setBisqEasyReputationsFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
-        controller.setBisqEasyReputationsFilerPredicate(predicate);
+    public void setBisqEasyPeerReputationFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        controller.setBisqEasyPeerReputationFilterPredicate(predicate);
     }
 
     public void refreshMessages() {
@@ -309,8 +309,8 @@ public class ChatMessagesListView {
             applyPredicate();
         }
 
-        private void setBisqEasyReputationsFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
-            model.setBisqEasyReputationsFilerPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
+        private void setBisqEasyPeerReputationFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+            model.setBisqEasyPeerReputationFilterPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
             applyPredicate();
         }
 
@@ -620,7 +620,7 @@ public class ChatMessagesListView {
             };
             model.filteredChatMessages.setPredicate(item -> model.getSearchPredicate().test(item)
                     && model.getBisqEasyOffersFilerPredicate().test(item)
-                    && model.getBisqEasyReputationsFilerPredicate().test(item)
+                    && model.getBisqEasyPeerReputationFilterPredicate().test(item)
                     && predicate.test(item));
         }
 
@@ -701,7 +701,7 @@ public class ChatMessagesListView {
         @Setter
         private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyOffersFilerPredicate = e -> true;
         @Setter
-        private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyReputationsFilerPredicate = e -> true;
+        private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyPeerReputationFilterPredicate = e -> true;
 
         private boolean autoScrollToBottom;
         private int numReadMessages;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/ChatMessagesListView.java
@@ -131,8 +131,8 @@ public class ChatMessagesListView {
         controller.setSearchPredicate(predicate);
     }
 
-    public void setBisqEasyOffersFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
-        controller.setBisqEasyOffersFilerPredicate(predicate);
+    public void setBisqEasyOfferDirectionOrOwnerFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+        controller.setBisqEasyOfferDirectionOrOwnerFilterPredicate(predicate);
     }
 
     public void setBisqEasyPeerReputationFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
@@ -304,8 +304,8 @@ public class ChatMessagesListView {
             applyPredicate();
         }
 
-        private void setBisqEasyOffersFilerPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
-            model.setBisqEasyOffersFilerPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
+        private void setBisqEasyOfferDirectionOrOwnerFilterPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
+            model.setBisqEasyOfferDirectionOrOwnerFilterPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
             applyPredicate();
         }
 
@@ -619,7 +619,7 @@ public class ChatMessagesListView {
                         userProfileService.findUserProfile(senderUserProfile.get().getId()).isPresent();
             };
             model.filteredChatMessages.setPredicate(item -> model.getSearchPredicate().test(item)
-                    && model.getBisqEasyOffersFilerPredicate().test(item)
+                    && model.getBisqEasyOfferDirectionOrOwnerFilterPredicate().test(item)
                     && model.getBisqEasyPeerReputationFilterPredicate().test(item)
                     && predicate.test(item));
         }
@@ -699,7 +699,7 @@ public class ChatMessagesListView {
         @Setter
         private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> searchPredicate = e -> true;
         @Setter
-        private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyOffersFilerPredicate = e -> true;
+        private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyOfferDirectionOrOwnerFilterPredicate = e -> true;
         @Setter
         private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> BisqEasyPeerReputationFilterPredicate = e -> true;
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/chatMessages/messages/BisqEasy/PeerOfferMessage.java
@@ -56,9 +56,7 @@ public final class PeerOfferMessage extends PeerMessage {
 
         // Reputation
         Label reputationLabel = new Label(Res.get("chat.message.reputation").toUpperCase());
-        ReputationScoreDisplay reputationScoreDisplay = new ReputationScoreDisplay();
-        reputationScoreDisplay.setReputationScore(item.getReputationScore());
-        VBox reputationVBox = new VBox(4, reputationLabel, reputationScoreDisplay);
+        VBox reputationVBox = new VBox(4, reputationLabel, item.getReputationScoreDisplay());
         reputationVBox.setAlignment(Pos.CENTER);
         reputationVBox.getStyleClass().add("reputation");
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileController.java
@@ -82,7 +82,7 @@ public class UserProfileController implements Controller {
                         model.getNickName().set(userProfile.getNickName());
                         model.getNymId().set(userProfile.getNym());
                         model.getProfileId().set(userProfile.getId());
-                        model.getRoboHash().set(CatHash.getImage(userProfile));
+                        model.getCatHash().set(CatHash.getImage(userProfile));
                         model.getStatement().set(userProfile.getStatement());
                         model.getTerms().set(userProfile.getTerms());
 
@@ -115,7 +115,7 @@ public class UserProfileController implements Controller {
         model.getNickName().set("");
         model.getNymId().set("");
         model.getProfileId().set("");
-        model.getRoboHash().set(null);
+        model.getCatHash().set(null);
         model.getStatement().set("");
         model.getTerms().set("");
         model.getProfileAge().set("");

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileModel.java
@@ -35,7 +35,7 @@ public class UserProfileModel implements Model {
     private final StringProperty nickName = new SimpleStringProperty();
     private final StringProperty nymId = new SimpleStringProperty();
     private final StringProperty profileId = new SimpleStringProperty();
-    private final ObjectProperty<Image> roboHash = new SimpleObjectProperty<>();
+    private final ObjectProperty<Image> catHash = new SimpleObjectProperty<>();
     private final StringProperty statement = new SimpleStringProperty("");
     private final StringProperty terms = new SimpleStringProperty("");
     private final StringProperty reputationScoreValue = new SimpleStringProperty();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileView.java
@@ -65,7 +65,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
     private final Button createNewProfileButton, deleteButton, saveButton;
     private final SplitPane deleteWrapper;
     private final MaterialTextField nymId, profileId, profileAge, reputationScoreField, statement;
-    private final ImageView roboIconImageView;
+    private final ImageView catIconImageView;
     private final MaterialTextArea terms;
     private final VBox formVBox;
     private final AutoCompleteComboBox<UserIdentity> comboBox;
@@ -79,10 +79,10 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         root.setAlignment(Pos.TOP_LEFT);
         root.setPadding(new Insets(20, 40, 40, 40));
 
-        roboIconImageView = new ImageView();
-        roboIconImageView.setFitWidth(125);
-        roboIconImageView.setFitHeight(125);
-        root.getChildren().add(roboIconImageView);
+        catIconImageView = new ImageView();
+        catIconImageView.setFitWidth(125);
+        catIconImageView.setFitHeight(125);
+        root.getChildren().add(catIconImageView);
 
         formVBox = new VBox(25);
         HBox.setHgrow(formVBox, Priority.ALWAYS);
@@ -156,7 +156,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         reputationScoreField.textProperty().bind(model.getReputationScoreValue());
         statement.textProperty().bindBidirectional(model.getStatement());
         terms.textProperty().bindBidirectional(model.getTerms());
-        roboIconImageView.imageProperty().bind(model.getRoboHash());
+        catIconImageView.imageProperty().bind(model.getCatHash());
 
         useDeleteTooltipPin = EasyBind.subscribe(model.getUseDeleteTooltip(), useDeleteTooltip ->
                 deleteWrapper.setTooltip(useDeleteTooltip ? deleteTooltip : null));
@@ -239,7 +239,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         reputationScoreField.textProperty().unbind();
         statement.textProperty().unbindBidirectional(model.getStatement());
         terms.textProperty().unbindBidirectional(model.getTerms());
-        roboIconImageView.imageProperty().unbind();
+        catIconImageView.imageProperty().unbind();
         saveButton.disableProperty().unbind();
         deleteButton.disableProperty().unbind();
         deleteWrapper.tooltipProperty().unbind();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Controller.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Controller.java
@@ -90,7 +90,7 @@ public class CreateNewProfileStep2Controller implements InitWithDataController<C
         model.setProofOfWork(data.getProofOfWork());
         model.getNickName().set(data.getNickName());
         model.getNym().set(data.getNym());
-        model.getRoboHashImage().set(CatHash.getImage(data.getPubKeyHash(), data.getProofOfWork().getSolution()));
+        model.getCatHashImage().set(CatHash.getImage(data.getPubKeyHash(), data.getProofOfWork().getSolution()));
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Model.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Model.java
@@ -38,7 +38,7 @@ public class CreateNewProfileStep2Model implements Model {
     private final StringProperty nym = new SimpleStringProperty();
     private final StringProperty terms = new SimpleStringProperty();
     private final StringProperty statement = new SimpleStringProperty();
-    private final ObjectProperty<Image> roboHashImage = new SimpleObjectProperty<>();
+    private final ObjectProperty<Image> catHashImage = new SimpleObjectProperty<>();
     private final BooleanProperty createProfileButtonDisabled = new SimpleBooleanProperty();
     private final DoubleProperty createProfileProgress = new SimpleDoubleProperty();
     private final BooleanProperty isEditable = new SimpleBooleanProperty();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2View.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2Model, CreateNewProfileStep2Controller> {
-    private final ImageView roboIconView;
+    private final ImageView catIconView;
     private final MaterialTextField statement;
     private final MaterialTextArea terms;
     private final Button saveButton, cancelButton;
@@ -62,19 +62,19 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
         nickName.getStyleClass().addAll("bisq-text-9", "font-semi-bold");
         nickName.setAlignment(Pos.TOP_CENTER);
 
-        roboIconView = new ImageView();
-        roboIconView.setFitWidth(128);
-        roboIconView.setFitHeight(128);
+        catIconView = new ImageView();
+        catIconView.setFitWidth(128);
+        catIconView.setFitHeight(128);
 
         nym = new Label();
         nym.getStyleClass().addAll("bisq-text-7");
         nym.setAlignment(Pos.TOP_CENTER);
 
         int width = 250;
-        VBox roboVBox = new VBox(8, nickName, roboIconView, nym);
-        roboVBox.setAlignment(Pos.TOP_CENTER);
-        roboVBox.setPrefWidth(width);
-        roboVBox.setPrefHeight(200);
+        VBox catVBox = new VBox(8, nickName, catIconView, nym);
+        catVBox.setAlignment(Pos.TOP_CENTER);
+        catVBox.setPrefWidth(width);
+        catVBox.setPrefHeight(200);
 
         statement = new MaterialTextField(Res.get("user.userProfile.new.statement"), Res.get("user.userProfile.new.statement.prompt"));
         statement.setPrefWidth(width);
@@ -90,7 +90,7 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
         fieldsAndButtonsVBox.setAlignment(Pos.CENTER);
 
         HBox.setMargin(fieldsAndButtonsVBox, new Insets(-55, 0, 0, 0));
-        HBox centerHBox = new HBox(10, roboVBox, fieldsAndButtonsVBox);
+        HBox centerHBox = new HBox(10, catVBox, fieldsAndButtonsVBox);
         centerHBox.setAlignment(Pos.TOP_CENTER);
 
         cancelButton = new Button(Res.get("action.cancel"));
@@ -112,7 +112,7 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
 
     @Override
     protected void onViewAttached() {
-        roboIconView.imageProperty().bind(model.getRoboHashImage());
+        catIconView.imageProperty().bind(model.getCatHashImage());
         nickName.textProperty().bind(model.getNickName());
         nym.textProperty().bind(model.getNym());
         terms.textProperty().bindBidirectional(model.getTerms());
@@ -123,7 +123,7 @@ public class CreateNewProfileStep2View extends View<VBox, CreateNewProfileStep2M
 
     @Override
     protected void onViewDetached() {
-        roboIconView.imageProperty().unbind();
+        catIconView.imageProperty().unbind();
         nickName.textProperty().unbind();
         nym.textProperty().unbind();
         terms.textProperty().unbindBidirectional(model.getTerms());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileController.java
@@ -157,9 +157,9 @@ public class CreateProfileController implements Controller {
                         String nym = NymIdGenerator.generate(pubKeyHash, powSolution);
                         Image image = CatHash.getImage(pubKeyHash, powSolution);
                         model.getNym().set(nym);
-                        model.getRoboHashImage().set(image);
+                        model.getCatHashImage().set(image);
                         model.getPowProgress().set(0);
-                        model.getRoboHashIconVisible().set(true);
+                        model.getCatHashIconVisible().set(true);
                         model.getReGenerateButtonDisabled().set(false);
                     });
                     return proofOfWork;
@@ -191,8 +191,8 @@ public class CreateProfileController implements Controller {
     }
 
     private void setPreGenerateState() {
-        model.getRoboHashImage().set(null);
-        model.getRoboHashIconVisible().set(false);
+        model.getCatHashImage().set(null);
+        model.getCatHashIconVisible().set(false);
         model.getReGenerateButtonDisabled().set(true);
         model.getPowProgress().set(-1);
         model.getNym().set(Res.get("onboarding.createProfile.nym.generating"));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileModel.java
@@ -38,9 +38,9 @@ public class CreateProfileModel implements Model {
 
     private final StringProperty nickName = new SimpleStringProperty();
     private final StringProperty nym = new SimpleStringProperty();
-    private final ObjectProperty<Image> roboHashImage = new SimpleObjectProperty<>();
+    private final ObjectProperty<Image> catHashImage = new SimpleObjectProperty<>();
     private final BooleanProperty reGenerateButtonDisabled = new SimpleBooleanProperty();
-    private final BooleanProperty roboHashIconVisible = new SimpleBooleanProperty();
+    private final BooleanProperty catHashIconVisible = new SimpleBooleanProperty();
     private final DoubleProperty powProgress = new SimpleDoubleProperty();
     private final BooleanProperty createProfileButtonDisabled = new SimpleBooleanProperty();
     private final DoubleProperty createProfileProgress = new SimpleDoubleProperty();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
@@ -39,7 +39,7 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
     protected final Button regenerateButton;
     protected final Button createProfileButton;
     protected final Label nym;
-    protected final ImageView roboIconView;
+    protected final ImageView catIconView;
     protected final ProgressIndicator powProgressIndicator;
     protected final MaterialTextField nickname;
     protected final ProgressIndicator createProfileIndicator;
@@ -66,12 +66,12 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         nickname = new MaterialTextField(Res.get("onboarding.createProfile.nickName"), Res.get("onboarding.createProfile.nickName.prompt"));
         nickname.setMaxWidth(315);
 
-        roboIconView = new ImageView();
-        roboIconView.setCursor(Cursor.HAND);
+        catIconView = new ImageView();
+        catIconView.setCursor(Cursor.HAND);
         int size = 120;
-        roboIconView.setFitWidth(size);
-        roboIconView.setFitHeight(size);
-        Tooltip.install(roboIconView, new BisqTooltip(Res.get("onboarding.createProfile.regenerate")));
+        catIconView.setFitWidth(size);
+        catIconView.setFitHeight(size);
+        Tooltip.install(catIconView, new BisqTooltip(Res.get("onboarding.createProfile.regenerate")));
 
         int indicatorSize = size / 2;
         powProgressIndicator = new ProgressIndicator();
@@ -79,10 +79,10 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         powProgressIndicator.setMaxSize(indicatorSize, indicatorSize);
         powProgressIndicator.setOpacity(0.5);
 
-        StackPane roboIconPane = new StackPane();
-        roboIconPane.setMinSize(size, size);
-        roboIconPane.setMaxSize(size, size);
-        roboIconPane.getChildren().addAll(powProgressIndicator, roboIconView);
+        StackPane catIconPane = new StackPane();
+        catIconPane.setMinSize(size, size);
+        catIconPane.setMaxSize(size, size);
+        catIconPane.getChildren().addAll(powProgressIndicator, catIconView);
 
         Label titleLabel = new Label(Res.get("onboarding.createProfile.nym").toUpperCase());
         titleLabel.getStyleClass().add("bisq-text-4");
@@ -94,8 +94,8 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         nymBox.setAlignment(Pos.CENTER);
 
 
-        VBox roboVBox = new VBox(8, roboIconPane, nymBox);
-        roboVBox.setAlignment(Pos.CENTER);
+        VBox catVBox = new VBox(8, catIconPane, nymBox);
+        catVBox.setAlignment(Pos.CENTER);
 
         regenerateButton = new Button(Res.get("onboarding.createProfile.regenerate"));
 
@@ -125,24 +125,24 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
                 headlineLabel,
                 subtitleLabel,
                 nickname,
-                roboVBox,
+                catVBox,
                 buttons
         );
     }
 
     @Override
     protected void onViewAttached() {
-        roboIconView.imageProperty().bind(model.getRoboHashImage());
-        roboIconView.managedProperty().bind(model.getRoboHashIconVisible());
-        roboIconView.visibleProperty().bind(model.getRoboHashIconVisible());
-        powProgressIndicator.managedProperty().bind(model.getRoboHashIconVisible().not());
-        powProgressIndicator.visibleProperty().bind(model.getRoboHashIconVisible().not());
+        catIconView.imageProperty().bind(model.getCatHashImage());
+        catIconView.managedProperty().bind(model.getCatHashIconVisible());
+        catIconView.visibleProperty().bind(model.getCatHashIconVisible());
+        powProgressIndicator.managedProperty().bind(model.getCatHashIconVisible().not());
+        powProgressIndicator.visibleProperty().bind(model.getCatHashIconVisible().not());
         powProgressIndicator.progressProperty().bind(model.getPowProgress());
 
         nym.textProperty().bind(model.getNym());
-        nym.disableProperty().bind(model.getRoboHashIconVisible().not());
+        nym.disableProperty().bind(model.getCatHashIconVisible().not());
         regenerateButton.disableProperty().bind(model.getReGenerateButtonDisabled());
-        roboIconView.mouseTransparentProperty().bind(model.getReGenerateButtonDisabled());
+        catIconView.mouseTransparentProperty().bind(model.getReGenerateButtonDisabled());
         nickname.mouseTransparentProperty().bind(model.getReGenerateButtonDisabled());
 
         nickname.textProperty().bindBidirectional(model.getNickName());
@@ -157,7 +157,7 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         feedbackLabel.visibleProperty().bind(model.getCreateProfileProgress().lessThan(0));
 
         regenerateButton.setOnMouseClicked(e -> controller.onRegenerate());
-        roboIconView.setOnMouseClicked(e -> controller.onRegenerate());
+        catIconView.setOnMouseClicked(e -> controller.onRegenerate());
         createProfileButton.setOnMouseClicked(e -> {
             controller.onCreateUserProfile();
             root.requestFocus();
@@ -168,9 +168,9 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
 
     @Override
     protected void onViewDetached() {
-        roboIconView.imageProperty().unbind();
-        roboIconView.managedProperty().unbind();
-        roboIconView.visibleProperty().unbind();
+        catIconView.imageProperty().unbind();
+        catIconView.managedProperty().unbind();
+        catIconView.visibleProperty().unbind();
         powProgressIndicator.managedProperty().unbind();
         powProgressIndicator.visibleProperty().unbind();
         powProgressIndicator.progressProperty().unbind();
@@ -180,7 +180,7 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         nym.textProperty().unbind();
         nym.disableProperty().unbind();
         regenerateButton.disableProperty().unbind();
-        roboIconView.mouseTransparentProperty().unbind();
+        catIconView.mouseTransparentProperty().unbind();
         nickname.mouseTransparentProperty().unbind();
 
         nickname.textProperty().unbindBidirectional(model.getNickName());
@@ -192,7 +192,7 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         createProfileIndicator.progressProperty().unbind();
 
         regenerateButton.setOnMouseClicked(null);
-        roboIconView.setOnMouseClicked(null);
+        catIconView.setOnMouseClicked(null);
         createProfileButton.setOnMouseClicked(null);
     }
 }

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -950,7 +950,7 @@
     -fx-font-family: "IBM Plex Sans";
 }
 
-.dropdown-menu-popup .menu-item:hover {
+.dropdown-menu-popup .menu-item:hover .dropdown-menu-item-content {
     -fx-background-color: -bisq-dark-grey-50;
 }
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -387,11 +387,11 @@ bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers=With offers
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.favourites=Favourites
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all=All
 
-bisqEasy.offerbook.dropdownMenu.filterOffersByType.tooltip=Filter by offer type
-bisqEasy.offerbook.dropdownMenu.filterOffersByType.allOffers=All offers
-bisqEasy.offerbook.dropdownMenu.filterOffersByType.myOffers=My offers
-bisqEasy.offerbook.dropdownMenu.filterOffersByType.buyOffers=Buy offers
-bisqEasy.offerbook.dropdownMenu.filterOffersByType.sellOffers=Sell offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.tooltip=Filter by offer type
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.allOffers=All offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.myOffers=My offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers=Buy offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers=Sell offers
 
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip=Filter offers by reputation
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations=All reputations

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -387,11 +387,19 @@ bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers=With offers
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.favourites=Favourites
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all=All
 
-bisqEasy.offerbook.dropdownMenu.filterMarketOffers.tooltip=Filter offers
-bisqEasy.offerbook.dropdownMenu.filterMarketOffers.allOffers=All offers
-bisqEasy.offerbook.dropdownMenu.filterMarketOffers.myOffers=My offers
-bisqEasy.offerbook.dropdownMenu.filterMarketOffers.buyOffers=Buy offers
-bisqEasy.offerbook.dropdownMenu.filterMarketOffers.sellOffers=Sell offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByType.tooltip=Filter by offer type
+bisqEasy.offerbook.dropdownMenu.filterOffersByType.allOffers=All offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByType.myOffers=My offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByType.buyOffers=Buy offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByType.sellOffers=Sell offers
+
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.tooltip=Filter offers by reputation
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.allReputations=All reputations
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.fiveStars=5 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastFourStars=At least 4 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastThreeStars=At least 3 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastTwoStars=At least 2 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastOneStar=At least 1 star
 
 bisqEasy.offerbook.chatMessage.deleteOffer.confirmation=Are you sure you want to delete this offer?
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -394,12 +394,13 @@ bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers=Sell Bi
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers=Buy Bitcoin
 
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip=Filter by peer reputation
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTitle=At least:
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations=All reputations
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars=5 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars=At least 4 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastThreeStars=At least 3 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTwoStars=At least 2 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastOneStar=At least 1 star
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars=4 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastThreeStars=3 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTwoStars=2 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastOneStar=1 star
 
 bisqEasy.offerbook.chatMessage.deleteOffer.confirmation=Are you sure you want to delete this offer?
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -393,13 +393,13 @@ bisqEasy.offerbook.dropdownMenu.filterOffersByType.myOffers=My offers
 bisqEasy.offerbook.dropdownMenu.filterOffersByType.buyOffers=Buy offers
 bisqEasy.offerbook.dropdownMenu.filterOffersByType.sellOffers=Sell offers
 
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.tooltip=Filter offers by reputation
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.allReputations=All reputations
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.fiveStars=5 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastFourStars=At least 4 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastThreeStars=At least 3 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastTwoStars=At least 2 stars
-bisqEasy.offerbook.dropdownMenu.filterOffersByReputation.atLeastOneStar=At least 1 star
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip=Filter offers by reputation
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations=All reputations
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars=5 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars=At least 4 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastThreeStars=At least 3 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTwoStars=At least 2 stars
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastOneStar=At least 1 star
 
 bisqEasy.offerbook.chatMessage.deleteOffer.confirmation=Are you sure you want to delete this offer?
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -390,8 +390,8 @@ bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all=All
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.tooltip=Filter by offer type
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.allOffers=All offers
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.myOffers=My offers
-bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers=Buy offers
-bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers=Sell offers
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers=Sell Bitcoin
+bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers=Buy Bitcoin
 
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip=Filter by peer reputation
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations=All reputations

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -393,7 +393,7 @@ bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.myOffers=My offer
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers=Buy offers
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers=Sell offers
 
-bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip=Filter offers by reputation
+bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip=Filter by peer reputation
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations=All reputations
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars=5 stars
 bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars=At least 4 stars

--- a/security/src/main/java/bisq/security/keys/KeyBundleService.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundleService.java
@@ -96,7 +96,7 @@ public class KeyBundleService implements PersistenceClient<KeyBundleStore> {
     }
 
     // When a user creates a new profile we generate only the keypair until the user choose to use that.
-    // The user can re-create many keyPairs until they are satisfied with the generated nym and robosat image
+    // The user can re-create many keyPairs until they are satisfied with the generated nym and cathash image
     public KeyPair generateKeyPair() {
         try {
             return KeyGeneration.generateKeyPair();

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -61,7 +61,7 @@ public final class UserProfile implements DistributedData {
     // We give a bit longer TTL than the chat messages to ensure the chat user is available as long the messages are 
     private final MetaData metaData = new MetaData(TTL_15_DAYS, DEFAULT_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_10_000);
     private final String nickName;
-    // We need the proofOfWork for verification of the nym and robohash icon
+    // We need the proofOfWork for verification of the nym and cathash icon
     private final ProofOfWork proofOfWork;
     private final NetworkId networkId;
     private final String terms;


### PR DESCRIPTION
Towards #1572.

* Add filter "by peer reputation".
    ![image](https://github.com/bisq-network/bisq2/assets/145597137/e0e5e578-fb53-44c5-9c98-3e267d167f5e)

* Rename "offers filter" to `offerDirectionOrOwnerFilter`, reorder its items and change strings:
    For more clarity, "Buy Bitcoin" filter will show "sell offers" and "Sell Bitcoin" will show "buy offers" (to follow the perspective from the user pov).
    ![image](https://github.com/bisq-network/bisq2/assets/145597137/eab958bb-72b0-4ae8-9641-69f14b9a1081)

* Rename the remaining `robohash` to `cathash`.
* Fix dropdown menu items *sometimes* missing to be resized on first run.
    For this, a `ChangeListener` is wrapped inside a `WakeChangeListener` since the latter applied directly was sometimes missing events.

