### PR TITLE
Add check for fix amount not less than min amount

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount/TradeWizardAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount/TradeWizardAmountController.java
@@ -61,6 +61,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 @Slf4j
 public class TradeWizardAmountController implements Controller {
     private final TradeWizardAmountModel model;
@@ -269,6 +271,11 @@ public class TradeWizardAmountController implements Controller {
 
         if (model.getIsMinAmountEnabled().get()) {
             Long minAmount = getAmountValue(minAmountComponent.getQuoteSideAmount());
+            checkNotNull(minAmount);
+            if (maxOrFixAmount.compareTo(minAmount) < 0) {
+                minAmountComponent.setQuoteSideAmount(maxOrFixAmountComponent.getQuoteSideAmount().get());
+                minAmount = getAmountValue(minAmountComponent.getQuoteSideAmount());
+            }
             applyRangeOrFixedAmountSpec(minAmount, maxOrFixAmount);
         } else {
             applyFixedAmountSpec(maxOrFixAmount);


### PR DESCRIPTION
Threw error when creating an offer if fix amount was lowered and then switching to range mode.

Set min amount to fix amount if min amount was larger than fix amount.