### PR TITLE
Update filtered markets on new offers

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -39,6 +39,7 @@ import bisq.desktop.main.content.components.MarketImageComposition;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.settings.CookieKey;
 import bisq.settings.SettingsService;
+import javafx.collections.ListChangeListener;
 import javafx.scene.layout.StackPane;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
@@ -130,6 +131,8 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 updateFilteredMarketChannelItems();
             });
         });
+
+        model.getMarketChannelItems().addListener((ListChangeListener<? super MarketChannelItem>) c -> updateFilteredMarketChannelItems());
 
         selectedOffersFilterPin = EasyBind.subscribe(model.getSelectedOffersFilter(), filter -> {
             if (filter == null) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.offerbook;
 
 import bisq.chat.ChatChannelDomain;
 import bisq.desktop.main.content.chat.ChatModel;
+import javafx.beans.Observable;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -36,7 +37,7 @@ public final class BisqEasyOfferbookModel extends ChatModel {
     private final BooleanProperty offerOnly = new SimpleBooleanProperty();
     private final BooleanProperty isTradeChannelVisible = new SimpleBooleanProperty();
     private final BooleanProperty showFilterOverlay = new SimpleBooleanProperty();
-    private final ObservableList<MarketChannelItem> marketChannelItems = FXCollections.observableArrayList();
+    private final ObservableList<MarketChannelItem> marketChannelItems = FXCollections.observableArrayList(p -> new Observable[]{p.getNumOffers()});
     private final FilteredList<MarketChannelItem> filteredMarketChannelItems = new FilteredList<>(marketChannelItems);
     private final SortedList<MarketChannelItem> sortedMarketChannelItems = new SortedList<>(filteredMarketChannelItems);
     private final ObjectProperty<MarketChannelItem> selectedMarketChannelItem = new SimpleObjectProperty<>();


### PR DESCRIPTION
To immediately show markets with new offers that previously had no offers the filtered markets need to be updated when new offers appear.

The most obvious use case is to allow a user that creates the first offer for a market to see the market pop up in the filtered list.