### PR TITLE
Apply dimming effect to fiat logos and market titles

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -183,6 +183,8 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         selectedMarketSortTypePin.unsubscribe();
 
         resetSelectedChildTarget();
+
+        model.getMarketChannelItems().forEach(MarketChannelItem::cleanUp);
     }
 
     @Override
@@ -202,7 +204,10 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 model.getMarketChannelItems().stream()
                         .filter(item -> item.getChannel().equals(channel))
                         .findAny()
-                        .ifPresent(item -> model.getSelectedMarketChannelItem().set(item));
+                        .ifPresent(item -> {
+                            model.getSelectedMarketChannelItem().set(item);
+                            updateSelectedMarketChannelItem(item);
+                        });
 
                 model.getSearchText().set("");
                 resetSelectedChildTarget();
@@ -287,5 +292,9 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 !model.getSortedMarketChannelItems().isEmpty()) {
             selectionService.selectChannel(model.getSortedMarketChannelItems().get(0).getChannel());
         }
+    }
+
+    private void updateSelectedMarketChannelItem(MarketChannelItem selectedItem) {
+        model.getMarketChannelItems().forEach(item -> item.getSelected().set(item == selectedItem));
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -244,14 +244,6 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         Navigation.navigateTo(NavigationTarget.TRADE_WIZARD, new TradeWizardController.InitData(true));
     }
 
-    void onToggleFilter() {
-        bisqEasyOfferbookModel.getShowFilterOverlay().set(!bisqEasyOfferbookModel.getShowFilterOverlay().get());
-    }
-
-    void onCloseFilter() {
-        bisqEasyOfferbookModel.getShowFilterOverlay().set(false);
-    }
-
     void onSortMarkets(MarketSortType marketSortType) {
         model.getSelectedMarketSortType().set(marketSortType);
         model.getSortedMarketChannelItems().setComparator(marketSortType.getComparator());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -35,7 +35,6 @@ import java.util.function.Predicate;
 public final class BisqEasyOfferbookModel extends ChatModel {
     private final BooleanProperty offerOnly = new SimpleBooleanProperty();
     private final BooleanProperty isTradeChannelVisible = new SimpleBooleanProperty();
-    private final BooleanProperty showFilterOverlay = new SimpleBooleanProperty(); // TODO: remove this
     private final ObservableList<MarketChannelItem> marketChannelItems = FXCollections.observableArrayList();
     private final FilteredList<MarketChannelItem> filteredMarketChannelItems = new FilteredList<>(marketChannelItems);
     private final SortedList<MarketChannelItem> sortedMarketChannelItems = new SortedList<>(filteredMarketChannelItems);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -241,16 +241,13 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         // Sorting options
         DropdownTitleMenuItem sortTitle = new DropdownTitleMenuItem(
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.sortTitle"));
-        sortByMostOffers = new DropdownSortByMenuItem("check-grey",
-                "check-white",
+        sortByMostOffers = new DropdownSortByMenuItem("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.mostOffers"),
                 MarketSortType.NUM_OFFERS);
-        sortByNameAZ = new DropdownSortByMenuItem("check-grey",
-                "check-white",
+        sortByNameAZ = new DropdownSortByMenuItem("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.nameAZ"),
                 MarketSortType.ASC);
-        sortByNameZA = new DropdownSortByMenuItem("check-grey",
-                "check-white",
+        sortByNameZA = new DropdownSortByMenuItem("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.nameZA"),
                 MarketSortType.DESC);
 
@@ -260,9 +257,9 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         // Filter options
         DropdownTitleMenuItem filterTitle = new DropdownTitleMenuItem(
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.filterTitle"));
-        filterWithOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        filterWithOffers = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers"), Filters.Markets.WITH_OFFERS);
-        filterShowAll = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        filterShowAll = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all"), Filters.Markets.ALL);
 
         dropdownMenu.addMenuItems(sortTitle, sortByMostOffers, sortByNameAZ, sortByNameZA, separator, filterTitle,
@@ -330,13 +327,13 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         dropdownMenu.setTooltip(Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.tooltip"));
         dropdownMenu.getStyleClass().add("dropdown-offers-filter-menu");
 
-        allOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        allOffers = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.allOffers"), Filters.OfferDirectionOrOwner.ALL);
-        myOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        myOffers = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.myOffers"), Filters.OfferDirectionOrOwner.MINE);
-        buyOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        buyOffers = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.buyOffers"), Filters.OfferDirectionOrOwner.BUY);
-        sellOffers = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        sellOffers = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.sellOffers"), Filters.OfferDirectionOrOwner.SELL);
 
         dropdownMenu.addMenuItems(sellOffers, buyOffers, myOffers, allOffers);
@@ -348,24 +345,24 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         dropdownMenu.setTooltip(Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.tooltip"));
         dropdownMenu.getStyleClass().add("dropdown-offers-filter-menu");
 
-        allReputations = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        allReputations = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.allReputations"),
                 Filters.PeerReputation.ALL);
-        fiveStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        fiveStars = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.fiveStars"),
                 Filters.PeerReputation.FIVE_STARS);
         atLeastTitle = new DropdownTitleMenuItem(
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTitle"));
-        atLeastFourStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        atLeastFourStars = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastFourStars"),
                 Filters.PeerReputation.AT_LEAST_FOUR_STARS);
-        atLeastThreeStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        atLeastThreeStars = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastThreeStars"),
                 Filters.PeerReputation.AT_LEAST_THREE_STARS);
-        atLeastTwoStars = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        atLeastTwoStars = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastTwoStars"),
                 Filters.PeerReputation.AT_LEAST_TWO_STARS);
-        atLeastOneStar = new DropdownFilterMenuItem<>("check-grey", "check-white",
+        atLeastOneStar = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.filterOffersByPeerReputation.atLeastOneStar"),
                 Filters.PeerReputation.AT_LEAST_ONE_STAR);
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -244,6 +244,11 @@
 }
 
 .market-selection-list .market-name .text {
+    -fx-fill: -fx-mid-text-color !important;
+    -fx-text-fill: -fx-mid-text-color !important;
+}
+
+.market-selection-list .market-name-selected .text {
     -fx-fill: -fx-light-text-color !important;
     -fx-text-fill: -fx-light-text-color !important;
 }

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -212,6 +212,11 @@
     -fx-opacity: 1;
 }
 
+.dropdown-menu-popup .dropdown-filter-menu-item .dropdown-menu-item-content:selected .label,
+.dropdown-menu-popup .dropdown-sort-by-menu-item .dropdown-menu-item-content:selected .label {
+    -fx-text-fill: -fx-light-text-color;
+}
+
 .market-selection-list .column-header-background {
     -fx-max-height: 0;
     -fx-pref-height: 0;


### PR DESCRIPTION
Towards #1718

* Apply dimming effect to fiat logos and market titles.
* Highlight selected items in sort and filter dropdown menus (including reputation and offer types).
* Remove unused code.

![image](https://github.com/bisq-network/bisq2/assets/145597137/94f0a3af-7547-4309-8c90-1d644a0f2203)
