### PR TITLE
Fix encoding issue on Windows

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/UnorderedList.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/UnorderedList.java
@@ -24,14 +24,14 @@ import javax.annotation.Nullable;
 @Slf4j
 public class UnorderedList extends TextList {
     public static final String REGEX = "- ";
-    public static final String MARK = "\u2022"; // Unicode code for "•"
+    public static final String BULLET_SYMBOL = "\u2022"; // Unicode for "•"
 
     public UnorderedList(String text, String style, String regex, String mark) {
         this(text, style, 7, 0, regex, mark);
     }
 
     public UnorderedList(String text, String style) {
-        this(text, style, 7, 0, REGEX, MARK);
+        this(text, style, 7, 0, REGEX, BULLET_SYMBOL);
     }
 
     public UnorderedList(String text, @Nullable String style, double gap, double vSpacing, String regex, String mark) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewView.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.content.bisq_easy.take_offer.review;
 
 import bisq.desktop.common.Transitions;
+import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.MultiStyleLabelPane;
@@ -26,15 +27,18 @@ import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
 import bisq.desktop.main.content.bisq_easy.components.WaitingState;
 import bisq.desktop.main.content.bisq_easy.take_offer.TakeOfferView;
 import bisq.i18n.Res;
-import javafx.animation.PauseTransition;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.layout.*;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
-import javafx.util.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
@@ -192,15 +196,13 @@ class TakeOfferReviewView extends View<StackPane, TakeOfferReviewModel, TakeOffe
             Transitions.slideInTop(takeOfferStatus, 450);
             takeOfferSendMessageWaitingAnimation.playIndefinitely();
 
-            PauseTransition delay = new PauseTransition(Duration.seconds(8));
-            delay.setOnFinished(e -> {
+            UIScheduler.run(() -> {
                 minWaitingTimePassed = true;
                 if (model.getTakeOfferStatus().get() == TakeOfferReviewModel.TakeOfferStatus.SUCCESS) {
                     takeOfferStatus.getChildren().setAll(takeOfferSuccess, Spacer.fillVBox());
                     takeOfferSendMessageWaitingAnimation.stop();
                 }
-            });
-            delay.play();
+            }).after(8000);
         } else if (status == TakeOfferReviewModel.TakeOfferStatus.SUCCESS && minWaitingTimePassed) {
             takeOfferStatus.getChildren().setAll(takeOfferSuccess, Spacer.fillVBox());
             takeOfferSendMessageWaitingAnimation.stop();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -78,7 +78,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class TradeWizardReviewController implements Controller {
-    private static final String DASH = "\u2013"; // Unicode code for "–"
+    private static final String DASH_SYMBOL = "\u2013"; // Unicode for "–"
 
     private final TradeWizardReviewModel model;
     @Getter
@@ -267,14 +267,14 @@ public class TradeWizardReviewController implements Controller {
             String formattedMaxQuoteAmount = AmountFormatter.formatAmount(maxQuoteSideAmount, true);
             String formattedMaxBaseAmount = AmountFormatter.formatAmount(maxBaseSideAmount, false);
             if (isCreateOfferMode && direction.isSell()) {
-                toSendAmount = formattedMinBaseAmount + " " + DASH + " " + formattedMaxBaseAmount;
+                toSendAmount = formattedMinBaseAmount + " " + DASH_SYMBOL + " " + formattedMaxBaseAmount;
                 toSendCode = maxBaseSideAmount.getCode();
-                toReceiveAmount = formattedMinQuoteAmount + " " + DASH + " " + formattedMaxQuoteAmount;
+                toReceiveAmount = formattedMinQuoteAmount + " " + DASH_SYMBOL + " " + formattedMaxQuoteAmount;
                 toReceiveCode = maxQuoteSideAmount.getCode();
             } else {
-                toSendAmount = formattedMinQuoteAmount + " " + DASH + " " + formattedMaxQuoteAmount;
+                toSendAmount = formattedMinQuoteAmount + " " + DASH_SYMBOL + " " + formattedMaxQuoteAmount;
                 toSendCode = maxQuoteSideAmount.getCode();
-                toReceiveAmount = formattedMinBaseAmount + " " + DASH + " " + formattedMaxBaseAmount;
+                toReceiveAmount = formattedMinBaseAmount + " " + DASH_SYMBOL + " " + formattedMaxBaseAmount;
                 toReceiveCode = maxBaseSideAmount.getCode();
             }
         } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -78,6 +78,8 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class TradeWizardReviewController implements Controller {
+    private static final String DASH = "\u2013"; // Unicode code for "–"
+
     private final TradeWizardReviewModel model;
     @Getter
     private final TradeWizardReviewView view;
@@ -265,14 +267,14 @@ public class TradeWizardReviewController implements Controller {
             String formattedMaxQuoteAmount = AmountFormatter.formatAmount(maxQuoteSideAmount, true);
             String formattedMaxBaseAmount = AmountFormatter.formatAmount(maxBaseSideAmount, false);
             if (isCreateOfferMode && direction.isSell()) {
-                toSendAmount = formattedMinBaseAmount + " – " + formattedMaxBaseAmount;
+                toSendAmount = formattedMinBaseAmount + " " + DASH + " " + formattedMaxBaseAmount;
                 toSendCode = maxBaseSideAmount.getCode();
-                toReceiveAmount = formattedMinQuoteAmount + " – " + formattedMaxQuoteAmount;
+                toReceiveAmount = formattedMinQuoteAmount + " " + DASH + " " + formattedMaxQuoteAmount;
                 toReceiveCode = maxQuoteSideAmount.getCode();
             } else {
-                toSendAmount = formattedMinQuoteAmount + " – " + formattedMaxQuoteAmount;
+                toSendAmount = formattedMinQuoteAmount + " " + DASH + " " + formattedMaxQuoteAmount;
                 toSendCode = maxQuoteSideAmount.getCode();
-                toReceiveAmount = formattedMinBaseAmount + " – " + formattedMaxBaseAmount;
+                toReceiveAmount = formattedMinBaseAmount + " " + DASH + " " + formattedMaxBaseAmount;
                 toReceiveCode = maxBaseSideAmount.getCode();
             }
         } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewView.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.trade_wizard.review;
 
 import bisq.account.payment_method.FiatPaymentMethod;
 import bisq.desktop.common.Transitions;
+import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.MultiStyleLabelPane;
@@ -28,16 +29,19 @@ import bisq.desktop.main.content.bisq_easy.components.WaitingState;
 import bisq.desktop.main.content.bisq_easy.take_offer.TakeOfferView;
 import bisq.desktop.main.content.bisq_easy.trade_wizard.TradeWizardView;
 import bisq.i18n.Res;
-import javafx.animation.PauseTransition;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
-import javafx.scene.layout.*;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
-import javafx.util.Duration;
 import javafx.util.StringConverter;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
@@ -274,15 +278,13 @@ class TradeWizardReviewView extends View<StackPane, TradeWizardReviewModel, Trad
             Transitions.slideInTop(takeOfferStatus, 450);
             takeOfferSendMessageWaitingAnimation.playIndefinitely();
 
-            PauseTransition delay = new PauseTransition(Duration.seconds(8));
-            delay.setOnFinished(e -> {
+            UIScheduler.run(() -> {
                 minWaitingTimePassed = true;
                 if (model.getTakeOfferStatus().get() == TradeWizardReviewModel.TakeOfferStatus.SUCCESS) {
                     takeOfferStatus.getChildren().setAll(takeOfferSuccess, Spacer.fillVBox());
                     takeOfferSendMessageWaitingAnimation.stop();
                 }
-            });
-            delay.play();
+            }).after(8000);
         } else if (status == TradeWizardReviewModel.TakeOfferStatus.SUCCESS && minWaitingTimePassed) {
             takeOfferStatus.getChildren().setAll(takeOfferSuccess, Spacer.fillVBox());
             takeOfferSendMessageWaitingAnimation.stop();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/chat_rules/ChatRulesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/chat_rules/ChatRulesView.java
@@ -49,7 +49,7 @@ public class ChatRulesView extends View<VBox, ChatRulesModel, ChatRulesControlle
         headline.getStyleClass().add("chat-guide-headline");
 
         UnorderedList content = new UnorderedList(Res.get("chat.chatRules.content"), "bisq-text-13",
-                7, 5, UnorderedList.REGEX, UnorderedList.MARK);
+                7, 5, UnorderedList.REGEX, UnorderedList.BULLET_SYMBOL);
 
         closeIconButton = BisqIconButton.createIconButton("close");
 


### PR DESCRIPTION
* Use unicode to encode `–` instead of using it directly. This fixes issues on Windows:
    Before:
    ![image](https://github.com/bisq-network/bisq2/assets/145597137/9614dcc8-81d6-4410-8057-04eca4ae1990)

    After:
    ![image](https://github.com/bisq-network/bisq2/assets/145597137/c8b6da6b-383d-4bf9-b634-9d391a593f2a)

* Replace `PauseTransition` with `UIScheduler`.