### PR TITLE
Update number validation to be more strict

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/NumberValidator.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/NumberValidator.java
@@ -23,6 +23,8 @@ import javafx.util.StringConverter;
 import javafx.util.converter.NumberStringConverter;
 import lombok.Getter;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.Optional;
 
 public class NumberValidator extends ValidatorBase {
@@ -70,37 +72,23 @@ public class NumberValidator extends ValidatorBase {
                 return;
             }
 
+            if (!isValidNumber(text)) {
+                hasErrors.set(true);
+                return;
+            }
+
             Number value = NUMBER_STRING_CONVERTER.fromString(text);
             numberValue = Optional.of(value);
 
             if (minValue.isPresent()) {
-                if (value instanceof Double) {
-                    if (value.doubleValue() < minValue.get().doubleValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Float) {
-                    if (value.floatValue() < minValue.get().floatValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Long) {
+                if (value instanceof Long) {
                     if (value.longValue() < minValue.get().longValue()) {
                         hasErrors.set(true);
                         return;
                     }
-                } else if (value instanceof Integer) {
-                    if (value.intValue() < minValue.get().intValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Short) {
-                    if (value.shortValue() < minValue.get().shortValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Byte) {
-                    if (value.byteValue() < minValue.get().byteValue()) {
+                } else {
+                    // Fallback to double since the rest of the types can be evaluated within a double
+                    if (value.doubleValue() < minValue.get().doubleValue()) {
                         hasErrors.set(true);
                         return;
                     }
@@ -108,33 +96,13 @@ public class NumberValidator extends ValidatorBase {
             }
 
             if (maxValue.isPresent()) {
-                if (value instanceof Double) {
-                    if (value.doubleValue() > maxValue.get().doubleValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Float) {
-                    if (value.floatValue() > maxValue.get().floatValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Long) {
+                if (value instanceof Long) {
                     if (value.longValue() > maxValue.get().longValue()) {
                         hasErrors.set(true);
                         return;
                     }
-                } else if (value instanceof Integer) {
-                    if (value.intValue() > maxValue.get().intValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Short) {
-                    if (value.shortValue() > maxValue.get().shortValue()) {
-                        hasErrors.set(true);
-                        return;
-                    }
-                } else if (value instanceof Byte) {
-                    if (value.byteValue() > maxValue.get().byteValue()) {
+                } else {
+                    if (value.doubleValue() > maxValue.get().doubleValue()) {
                         hasErrors.set(true);
                         return;
                     }
@@ -144,6 +112,16 @@ public class NumberValidator extends ValidatorBase {
             hasErrors.set(false);
         } catch (Exception e) {
             hasErrors.set(true);
+        }
+    }
+
+    private static boolean isValidNumber(String inputText) {
+        NumberFormat format = NumberFormat.getNumberInstance();
+        try {
+            format.parse(inputText);
+            return true;
+        } catch (ParseException e) {
+            return false;
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/NumberValidator.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/NumberValidator.java
@@ -28,7 +28,6 @@ import java.text.ParseException;
 import java.util.Optional;
 
 public class NumberValidator extends ValidatorBase {
-
     private static final StringConverter<Number> NUMBER_STRING_CONVERTER = new NumberStringConverter();
     @Getter
     private Optional<Number> minValue = Optional.empty();
@@ -40,6 +39,7 @@ public class NumberValidator extends ValidatorBase {
 
     public NumberValidator(String message) {
         super(message);
+
         this.allowEmptyString = false;
     }
 
@@ -49,6 +49,7 @@ public class NumberValidator extends ValidatorBase {
 
     public NumberValidator(String message, Number minValue, Number maxValue, boolean allowEmptyString) {
         super(message);
+
         this.minValue = Optional.of(minValue);
         this.maxValue = Optional.of(maxValue);
         this.allowEmptyString = allowEmptyString;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/preferences/PreferencesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/preferences/PreferencesView.java
@@ -63,7 +63,7 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
     private final ChangeListener<Toggle> notificationsToggleListener;
     private final AutoCompleteComboBox<String> languageSelection, supportedLanguagesComboBox;
     private final MaterialTextField minRequiredReputationScore, difficultyAdjustmentFactor;
-    private Subscription selectedNotificationTypePin, getSelectedLSupportedLanguageCodePin;
+    private Subscription selectedNotificationTypePin, getSelectedSupportedLanguageCodePin;
 
     public PreferencesView(PreferencesModel model, PreferencesController controller) {
         super(new VBox(50), model, controller);
@@ -275,7 +275,7 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
             controller.onSelectSupportedLanguage(supportedLanguagesComboBox.getSelectionModel().getSelectedItem());
         });
 
-        getSelectedLSupportedLanguageCodePin = EasyBind.subscribe(model.getSelectedLSupportedLanguageCode(),
+        getSelectedSupportedLanguageCodePin = EasyBind.subscribe(model.getSelectedLSupportedLanguageCode(),
                 e -> supportedLanguagesComboBox.getSelectionModel().select(e));
 
         resetDontShowAgain.setOnAction(e -> controller.onResetDontShowAgain());
@@ -308,7 +308,7 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
 
         notificationsToggleGroup.selectedToggleProperty().removeListener(notificationsToggleListener);
         selectedNotificationTypePin.unsubscribe();
-        getSelectedLSupportedLanguageCodePin.unsubscribe();
+        getSelectedSupportedLanguageCodePin.unsubscribe();
 
         resetDontShowAgain.setOnAction(null);
         clearNotifications.setOnAction(null);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/preferences/PreferencesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/preferences/PreferencesView.java
@@ -52,6 +52,7 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
     private static final ValidatorBase DIFFICULTY_ADJUSTMENT_FACTOR_VALIDATOR =
             new NumberValidator(Res.get("settings.preferences.network.difficultyAdjustmentFactor.invalid", NetworkLoad.MAX_DIFFICULTY_ADJUSTMENT),
                     0, NetworkLoad.MAX_DIFFICULTY_ADJUSTMENT);
+    private static final StringConverter<Number> NUMBER_STRING_CONVERTER = new NumberStringConverter();
 
     private final Button resetDontShowAgain, clearNotifications, addLanguageButton;
     private final Switch useAnimations, preventStandbyMode, offersOnlySwitch, closeMyOfferWhenTaken, notifyForPreRelease,
@@ -249,11 +250,11 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
         ignoreMinRequiredReputationScoreFromSecManagerSwitch.selectedProperty().bindBidirectional(model.getIgnoreMinRequiredReputationScoreFromSecManager());
         closeMyOfferWhenTaken.selectedProperty().bindBidirectional(model.getCloseMyOfferWhenTaken());
 
-        Bindings.bindBidirectional(minRequiredReputationScore.textProperty(), model.getMinRequiredReputationScore(), new NumberStringConverter());
+        Bindings.bindBidirectional(minRequiredReputationScore.textProperty(), model.getMinRequiredReputationScore(), NUMBER_STRING_CONVERTER);
         minRequiredReputationScore.descriptionProperty().bind(model.getMinRequiredReputationScoreDescriptionText());
         minRequiredReputationScore.getTextInputControl().editableProperty().bind(model.getMinRequiredReputationScoreEditable());
 
-        Bindings.bindBidirectional(difficultyAdjustmentFactor.textProperty(), model.getDifficultyAdjustmentFactor(), new NumberStringConverter());
+        Bindings.bindBidirectional(difficultyAdjustmentFactor.textProperty(), model.getDifficultyAdjustmentFactor(), NUMBER_STRING_CONVERTER);
         difficultyAdjustmentFactor.descriptionProperty().bind(model.getDifficultyAdjustmentFactorDescriptionText());
         difficultyAdjustmentFactor.getTextInputControl().editableProperty().bind(model.getDifficultyAdjustmentFactorEditable());
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/preferences/PreferencesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/preferences/PreferencesView.java
@@ -63,7 +63,8 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
     private final ChangeListener<Toggle> notificationsToggleListener;
     private final AutoCompleteComboBox<String> languageSelection, supportedLanguagesComboBox;
     private final MaterialTextField minRequiredReputationScore, difficultyAdjustmentFactor;
-    private Subscription selectedNotificationTypePin, getSelectedSupportedLanguageCodePin;
+    private Subscription selectedNotificationTypePin, getSelectedSupportedLanguageCodePin,
+            ignoreDiffAdjustFromSecManagerSwitchPin, ignoreMinRequiredReputationScoreFromSecManagerSwitchPin;
 
     public PreferencesView(PreferencesModel model, PreferencesController controller) {
         super(new VBox(50), model, controller);
@@ -278,6 +279,12 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
         getSelectedSupportedLanguageCodePin = EasyBind.subscribe(model.getSelectedLSupportedLanguageCode(),
                 e -> supportedLanguagesComboBox.getSelectionModel().select(e));
 
+        ignoreDiffAdjustFromSecManagerSwitchPin = EasyBind.subscribe(
+                ignoreDiffAdjustFromSecManagerSwitch.selectedProperty(), s -> difficultyAdjustmentFactor.validate());
+
+        ignoreMinRequiredReputationScoreFromSecManagerSwitchPin = EasyBind.subscribe(
+                ignoreMinRequiredReputationScoreFromSecManagerSwitch.selectedProperty(), s -> minRequiredReputationScore.validate());
+
         resetDontShowAgain.setOnAction(e -> controller.onResetDontShowAgain());
         clearNotifications.setOnAction(e -> controller.onClearNotifications());
         addLanguageButton.setOnAction(e -> {
@@ -309,6 +316,8 @@ public class PreferencesView extends View<VBox, PreferencesModel, PreferencesCon
         notificationsToggleGroup.selectedToggleProperty().removeListener(notificationsToggleListener);
         selectedNotificationTypePin.unsubscribe();
         getSelectedSupportedLanguageCodePin.unsubscribe();
+        ignoreDiffAdjustFromSecManagerSwitchPin.unsubscribe();
+        ignoreMinRequiredReputationScoreFromSecManagerSwitchPin.unsubscribe();
 
         resetDontShowAgain.setOnAction(null);
         clearNotifications.setOnAction(null);


### PR DESCRIPTION
Based on #1993

* Use a more strict number validation to prevent cases like "123abc" to be flagged as valid.
Before:
![image](https://github.com/bisq-network/bisq2/assets/145597137/17485ab8-0388-4397-bff0-d9e6fab002a0)

    After:
    ![image](https://github.com/bisq-network/bisq2/assets/145597137/58ac10bc-94bd-4fb8-8ec7-bae23762451f)

* Force a validation after updating the switch for both min. required rep. and diff. factor. This avoids getting into an inconsistent state when switching back to default with a previous errorLabel.
Before:
![image](https://github.com/bisq-network/bisq2/assets/145597137/78206c04-af1d-4738-b2ed-3eae4910a713)

    After:
    ![image](https://github.com/bisq-network/bisq2/assets/145597137/32d52888-ed16-4f8a-8e94-45d6027baad2)

* Misc. refactors and improvements.