### PR TITLE
Open browser with link to video if embedded video cannot be played

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -29,6 +29,7 @@ import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.components.containers.BisqGridPane;
 import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.BusyAnimation;
 import bisq.i18n.Res;
 import bisq.settings.DontShowAgainService;
@@ -109,7 +110,9 @@ public abstract class Overlay<T extends Overlay<T>> {
     public enum Type {
         UNDEFINED(AnimationType.ScaleFromCenter),
 
-        NOTIFICATION(AnimationType.SlideFromRightTop),
+        // NOTIFICATION(AnimationType.SlideFromRightTop),
+        // TODO https://github.com/bisq-network/bisq2/issues/1883
+        NOTIFICATION(AnimationType.SlideDownFromCenterTop, Transitions.Type.LIGHT_BLUR_LIGHT),
 
         BACKGROUND_INFO(AnimationType.SlideDownFromCenterTop),
         FEEDBACK(AnimationType.SlideDownFromCenterTop),
@@ -323,6 +326,12 @@ public abstract class Overlay<T extends Overlay<T>> {
         type = Type.BACKGROUND_INFO;
         if (headline == null)
             this.headline = Res.get("popup.headline.backgroundInfo");
+        processMessage(message);
+        return cast();
+    }
+
+    public T notify(String message) {
+        type = Type.NOTIFICATION;
         processMessage(message);
         return cast();
     }
@@ -798,12 +807,15 @@ public abstract class Overlay<T extends Overlay<T>> {
             headlineIcon.setVisible(true);
             headlineLabel.getStyleClass().add("overlay-headline");
             switch (type) {
+                case NOTIFICATION:
+                    headlineIcon.setManaged(false);
+                    headlineIcon.setVisible(false);
+                    break;
                 case INFORMATION:
                 case BACKGROUND_INFO:
                 case INSTRUCTION:
                 case CONFIRMATION:
                 case FEEDBACK:
-                case NOTIFICATION:
                 case ATTENTION:
                     Icons.getIconForLabel(AwesomeIcon.INFO_SIGN, headlineIcon, "1.8em");
                     headlineLabel.getStyleClass().add("overlay-headline-information");
@@ -899,6 +911,10 @@ public abstract class Overlay<T extends Overlay<T>> {
                 Hyperlink link = new Hyperlink(messageHyperlinks.get(i));
                 link.getStyleClass().add("overlay-message");
                 link.setOnAction(event -> Browser.open(link.getText()));
+                String tooltipText = Browser.hyperLinksGetCopiesWithoutPopup()
+                        ? Res.get("popup.hyperlink.copy.tooltip", link.getText())
+                        : Res.get("popup.hyperlink.openInBrowser.tooltip", link.getText());
+                link.setTooltip(new BisqTooltip(tooltipText));
                 HBox hBox = new HBox(5, enumeration, link);
                 hBox.setAlignment(Pos.CENTER_LEFT);
                 footerBox.getChildren().addAll(hBox);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/onboarding/video/BisqEasyVideoController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/onboarding/video/BisqEasyVideoController.java
@@ -18,8 +18,12 @@
 package bisq.desktop.main.content.bisq_easy.onboarding.video;
 
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.Browser;
+import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
+import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.overlay.OverlayController;
+import bisq.i18n.Res;
 import bisq.settings.CookieKey;
 import bisq.settings.SettingsService;
 import lombok.Getter;
@@ -52,5 +56,24 @@ public class BisqEasyVideoController implements Controller {
 
     void onCompleted() {
         settingsService.setCookie(CookieKey.BISQ_EASY_VIDEO_OPENED, true);
+    }
+
+    public void onHandleVideoPlayerError(Exception e) {
+        UIThread.runOnNextRenderFrame(this::onClose);
+
+        // If OS does not support mp4 we get an exception
+        log.warn("mp4 not supported", e);
+
+        String videoUrl = "https://bisq.network/bisq-easy";
+        if (Browser.hyperLinksGetCopiesWithoutPopup()) {
+            // User has set don't show again flag for popup and set to not open browser.
+            // We would only copy the link but user might be confused that nothing visually happened,
+            // so we show a popup.
+            new Popup().headline(Res.get("video.mp4NotSupported.warning.headline"))
+                    .warning(Res.get("video.mp4NotSupported.warning", videoUrl))
+                    .show();
+        } else {
+            Browser.open(videoUrl);
+        }
     }
 }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -119,7 +119,7 @@ public class StringUtils {
         while (matcher.find()) {
             String link = matcher.group(1);
             hyperlinks.add(link);
-            message = message.replaceFirst(pattern.toString(), String.format("%s [%d]", link, hyperlinks.size()));
+            message = message.replaceFirst(pattern.toString(), String.format("'%s' [%d]", link, hyperlinks.size()));
         }
         return message;
     }

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -236,19 +236,21 @@ popup.startup.error=An error occurred at initializing Bisq: {0}.
 popup.shutdown=Shut down is in process.\n\n\
   It might take up to {0} seconds until shut down is completed.
 popup.shutdown.error=An error occurred at shut down: {0}.
+popup.hyperlink.openInBrowser.tooltip=Open link in browser: {0}.
+popup.hyperlink.copy.tooltip=Copy link: {0}.
 
 
 ####################################################################
 # Messages
 ####################################################################
-
+hyperlinks.openInBrowser.attention.headline=Open web link
 hyperlinks.openInBrowser.attention=Do you want to open the link to `{0}` in your default web browser?
 hyperlinks.openInBrowser.no=No, copy link
+hyperlinks.copiedToClipboard=Link was copied to clipboard
 
 ####################################################################
 # Video
 ####################################################################
-
-video.mp4NotSupported.warning=Your operating system does not support mp4 video format.\n\n\
-  Reported error: {0}
+video.mp4NotSupported.warning.headline=Embedded video cannot be played
+video.mp4NotSupported.warning=You can watch the video in your browser at: [HYPERLINK:{0}]
 


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq2/issues/1874

If video cannot be played we open the link to https://bisq.network/bisq-easy or if the user has previously decided to not open links in the browser we show a popup.

Improve handling of hyperlinks:
- Add tooltip
- Wrap links in '

Improve Browser.open calls:
- Show notification popup to give feedback that link got copied, if user has previously decided to not open links in the browser we show a popup.