### PR TITLE
Improve style of matching offers in trade wizard

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
@@ -60,9 +60,9 @@ import java.util.Optional;
 
 @Slf4j
 class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel, TradeWizardSelectOfferController> {
-    private final static int TABLE_WIDTH = 800;
-    private final HBox noMatchingOffersBox;
+    private static final int TABLE_WIDTH = 800;
 
+    private final HBox noMatchingOffersBox;
     private final BisqTableView<ListItem> tableView;
     private final Label headlineLabel, subtitleLabel;
     private Button goBackButton, browseOfferbookButton;
@@ -170,9 +170,7 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
         }
 
         // Maker 
-        String peer = model.getDirection() == Direction.BUY ?
-                Res.get("offer.seller") :
-                Res.get("offer.buyer");
+        String peer = model.getDirection() == Direction.BUY ? Res.get("offer.seller") : Res.get("offer.buyer");
         tableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
                 .title(peer)
                 .left()
@@ -203,9 +201,9 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
         }
 
         // BTC amount
-        String baseAmountTitle = model.getDirection().isBuy() ?
-                Res.get("bisqEasy.tradeWizard.review.table.baseAmount.buyer") :
-                Res.get("bisqEasy.tradeWizard.review.table.baseAmount.seller");
+        String baseAmountTitle = model.getDirection().isBuy()
+                ? Res.get("bisqEasy.tradeWizard.review.table.baseAmount.buyer")
+                : Res.get("bisqEasy.tradeWizard.review.table.baseAmount.seller");
         tableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
                 .title(baseAmountTitle)
                 .minWidth(160)
@@ -262,8 +260,6 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
 
     private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getReputationCellFactory() {
         return new Callback<>() {
-
-
             @Override
             public TableCell<ListItem, ListItem> call(TableColumn<ListItem, ListItem> column) {
                 return new TableCell<>() {
@@ -301,7 +297,6 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
 
     private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getSelectButtonCellFactory() {
         return column -> new TableCell<>() {
-
             private final Button button = new Button(Res.get("bisqEasy.tradeWizard.selectOffer.table.select"));
             private TableRow<ListItem> tableRow;
             private Subscription selectedItemPin;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
@@ -86,7 +86,7 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
         tableView.getStyleClass().add("bisq-easy-trade-wizard-select-offer");
         tableView.setMinWidth(TABLE_WIDTH);
         // fits 4 rows
-        tableView.setMaxHeight(262); // 4 * 55 (row height) + 40 (header height) + 2 (border)
+        tableView.setMaxHeight(260); // 4 * 55 (row height) + 40 (header height)
 
         VBox tableContainer = new VBox(tableView);
         tableContainer.getStyleClass().add("matching-offers-table-container");

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferView.java
@@ -85,14 +85,16 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
         tableView = new BisqTableView<>(model.getSortedList());
         tableView.getStyleClass().add("bisq-easy-trade-wizard-select-offer");
         tableView.setMinWidth(TABLE_WIDTH);
-        tableView.setMaxWidth(tableView.getMinWidth());
         // fits 4 rows
         tableView.setMaxHeight(262); // 4 * 55 (row height) + 40 (header height) + 2 (border)
+
+        VBox tableContainer = new VBox(tableView);
+        tableContainer.getStyleClass().add("matching-offers-table-container");
 
         noMatchingOffersBox = new HBox(25);
 
         VBox.setMargin(noMatchingOffersBox, new Insets(10, 0, 0, 0));
-        root.getChildren().addAll(Spacer.fillVBox(), headlineLabel, subtitleLabel, tableView, noMatchingOffersBox, Spacer.fillVBox());
+        root.getChildren().addAll(Spacer.fillVBox(), headlineLabel, subtitleLabel, tableContainer, noMatchingOffersBox, Spacer.fillVBox());
     }
 
     @Override
@@ -232,7 +234,7 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
 
                     {
                         userName.setId("chat-user-name");
-                        int size = 20;
+                        int size = 30;
                         catIcon.setFitWidth(size);
                         catIcon.setFitHeight(size);
                         StackPane catIconWithRing = ImageUtil.addRingToNode(catIcon, size, 1.5, "-bisq-dark-grey-50");
@@ -269,6 +271,7 @@ class TradeWizardSelectOfferView extends View<VBox, TradeWizardSelectOfferModel,
                     @Override
                     public void updateItem(final ListItem item, boolean empty) {
                         super.updateItem(item, empty);
+
                         if (item != null && !empty) {
                             getTableRow().setOnMouseClicked(e -> reputationScoreDisplay.useWhiteAcceptStar());
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -730,10 +730,13 @@
 
 .matching-offers-table-container {
     -fx-background-color: -bisq-dark-grey-20;
+    -fx-border-width: 0 0 5px 0;
+    -fx-border-color: -bisq-dark-grey-20;
 }
 
-.bisq-easy-trade-wizard-select-trade.table-view {
-    -fx-font-size: 1.15em;
+.bisq-easy-trade-wizard-select-offer.table-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
 }
 
 .bisq-easy-trade-wizard-select-offer.table-view .column-header {
@@ -750,6 +753,11 @@
 
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell {
     -fx-pref-height: 55px;
+    -fx-border-width: 0;
+}
+
+.bisq-easy-trade-wizard-select-offer.table-view .table-cell {
+    -fx-padding: 0;
 }
 
 /* the text property from list view need to set to apply the color to the button label */

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -744,6 +744,10 @@
     -fx-alignment: center;
 }
 
+.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:hover {
+    -fx-cursor: hand;
+}
+
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell {
     -fx-pref-height: 55px;
 }

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -725,8 +725,12 @@
 
 
 /*******************************************************************************
- * TradeWizardTakeOfferView.tableView                                                       *
+ * TradeWizardTakeOfferView.tableView                                          *
  ******************************************************************************/
+
+.matching-offers-table-container {
+    -fx-background-color: -bisq-dark-grey-20;
+}
 
 .bisq-easy-trade-wizard-select-trade.table-view {
     -fx-font-size: 1.15em;
@@ -736,42 +740,12 @@
     -fx-pref-height: 40px;
 }
 
+.bisq-easy-trade-wizard-select-offer.table-view .column-header .label {
+    -fx-alignment: center;
+}
+
 .bisq-easy-trade-wizard-select-offer.table-view .table-row-cell {
     -fx-pref-height: 55px;
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell .table-cell {
-    -fx-background-color: -bisq-dark-grey-40;
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:hover .table-cell {
-    -fx-background-color: -bisq-darker-grey;
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:selected .table-cell {
-    -fx-background-color: -bisq2-green;
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty {
-    -fx-border-color: derive(-bisq-dark-grey-40, -30%);
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty .table-cell {
-    -fx-background-color: derive(-bisq-dark-grey-40, -15%);
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:empty:hover .table-cell {
-    -fx-background-color: derive(-bisq-dark-grey-40, -15%);
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:selected .button.white-button .text {
-    -fx-fill: -bisq-black !important;
-    -fx-font-family: "IBM Plex Sans Medium" !important;
-}
-
-.bisq-easy-trade-wizard-select-offer.table-view .table-row-cell:hover .button.outlined-button .text {
-    -fx-fill: -bisq2-green;
-    -fx-font-family: "IBM Plex Sans Medium";
 }
 
 /* the text property from list view need to set to apply the color to the button label */


### PR DESCRIPTION
Resolves #1833

* Change matching offers table styles to match the standard style of tables used in the app.
* Add selection marker column.
* Remove unnecessary and confusing column used to select offer.
* Minor refactors.

![table-imp](https://github.com/bisq-network/bisq2/assets/145597137/08d6f541-46de-4cbf-a1d8-2d4d300b74a1)
