### PR TITLE
Add "Only favourites" filter and other improvements

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -149,7 +149,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 settingsService.setCookie(CookieKey.MARKETS_FILTER, model.getSelectedMarketsFilter().get().name());
                 updateFilteredMarketChannelItems();
             }
-            model.getShouldShowAppliedFilters().set(filter == Filters.Markets.WITH_OFFERS);
+            model.getShouldShowAppliedFilters().set(filter == Filters.Markets.WITH_OFFERS || filter == Filters.Markets.FAVOURITES);
         });
 
         marketPriceByCurrencyMapPin = marketPriceService.getMarketPriceByCurrencyMap().addObserver(() -> {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -149,6 +149,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                 settingsService.setCookie(CookieKey.MARKETS_FILTER, model.getSelectedMarketsFilter().get().name());
                 updateFilteredMarketChannelItems();
             }
+            model.getShouldShowAppliedFilters().set(filter == Filters.Markets.WITH_OFFERS);
         });
 
         marketPriceByCurrencyMapPin = marketPriceService.getMarketPriceByCurrencyMap().addObserver(() -> {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -320,7 +320,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
 
     private void updateFavouriteMarketChannelItems() {
         model.getFavouriteMarketChannelItems().setPredicate(item -> model.getFavouriteMarkets().contains(item.getMarket()));
-        double padding = 15;
+        double padding = 21;
         double tableViewHeight = (model.getFavouriteMarketChannelItems().size() * MARKET_SELECTION_LIST_CELL_HEIGHT) + padding;
         model.getFavouritesTableViewHeight().set(tableViewHeight);
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -38,7 +38,7 @@ import java.util.function.Predicate;
 public final class BisqEasyOfferbookModel extends ChatModel {
     private final BooleanProperty offerOnly = new SimpleBooleanProperty();
     private final BooleanProperty isTradeChannelVisible = new SimpleBooleanProperty();
-    private final BooleanProperty showFilterOverlay = new SimpleBooleanProperty(); // TODO: remove this
+    private final BooleanProperty shouldShowAppliedFilters = new SimpleBooleanProperty();
     private final ObservableList<MarketChannelItem> marketChannelItems = FXCollections.observableArrayList(p -> new Observable[]{p.getNumOffers()});
     private final FilteredList<MarketChannelItem> filteredMarketChannelItems = new FilteredList<>(marketChannelItems);
     private final SortedList<MarketChannelItem> sortedMarketChannelItems = new SortedList<>(filteredMarketChannelItems);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -57,7 +57,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     private VBox marketSelectionList;
     private Subscription marketsTableViewSelectionPin, selectedModelItemPin, channelHeaderIconPin, selectedMarketFilterPin,
             selectedOfferDirectionOrOwnerFilterPin, selectedPeerReputationFilterPin, selectedMarketSortTypePin,
-            marketSelectorSearchPin, favouritesTableViewHeightPin, favouritesTableViewSelectionPin;
+            marketSelectorSearchPin, favouritesTableViewHeightPin, favouritesTableViewSelectionPin,
+            shouldShowAppliedFiltersPin;
     private Button createOfferButton;
     private DropdownMenu sortAndFilterMarketsMenu, filterOffersByDirectionOrOwnerMenu, filterOffersByPeerReputationMenu;
     private DropdownSortByMenuItem sortByMostOffers, sortByNameAZ, sortByNameZA;
@@ -68,7 +69,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     private DropdownTitleMenuItem atLeastTitle;
     private CheckBox hideUserMessagesCheckbox;
     private Label channelHeaderIcon, marketPrice, removeWithOffersFilter;
-    private HBox withOffersDisplayHint;
+    private HBox appliedFiltersSection, withOffersDisplayHint;
     private ImageView defaultCloseIcon, activeCloseIcon;
 
     public BisqEasyOfferbookView(BisqEasyOfferbookModel model,
@@ -127,7 +128,6 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         favouritesTableView.managedProperty().bind(Bindings.isNotEmpty(getModel().getFavouriteMarketChannelItems()));
 
         selectedModelItemPin = EasyBind.subscribe(getModel().getSelectedMarketChannelItem(), this::updateTableViewSelection);
-
         marketsTableViewSelectionPin = EasyBind.subscribe(marketsTableView.getSelectionModel().selectedItemProperty(), item -> {
             if (item != null) {
                 getController().onSelectMarketChannelItem(item);
@@ -150,9 +150,10 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         selectedPeerReputationFilterPin = EasyBind.subscribe(getModel().getSelectedPeerReputationFilter(), filter ->
                 updateSelectedFilterInDropdownMenu(filter, filterOffersByPeerReputationMenu));
         selectedMarketSortTypePin = EasyBind.subscribe(getModel().getSelectedMarketSortType(), this::updateMarketSortType);
-
         favouritesTableViewHeightPin = EasyBind.subscribe(getModel().getFavouritesTableViewHeight(),
                 height -> updateFavouritesTableViewHeight(height.doubleValue()));
+        shouldShowAppliedFiltersPin = EasyBind.subscribe(getModel().getShouldShowAppliedFilters(),
+                this::updateAppliedFiltersSectionStyles);
 
         sortByMostOffers.setOnAction(e -> getController().onSortMarkets(MarketSortType.NUM_OFFERS));
         sortByNameAZ.setOnAction(e -> getController().onSortMarkets(MarketSortType.ASC));
@@ -223,6 +224,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         selectedPeerReputationFilterPin.unsubscribe();
         selectedMarketSortTypePin.unsubscribe();
         favouritesTableViewHeightPin.unsubscribe();
+        shouldShowAppliedFiltersPin.unsubscribe();
 
         sortByMostOffers.setOnAction(null);
         sortByNameAZ.setOnAction(null);
@@ -273,9 +275,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         subheader.getStyleClass().add("market-selection-subheader");
 
         setUpWithOffersFiltersDisplayHint();
-        HBox appliedFiltersSection = new HBox(withOffersDisplayHint);
+        appliedFiltersSection = new HBox(withOffersDisplayHint);
         appliedFiltersSection.setAlignment(Pos.CENTER_RIGHT);
-        appliedFiltersSection.getStyleClass().add("market-selection-applied-filters");
         HBox.setHgrow(appliedFiltersSection, Priority.ALWAYS);
 
         favouritesTableView = new BisqTableView<>(getModel().getFavouriteMarketChannelItems());
@@ -500,6 +501,13 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                         dropdownMenu.setLabel(menuItemLabel);
                     }
                 });
+    }
+
+    private void updateAppliedFiltersSectionStyles(boolean shouldShowAppliedFilters) {
+        appliedFiltersSection.getStyleClass().clear();
+        appliedFiltersSection.getStyleClass().add(shouldShowAppliedFilters
+                ? "market-selection-show-applied-filters"
+                : "market-selection-no-filters");
     }
 
     private String createPeerReputationLabel(Filters.PeerReputation filter, String label) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -326,6 +326,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         marketsTableView.allowVerticalScrollbar();
         marketsTableView.hideHorizontalScrollbar();
         marketsTableView.setFixedCellSize(getController().getMarketSelectionListCellHeight());
+        marketsTableView.setPlaceholder(new Label());
         configTableView(marketsTableView);
         VBox.setVgrow(marketsTableView, Priority.ALWAYS);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -62,15 +62,16 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     private Button createOfferButton;
     private DropdownMenu sortAndFilterMarketsMenu, filterOffersByDirectionOrOwnerMenu, filterOffersByPeerReputationMenu;
     private DropdownSortByMenuItem sortByMostOffers, sortByNameAZ, sortByNameZA;
-    private DropdownFilterMenuItem<MarketChannelItem> filterShowAll, filterWithOffers;
+    private DropdownFilterMenuItem<MarketChannelItem> filterShowAll, filterWithOffers, filterFavourites;
     private DropdownFilterMenuItem<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>
             allOffers, myOffers, buyOffers, sellOffers, allReputations, fiveStars, atLeastFourStars, atLeastThreeStars,
             atLeastTwoStars, atLeastOneStar;
     private DropdownTitleMenuItem atLeastTitle;
     private CheckBox hideUserMessagesCheckbox;
-    private Label channelHeaderIcon, marketPrice, removeWithOffersFilter;
-    private HBox appliedFiltersSection, withOffersDisplayHint;
-    private ImageView defaultCloseIcon, activeCloseIcon;
+    private Label channelHeaderIcon, marketPrice, removeWithOffersFilter, removeFavouritesFilter;
+    private HBox appliedFiltersSection, withOffersDisplayHint, onlyFavouritesDisplayHint;
+    private ImageView withOffersRemoveFilterDefaultIcon, withOffersRemoveFilterActiveIcon,
+            favouritesRemoveFilterDefaultIcon, favouritesRemoveFilterActiveIcon;
 
     public BisqEasyOfferbookView(BisqEasyOfferbookModel model,
                                  BisqEasyOfferbookController controller,
@@ -124,6 +125,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         marketPrice.textProperty().bind(getModel().getMarketPrice());
         withOffersDisplayHint.visibleProperty().bind(getModel().getSelectedMarketsFilter().isEqualTo(Filters.Markets.WITH_OFFERS));
         withOffersDisplayHint.managedProperty().bind(getModel().getSelectedMarketsFilter().isEqualTo(Filters.Markets.WITH_OFFERS));
+        onlyFavouritesDisplayHint.visibleProperty().bind(getModel().getSelectedMarketsFilter().isEqualTo(Filters.Markets.FAVOURITES));
+        onlyFavouritesDisplayHint.managedProperty().bind(getModel().getSelectedMarketsFilter().isEqualTo(Filters.Markets.FAVOURITES));
         favouritesTableView.visibleProperty().bind(Bindings.isNotEmpty(getModel().getFavouriteMarketChannelItems()));
         favouritesTableView.managedProperty().bind(Bindings.isNotEmpty(getModel().getFavouriteMarketChannelItems()));
 
@@ -161,6 +164,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
 
         filterWithOffers.setOnAction(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.WITH_OFFERS));
         filterShowAll.setOnAction(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.ALL));
+        filterFavourites.setOnAction(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.FAVOURITES));
 
         allOffers.setOnAction(e -> setOfferDirectionOrOwnerFilter(allOffers));
         myOffers.setOnAction(e -> setOfferDirectionOrOwnerFilter(myOffers));
@@ -177,8 +181,12 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         createOfferButton.setOnAction(e -> getController().onCreateOffer());
 
         removeWithOffersFilter.setOnMouseClicked(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.ALL));
-        withOffersDisplayHint.setOnMouseEntered(e -> removeWithOffersFilter.setGraphic(activeCloseIcon));
-        withOffersDisplayHint.setOnMouseExited(e -> removeWithOffersFilter.setGraphic(defaultCloseIcon));
+        withOffersDisplayHint.setOnMouseEntered(e -> removeWithOffersFilter.setGraphic(withOffersRemoveFilterActiveIcon));
+        withOffersDisplayHint.setOnMouseExited(e -> removeWithOffersFilter.setGraphic(withOffersRemoveFilterDefaultIcon));
+
+        removeFavouritesFilter.setOnMouseClicked(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.ALL));
+        onlyFavouritesDisplayHint.setOnMouseEntered(e -> removeFavouritesFilter.setGraphic(favouritesRemoveFilterActiveIcon));
+        onlyFavouritesDisplayHint.setOnMouseExited(e -> removeFavouritesFilter.setGraphic(favouritesRemoveFilterDefaultIcon));
     }
 
     private void updateTableViewSelection(MarketChannelItem selectedItem) {
@@ -211,6 +219,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         marketPrice.textProperty().unbind();
         withOffersDisplayHint.visibleProperty().unbind();
         withOffersDisplayHint.managedProperty().unbind();
+        onlyFavouritesDisplayHint.visibleProperty().unbind();
+        onlyFavouritesDisplayHint.managedProperty().unbind();
         favouritesTableView.visibleProperty().unbind();
         favouritesTableView.managedProperty().unbind();
 
@@ -231,6 +241,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         sortByNameZA.setOnAction(null);
         filterWithOffers.setOnAction(null);
         filterShowAll.setOnAction(null);
+        filterFavourites.setOnAction(null);
         allOffers.setOnAction(null);
         myOffers.setOnAction(null);
         buyOffers.setOnAction(null);
@@ -246,6 +257,10 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         removeWithOffersFilter.setOnMouseClicked(null);
         withOffersDisplayHint.setOnMouseEntered(null);
         withOffersDisplayHint.setOnMouseExited(null);
+
+        removeFavouritesFilter.setOnMouseClicked(null);
+        onlyFavouritesDisplayHint.setOnMouseEntered(null);
+        onlyFavouritesDisplayHint.setOnMouseExited(null);
 
         getModel().getFavouriteMarketChannelItems().removeListener(listChangeListener);
     }
@@ -274,8 +289,28 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         subheader.setAlignment(Pos.CENTER);
         subheader.getStyleClass().add("market-selection-subheader");
 
-        setUpWithOffersFiltersDisplayHint();
-        appliedFiltersSection = new HBox(withOffersDisplayHint);
+        // TODO: Introduce new icons with proper scale
+        withOffersRemoveFilterDefaultIcon = ImageUtil.getImageViewById("close");
+        withOffersRemoveFilterDefaultIcon.setScaleX(0.4);
+        withOffersRemoveFilterDefaultIcon.setScaleY(0.4);
+        withOffersRemoveFilterActiveIcon = ImageUtil.getImageViewById("close-white");
+        withOffersRemoveFilterActiveIcon.setScaleX(0.4);
+        withOffersRemoveFilterActiveIcon.setScaleY(0.4);
+        removeWithOffersFilter = createAndGetRemoveFilterLabel(withOffersRemoveFilterDefaultIcon);
+        withOffersDisplayHint = createAndGetDisplayHintHBox(
+                Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers"), removeWithOffersFilter);
+
+        favouritesRemoveFilterDefaultIcon = ImageUtil.getImageViewById("close");
+        favouritesRemoveFilterDefaultIcon.setScaleX(0.4);
+        favouritesRemoveFilterDefaultIcon.setScaleY(0.4);
+        favouritesRemoveFilterActiveIcon = ImageUtil.getImageViewById("close-white");
+        favouritesRemoveFilterActiveIcon.setScaleX(0.4);
+        favouritesRemoveFilterActiveIcon.setScaleY(0.4);
+        removeFavouritesFilter = createAndGetRemoveFilterLabel(favouritesRemoveFilterDefaultIcon);
+        onlyFavouritesDisplayHint = createAndGetDisplayHintHBox(
+                Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.favourites"), removeFavouritesFilter);
+
+        appliedFiltersSection = new HBox(withOffersDisplayHint, onlyFavouritesDisplayHint);
         appliedFiltersSection.setAlignment(Pos.CENTER_RIGHT);
         HBox.setHgrow(appliedFiltersSection, Priority.ALWAYS);
 
@@ -302,21 +337,20 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         marketSelectionList.getStyleClass().add("chat-container");
     }
 
-    private void setUpWithOffersFiltersDisplayHint() {
-        Label withOffersLabel = new Label(Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers"));
-        withOffersLabel.getStyleClass().add("small-text");
-        removeWithOffersFilter = new Label();
-        defaultCloseIcon = ImageUtil.getImageViewById("close");
-        defaultCloseIcon.setScaleX(0.4);
-        defaultCloseIcon.setScaleY(0.4);
-        activeCloseIcon = ImageUtil.getImageViewById("close-white");
-        activeCloseIcon.setScaleX(0.4);
-        activeCloseIcon.setScaleY(0.4);
-        removeWithOffersFilter.setGraphic(defaultCloseIcon);
-        removeWithOffersFilter.setCursor(Cursor.HAND);
-        withOffersDisplayHint = new HBox(withOffersLabel, removeWithOffersFilter);
-        withOffersDisplayHint.setAlignment(Pos.CENTER);
-        withOffersDisplayHint.getStyleClass().add("filter-display-hint");
+    private Label createAndGetRemoveFilterLabel(ImageView defaultCloseIcon) {
+        Label removeFilterLabel = new Label();
+        removeFilterLabel.setGraphic(defaultCloseIcon);
+        removeFilterLabel.setCursor(Cursor.HAND);
+        return removeFilterLabel;
+    }
+
+    private HBox createAndGetDisplayHintHBox(String labelText, Label removeFilter) {
+        Label label = new Label(labelText);
+        label.getStyleClass().add("small-text");
+        HBox displayHintHBox = new HBox(label, removeFilter);
+        displayHintHBox.setAlignment(Pos.CENTER);
+        displayHintHBox.getStyleClass().add("filter-display-hint");
+        return displayHintHBox;
     }
 
     private DropdownMenu createAndGetSortAndFilterMarketsMenu() {
@@ -345,11 +379,13 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.filterTitle"));
         filterWithOffers = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers"), Filters.Markets.WITH_OFFERS);
+        filterFavourites = new DropdownFilterMenuItem<>("check-white", "check-white",
+                Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.favourites"), Filters.Markets.FAVOURITES);
         filterShowAll = new DropdownFilterMenuItem<>("check-white", "check-white",
                 Res.get("bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all"), Filters.Markets.ALL);
 
         dropdownMenu.addMenuItems(sortTitle, sortByMostOffers, sortByNameAZ, sortByNameZA, separator, filterTitle,
-                filterWithOffers, filterShowAll);
+                filterWithOffers, filterFavourites, filterShowAll);
         return dropdownMenu;
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -188,7 +188,9 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     }
 
     private void updateFavouritesTableViewHeight(double height) {
+        favouritesTableView.setMinHeight(height);
         favouritesTableView.setPrefHeight(height);
+        favouritesTableView.setMaxHeight(height);
     }
 
     private void setOfferDirectionOrOwnerFilter(DropdownFilterMenuItem<?> filterMenuItem) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -506,6 +506,9 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
                 .filter(menuItem -> menuItem instanceof DropdownFilterMenuItem)
                 .map(menuItem -> (DropdownFilterMenuItem<?>) menuItem)
                 .forEach(menuItem -> menuItem.updateSelection(marketFilter == menuItem.getFilter()));
+
+        favouritesTableView.getSelectionModel().select(getModel().getSelectedMarketChannelItem().get());
+        marketsTableView.getSelectionModel().select(getModel().getSelectedMarketChannelItem().get());
     }
 
     private void updateMarketSortType(MarketSortType marketSortType) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
@@ -170,6 +170,7 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
         tableView = new BisqTableView<>(getModel().getSortedList());
         tableView.getStyleClass().add("private-chats-selection-list");
         tableView.allowVerticalScrollbar();
+        tableView.hideHorizontalScrollbar();
         configTableView();
         VBox.setVgrow(tableView, Priority.ALWAYS);
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -217,12 +217,18 @@
     -fx-text-fill: -fx-light-text-color;
 }
 
-.market-selection-applied-filters {
+.market-selection-no-filters {
+    -fx-padding: 10 0 0 0;
+}
+
+.market-selection-show-applied-filters {
+    -fx-min-height: 35;
     -fx-pref-height: 35;
+    -fx-max-height: 35;
     -fx-padding: 5;
 }
 
-.market-selection-applied-filters .filter-display-hint {
+.market-selection-show-applied-filters .filter-display-hint {
     -fx-background-color: transparent;
     -fx-border-color: -bisq-mid-grey-20;
     -fx-border-width: 1;
@@ -233,15 +239,15 @@
     -fx-padding: 0 0 0 5;
 }
 
-.market-selection-applied-filters .filter-display-hint:hover {
+.market-selection-show-applied-filters .filter-display-hint:hover {
     -fx-border-color: -bisq-white;
 }
 
-.market-selection-applied-filters .filter-display-hint:hover .label {
+.market-selection-show-applied-filters .filter-display-hint:hover .label {
     -fx-text-fill: -bisq-white;
 }
 
-.market-selection-applied-filters .filter-display-hint .label {
+.market-selection-show-applied-filters .filter-display-hint .label {
     -fx-text-fill: -fx-mid-text-color;
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -285,6 +285,7 @@
 .favourites-list {
     -fx-padding: 0 0 10 0;
     -fx-border-width: 0 0 1 0;
+    -fx-border-insets: 0 0 10 0;
     -fx-border-color: -bisq-dark-grey-50;
 }
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -395,7 +395,7 @@ bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.nameAZ=Name A-Z
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.nameZA=Name Z-A
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.filterTitle=Show markets:
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.withOffers=With offers
-bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.favourites=Favourites
+bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.favourites=Only favourites
 bisqEasy.offerbook.dropdownMenu.sortAndFilterMarkets.all=All
 
 bisqEasy.offerbook.dropdownMenu.filterOffersByDirectionOrOwner.tooltip=Filter by offer type


### PR DESCRIPTION
* Add "Only favourites" filter.
* Set height correctly for favourite markets and improve paddings.
* Show selected market after applying a new filter to market channel items list.
* Hide horizontal scrollbar in private chats list.

![image](https://github.com/bisq-network/bisq2/assets/145597137/22b3badd-3a3d-43b9-8657-81a5a12e6e5c)
