### PR TITLE
Unify markets table style in trade wizard

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/SearchBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/SearchBox.java
@@ -79,6 +79,10 @@ public class SearchBox extends HBox {
         applyStyle(searchField.isFocused());
     }
 
+    public void setPromptText(String promptText) {
+        searchField.setPromptText(promptText);
+    }
+
     public final StringProperty textProperty() {
         return searchField.textProperty();
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/market/TradeWizardMarketView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/market/TradeWizardMarketView.java
@@ -85,6 +85,7 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
         tableViewWithSearchBox.setAlignment(Pos.TOP_RIGHT);
         tableViewWithSearchBox.setPrefSize(tableWidth, tableHeight);
         tableViewWithSearchBox.setMaxWidth(tableWidth);
+        tableViewWithSearchBox.getStyleClass().add("markets-table-container");
 
         root.getChildren().addAll(Spacer.fillVBox(), headlineLabel, subtitleLabel, tableViewWithSearchBox, Spacer.fillVBox());
     }
@@ -113,6 +114,7 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
     }
 
     private void configTableView() {
+        tableView.getColumns().add(tableView.getSelectionMarkerColumn());
         tableView.getColumns().add(new BisqTableColumn.Builder<MarketListItem>()
                 .title(Res.get("bisqEasy.tradeWizard.market.columns.name"))
                 .left()
@@ -144,7 +146,7 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
             private final Label label = new Label();
 
             {
-                label.setPadding(new Insets(0, 0, 0, -10));
+                label.setPadding(new Insets(0, 0, 0, 10));
                 label.setGraphicTextGap(8);
                 label.getStyleClass().add("bisq-text-8");
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/market/TradeWizardMarketView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/market/TradeWizardMarketView.java
@@ -67,8 +67,10 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
         subtitleLabel.getStyleClass().addAll("bisq-text-3", "wrap-text");
 
         searchBox = new SearchBox();
+        searchBox.setPromptText(Res.get("bisqEasy.tradeWizard.market.columns.name").toUpperCase());
         searchBox.setMinWidth(140);
         searchBox.setMaxWidth(140);
+        searchBox.getStyleClass().add("bisq-easy-trade-wizard-market-search");
 
         tableView = new BisqTableView<>(model.getSortedList());
         tableView.getStyleClass().add("bisq-easy-trade-wizard-market");
@@ -80,9 +82,9 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
         tableView.setMaxWidth(tableWidth);
         configTableView();
 
-        StackPane.setMargin(searchBox, new Insets(5, 15, 0, 0));
+        StackPane.setMargin(searchBox, new Insets(5, 0, 0, 15));
         StackPane tableViewWithSearchBox = new StackPane(tableView, searchBox);
-        tableViewWithSearchBox.setAlignment(Pos.TOP_RIGHT);
+        tableViewWithSearchBox.setAlignment(Pos.TOP_LEFT);
         tableViewWithSearchBox.setPrefSize(tableWidth, tableHeight);
         tableViewWithSearchBox.setMaxWidth(tableWidth);
         tableViewWithSearchBox.getStyleClass().add("markets-table-container");
@@ -116,9 +118,8 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
     private void configTableView() {
         tableView.getColumns().add(tableView.getSelectionMarkerColumn());
         tableView.getColumns().add(new BisqTableColumn.Builder<MarketListItem>()
-                .title(Res.get("bisqEasy.tradeWizard.market.columns.name"))
                 .left()
-                .minWidth(150)
+                .minWidth(120)
                 .comparator(Comparator.comparing(MarketListItem::getQuoteCurrencyName))
                 .setCellFactory(getNameCellFactory())
                 .build());
@@ -133,10 +134,6 @@ public class TradeWizardMarketView extends View<VBox, TradeWizardMarketModel, Tr
                 .minWidth(60)
                 .valueSupplier(MarketListItem::getNumUsers)
                 .comparator(Comparator.comparing(MarketListItem::getNumUsersAsInteger))
-                .build());
-        // We add a placeholder column as we show the search field at the header which would hide the column header
-        tableView.getColumns().add(new BisqTableColumn.Builder<MarketListItem>()
-                .fixWidth(140)
                 .build());
     }
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -738,6 +738,15 @@
     -fx-padding: 0;
 }
 
+.bisq-easy-trade-wizard-market-search {
+    -fx-background-color: -bisq-dark-grey-20;
+}
+
+.bisq-easy-trade-wizard-market-search .search-text-field {
+    -fx-font-family: "IBM Plex Sans Light";
+    -fx-font-size: 0.9em;
+}
+
 
 /*******************************************************************************
  * TradeWizardTakeOfferView.tableView                                          *

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -706,28 +706,36 @@
  * TradeWizardMarketView.tableView                                                       *
  ******************************************************************************/
 
-.bisq-easy-trade-wizard-market.table-view {
-    -fx-font-size: 1.15em;
+.markets-table-container {
+    -fx-background-color: -bisq-dark-grey-20;
+    -fx-border-width: 0 0 5px 0;
+    -fx-border-color: -bisq-dark-grey-20;
 }
 
-.bisq-easy-trade-wizard-market.table-view .column-header {
-    -fx-pref-height: 40;
+.bisq-easy-trade-wizard-market.table-view.table-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
 }
 
-.bisq-easy-trade-wizard-market.table-view .table-row-cell {
-    -fx-pref-height: 50;
+.bisq-easy-trade-wizard-market.table-view.table-view .column-header {
+    -fx-pref-height: 40px;
 }
 
-.bisq-easy-trade-wizard-market.table-view .table-row-cell .table-cell {
-    -fx-background-color: -bisq-dark-grey-40;
+.bisq-easy-trade-wizard-market.table-view.table-view .column-header .label {
+    -fx-alignment: center;
 }
 
-.bisq-easy-trade-wizard-market.table-view .table-row-cell:hover .table-cell {
-    -fx-background-color: -bisq-darker-grey;
+.bisq-easy-trade-wizard-market.table-view.table-view .table-row-cell:hover {
+    -fx-cursor: hand;
 }
 
-.bisq-easy-trade-wizard-market.table-view .table-row-cell:selected .table-cell {
-    -fx-background-color: -bisq2-green;
+.bisq-easy-trade-wizard-market.table-view.table-view .table-row-cell {
+    -fx-pref-height: 55px;
+    -fx-border-width: 0;
+}
+
+.bisq-easy-trade-wizard-market.table-view.table-view .table-cell {
+    -fx-padding: 0;
 }
 
 


### PR DESCRIPTION
* Unify markets table style in trade wizard.
* Use search fiat currency box as column title.

![image](https://github.com/bisq-network/bisq2/assets/145597137/7106ace4-137a-4178-96b1-525b2a5e2178)
