### PR TITLE
Add number of notifications pending to be read in private chats

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
@@ -70,6 +70,7 @@ public class BisqEasyOfferbookUtil {
             @Override
             protected void updateItem(MarketChannelItem item, boolean empty) {
                 super.updateItem(item, empty);
+
                 if (item != null && !empty) {
                     marketName.setText(item.getMarket().getQuoteCurrencyName());
                     marketCode.setText(item.getMarket().getQuoteCurrencyCode());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/common/CommonChatTabController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/common/CommonChatTabController.java
@@ -52,8 +52,7 @@ public final class CommonChatTabController extends ContentTabController<CommonCh
     private final CommonPublicChatChannelService commonPublicChatChannelService;
     private final TwoPartyPrivateChatChannelService twoPartyPrivateChatChannelService;
     private final CommonChannelSelectionService chatChannelSelectionService;
-    private Pin selectedChannelPin;
-    private Pin changedChatNotificationPin;
+    private Pin selectedChannelPin, changedChatNotificationPin;
 
     public CommonChatTabController(ServiceProvider serviceProvider, ChatChannelDomain chatChannelDomain, NavigationTarget navigationTarget) {
         super(new CommonChatTabModel(chatChannelDomain), navigationTarget, serviceProvider);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/common/CommonChatTabView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/common/CommonChatTabView.java
@@ -42,6 +42,7 @@ final class CommonChatTabView extends ContentTabView<CommonChatTabModel, CommonC
     protected void onChildView(View<? extends Parent, ? extends Model, ? extends Controller> oldValue,
                                View<? extends Parent, ? extends Model, ? extends Controller> newValue) {
         super.onChildView(oldValue, newValue);
+
         controller.onSelected(model.getNavigationTarget());
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
@@ -21,6 +21,7 @@ import bisq.chat.two_party.TwoPartyPrivateChatChannel;
 import bisq.desktop.common.Layout;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.Badge;
 import bisq.desktop.components.controls.DropdownMenuItem;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.BisqTableView;
@@ -202,6 +203,8 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
 
     private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getTradePeerCellFactory() {
         return column -> new TableCell<>() {
+            private final HBox hBox = new HBox(5);
+
             @Override
             public void updateItem(final ListItem item, boolean empty) {
                 super.updateItem(item, empty);
@@ -210,7 +213,9 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
                     UserProfileDisplay userProfileDisplay = new UserProfileDisplay(item.getChannel().getPeer());
                     userProfileDisplay.setReputationScore(item.getReputationScore());
                     getStyleClass().add("user-profile-table-cell");
-                    setGraphic(userProfileDisplay);
+                    hBox.getChildren().setAll(userProfileDisplay, Spacer.fillHBox(), item.getNumMessagesBadge());
+
+                    setGraphic(hBox);
                 } else {
                     setGraphic(null);
                 }
@@ -269,6 +274,8 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
         private final long totalReputationScore, profileAge;
         private final String totalReputationScoreString, profileAgeString;
         private final ReputationScore reputationScore;
+        @EqualsAndHashCode.Exclude
+        private final Badge numMessagesBadge;
 
         public ListItem(TwoPartyPrivateChatChannel channel, ReputationService reputationService) {
             this.channel = channel;
@@ -286,6 +293,12 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             profileAgeString = optionalProfileAge
                     .map(TimeFormatter::formatAgeInDays)
                     .orElse(Res.get("data.na"));
+
+            numMessagesBadge = new Badge(null, Pos.CENTER_RIGHT);
+        }
+
+        public void setNumNotifications(long numNotifications) {
+            numMessagesBadge.setText(numNotifications == 0 ? "" : String.valueOf(numNotifications));
         }
     }
 }

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -413,6 +413,9 @@
     -fx-padding: 0 0 0 13;
 }
 
+.private-chats-selection-list .user-profile-table-cell .bisq-badge {
+    -fx-padding: 0 13 0 0;
+}
 
 /*******************************************************************************
  *                                                                             *


### PR DESCRIPTION
We have the global notification count in private chats (sum of all the unread notifications).
This introduces the notification count per chat inside the tab.

Resolves #1774

![image](https://github.com/bisq-network/bisq2/assets/145597137/d1d22865-fb85-4b96-bc87-b2e6dd69a7ff)
