### PR TITLE
Ignore check for meta data until end of May at remove.

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public abstract class DataStorageService<T extends DataRequest> extends RateLimitedPersistenceClient<DataStore<T>> {
     // We had too narrow limits of the max map size and need to skip the check until data with the old values have expired
-    private final static Date IGNORE_MAX_MAP_SIZE_UNTIL = DateUtils.getUTCDate(2024, GregorianCalendar.MAY, 30);
+    public final static Date IGNORE_MAX_MAP_SIZE_UNTIL = DateUtils.getUTCDate(2024, GregorianCalendar.MAY, 30);
 
     public static final String STORE_POST_FIX = "Store";
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
@@ -29,6 +29,7 @@ import bisq.security.DigestUtil;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -169,13 +170,14 @@ public class AuthenticatedDataStorageService extends DataStorageService<Authenti
                     "requestFromMap expected be type of AddProtectedDataRequest");
             AddAuthenticatedDataRequest addRequestFromMap = (AddAuthenticatedDataRequest) requestFromMap;
 
-            // The metaData provided in the RemoveAuthenticatedDataRequest must be the same as we had in the AddAuthenticatedDataRequest
-            // The AddAuthenticatedDataRequest does use the metaData from the code base, not one provided by the message, thus it is trusted.
-            if (!request.getMetaData().equals(addRequestFromMap.getAuthenticatedSequentialData().getAuthenticatedData().getMetaData())) {
-                log.warn("MetaData of remove request not matching the one from the addRequest from the map. {} vs. {}",
-                        request.getMetaData(),
-                        addRequestFromMap.getAuthenticatedSequentialData().getAuthenticatedData().getMetaData());
-                return new DataStorageResult(false).metaDataInvalid();
+            if (new Date().after(IGNORE_MAX_MAP_SIZE_UNTIL)) {
+                // The metaData provided in the RemoveAuthenticatedDataRequest must be the same as we had in the AddAuthenticatedDataRequest
+                // The AddAuthenticatedDataRequest does use the metaData from the code base, not one provided by the message, thus it is trusted.
+                if (!request.getMetaData().equals(addRequestFromMap.getAuthenticatedSequentialData().getAuthenticatedData().getMetaData())) {
+                    log.warn("MetaData of remove request not matching the one from the addRequest from the map. {} vs. {}",
+                            request.getMetaData(),
+                            addRequestFromMap.getAuthenticatedSequentialData().getAuthenticatedData().getMetaData());
+                }
             }
 
             // We have an entry, lets validate if we can remove it


### PR DESCRIPTION
Do not return a failed result in case if it is different (might have further changes in future). The result would only have impact on the broadcast.