### PR TITLE
Replace nullable with optional

### DIFF
--- a/account/src/main/java/bisq/account/accounts/BankAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/BankAccountPayload.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import java.util.Optional;
 
-//fixme (low prio) use Optional instead of Nullable
 @EqualsAndHashCode(callSuper = true)
 @Setter
 @Getter
@@ -23,10 +22,8 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
     protected String branchId;
     protected String accountNr;
     protected String accountType;
-    @Nullable
     protected String holderTaxId;
     protected String bankId;
-    @Nullable
     protected String nationalAccountId;
 
     protected BankAccountPayload(String id,
@@ -60,13 +57,9 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
         NetworkDataValidation.validateText(branchId, 30);
         NetworkDataValidation.validateText(accountNr, 30);
         NetworkDataValidation.validateText(accountType, 20);
-        if (holderTaxId != null) {
-            NetworkDataValidation.validateText(holderTaxId, 50);
-        }
+        getHolderTaxId().ifPresent(taxId ->  NetworkDataValidation.validateText(taxId, 50));
         NetworkDataValidation.validateText(bankId, 50);
-        if (nationalAccountId != null) {
-            NetworkDataValidation.validateText(nationalAccountId, 50);
-        }
+        getNationalAccountId().ifPresent(accId ->  NetworkDataValidation.validateText(nationalAccountId, 50));
     }
 
     protected bisq.account.protobuf.BankAccountPayload.Builder getBankAccountPayloadBuilder() {
@@ -78,8 +71,8 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
                 .setAccountType(accountType)
                 .setBranchId(branchId)
                 .setBankId(bankId);
-        Optional.ofNullable(holderTaxId).ifPresent(builder::setHolderTaxId);
-        Optional.ofNullable(nationalAccountId).ifPresent(builder::setNationalAccountId);
+        getHolderTaxId().ifPresent(builder::setHolderTaxId);
+        getNationalAccountId().ifPresent(builder::setNationalAccountId);
         return builder;
     }
 
@@ -97,4 +90,15 @@ public abstract class BankAccountPayload extends CountryBasedAccountPayload {
         }
         throw new UnresolvableProtobufMessageException(proto);
     }
+
+    private Optional<String> getHolderTaxId()
+    {
+        return Optional.ofNullable(this.holderTaxId);
+    }
+
+    private Optional<String> getNationalAccountId()
+    {
+        return Optional.ofNullable(this.nationalAccountId);
+    }
+
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BaseState.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BaseState.java
@@ -86,12 +86,15 @@ public abstract class BaseState {
         public void onDeactivate() {
         }
 
-        protected Optional<String> findUsersAccountData() {
-            return Optional.ofNullable(accountService.getSelectedAccount()).stream()
-                    .filter(account -> account instanceof UserDefinedFiatAccount)
-                    .map(account -> (UserDefinedFiatAccount) account)
-                    .map(account -> account.getAccountPayload().getAccountData())
-                    .findFirst();
+        protected Optional<String> findUsersAccountData()
+        {
+            return accountService
+                .getSelectedAccount()
+                .stream()
+                .filter(UserDefinedFiatAccount.class::isInstance)
+                .map(UserDefinedFiatAccount.class::cast)
+                .map(account -> account.getAccountPayload().getAccountData())
+                .findFirst();
         }
 
         protected void sendSystemMessage(String message) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState1.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState1.java
@@ -135,7 +135,7 @@ public class SellerState1 extends BaseState {
         }
 
         private void maybeSelectFirstAccount() {
-            if (!model.getSortedAccounts().isEmpty() && accountService.getSelectedAccount() == null) {
+            if (!model.getSortedAccounts().isEmpty() && accountService.getSelectedAccount().isEmpty()) {
                 accountService.setSelectedAccount(model.getSortedAccounts().get(0));
             }
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/PaymentAccountsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/PaymentAccountsController.java
@@ -34,6 +34,7 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.util.Comparator;
+import java.util.NoSuchElementException;
 
 import static bisq.bisq_easy.NavigationTarget.CREATE_BISQ_EASY_PAYMENT_ACCOUNT;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -107,37 +108,37 @@ public class PaymentAccountsController implements Controller {
     }
 
     void onSaveAccount() {
-        checkNotNull(model.getSelectedAccount());
-        String accountName = model.getSelectedAccount().getAccountName();
-        String accountData = model.getAccountData();
-        if (accountData != null) {
+        var selectedAccount = getSelectedAccount();
+        String accountName = selectedAccount.getAccountName();
+        model.getAccountData().ifPresent(accountData -> {
             checkArgument(accountData.length() <= UserDefinedFiatAccountPayload.MAX_DATA_LENGTH, "Account data must not be longer than 1000 characters");
             UserDefinedFiatAccount newAccount = new UserDefinedFiatAccount(accountName, accountData);
-            accountService.removePaymentAccount(model.getSelectedAccount());
+            accountService.removePaymentAccount(selectedAccount);
             accountService.addPaymentAccount(newAccount);
             accountService.setSelectedAccount(newAccount);
-        }
+        });
     }
 
     void onDeleteAccount() {
-        checkNotNull(model.getSelectedAccount());
-        accountService.removePaymentAccount(model.getSelectedAccount());
+        accountService.removePaymentAccount(getSelectedAccount());
         maybeSelectFirstAccount();
     }
 
     private void updateButtonStates() {
-        model.setSaveButtonDisabled(model.getSelectedAccount() == null
-                || model.getAccountData() == null
+        model.setSaveButtonDisabled(model.getSelectedAccount().isEmpty()
                 || model.getAccountData().isEmpty()
-                || model.getSelectedAccount() == null
-                || ((UserDefinedFiatAccount) model.getSelectedAccount()).getAccountPayload().getAccountData().equals(model.getAccountData()));
+                || ((UserDefinedFiatAccount) model.getSelectedAccount().get()).getAccountPayload().getAccountData().equals(model.getAccountData().get()));
 
-        model.setDeleteButtonDisabled(model.getSelectedAccount() == null);
+        model.setDeleteButtonDisabled(model.getSelectedAccount().isEmpty());
     }
 
     private void maybeSelectFirstAccount() {
-        if (!model.getSortedAccounts().isEmpty() && accountService.getSelectedAccount() == null) {
+        if (!model.getSortedAccounts().isEmpty() && accountService.getSelectedAccount().isEmpty()) {
             accountService.setSelectedAccount(model.getSortedAccounts().get(0));
         }
+    }
+
+    private Account<?, ? extends PaymentMethod<?>> getSelectedAccount() throws NoSuchElementException {
+        return model.getSelectedAccount().orElseThrow(() -> new NoSuchElementException("There is no account selected."));
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/PaymentAccountsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/PaymentAccountsModel.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Optional;
 
 @Getter
 @Slf4j
@@ -43,9 +44,8 @@ public class PaymentAccountsModel implements Model {
     private final SortedList<Account<?, ? extends PaymentMethod<?>>> sortedAccounts = new SortedList<>(accounts);
 
     // selectedAccount
-    @Nullable
-    public Account<?, ? extends PaymentMethod<?>> getSelectedAccount() {
-        return selectedAccount.get();
+    public Optional<Account<?, ? extends PaymentMethod<?>>> getSelectedAccount() {
+        return Optional.ofNullable(selectedAccount.get());
     }
 
     public ObjectProperty<Account<?, ? extends PaymentMethod<?>>> selectedAccountProperty() {
@@ -57,9 +57,8 @@ public class PaymentAccountsModel implements Model {
     }
 
     // accountData
-    @Nullable
-    public String getAccountData() {
-        return accountData.get();
+    public Optional<String> getAccountData() {
+        return Optional.ofNullable(accountData.get());
     }
 
     public StringProperty accountDataProperty() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/PaymentAccountsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/PaymentAccountsView.java
@@ -124,7 +124,7 @@ public class PaymentAccountsView extends View<VBox, PaymentAccountsModel, Paymen
 
         accountSelection.setOnChangeConfirmed(e -> {
             if (accountSelection.getSelectionModel().getSelectedItem() == null) {
-                accountSelection.getSelectionModel().select(model.getSelectedAccount());
+                accountSelection.getSelectionModel().select(model.getSelectedAccount().orElse(null));
                 return;
             }
             controller.onSelectAccount(accountSelection.getSelectionModel().getSelectedItem());
@@ -154,7 +154,7 @@ public class PaymentAccountsView extends View<VBox, PaymentAccountsModel, Paymen
     @Override
     protected void onViewDetached() {
         headline.textProperty().unbind();
-        accountData.textProperty().unbindBidirectional(model.getAccountData());
+        accountData.textProperty().unbindBidirectional(model.getAccountData().orElse(null));
         saveButton.disableProperty().unbind();
         deletedButton.disableProperty().unbind();
 


### PR DESCRIPTION
Closes #1631  

* Updated the methods in the PaymentAccountsModel to return optional where the return value could be null.
* Updated the BankAccountPayload by replacing the Nullable annotations with Optional.
* Updated all the classes affected by the changes of adding Optional.