### PR TITLE
Improve logs

### DIFF
--- a/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRolesService.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRolesService.java
@@ -258,7 +258,9 @@ public class AuthorizedBondedRolesService implements Service, DataService.Listen
                 }
             } else {
                 failedAuthorizedData.add(authorizedData);
-                log.warn("hasAuthorizedPubKey failed for AuthorizedDistributedData={}, {}",
+                // TODO Set log level for to debug for now, as too many logs are printed.
+                //  Once the TTL has cleared the old data we can change back to warn level.
+                log.debug("hasAuthorizedPubKey failed for AuthorizedDistributedData={}, {}",
                         data.getClass().getSimpleName(), StringUtils.truncate(data.toString(), 200));
                 log.debug("AuthorizedPublicKey is not matching any key from our authorizedBondedRolesPubKeys and does " +
                                 "not provide a matching static key.\n" +

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoadService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoadService.java
@@ -108,8 +108,8 @@ public class NetworkLoadService {
                 .sum();
         long networkDatabaseSize = dataRequests.stream().mapToLong(e -> e.toProto().getSerializedSize()).sum();
 
-        StringBuilder sb = new StringBuilder("\n\n##########################################################################################");
-        sb.append("\nNetwork statistics").append(("\n##########################################################################################"))
+        StringBuilder sb = new StringBuilder("\n\n////////////////////////////////////////////////////////////////////////////////////////////////////");
+        sb.append("\nNetwork statistics").append(("\n////////////////////////////////////////////////////////////////////////////////////////////////////"))
                 .append("\nNumber of Connections: ").append(numConnections)
                 .append("\nNumber of messages sent in last hour: ").append(numMessagesSentOfLastHour)
                 .append("\nNumber of messages received in last hour: ").append(numMessagesReceivedOfLastHour)
@@ -118,7 +118,7 @@ public class NetworkLoadService {
                 .append("\nData received in last hour: ").append(ByteUnit.BYTE.toKB(receivedBytesOfLastHour)).append(" KB")
                 .append("\nTime for message sending in last hour: ").append(spentSendMessageTimeOfLastHour / 1000d).append(" sec.")
                 .append("\nTime for message deserializing in last hour: ").append(deserializeTimeOfLastHour / 1000d).append(" sec.")
-                .append("\n##########################################################################################\n");
+                .append("\n////////////////////////////////////////////////////////////////////////////////////////////////////\n");
         log.info(sb.toString());
 
         double MAX_NUM_CON = 30;

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
@@ -36,12 +36,11 @@ import java.util.concurrent.TimeUnit;
  */
 @EqualsAndHashCode
 @ToString
+@Getter
 public final class MailboxData implements StorageData {
     public final static long MAX_TLL = TimeUnit.DAYS.toMillis(15);
 
-    @Getter
     private final ConfidentialMessage confidentialMessage;
-    @Getter
     private final MetaData metaData;
 
     public MailboxData(ConfidentialMessage confidentialMessage, MetaData metaData) {


### PR DESCRIPTION
Prints better overview of P2P network data
```
##########################################################################################
Received 1255.19 KB of inventory data from: plur5t7zhcf45bltdhtb4o43p726dqhibc6xo2lhjfxctjcoinlclaid.onion:1000
##########################################################################################
  43 item(s) of RemoveAuthenticatedDataRequest
  20 item(s) of AddAuthenticatedDataRequest.CommonPublicChatMessage
  17 item(s) of AddAuthenticatedDataRequest.AuthorizedBondedRole
  85 item(s) of AddAuthenticatedDataRequest.AuthorizedTimestampData
 264 item(s) of AddAuthenticatedDataRequest.AuthorizedProofOfBurnData
  61 item(s) of AddAuthenticatedDataRequest.UserProfile
   6 item(s) of AddAuthenticatedDataRequest.AuthorizedMarketPriceData
   1 item(s) of AddAuthenticatedDataRequest.AuthorizedOracleNode
   2 item(s) of AddAuthenticatedDataRequest.BisqEasyOfferbookMessage
4030 item(s) of RemoveMailboxRequest
  13 item(s) of AddMailboxRequest
########################################################################################## 
```