### PR TITLE
List offers

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/BisqTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/BisqTableView.java
@@ -66,6 +66,10 @@ public class BisqTableView<T> extends TableView<T> {
         setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
     }
 
+    public void bindSort() {
+        ((SortedList<T>) getItems()).comparatorProperty().bind(comparatorProperty());
+    }
+
     public void setPlaceholderText(String placeHolderText) {
         setPlaceholder(new Label(placeHolderText));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -71,6 +71,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     public BisqEasyOfferbookController(ServiceProvider serviceProvider) {
         super(serviceProvider, ChatChannelDomain.BISQ_EASY_OFFERBOOK, NavigationTarget.BISQ_EASY_OFFERBOOK);
 
+        chatMessageContainerController.setListable(true);
         bisqEasyOfferbookChannelService = chatService.getBisqEasyOfferbookChannelService();
         settingsService = serviceProvider.getSettingsService();
         marketPriceService = serviceProvider.getBondedRolesService().getMarketPriceService();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -64,7 +64,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     private final BisqEasyOfferbookModel bisqEasyOfferbookModel;
     private final SetChangeListener<Market> favouriteMarketsListener;
     private Pin offerOnlySettingsPin, bisqEasyPrivateTradeChatChannelsPin, selectedChannelPin,
-            marketPriceByCurrencyMapPin, favouriteMarketsPin;
+            marketPriceByCurrencyMapPin, favouriteMarketsPin, listOffersSettingsPin;
     private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOfferDirectionOrOwnerFilterPin,
             selectedPeerReputationFilterPin, selectedMarketSortTypePin;
 
@@ -117,6 +117,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         model.getMarketSelectorSearchText().set("");
 
         offerOnlySettingsPin = FxBindings.bindBiDir(model.getOfferOnly()).to(settingsService.getOffersOnly());
+        listOffersSettingsPin = FxBindings.bindBiDir(model.getListOffers()).to(settingsService.getListOffers());
 
         ObservableArray<BisqEasyOpenTradeChannel> bisqEasyOpenTradeChannels = chatService.getBisqEasyOpenTradeChannelService().getChannels();
         bisqEasyPrivateTradeChatChannelsPin = bisqEasyOpenTradeChannels.addObserver(() ->
@@ -228,6 +229,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         super.onDeactivate();
 
         offerOnlySettingsPin.unbind();
+        listOffersSettingsPin.unbind();
         bisqEasyPrivateTradeChatChannelsPin.unbind();
         selectedChannelPin.unbind();
         marketSelectorSearchPin.unsubscribe();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -37,6 +37,7 @@ import java.util.function.Predicate;
 @Getter
 public final class BisqEasyOfferbookModel extends ChatModel {
     private final BooleanProperty offerOnly = new SimpleBooleanProperty();
+    private final BooleanProperty listOffers = new SimpleBooleanProperty();
     private final BooleanProperty isTradeChannelVisible = new SimpleBooleanProperty();
     private final BooleanProperty shouldShowAppliedFilters = new SimpleBooleanProperty();
     private final ObservableList<MarketChannelItem> marketChannelItems = FXCollections.observableArrayList(p -> new Observable[]{p.getNumOffers()});

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -70,7 +70,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
             allOffers, myOffers, buyOffers, sellOffers, allReputations, fiveStars, atLeastFourStars, atLeastThreeStars,
             atLeastTwoStars, atLeastOneStar;
     private DropdownTitleMenuItem atLeastTitle;
-    private CheckBox hideUserMessagesCheckbox;
+    private CheckBox hideUserMessagesCheckbox, listOffersCheckBox;
     private Label channelHeaderIcon, marketPrice, removeWithOffersFilter, removeFavouritesFilter;
     private HBox appliedFiltersSection, withOffersDisplayHint, onlyFavouritesDisplayHint;
     private ImageView withOffersRemoveFilterDefaultIcon, withOffersRemoveFilterActiveIcon,
@@ -124,6 +124,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         super.onViewAttached();
 
         hideUserMessagesCheckbox.selectedProperty().bindBidirectional(getModel().getOfferOnly());
+        listOffersCheckBox.selectedProperty().bindBidirectional(getModel().getListOffers());
         marketSelectorSearchBox.textProperty().bindBidirectional(getModel().getMarketSelectorSearchText());
         marketPrice.textProperty().bind(getModel().getMarketPrice());
         withOffersDisplayHint.visibleProperty().bind(getModel().getSelectedMarketsFilter().isEqualTo(Filters.Markets.WITH_OFFERS));
@@ -218,6 +219,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         super.onViewDetached();
 
         hideUserMessagesCheckbox.selectedProperty().unbindBidirectional(getModel().getOfferOnly());
+        listOffersCheckBox.selectedProperty().unbindBidirectional(getModel().getListOffers());
         marketSelectorSearchBox.textProperty().unbindBidirectional(getModel().getMarketSelectorSearchText());
         marketPrice.textProperty().unbind();
         withOffersDisplayHint.visibleProperty().unbind();
@@ -418,11 +420,17 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         checkbox.getStyleClass().add("offerbook-subheader-checkbox");
         checkbox.setAlignment(Pos.CENTER);
 
+        Label listOffersLabel = new Label(Res.get("bisqEasy.topPane.filter.listOffers"));
+        listOffersCheckBox = new CheckBox();
+        HBox listOffersHBox = new HBox(5, listOffersLabel, listOffersCheckBox);
+        listOffersHBox.getStyleClass().add("offerbook-subheader-checkbox");
+        listOffersHBox.setAlignment(Pos.CENTER);
+
         filterOffersByPeerReputationMenu = createAndGetPeerReputationFilterMenu();
         filterOffersByDirectionOrOwnerMenu = createAndGetOfferDirectionOrOwnerFilterMenu();
 
         searchBox.getStyleClass().add("offerbook-search-box");
-        HBox subheaderContent = new HBox(30, searchBox, Spacer.fillHBox(), checkbox,
+        HBox subheaderContent = new HBox(30, searchBox, Spacer.fillHBox(), listOffersHBox, checkbox,
                 filterOffersByPeerReputationMenu, filterOffersByDirectionOrOwnerMenu);
         subheaderContent.getStyleClass().add("offerbook-subheader-content");
         HBox.setHgrow(subheaderContent, Priority.ALWAYS);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -115,6 +115,9 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
         chatMessagesListController.setBisqEasyPeerReputationFilterPredicate(predicate);
     }
 
+    public void setListable(boolean isListable) {
+        chatMessagesListController.setListable(isListable);
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     // Controller

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -262,6 +262,9 @@ public class ChatMessagesListController implements bisq.desktop.common.view.Cont
         applyPredicate();
     }
 
+    public void setListable(boolean isListable) {
+        model.getListable().set(isListable);
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     // UI - delegate to client

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -87,7 +87,7 @@ public class ChatMessagesListController implements bisq.desktop.common.view.Cont
     private final Optional<ResendMessageService> resendMessageService;
     private final BisqEasyService bisqEasyService;
     private final MarketPriceService marketPriceService;
-    private Pin selectedChannelPin, chatMessagesPin, offerOnlySettingsPin;
+    private Pin selectedChannelPin, chatMessagesPin, offerOnlySettingsPin, listOffersPin;
     private Subscription selectedChannelSubscription, focusSubscription, scrollValuePin, scrollBarVisiblePin,
             layoutChildrenDonePin;
 
@@ -121,6 +121,7 @@ public class ChatMessagesListController implements bisq.desktop.common.view.Cont
         model.getSortedChatMessages().setComparator(ChatMessageListItem::compareTo);
 
         offerOnlySettingsPin = FxBindings.subscribe(settingsService.getOffersOnly(), offerOnly -> UIThread.run(this::applyPredicate));
+        listOffersPin = FxBindings.subscribe(settingsService.getListOffers(), listOffers -> model.getListOffers().set(listOffers));
 
         if (selectedChannelPin != null) {
             selectedChannelPin.unbind();
@@ -167,6 +168,9 @@ public class ChatMessagesListController implements bisq.desktop.common.view.Cont
         }
         if (selectedChannelSubscription != null) {
             selectedChannelSubscription.unsubscribe();
+        }
+        if (listOffersPin != null) {
+            listOffersPin.unbind();
         }
 
         layoutChildrenDonePin.unsubscribe();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListModel.java
@@ -44,6 +44,7 @@ public class ChatMessagesListModel implements bisq.desktop.common.view.Model {
     private final BooleanProperty showScrolledDownButton = new SimpleBooleanProperty();
     private final BooleanProperty scrollBarVisible = new SimpleBooleanProperty();
     private final DoubleProperty scrollValue = new SimpleDoubleProperty();
+    private final BooleanProperty listOffers = new SimpleBooleanProperty();
 
     public ChatMessagesListModel(UserIdentityService userIdentityService,
                                  ChatChannelDomain chatChannelDomain) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListModel.java
@@ -44,6 +44,7 @@ public class ChatMessagesListModel implements bisq.desktop.common.view.Model {
     private final BooleanProperty showScrolledDownButton = new SimpleBooleanProperty();
     private final BooleanProperty scrollBarVisible = new SimpleBooleanProperty();
     private final DoubleProperty scrollValue = new SimpleDoubleProperty();
+    private final BooleanProperty listable = new SimpleBooleanProperty(false);
     private final BooleanProperty listOffers = new SimpleBooleanProperty();
 
     public ChatMessagesListModel(UserIdentityService userIdentityService,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListView.java
@@ -98,7 +98,7 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
         StackPane.setAlignment(scrollDownBackground, Pos.BOTTOM_CENTER);
         StackPane.setMargin(scrollDownBackground, new Insets(0, 15, 0, 0));
         root.setAlignment(Pos.CENTER);
-        setMessageView(model.getListOffers().get());
+        setMessageView(model.getListOffers().get() && model.getListable().get());
     }
 
     private void setMessageView(boolean listOffers) {
@@ -168,7 +168,7 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
             placeholderTitle.setText("");
             placeholderDescription.setText("");
         }
-        listOffersPin = EasyBind.subscribe(model.getListOffers(), this::setMessageView);
+        listOffersPin = EasyBind.subscribe(model.getListOffers(), listOffers -> setMessageView(listOffers && model.getListable().get()));
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatOfferTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatOfferTable.java
@@ -1,0 +1,313 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list;
+
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatMessage;
+import bisq.chat.bisqeasy.BisqEasyOfferMessage;
+import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.monetary.Monetary;
+import bisq.desktop.components.table.BisqTableColumn;
+import bisq.desktop.components.table.BisqTableView;
+import bisq.desktop.main.content.components.ReputationScoreDisplay;
+import bisq.desktop.main.content.components.UserProfileIcon;
+import bisq.i18n.Res;
+import bisq.offer.amount.spec.FixedAmountSpec;
+import bisq.offer.amount.spec.RangeAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.offer.price.spec.FloatPriceSpec;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.offer.price.spec.PriceSpec;
+import bisq.presentation.formatters.AmountFormatter;
+import bisq.presentation.formatters.PercentageFormatter;
+import bisq.presentation.formatters.PriceFormatter;
+import javafx.collections.transformation.FilteredList;
+import javafx.css.PseudoClass;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.util.Callback;
+import lombok.Getter;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+public final class ChatOfferTable {
+    private static final PseudoClass OWN_OFFER_PSEUDO_CLASS = PseudoClass.getPseudoClass("own-offer");
+
+    private final ChatMessagesListController controller;
+    @Getter
+    BisqTableView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> tableView;
+
+    public ChatOfferTable(ChatMessagesListController controller, ChatMessagesListModel model) {
+        this.controller = controller;
+        FilteredList<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> chatOffers = new FilteredList<>(model.getFilteredChatMessages());
+        chatOffers.setPredicate(ChatMessageListItem::hasTradeChatOffer);
+        this.tableView = new BisqTableView<>(chatOffers);
+        tableView.bindSort();
+        configTableView();
+    }
+
+
+    private void configTableView() {
+        VBox.setVgrow(tableView, Priority.ALWAYS);
+        tableView.getStyleClass().add("bisq-easy-offer-book-table-view");
+
+        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+                .title(Res.get("chat.offerTable.userProfile"))
+                .isSortable(false)
+                .left()
+                .minWidth(150)
+                .setCellFactory(getUserProfileCellFactory())
+                .build());
+
+        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+                .title(Res.get("chat.offerTable.reputation"))
+                .isSortable(true)
+                .left()
+                .minWidth(100)
+                .comparator(Comparator.comparing(ChatMessageListItem::getReputationScore))
+                .setCellFactory(getReputationCellFactory())
+                .build());
+
+        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+                .title(Res.get("chat.offerTable.intention"))
+                .isSortable(true)
+                .left()
+                .minWidth(50)
+                .comparator(Comparator.comparing(m -> getOffer(m).map(o -> o.getDirection().getDisplayString()).orElse("")))
+                .valueSupplier(m -> getOffer(m).map(o -> o.getDirection().getDisplayString().toUpperCase()).orElse(""))
+                .build());
+
+//        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+//                .title(Res.get("chat.offer.table.method"))
+//                .isSortable(false)
+//                .left()
+//                .minWidth(100)
+//                .comparator(Comparator.comparing(m -> getOffer(m).map(o -> o.getBaseSidePaymentMethodSpecs().toString()).orElse("")))
+//                .valueSupplier(m -> getOffer(m).map(o -> o.getBaseSidePaymentMethodSpecs().stream()
+//                        .map(spec -> spec.getPaymentMethod().getDisplayString())
+//                        .collect(Collectors.joining(", "))).orElse(""))
+//                .build());
+
+        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+                .title(Res.get("chat.offerTable.fiatAmount"))
+                .isSortable(true)
+                .left()
+                .minWidth(200)
+                .comparator(Comparator.comparing(m -> getOffer(m).map(this::getAmount).orElse("")))
+                .valueSupplier(m -> getOffer(m).map(this::getAmount).orElse(""))
+                .build());
+
+        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+                .title(Res.get("chat.offerTable.price"))
+                .isSortable(true)
+                .right()
+                .minWidth(100)
+                .comparator(new PriceComparator())
+                .valueSupplier(m -> getOffer(m).map(this::getPriceString).orElse(""))
+                .build());
+
+        tableView.getColumns().add(new BisqTableColumn.Builder<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>()
+                .title(Res.get("chat.offerTable.takeOffer"))
+                .isSortable(false)
+                .right()
+                .minWidth(200)
+                .setCellFactory(getTakeOfferCellFactory())
+                .build());
+    }
+
+    private static Optional<BisqEasyOffer> getOffer(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> messageListItem) {
+        return messageListItem.hasTradeChatOffer() ? ((BisqEasyOfferMessage) messageListItem.getChatMessage()).getBisqEasyOffer() : Optional.empty();
+    }
+
+    private String getAmount(BisqEasyOffer offer) {
+        if (offer.hasAmountRange()) {
+            RangeAmountSpec rangedSpec = (RangeAmountSpec) offer.getAmountSpec();
+            String minAmount = AmountFormatter.formatAmount(Monetary.from(rangedSpec.getMinAmount(), offer.getMarket().getQuoteCurrencyCode()), true);
+            String maxAmount = AmountFormatter.formatAmount(Monetary.from(rangedSpec.getMaxAmount(), offer.getMarket().getQuoteCurrencyCode()), true);
+            return minAmount + " - " + maxAmount;
+        }
+
+        FixedAmountSpec fixSpec = (FixedAmountSpec) offer.getAmountSpec();
+        return AmountFormatter.formatAmount(Monetary.from(fixSpec.getAmount(), offer.getMarket().getQuoteCurrencyCode()), true);
+    }
+
+    private static class PriceComparator implements Comparator<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> {
+        @Override
+        public int compare(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> msg1,
+                           ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> msg2) {
+            Optional<BisqEasyOffer> offer1 = getOffer(msg1);
+            Optional<BisqEasyOffer> offer2 = getOffer(msg2);
+            if (offer1.isEmpty() || offer2.isEmpty()) {
+                return 0;
+            }
+
+            if (offer1.get().getDirection().isBuy()) {
+                return -1;
+            }
+
+            if (offer2.get().getDirection().isBuy()) {
+                return 1;
+            }
+
+            PriceSpec spec1 = offer1.get().getPriceSpec();
+            PriceSpec spec2 = offer2.get().getPriceSpec();
+            if (spec1 instanceof FixPriceSpec) {
+                if (spec2 instanceof FixPriceSpec) {
+                    return ((FixPriceSpec) spec1).getPriceQuote().compareTo(((FixPriceSpec) spec2).getPriceQuote());
+                }
+                return 1;
+            } else if (spec1 instanceof FloatPriceSpec) {
+                if (spec2 instanceof FixPriceSpec) {
+                    return -1;
+                } else if (spec2 instanceof FloatPriceSpec) {
+                    return Double.compare(((FloatPriceSpec) spec1).getPercentage(), ((FloatPriceSpec) spec2).getPercentage());
+                } else if (spec2 instanceof MarketPriceSpec) {
+                    return Double.compare(((FloatPriceSpec) spec1).getPercentage(), 0d);
+                }
+                return 1;
+            } else if (spec1 instanceof MarketPriceSpec) {
+                if (spec2 instanceof FixPriceSpec) {
+                    return -1;
+                } else if (spec2 instanceof FloatPriceSpec) {
+                    return Double.compare(0d, ((FloatPriceSpec) spec2).getPercentage());
+                } else if (spec2 instanceof MarketPriceSpec) {
+                    return 0;
+                }
+                return -1;
+            }
+            return 0;
+        }
+    }
+
+    private String getPriceString(BisqEasyOffer offer) {
+        if (offer.getDirection().isBuy()) {
+            return "";
+        }
+        if (offer.getPriceSpec() instanceof FixPriceSpec) {
+            FixPriceSpec fixPriceSpec = (FixPriceSpec) offer.getPriceSpec();
+            return PriceFormatter.formatWithCode(fixPriceSpec.getPriceQuote());
+        } else if (offer.getPriceSpec() instanceof FloatPriceSpec) {
+            FloatPriceSpec floatPriceSpec = (FloatPriceSpec) offer.getPriceSpec();
+            return PercentageFormatter.formatToPercentWithSymbol(floatPriceSpec.getPercentage());
+        } else {
+            return PercentageFormatter.formatToPercentWithSymbol(0d);
+        }
+    }
+
+    private Callback<TableColumn<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>,
+            ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>,
+            TableCell<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>,
+                    ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>> getUserProfileCellFactory() {
+        return column -> new TableCell<>() {
+            private final Label userName = new Label();
+            private final UserProfileIcon userProfileIcon = new UserProfileIcon(30);
+            private final HBox hBox = new HBox(10, userProfileIcon, userName);
+
+            {
+                userName.setId("chat-user-name");
+                hBox.setAlignment(Pos.CENTER_LEFT);
+            }
+
+            @Override
+            public void updateItem(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (item != null && !empty) {
+                    item.getSenderUserProfile().ifPresent(author -> {
+                        userName.setText(author.getUserName());
+                        userProfileIcon.setUserProfile(author);
+                    });
+                    setGraphic(hBox);
+                } else {
+                    setGraphic(null);
+                }
+            }
+        };
+    }
+
+    private Callback<TableColumn<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>,
+            ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>,
+            TableCell<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>,
+                    ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>> getReputationCellFactory() {
+        return column -> new TableCell<>() {
+            private final ReputationScoreDisplay reputationScoreDisplay = new ReputationScoreDisplay();
+            private final HBox hBox = new HBox(reputationScoreDisplay);
+
+            {
+                hBox.setAlignment(Pos.CENTER_LEFT);
+                hBox.getStyleClass().add("reputation");
+            }
+
+            @Override
+            public void updateItem(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (item != null && !empty) {
+                    reputationScoreDisplay.setReputationScore(item.getReputationScore());
+                    setGraphic(hBox);
+                } else {
+                    setGraphic(null);
+                }
+            }
+        };
+    }
+
+    private Callback<TableColumn<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>,
+            ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>,
+            TableCell<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>,
+                    ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>>> getTakeOfferCellFactory() {
+        return column -> new TableCell<>() {
+            private final Button takeOfferButton = new Button(Res.get("offer.takeOffer"));
+
+            {
+                takeOfferButton.setAlignment(Pos.CENTER_RIGHT);
+                takeOfferButton.getStyleClass().add("take-offer-button");
+            }
+
+            @Override
+            public void updateItem(final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (item != null && !empty && item.getChatMessage() instanceof BisqEasyOfferbookMessage) {
+                    if (item.isMyMessage()) {
+                        getTableRow().pseudoClassStateChanged(OWN_OFFER_PSEUDO_CLASS, true);
+                        takeOfferButton.setOnAction(null);
+                        setGraphic(null);
+                        return;
+                    }
+                    getTableRow().pseudoClassStateChanged(OWN_OFFER_PSEUDO_CLASS, false);
+                    BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) item.getChatMessage();
+                    takeOfferButton.setOnAction(e -> controller.onTakeOffer(bisqEasyOfferbookMessage));
+                    takeOfferButton.setDefaultButton(!item.isOfferAlreadyTaken());
+                    setGraphic(takeOfferButton);
+                } else {
+                    takeOfferButton.setOnAction(null);
+                    setGraphic(null);
+                }
+            }
+        };
+    }
+}

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -793,6 +793,23 @@
     -fx-border-color: -bisq2-green;
 }
 
+/*******************************************************************************
+ * ChatOfferTable.tableView                                          *
+ ******************************************************************************/
+
+.bisq-easy-offer-book-table-view .table-row-cell {
+    -fx-pref-height: 55px;
+    -fx-border-width: 0;
+    -fx-background-color: -bisq-dark-grey-20;
+}
+
+.bisq-easy-offer-book-table-view.table-view .table-cell {
+    -fx-padding: 0 0 0 10;
+}
+
+.bisq-easy-offer-book-table-view .table-row-cell:own-offer {
+    -fx-opacity: 0.5;
+}
 
 /*******************************************************************************
  * Chat                                                              *

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -811,6 +811,14 @@
     -fx-opacity: 0.5;
 }
 
+.bisq-easy-offer-book-table-view .sell-offer-button {
+    -fx-background-color:  -bisq2-red-dim-30;
+}
+
+.bisq-easy-offer-book-table-view .buy-offer-button {
+    -fx-background-color:  -bisq2-green-dim-60;
+}
+
 /*******************************************************************************
  * Chat                                                              *
  ******************************************************************************/

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -507,6 +507,7 @@ bisqEasy.topPane.filter=Filter offerbook
 bisqEasy.topPane.closeFilter=Close filter
 bisqEasy.topPane.filter.offersOnly=Show offers only
 bisqEasy.topPane.filter.hideUserMessages=Hide user messages
+bisqEasy.topPane.filter.listOffers=Offers as list
 
 
 ################################################################################

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -257,5 +257,11 @@ chat.message.citation.headline=Replying to:
 chat.listView.scrollDown=Scroll down
 chat.listView.scrollDown.newMessages=Scroll down to read new messages
 
-
+chat.offerTable.userProfile=User profile
+chat.offerTable.reputation=Reputation
+chat.offerTable.intention=Wants to
+chat.offerTable.method=Method
+chat.offerTable.fiatAmount=Fiat amount
+chat.offerTable.price=Price
+chat.offerTable.takeOffer=Take offer
 

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -64,6 +64,8 @@ data.remove=Remove
 
 offer.createOffer=Create offer
 offer.takeOffer=Take offer
+offer.sellTo=Sell bitcoin to {0}
+offer.buyFrom=Buy bitcoin from {0}
 offer.deleteOffer=Delete my offer
 offer.buy=buy
 offer.sell=sell

--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -65,6 +65,7 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
         // If used with FxBindings.bindBiDir we need to trigger persist call
         getIsTacAccepted().addObserver(value -> persist());
         getOffersOnly().addObserver(value -> persist());
+        getListOffers().addObserver(value -> persist());
         getChatNotificationType().addObserver(value -> persist());
         getUseAnimations().addObserver(value -> persist());
         getPreventStandbyMode().addObserver(value -> persist());
@@ -135,6 +136,10 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
 
     public Observable<Boolean> getOffersOnly() {
         return persistableStore.offersOnly;
+    }
+
+    public Observable<Boolean> getListOffers() {
+        return persistableStore.listOffers;
     }
 
     public Observable<Boolean> getTradeRulesConfirmed() {

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -41,6 +41,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
     final Observable<Market> selectedMarket = new Observable<>();
     final Observable<Long> minRequiredReputationScore = new Observable<>();
     final Observable<Boolean> offersOnly = new Observable<>();
+    final Observable<Boolean> listOffers = new Observable<>();
     final Observable<Boolean> tradeRulesConfirmed = new Observable<>();
     final Observable<ChatNotificationType> chatNotificationType = new Observable<>();
     final ObservableSet<String> consumedAlertIds = new ObservableSet<>();
@@ -72,6 +73,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 NetworkLoad.DEFAULT_DIFFICULTY_ADJUSTMENT,
                 false,
                 new HashSet<>(),
+                false,
                 false);
     }
 
@@ -92,13 +94,15 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                          double difficultyAdjustmentFactor,
                          boolean ignoreDiffAdjustmentFromSecManager,
                          Set<Market> favouriteMarkets,
-                         boolean ignoreMinRequiredReputationScoreFromSecManager) {
+                         boolean ignoreMinRequiredReputationScoreFromSecManager,
+                         boolean listOffers) {
         this.cookie = cookie;
         this.dontShowAgainMap.putAll(dontShowAgainMap);
         this.useAnimations.set(useAnimations);
         this.selectedMarket.set(selectedMarket);
         this.minRequiredReputationScore.set(requiredTotalReputationScore);
         this.offersOnly.set(offersOnly);
+        this.listOffers.set(listOffers);
         this.tradeRulesConfirmed.set(tradeRulesConfirmed);
         this.chatNotificationType.set(chatNotificationType);
         this.isTacAccepted.set(isTacAccepted);
@@ -122,6 +126,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 .setSelectedMarket(selectedMarket.get().toProto())
                 .setMinRequiredReputationScore(minRequiredReputationScore.get())
                 .setOffersOnly(offersOnly.get())
+                .setListOffers(listOffers.get())
                 .setTradeRulesConfirmed(tradeRulesConfirmed.get())
                 .setChatNotificationType(chatNotificationType.get().toProto())
                 .setIsTacAccepted(isTacAccepted.get())
@@ -157,7 +162,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 proto.getIgnoreDiffAdjustmentFromSecManager(),
                 new HashSet<>(proto.getFavouriteMarketsList().stream()
                         .map(Market::fromProto).collect(Collectors.toSet())),
-                proto.getIgnoreMinRequiredReputationScoreFromSecManager());
+                proto.getIgnoreMinRequiredReputationScoreFromSecManager(),
+                proto.getListOffers());
     }
 
     @Override
@@ -190,7 +196,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 difficultyAdjustmentFactor.get(),
                 ignoreDiffAdjustmentFromSecManager.get(),
                 new HashSet<>(favouriteMarkets),
-                ignoreMinRequiredReputationScoreFromSecManager.get());
+                ignoreMinRequiredReputationScoreFromSecManager.get(),
+                listOffers.get());
     }
 
     @Override
@@ -202,6 +209,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
             selectedMarket.set(persisted.selectedMarket.get());
             minRequiredReputationScore.set(persisted.minRequiredReputationScore.get());
             offersOnly.set(persisted.offersOnly.get());
+            listOffers.set(persisted.listOffers.get());
             tradeRulesConfirmed.set(persisted.tradeRulesConfirmed.get());
             chatNotificationType.set(persisted.chatNotificationType.get());
             isTacAccepted.set(persisted.isTacAccepted.get());

--- a/settings/src/main/proto/settings.proto
+++ b/settings/src/main/proto/settings.proto
@@ -56,4 +56,5 @@ message SettingsStore {
   bool ignoreDiffAdjustmentFromSecManager = 16;
   repeated common.Market favouriteMarkets = 17;
   bool ignoreMinRequiredReputationScoreFromSecManager = 18;
+  bool listOffers = 19;
 }


### PR DESCRIPTION
Add checkbox to show offers as list instead of as chat

It's quite hard to get an overview of the offers in the chats. This draft PR adds an option to display the offers in a compact table that can be sorted on price or reputation for example.

Are there some arguments against showing the offers as a table? It seems like a natural way to get some order, but it does lose some of the community feel of the chat.

![image](https://github.com/bisq-network/bisq2/assets/123634778/76973314-8494-4d27-9fb6-279ade698f22)


![image](https://github.com/bisq-network/bisq2/assets/123634778/1d70be65-5e62-402e-b580-6d7ed4e47e2e)
