### PR TITLE
Avoid nullable user identity

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/AuthorizedRoleController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/AuthorizedRoleController.java
@@ -111,7 +111,7 @@ public class AuthorizedRoleController extends ContentTabController<AuthorizedRol
         UIThread.run(() -> {
             UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
             model.getAuthorizedBondedRoles().setAll(authorizedBondedRolesService.getAuthorizedBondedRoleStream()
-                    .filter(bondedRole -> selectedUserIdentity != null && selectedUserIdentity.getUserProfile().getId().equals(bondedRole.getProfileId()))
+                    .filter(bondedRole -> selectedUserIdentity.getUserProfile().getId().equals(bondedRole.getProfileId()))
                     .map(AuthorizedBondedRole::getBondedRoleType)
                     .collect(Collectors.toSet()));
         });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/info/RoleInfo.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/info/RoleInfo.java
@@ -82,7 +82,7 @@ public class RoleInfo {
         private void onUserIdentity() {
             UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
             authorizedBondedRolesService.getBondedRoles().stream()
-                    .filter(bondedRole -> selectedUserIdentity != null && selectedUserIdentity.getUserProfile().getId().equals(bondedRole.getAuthorizedBondedRole().getProfileId()))
+                    .filter(bondedRole -> selectedUserIdentity.getUserProfile().getId().equals(bondedRole.getAuthorizedBondedRole().getProfileId()))
                     .findAny()
                     .ifPresent(bondedRole -> {
                         model.setIsBanned(BooleanFormatter.toYesNo(bondedRole.isBanned()));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/release_manager/ReleaseManagerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/release_manager/ReleaseManagerController.java
@@ -35,8 +35,6 @@ import bisq.user.profile.UserProfileService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 @Slf4j
 public class ReleaseManagerController implements Controller {
     @Getter
@@ -99,14 +97,11 @@ public class ReleaseManagerController implements Controller {
     }
 
     void onRemoveReleaseNotification(ReleaseNotification releaseNotification) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         releaseManagerService.removeReleaseNotification(releaseNotification, userIdentity.getNetworkIdWithKeyPair().getKeyPair());
     }
 
     boolean isRemoveButtonVisible(ReleaseNotification releaseNotification) {
-        if (userIdentityService.getSelectedUserIdentity() == null) {
-            return false;
-        }
         return userIdentityService.getSelectedUserIdentity().getId().equals(releaseNotification.getReleaseManagerProfileId());
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/security_manager/SecurityManagerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/security_manager/SecurityManagerController.java
@@ -50,8 +50,6 @@ import org.fxmisc.easybind.Subscription;
 
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 @Slf4j
 public class SecurityManagerController implements Controller {
     @Getter
@@ -182,14 +180,11 @@ public class SecurityManagerController implements Controller {
     }
 
     boolean isRemoveDifficultyAdjustmentButtonVisible(AuthorizedAlertData authorizedAlertData) {
-        if (userIdentityService.getSelectedUserIdentity() == null) {
-            return false;
-        }
         return userIdentityService.getSelectedUserIdentity().getId().equals(authorizedAlertData.getSecurityManagerProfileId());
     }
 
     void onRemoveAlert(AuthorizedAlertData authorizedAlertData) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         securityManagerService.removeAlert(authorizedAlertData, userIdentity.getNetworkIdWithKeyPair().getKeyPair());
     }
 
@@ -253,27 +248,21 @@ public class SecurityManagerController implements Controller {
     }
 
     boolean isRemoveDifficultyAdjustmentButtonVisible(AuthorizedDifficultyAdjustmentData data) {
-        if (userIdentityService.getSelectedUserIdentity() == null) {
-            return false;
-        }
         return userIdentityService.getSelectedUserIdentity().getId().equals(data.getSecurityManagerProfileId());
     }
 
     boolean isRemoveMinRequiredReputationScoreButtonVisible(AuthorizedMinRequiredReputationScoreData data) {
-        if (userIdentityService.getSelectedUserIdentity() == null) {
-            return false;
-        }
         return userIdentityService.getSelectedUserIdentity().getId().equals(data.getSecurityManagerProfileId());
     }
 
     void onRemoveDifficultyAdjustmentListItem(SecurityManagerView.DifficultyAdjustmentListItem item) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         securityManagerService.removeDifficultyAdjustment(item.getData(), userIdentity.getNetworkIdWithKeyPair().getKeyPair());
         model.getDifficultyAdjustmentFactor().set(difficultyAdjustmentService.getMostRecentValueOrDefault().get());
     }
 
     void onRemoveMinRequiredReputationScoreListItem(SecurityManagerView.MinRequiredReputationScoreListItem item) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         securityManagerService.removeMinRequiredReputationScore(item.getData(), userIdentity.getNetworkIdWithKeyPair().getKeyPair());
         model.getMinRequiredReputationScore().set(minRequiredReputationScoreService.getMostRecentValueOrDefault().get());
     }
@@ -304,9 +293,9 @@ public class SecurityManagerController implements Controller {
 
     private void updateSendButtonDisabled() {
         AlertType alertType = model.getSelectedAlertType().get();
-        boolean value = userIdentityService.getSelectedUserIdentity() == null || alertType == null;
-        if (value) {
-            model.getActionButtonDisabled().set(value);
+        boolean isInvalid = alertType == null;
+        if (isInvalid) {
+            model.getActionButtonDisabled().set(isInvalid);
             return;
         }
         boolean isMessageEmpty = StringUtils.isEmpty(model.getMessage().get());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyServiceUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyServiceUtil.java
@@ -17,8 +17,8 @@
 
 package bisq.desktop.main.content.bisq_easy;
 
-import bisq.bisq_easy.BisqEasyService;
 import bisq.account.payment_method.FiatPaymentMethod;
+import bisq.bisq_easy.BisqEasyService;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.common.currency.Market;
@@ -80,9 +80,6 @@ public class BisqEasyServiceUtil {
             // Maker as seller's score must be > than my required score (as buyer)
             return makerAsSellersScore >= myMinRequiredScore;
         } else {
-            if (userIdentityService.getSelectedUserIdentity() == null) {
-                return false;
-            }
             // My score (as offer is a buy offer, I am the seller) must be > as offers required score
             long myScoreAsSeller = reputationService.getReputationScore(userIdentityService.getSelectedUserIdentity().getUserProfile()).getTotalScore();
             long offersRequiredScore = OfferOptionUtil.findRequiredTotalReputationScore(peersOffer).orElse(0L);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
@@ -64,8 +64,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 // TODO (refactor, low prio) Consider to use a base class to avoid code duplication with TradeWizardReviewController
 @Slf4j
 public class TakeOfferReviewController implements Controller {
@@ -187,7 +185,7 @@ public class TakeOfferReviewController implements Controller {
             onCancelHandler.run();
             return;
         }
-        UserIdentity takerIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity takerIdentity = userIdentityService.getSelectedUserIdentity();
         if (bannedUserService.isUserProfileBanned(takerIdentity.getUserProfile())) {
             // If taker is banned we don't need to show them a popup
             onCancelHandler.run();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/direction/TradeWizardDirectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/direction/TradeWizardDirectionController.java
@@ -108,9 +108,7 @@ public class TradeWizardDirectionController implements Controller {
             return;
         }
 
-        ReputationScore reputationScore = userIdentityService.getSelectedUserIdentity() != null ?
-                reputationService.getReputationScore(userIdentityService.getSelectedUserIdentity().getUserProfile()) :
-                ReputationScore.NONE;
+        ReputationScore reputationScore = reputationService.getReputationScore(userIdentityService.getSelectedUserIdentity().getUserProfile());
         if (!reputationScore.hasReputation()) {
             navigationButtonsVisibleHandler.accept(false);
             model.getShowReputationInfo().set(true);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -76,8 +76,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 @Slf4j
 public class TradeWizardReviewController implements Controller {
     private final TradeWizardReviewModel model;
@@ -146,7 +144,7 @@ public class TradeWizardReviewController implements Controller {
                 fiatPaymentMethods,
                 amountSpec,
                 priceSpec);
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         BisqEasyOffer bisqEasyOffer = new BisqEasyOffer(
                 userIdentity.getUserProfile().getNetworkId(),
                 direction,
@@ -367,7 +365,7 @@ public class TradeWizardReviewController implements Controller {
     }
 
     public void publishOffer() {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         bisqEasyOfferbookChannelService.publishChatMessage(model.getMyOfferMessage(), userIdentity)
                 .thenAccept(result -> UIThread.run(() -> {
                     model.getShowCreateOfferSuccess().set(true);
@@ -381,7 +379,7 @@ public class TradeWizardReviewController implements Controller {
             new Popup().warning(Res.get("bisqEasy.takeOffer.makerBanned.warning")).show();
             return;
         }
-        UserIdentity takerIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity takerIdentity = userIdentityService.getSelectedUserIdentity();
         if (bannedUserService.isUserProfileBanned(takerIdentity.getUserProfile())) {
             // If taker is banned we don't need to show them a popup
             return;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferController.java
@@ -258,8 +258,7 @@ public class TradeWizardSelectOfferController implements Controller {
                     return false;
                 }
 
-                if (userIdentityService.getSelectedUserIdentity() == null ||
-                        bannedUserService.isUserProfileBanned(userIdentityService.getSelectedUserIdentity().getUserProfile()) ||
+                if (bannedUserService.isUserProfileBanned(userIdentityService.getSelectedUserIdentity().getUserProfile()) ||
                         bannedUserService.isNetworkIdBanned(makerUserProfile.getNetworkId()) ||
                         bannedUserService.isUserProfileBanned(makerUserProfile)) {
                     return false;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -31,8 +31,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public class ChatMessageContainerController implements bisq.desktop.common.view.Controller {
     private final ChatMessageContainerModel model;
     @Getter
@@ -245,7 +243,7 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
         }
 
         ChatChannel<? extends ChatMessage> chatChannel = model.getSelectedChannel().get();
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity(), "user identity must not be null");
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         Optional<Citation> citation = citationBlock.getCitation();
 
         if (citation.isPresent() && citation.get().getText().length() > Citation.MAX_TEXT_LENGTH) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -139,7 +139,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                 ((BisqEasyOfferbookMessage) chatMessage).hasBisqEasyOffer()) {
             BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
             message = getLocalizedOfferbookMessage(bisqEasyOfferbookMessage);
-            if (userIdentityService.getSelectedUserIdentity() != null && bisqEasyOfferbookMessage.getBisqEasyOffer().isPresent()) {
+            if (bisqEasyOfferbookMessage.getBisqEasyOffer().isPresent()) {
                 UserProfile userProfile = userIdentityService.getSelectedUserIdentity().getUserProfile();
                 NetworkId takerNetworkId = userProfile.getNetworkId();
                 BisqEasyOffer bisqEasyOffer = bisqEasyOfferbookMessage.getBisqEasyOffer().get();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -65,7 +65,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class ChatMessagesListController implements bisq.desktop.common.view.Controller {
@@ -282,8 +281,6 @@ public class ChatMessagesListController implements bisq.desktop.common.view.Cont
 
     public void onTakeOffer(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
         checkArgument(bisqEasyOfferbookMessage.getBisqEasyOffer().isPresent(), "message must contain offer");
-        checkArgument(userIdentityService.getSelectedUserIdentity() != null,
-                "userIdentityService.getSelectedUserIdentity() must not be null");
         checkArgument(!model.isMyMessage(bisqEasyOfferbookMessage), "tradeChatMessage must not be mine");
 
         UserProfile userProfile = userIdentityService.getSelectedUserIdentity().getUserProfile();
@@ -390,7 +387,7 @@ public class ChatMessagesListController implements bisq.desktop.common.view.Cont
             return;
         }
 
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         if (chatMessage instanceof BisqEasyOfferbookMessage) {
             BisqEasyOfferbookMessage bisqEasyOfferbookMessage = (BisqEasyOfferbookMessage) chatMessage;
             chatService.getBisqEasyOfferbookChannelService().publishEditedChatMessage(bisqEasyOfferbookMessage, editedText, userIdentity);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/UserProfileSelection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/UserProfileSelection.java
@@ -157,7 +157,7 @@ public class UserProfileSelection {
                 UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
                 // To make sure a different user is never selected for a private channel it's safest to keep this check
                 // even though the combobox should be disabled
-                if (model.getIsPrivateChannel().get() && selectedUserIdentity != null) {
+                if (model.getIsPrivateChannel().get()) {
                     new Popup().warning(Res.get("chat.privateChannel.changeUserProfile.warn",
                                     selectedUserIdentity.getUserProfile().getUserName()))
                             .onClose(() -> {
@@ -277,7 +277,6 @@ public class UserProfileSelection {
                         if (selected != null) {
                             UserIdentity userIdentity = selected.userIdentity;
                             if (userIdentity != null) {
-
                                 userName.setText(comboBox.getConverter().toString(selected));
                                 icon.setImage(CatHash.getImage(userIdentity.getUserProfile()));
                             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/bonded_roles/nodes/tabs/registration/NodeRegistrationController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/bonded_roles/nodes/tabs/registration/NodeRegistrationController.java
@@ -107,7 +107,7 @@ public class NodeRegistrationController extends BondedRolesRegistrationControlle
         getNodesRegistrationModel().getPubKey().set(null);
         getNodesRegistrationModel().getPrivKey().set(null);
 
-        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentityObservable().get();
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         KeyPair keyPair = userIdentity.getNetworkIdWithKeyPair().getKeyPair();
         getNodesRegistrationModel().getPubKey().set(Hex.encode(keyPair.getPublic().getEncoded()));
         getNodesRegistrationModel().getPrivKey().set(Hex.encode(keyPair.getPrivate().getEncoded()));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/bonded_roles/tabs/registration/BondedRolesRegistrationController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/bonded_roles/tabs/registration/BondedRolesRegistrationController.java
@@ -137,14 +137,12 @@ public abstract class BondedRolesRegistrationController implements Controller {
 
     protected void applyRequestCancellationButtonVisible() {
         UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
-        model.getRequestCancellationButtonVisible().set(
-                selectedUserIdentity != null && authorizedBondedRolesService.getAuthorizedBondedRoleStream()
+        model.getRequestCancellationButtonVisible().set(authorizedBondedRolesService.getAuthorizedBondedRoleStream()
                         .filter(bondedRole -> bondedRole.getBondedRoleType() == model.getBondedRoleType())
                         .anyMatch(bondedRole -> selectedUserIdentity.getUserProfile().getId().equals(bondedRole.getProfileId())));
     }
 
     protected void requestBondedRoleRegistration(boolean isCancellationRequest) {
-        checkNotNull(userIdentityService.getSelectedUserIdentity());
         checkNotNull(model.getProfileId().get());
         checkNotNull(model.getAuthorizedPublicKey());
         boolean success = bondedRoleRegistrationService.requestBondedRoleRegistration(
@@ -154,7 +152,7 @@ public abstract class BondedRolesRegistrationController implements Controller {
                 model.getBondUserName().get(),
                 model.getSignature().get(),
                 model.getAddressByNetworkType(),
-                checkNotNull(userIdentityService.getSelectedUserIdentity()).getNetworkIdWithKeyPair(),
+                userIdentityService.getSelectedUserIdentity().getNetworkIdWithKeyPair(),
                 isCancellationRequest);
         if (success) {
             model.getBondUserName().set("");

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileController.java
@@ -42,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.concurrent.CompletableFuture;
 
 import static bisq.bisq_easy.NavigationTarget.CREATE_PROFILE_STEP1;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class UserProfileController implements Controller {
@@ -159,7 +158,7 @@ public class UserProfileController implements Controller {
     }
 
     public void onDeleteProfile() {
-        String profileName = checkNotNull(userIdentityService.getSelectedUserIdentity()).getUserName();
+        String profileName = userIdentityService.getSelectedUserIdentity().getUserName();
         new Popup().warning(Res.get("user.userProfile.deleteProfile.popup.warning", profileName))
                 .onAction(this::doDeleteProfile)
                 .actionButtonText(Res.get("user.userProfile.deleteProfile.popup.warning.yes"))

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavController.java
@@ -188,8 +188,7 @@ public class LeftNavController implements Controller {
     private void onBondedRolesChanged() {
         UIThread.run(() -> {
             UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
-            boolean authorizedRoleVisible = selectedUserIdentity != null &&
-                    authorizedBondedRolesService.getAuthorizedBondedRoleStream()
+            boolean authorizedRoleVisible = authorizedBondedRolesService.getAuthorizedBondedRoleStream()
                             .anyMatch(bondedRole -> selectedUserIdentity.getUserProfile().getId().equals(bondedRole.getProfileId()));
             if (model.getAuthorizedRoleVisible().get() && !authorizedRoleVisible &&
                     model.getSelectedNavigationTarget().get() == NavigationTarget.AUTHORIZED_ROLE) {

--- a/chat/src/main/java/bisq/chat/bisqeasy/open_trades/BisqEasyOpenTradeChannelService.java
+++ b/chat/src/main/java/bisq/chat/bisqeasy/open_trades/BisqEasyOpenTradeChannelService.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelService<BisqEasyOpenTradeMessage, BisqEasyOpenTradeChannel, BisqEasyOpenTradeChannelStore> {
@@ -127,7 +126,7 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
                     if (bannedUserService.isUserProfileBanned(makerUserProfile)) {
                         return CompletableFuture.<SendMessageResult>failedFuture(new RuntimeException("Maker is banned"));
                     }
-                    UserIdentity myUserIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+                    UserIdentity myUserIdentity = userIdentityService.getSelectedUserIdentity();
                     if (bannedUserService.isUserProfileBanned(myUserIdentity.getUserProfile())) {
                         return CompletableFuture.<SendMessageResult>failedFuture(new RuntimeException());
                     }

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
@@ -82,9 +82,9 @@ public class TwoPartyPrivateChatChannelService extends PrivateChatChannelService
 
     public Optional<TwoPartyPrivateChatChannel> findOrCreateChannel(ChatChannelDomain chatChannelDomain, UserProfile peer) {
         synchronized (this) {
-            return Optional.ofNullable(userIdentityService.getSelectedUserIdentity())
-                    .flatMap(myUserIdentity -> findChannel(chatChannelDomain, peer, myUserIdentity.getId())
-                            .or(() -> createAndAddChannel(peer, myUserIdentity.getId())));
+            UserIdentity myUserIdentity = userIdentityService.getSelectedUserIdentity();
+            return findChannel(chatChannelDomain, peer, myUserIdentity.getId())
+                    .or(() -> createAndAddChannel(peer, myUserIdentity.getId()));
         }
     }
 

--- a/support/src/main/java/bisq/support/moderator/ModeratorService.java
+++ b/support/src/main/java/bisq/support/moderator/ModeratorService.java
@@ -141,9 +141,6 @@ public class ModeratorService implements PersistenceClient<ModeratorStore>, Serv
 
     public void reportUserProfile(UserProfile accusedUserProfile, String message, ChatChannelDomain chatChannelDomain) {
         UserIdentity myUserIdentity = userIdentityService.getSelectedUserIdentity();
-        if (myUserIdentity == null) {
-            return;
-        }
         checkArgument(!bannedUserService.isUserProfileBanned(myUserIdentity.getUserProfile()));
 
         NetworkIdWithKeyPair senderNetworkIdWithKeyPair = myUserIdentity.getNetworkIdWithKeyPair();
@@ -167,9 +164,6 @@ public class ModeratorService implements PersistenceClient<ModeratorStore>, Serv
 
     public CompletableFuture<BroadcastResult> banReportedUser(ReportToModeratorMessage message) {
         UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
-        if (selectedUserIdentity == null) {
-            return CompletableFuture.failedFuture(new RuntimeException("selectedUserIdentity must not be null"));
-        }
         KeyPair keyPair = selectedUserIdentity.getNetworkIdWithKeyPair().getKeyPair();
         BannedUserProfileData data = new BannedUserProfileData(message.getAccusedUserProfile(), staticPublicKeysProvided);
         return networkService.publishAuthorizedData(data, keyPair);
@@ -177,9 +171,6 @@ public class ModeratorService implements PersistenceClient<ModeratorStore>, Serv
 
     public CompletableFuture<BroadcastResult> unBanReportedUser(BannedUserProfileData data) {
         UserIdentity selectedUserIdentity = userIdentityService.getSelectedUserIdentity();
-        if (selectedUserIdentity == null) {
-            return CompletableFuture.failedFuture(new RuntimeException("selectedUserIdentity must not be null"));
-        }
         KeyPair keyPair = selectedUserIdentity.getNetworkIdWithKeyPair().getKeyPair();
         return networkService.removeAuthorizedData(data, keyPair);
     }

--- a/support/src/main/java/bisq/support/release_manager/ReleaseManagerService.java
+++ b/support/src/main/java/bisq/support/release_manager/ReleaseManagerService.java
@@ -36,8 +36,6 @@ import java.security.PublicKey;
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 @Slf4j
 public class ReleaseManagerService implements Service {
     @Getter
@@ -94,7 +92,7 @@ public class ReleaseManagerService implements Service {
                                                                  boolean isLauncherUpdate,
                                                                  String releaseNotes,
                                                                  String version) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         String profileId = userIdentity.getId();
         KeyPair keyPair = userIdentity.getIdentity().getKeyBundle().getKeyPair();
         PublicKey authorizedPublicKey = keyPair.getPublic();

--- a/support/src/main/java/bisq/support/security_manager/SecurityManagerService.java
+++ b/support/src/main/java/bisq/support/security_manager/SecurityManagerService.java
@@ -41,8 +41,6 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 @Slf4j
 public class SecurityManagerService implements Service {
     @Getter
@@ -102,7 +100,7 @@ public class SecurityManagerService implements Service {
                                                    boolean requireVersionForTrading,
                                                    Optional<String> minVersion,
                                                    Optional<AuthorizedBondedRole> bannedRole) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         String profileId = userIdentity.getId();
         KeyPair keyPair = userIdentity.getIdentity().getKeyBundle().getKeyPair();
         PublicKey authorizedPublicKey = keyPair.getPublic();
@@ -131,7 +129,7 @@ public class SecurityManagerService implements Service {
     }
 
     public CompletableFuture<Boolean> publishDifficultyAdjustment(double difficultyAdjustmentFactor) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         String profileId = userIdentity.getId();
         KeyPair keyPair = userIdentity.getIdentity().getKeyBundle().getKeyPair();
         PublicKey authorizedPublicKey = keyPair.getPublic();
@@ -148,7 +146,7 @@ public class SecurityManagerService implements Service {
     }
 
     public CompletableFuture<Boolean> publishMinRequiredReputationScore(long minRequiredReputationScore) {
-        UserIdentity userIdentity = checkNotNull(userIdentityService.getSelectedUserIdentity());
+        UserIdentity userIdentity = userIdentityService.getSelectedUserIdentity();
         String profileId = userIdentity.getId();
         KeyPair keyPair = userIdentity.getIdentity().getKeyBundle().getKeyPair();
         PublicKey authorizedPublicKey = keyPair.getPublic();

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/events/BisqEasyFsmErrorEventHandler.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/events/BisqEasyFsmErrorEventHandler.java
@@ -45,20 +45,20 @@ public class BisqEasyFsmErrorEventHandler extends SendTradeMessageHandler<BisqEa
         commitToModel(ExceptionUtil.getRootCauseMessage(fsmException),
                 ExceptionUtil.getStackTraceAsString(fsmException));
 
-            // We do not send the error message to the peer as there is risk that private data could be leaked.
-            // Instead, we send the stack of causes as error message.
-            // We might send more meaningful error messages in the future.
+        // We do not send the error message to the peer as there is risk that private data could be leaked.
+        // Instead, we send the stack of causes as error message.
+        // We might send more meaningful error messages in the future.
         String errorMessage = truncate(ExceptionUtil.getCauseStackClassNames(fsmException), MAX_LENGTH_ERROR_MESSAGE);
         String stackTrace = truncate(ExceptionUtil.getSafeStackTraceAsString(fsmException), MAX_LENGTH_STACKTRACE);
-            log.warn("We send the cause stack and stackTrace to our peer.\n" +
-                    "errorMessage={}\nstackTrace={}", errorMessage, stackTrace);
-            sendMessage(new BisqEasyReportErrorMessage(createUid(),
-                    trade.getId(),
-                    trade.getProtocolVersion(),
-                    trade.getMyIdentity().getNetworkId(),
-                    trade.getPeer().getNetworkId(),
-                    errorMessage,
-                    stackTrace));
+        log.warn("We send the cause stack and stackTrace to our peer.\n" +
+                "errorMessage={}\nstackTrace={}", errorMessage, stackTrace);
+        sendMessage(new BisqEasyReportErrorMessage(createUid(),
+                trade.getId(),
+                trade.getProtocolVersion(),
+                trade.getMyIdentity().getNetworkId(),
+                trade.getPeer().getNetworkId(),
+                errorMessage,
+                stackTrace));
     }
 
     private void commitToModel(String errorMessage, String errorStackTrace) {

--- a/user/src/main/java/bisq/user/identity/UserIdentityService.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityService.java
@@ -216,10 +216,9 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
         }
         synchronized (lock) {
             getUserIdentities().remove(userIdentity);
-
-            getUserIdentities().stream().findAny()
-                    .ifPresentOrElse(persistableStore::setSelectedUserIdentity,
-                            () -> persistableStore.setSelectedUserIdentity(null));
+            // We have at least 1 userIdentity left
+            getUserIdentities().stream().findFirst()
+                    .ifPresent(persistableStore::setSelectedUserIdentity);
         }
         persist();
         identityService.retireActiveIdentity(userIdentity.getIdentity().getTag());
@@ -256,7 +255,6 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
         return persistableStore.getSelectedUserIdentityObservable();
     }
 
-    @Nullable
     public UserIdentity getSelectedUserIdentity() {
         return persistableStore.getSelectedUserIdentity();
     }

--- a/user/src/main/java/bisq/user/identity/UserIdentityService.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityService.java
@@ -188,6 +188,11 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
     }
 
     public void selectChatUserIdentity(UserIdentity userIdentity) {
+        if (userIdentity == null) {
+            log.warn("userIdentity is null at selectChatUserIdentity");
+            return;
+        }
+
         persistableStore.setSelectedUserIdentity(userIdentity);
         persist();
     }
@@ -217,8 +222,7 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
         synchronized (lock) {
             getUserIdentities().remove(userIdentity);
             // We have at least 1 userIdentity left
-            getUserIdentities().stream().findFirst()
-                    .ifPresent(persistableStore::setSelectedUserIdentity);
+            persistableStore.setSelectedUserIdentity(getUserIdentities().stream().findFirst().orElseThrow());
         }
         persist();
         identityService.retireActiveIdentity(userIdentity.getIdentity().getTag());


### PR DESCRIPTION
Should resolve https://github.com/bisq-network/bisq2/issues/1899

I could not reproduce and have not seen a valid code path how selected user identity could be null.
Either it might happen at a subscription where a null values is applied to the domain or corrupted persistence files.
In any case we require now that userIdentities must not be empty and in case there is no user identity selected we take the first from the set. Otherwise we ignore the call.

