### PR TITLE
Fix backward compatibility issue with avatar version

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/cathash/BucketConfig.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/cathash/BucketConfig.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 @Slf4j
 public abstract class BucketConfig {
-    static final String CURRENT_VERSION = "v1";
+    static final int CURRENT_VERSION = 0;
     static final String DIGIT = "#";
     static final String SHAPE_NUMBER = "#SHAPE_NUMBER#";
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/cathash/CatHash.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/cathash/CatHash.java
@@ -38,11 +38,11 @@ public class CatHash {
                 userProfile.getAvatarVersion(), true);
     }
 
-    public static Image getImage(byte[] pubKeyHash, byte[] powSolution, String avatarVersion) {
+    public static Image getImage(byte[] pubKeyHash, byte[] powSolution, int avatarVersion) {
         return getImage(pubKeyHash, powSolution, avatarVersion, true);
     }
 
-    public static Image getImage(byte[] pubKeyHash, byte[] powSolution, String avatarVersion, boolean useCache) {
+    public static Image getImage(byte[] pubKeyHash, byte[] powSolution, int avatarVersion, boolean useCache) {
         byte[] combined = ByteArrayUtils.concat(powSolution, pubKeyHash);
         BigInteger input = new BigInteger(combined);
         if (useCache && CACHE.containsKey(input)) {
@@ -61,14 +61,14 @@ public class CatHash {
         return image;
     }
 
-    public static String currentAvatarsVersion() {
+    public static int currentAvatarsVersion() {
         return BucketConfig.CURRENT_VERSION;
     }
 
-    private static BucketConfig getBucketConfig(String avatarVersion) {
+    private static BucketConfig getBucketConfig(int avatarVersion) {
         BucketConfig bucketConfig;
         switch (avatarVersion) {
-            case "v1": {
+            case 0: {
                 bucketConfig = new BucketConfigV1();
                 log.info("Creating v1 BucketConfig: {}", bucketConfig.getClass().getName());
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Controller.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Controller.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class CreateNewProfileStep2Controller implements InitWithDataController<CreateNewProfileStep2Controller.InitData> {
-    private static final String CURRENT_AVATARS_VERSION = CatHash.currentAvatarsVersion();
+    private static final int CURRENT_AVATARS_VERSION = CatHash.currentAvatarsVersion();
 
     @Getter
     @ToString

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileController.java
@@ -46,7 +46,7 @@ import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 public class CreateProfileController implements Controller {
-    private static final String CURRENT_AVATARS_VERSION = CatHash.currentAvatarsVersion();
+    private static final int CURRENT_AVATARS_VERSION = CatHash.currentAvatarsVersion();
 
     protected final CreateProfileModel model;
     @Getter

--- a/user/src/main/java/bisq/user/identity/UserIdentityService.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityService.java
@@ -173,7 +173,7 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
                                                                           KeyPair keyPair,
                                                                           byte[] pubKeyHash,
                                                                           ProofOfWork proofOfWork,
-                                                                          String avatarVersion,
+                                                                          int avatarVersion,
                                                                           String terms,
                                                                           String statement) {
         String identityTag = nickName + "-" + Hex.encode(pubKeyHash);
@@ -315,7 +315,7 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
 
     private UserIdentity createUserIdentity(String nickName,
                                             ProofOfWork proofOfWork,
-                                            String avatarVersion,
+                                            int avatarVersion,
                                             String terms,
                                             String statement,
                                             Identity identity) {

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -64,7 +64,7 @@ public final class UserProfile implements DistributedData {
     private final String nickName;
     // We need the proofOfWork for verification of the nym and cathash icon
     private final ProofOfWork proofOfWork;
-    private final String avatarVersion;
+    private final int avatarVersion;
     private final NetworkId networkId;
     private final String terms;
     private final String statement;
@@ -75,7 +75,7 @@ public final class UserProfile implements DistributedData {
 
     public UserProfile(String nickName,
                        ProofOfWork proofOfWork,
-                       String avatarVersion,
+                       int avatarVersion,
                        NetworkId networkId,
                        String terms,
                        String statement) {

--- a/user/src/main/proto/user.proto
+++ b/user/src/main/proto/user.proto
@@ -30,7 +30,7 @@ message UserProfile {
   security.ProofOfWork proofOfWork = 3;
   string terms = 4;
   string statement = 5;
-  string avatarVersion = 6;
+  sint32 avatarVersion = 6;
 }
 
 message UserIdentity {


### PR DESCRIPTION
Use integer for version instead of a string and set initial version to 0. This avoids that it breaks backward compatibility as 0 is default value for integers and proto serialization does not change if that value is set or not.

FYI: 
"if a scalar message field is set to its default, the value will not be serialized on the wire" - https://protobuf.dev/programming-guides/proto3/