### PR TITLE
Fix alignment issue in create offer wizard

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/direction/TradeWizardDirectionView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/direction/TradeWizardDirectionView.java
@@ -73,7 +73,7 @@ public class TradeWizardDirectionView extends View<StackPane, TradeWizardDirecti
         sellButton = sellPair.getSecond();
 
         HBox directionBox = new HBox(25, buyBox, sellBox);
-        directionBox.setAlignment(Pos.CENTER);
+        directionBox.setAlignment(Pos.BASELINE_CENTER);
 
         VBox.setMargin(headlineLabel, new Insets(-20, 0, 0, 0));
         VBox.setMargin(directionBox, new Insets(10, 0, 0, 0));


### PR DESCRIPTION
Fix alignment of direction box to work well when using a different language other than English.

Before:
![image](https://github.com/bisq-network/bisq2/assets/145597137/25fad9da-68fd-41b7-93df-d71f0b71a293)

After:
![image](https://github.com/bisq-network/bisq2/assets/145597137/e54a853f-53db-4d48-8059-540cfc66f048)
