### PR TITLE
Only send system notification for real time messages

### DIFF
--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -243,7 +243,7 @@ public class DesktopApplicationService extends ApplicationService {
                 .thenCompose(result -> settingsService.initialize())
                 .thenCompose(result -> offerService.initialize())
                 .thenCompose(result -> chatService.initialize())
-                .thenCompose(result -> sendNotificationService.initialize()) // We initialize after chatService to avoid flooding the notification center
+                .thenCompose(result -> sendNotificationService.initialize())
                 .thenCompose(result -> supportService.initialize())
                 .thenCompose(result -> tradeService.initialize())
                 .thenCompose(result -> updaterService.initialize())

--- a/chat/src/main/java/bisq/chat/ChatService.java
+++ b/chat/src/main/java/bisq/chat/ChatService.java
@@ -84,7 +84,7 @@ public class ChatService implements Service {
                 userIdentityService,
                 userProfileService);
 
-        //BISQ_EASY
+        // BISQ_EASY
         bisqEasyOfferbookChannelService = new BisqEasyOfferbookChannelService(persistenceService,
                 networkService,
                 userService);

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
@@ -48,6 +48,7 @@ public abstract class DataStorageService<T extends DataRequest> extends RateLimi
 
     public DataStorageService(PersistenceService persistenceService, String storeName, String storeKey) {
         super();
+
         this.storeKey = storeKey;
         String storageFileName = StringUtils.camelCaseToSnakeCase(storeKey + STORE_POST_FIX);
         subDirectory = DbSubDirectory.NETWORK_DB.getDbPath() + File.separator + storeName;
@@ -58,11 +59,6 @@ public abstract class DataStorageService<T extends DataRequest> extends RateLimi
     }
 
     public void shutdown() {
-    }
-
-    @Override
-    protected long getMaxWriteRateInMs() {
-        return 1000;
     }
 
     @Override


### PR DESCRIPTION
While online, for each message we (1) show the badge and (2) send
a system notification. The latter should be avoided when a message was
received before the user went offline. This prevents a flood of system
notifications at start-up.

Resolves #1546