### PR TITLE
Fix inconsistent market logo effect

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -189,8 +189,6 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         selectedMarketSortTypePin.unsubscribe();
 
         resetSelectedChildTarget();
-
-        model.getMarketChannelItems().forEach(MarketChannelItem::cleanUp);
     }
 
     @Override
@@ -210,10 +208,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 model.getMarketChannelItems().stream()
                         .filter(item -> item.getChannel().equals(channel))
                         .findAny()
-                        .ifPresent(item -> {
-                            model.getSelectedMarketChannelItem().set(item);
-                            updateSelectedMarketChannelItem(item);
-                        });
+                        .ifPresent(item -> model.getSelectedMarketChannelItem().set(item));
 
                 model.getSearchText().set("");
                 resetSelectedChildTarget();
@@ -290,9 +285,5 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 !model.getSortedMarketChannelItems().isEmpty()) {
             selectionService.selectChannel(model.getSortedMarketChannelItems().get(0).getChannel());
         }
-    }
-
-    private void updateSelectedMarketChannelItem(MarketChannelItem selectedItem) {
-        model.getMarketChannelItems().forEach(item -> item.getSelected().set(item == selectedItem));
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
@@ -8,13 +8,12 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringExpression;
 import javafx.geometry.Pos;
 import javafx.scene.Cursor;
-import javafx.scene.control.Label;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.Tooltip;
+import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.Subscription;
 
 import java.util.Comparator;
 import java.util.List;
@@ -58,6 +57,7 @@ public class BisqEasyOfferbookUtil {
             private final HBox hBox = new HBox(10, marketCode, numOffers);
             private final VBox vBox = new VBox(0, marketName, hBox);
             private final Tooltip tooltip = new BisqTooltip();
+            private Subscription selectedPin;
 
             {
                 setCursor(Cursor.HAND);
@@ -71,6 +71,11 @@ public class BisqEasyOfferbookUtil {
             protected void updateItem(MarketChannelItem item, boolean empty) {
                 super.updateItem(item, empty);
 
+                // Clean up previous row
+                if (getTableRow() != null && selectedPin != null) {
+                    selectedPin.unsubscribe();
+                }
+
                 if (item != null && !empty) {
                     marketName.setText(item.getMarket().getQuoteCurrencyName());
                     marketCode.setText(item.getMarket().getQuoteCurrencyCode());
@@ -82,13 +87,28 @@ public class BisqEasyOfferbookUtil {
                     tooltip.textProperty().bind(formattedTooltip);
                     tooltip.setStyle("-fx-text-fill: -fx-dark-text-color;");
 
+                    // Set up new row
+                    TableRow<MarketChannelItem> newRow = getTableRow();
+                    if (newRow != null) {
+                        selectedPin = EasyBind.subscribe(newRow.selectedProperty(), isSelected ->
+                                updateMarketLogoEffect(item, isSelected));
+                    }
+
                     setGraphic(vBox);
                 } else {
                     numOffers.textProperty().unbind();
                     tooltip.textProperty().unbind();
+                    selectedPin.unsubscribe();
 
                     setGraphic(null);
                 }
+            }
+
+            private void updateMarketLogoEffect(MarketChannelItem item, boolean isSelected) {
+                item.getMarketLogo().setEffect(null);
+                item.getMarketLogo().setEffect(isSelected
+                        ? MarketChannelItem.SELECTED_COLOR_ADJUST
+                        : MarketChannelItem.DEFAULT_COLOR_ADJUST);
             }
         };
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookUtil.java
@@ -34,11 +34,11 @@ public class BisqEasyOfferbookUtil {
     }
 
     public static Comparator<MarketChannelItem> sortByMarketNameAsc() {
-        return Comparator.comparing(MarketChannelItem::getMarketString);
+        return Comparator.comparing(MarketChannelItem::toString);
     }
 
     public static Comparator<MarketChannelItem> sortByMarketNameDesc() {
-        return Comparator.comparing(MarketChannelItem::getMarketString).reversed();
+        return Comparator.comparing(MarketChannelItem::toString).reversed();
     }
 
     public static Comparator<MarketChannelItem> sortByMarketActivity() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -22,9 +22,7 @@ import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
 import bisq.common.currency.Market;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.main.content.components.MarketImageComposition;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.CacheHint;
 import javafx.scene.Node;
@@ -44,7 +42,6 @@ public class MarketChannelItem {
     private final Market market;
     private final Node marketLogo;
     private final IntegerProperty numOffers = new SimpleIntegerProperty(0);
-    private final BooleanProperty selected = new SimpleBooleanProperty(false);
 
     public MarketChannelItem(BisqEasyOfferbookChannel channel) {
         this.channel = channel;
@@ -54,8 +51,6 @@ public class MarketChannelItem {
         marketLogo.setCacheHint(CacheHint.SPEED);
 
         setUpColorAdjustments();
-
-        //selected.addListener(selectedChangeListener);
         marketLogo.setEffect(DEFAULT_COLOR_ADJUST);
 
         channel.getChatMessages().addObserver(new WeakReference<Runnable>(this::updateNumOffers).get());
@@ -86,12 +81,5 @@ public class MarketChannelItem {
     @Override
     public String toString() {
         return market.toString();
-    }
-
-    public void cleanUp() {
-//        if (selectedChangeListener != null) {
-//            selected.removeListener(selectedChangeListener);
-//            selectedChangeListener = null;
-//        }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -74,10 +74,6 @@ public class MarketChannelItem {
         });
     }
 
-    public String getMarketString() {
-        return market.toString();
-    }
-
     @Override
     public String toString() {
         return market.toString();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -26,7 +26,6 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.scene.CacheHint;
 import javafx.scene.Node;
 import javafx.scene.effect.ColorAdjust;
@@ -38,14 +37,14 @@ import java.lang.ref.WeakReference;
 @EqualsAndHashCode
 @Getter
 public class MarketChannelItem {
+    static final ColorAdjust DEFAULT_COLOR_ADJUST = new ColorAdjust();
+    static final ColorAdjust SELECTED_COLOR_ADJUST = new ColorAdjust();
+
     private final BisqEasyOfferbookChannel channel;
     private final Market market;
     private final Node marketLogo;
     private final IntegerProperty numOffers = new SimpleIntegerProperty(0);
     private final BooleanProperty selected = new SimpleBooleanProperty(false);
-    private final ChangeListener<Boolean> selectedChangeListener;
-    private final ColorAdjust defaultColorAdjust = new ColorAdjust();
-    private final ColorAdjust selectedColorAdjust = new ColorAdjust();
 
     public MarketChannelItem(BisqEasyOfferbookChannel channel) {
         this.channel = channel;
@@ -55,21 +54,20 @@ public class MarketChannelItem {
         marketLogo.setCacheHint(CacheHint.SPEED);
 
         setUpColorAdjustments();
-        selectedChangeListener = (observable, oldValue, newValue) ->
-                marketLogo.setEffect(newValue ? selectedColorAdjust : defaultColorAdjust);
-        selected.addListener(selectedChangeListener);
-        marketLogo.setEffect(defaultColorAdjust);
+
+        //selected.addListener(selectedChangeListener);
+        marketLogo.setEffect(DEFAULT_COLOR_ADJUST);
 
         channel.getChatMessages().addObserver(new WeakReference<Runnable>(this::updateNumOffers).get());
         updateNumOffers();
     }
 
     private void setUpColorAdjustments() {
-        defaultColorAdjust.setBrightness(-0.4);
-        defaultColorAdjust.setSaturation(-0.2);
-        defaultColorAdjust.setContrast(-0.1);
+        DEFAULT_COLOR_ADJUST.setBrightness(-0.4);
+        DEFAULT_COLOR_ADJUST.setSaturation(-0.2);
+        DEFAULT_COLOR_ADJUST.setContrast(-0.1);
 
-        selectedColorAdjust.setBrightness(-0.1);
+        SELECTED_COLOR_ADJUST.setBrightness(-0.1);
     }
 
     private void updateNumOffers() {
@@ -91,6 +89,9 @@ public class MarketChannelItem {
     }
 
     public void cleanUp() {
-        selected.removeListener(selectedChangeListener);
+//        if (selectedChangeListener != null) {
+//            selected.removeListener(selectedChangeListener);
+//            selectedChangeListener = null;
+//        }
     }
 }


### PR DESCRIPTION
* Fix market logo effect not matching selected row.
  Make `updateItem()` from markets table decide when to lit the market logo depending on whether that row is selected or not. This is also more efficient than updating each `MarketChannelItem` every time a different channel is selected.
  Resolves #1802


* Minor refactors.