### PR TITLE
Add overlay to accept or reject new seller's price

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/UnorderedList.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/UnorderedList.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 public class UnorderedList extends TextList {
     public static final String REGEX = "- ";
     public static final String BULLET_SYMBOL = "\u2022"; // Unicode for "•"
+    private static final String STYLE_CLASS = "unordered-list";
 
     public UnorderedList(String text, String style, String regex, String mark) {
         this(text, style, 7, 0, regex, mark);
@@ -36,5 +37,7 @@ public class UnorderedList extends TextList {
 
     public UnorderedList(String text, @Nullable String style, double gap, double vSpacing, String regex, String mark) {
         super(text, style, gap, vSpacing, regex, mark);
+
+        getStyleClass().add(STYLE_CLASS);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyServiceUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyServiceUtil.java
@@ -113,6 +113,13 @@ public class BisqEasyServiceUtil {
                                                     String paymentMethodNames,
                                                     AmountSpec amountSpec,
                                                     PriceSpec priceSpec) {
+        String priceInfo = getFormattedPriceSpec(priceSpec);
+        boolean hasAmountRange = amountSpec instanceof RangeAmountSpec;
+        String quoteAmountAsString = OfferAmountFormatter.formatQuoteAmount(marketPriceService, amountSpec, priceSpec, market, hasAmountRange, true);
+        return buildOfferBookMessage(isMyMessage, messageOwnerNickName, direction, quoteAmountAsString, paymentMethodNames, priceInfo);
+    }
+
+    public static String getFormattedPriceSpec(PriceSpec priceSpec) {
         String priceInfo;
         if (priceSpec instanceof FixPriceSpec) {
             FixPriceSpec fixPriceSpec = (FixPriceSpec) priceSpec;
@@ -125,10 +132,7 @@ public class BisqEasyServiceUtil {
         } else {
             priceInfo = Res.get("bisqEasy.tradeWizard.review.chatMessage.marketPrice");
         }
-
-        boolean hasAmountRange = amountSpec instanceof RangeAmountSpec;
-        String quoteAmountAsString = OfferAmountFormatter.formatQuoteAmount(marketPriceService, amountSpec, priceSpec, market, hasAmountRange, true);
-        return buildOfferBookMessage(isMyMessage, messageOwnerNickName, direction, quoteAmountAsString, paymentMethodNames, priceInfo);
+        return priceInfo;
     }
 
     private static String buildOfferBookMessage(boolean isMyMessage,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyServiceUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyServiceUtil.java
@@ -113,7 +113,7 @@ public class BisqEasyServiceUtil {
                                                     String paymentMethodNames,
                                                     AmountSpec amountSpec,
                                                     PriceSpec priceSpec) {
-        String priceInfo = getFormattedPriceSpec(priceSpec);
+        String priceInfo = String.format("%s %s", Res.get("bisqEasy.tradeWizard.review.chatMessage.price"), getFormattedPriceSpec(priceSpec));
         boolean hasAmountRange = amountSpec instanceof RangeAmountSpec;
         String quoteAmountAsString = OfferAmountFormatter.formatQuoteAmount(marketPriceService, amountSpec, priceSpec, market, hasAmountRange, true);
         return buildOfferBookMessage(isMyMessage, messageOwnerNickName, direction, quoteAmountAsString, paymentMethodNames, priceInfo);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradePhaseBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradePhaseBox.java
@@ -18,7 +18,6 @@
 package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
 
 import bisq.bisq_easy.NavigationTarget;
-import bisq.chat.ChatService;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannelService;
 import bisq.common.data.Triple;
@@ -74,6 +73,10 @@ class TradePhaseBox {
 
     void reset() {
         controller.model.reset();
+    }
+
+    int getPhaseIndex() {
+        return controller.model.getPhaseIndex().get();
     }
 
     private static class Controller implements bisq.desktop.common.view.Controller {
@@ -230,7 +233,6 @@ class TradePhaseBox {
                     model.getBisqEasyTrade().getContract(),
                     mediationRequestService, channelService);
         }
-
     }
 
     @Getter

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -470,7 +470,8 @@ public class TradeStateController implements Controller {
 
     private void updateShouldShowSellerPriceApprovalOverlay() {
         model.getShouldShowSellerPriceApprovalOverlay().set(
-                model.getBisqEasyTrade().get().isBuyer()
+                model.getBisqEasyTrade().get() != null
+                        && model.getBisqEasyTrade().get().isBuyer()
                         && model.getBisqEasyTrade().get().isMaker()
                         && tradePhaseBox.getPhaseIndex() == 0
                         && requiresSellerPriceAcceptance()

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -28,7 +28,6 @@ import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
-import bisq.desktop.components.controls.UnorderedList;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.BisqEasyServiceUtil;
 import bisq.desktop.main.content.bisq_easy.components.TradeDataHeader;
@@ -155,15 +154,10 @@ public class TradeStateController implements Controller {
             updateShouldShowSellerPriceApprovalOverlay();
 
             VBox vBox = new VBox(
-                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice")),
-                    new UnorderedList(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.price",
-                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getOffer().getPriceSpec())),
-                            "bisq-text-13"),
-                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice")),
-                    new UnorderedList(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.price",
-                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getContract().getAgreedPriceSpec())),
-                            "bisq-text-13"),
-                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.question"))
+                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice",
+                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getOffer().getPriceSpec()))),
+                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice",
+                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getContract().getAgreedPriceSpec())))
             );
             model.getSellerPriceApprovalContent().set(vBox);
         });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -151,7 +151,7 @@ public class TradeStateController implements Controller {
                     hasAccepted -> updateShouldShowSellerPriceApprovalOverlay());
             updateShouldShowSellerPriceApprovalOverlay();
             model.getSellerPriceApprovalLabel().set(
-                    Res.get("bisqEasy.tradeState.info.buyer.phase1a.acceptOrRejectPrice",
+                    Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description",
                             BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getOffer().getPriceSpec()),
                             BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getContract().getAgreedPriceSpec()))
             );

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -28,6 +28,7 @@ import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
+import bisq.desktop.components.controls.UnorderedList;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.BisqEasyServiceUtil;
 import bisq.desktop.main.content.bisq_easy.components.TradeDataHeader;
@@ -39,6 +40,8 @@ import bisq.support.mediation.MediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
@@ -150,11 +153,19 @@ public class TradeStateController implements Controller {
             hasBuyerAcceptedPriceSpecPin = EasyBind.subscribe(model.getHasBuyerAcceptedSellersPriceSpec(),
                     hasAccepted -> updateShouldShowSellerPriceApprovalOverlay());
             updateShouldShowSellerPriceApprovalOverlay();
-            model.getSellerPriceApprovalLabel().set(
-                    Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description",
-                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getOffer().getPriceSpec()),
-                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getContract().getAgreedPriceSpec()))
+
+            VBox vBox = new VBox(
+                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice")),
+                    new UnorderedList(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.price",
+                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getOffer().getPriceSpec())),
+                            "bisq-text-13"),
+                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice")),
+                    new UnorderedList(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.price",
+                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getContract().getAgreedPriceSpec())),
+                            "bisq-text-13"),
+                    new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.question"))
             );
+            model.getSellerPriceApprovalContent().set(vBox);
         });
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -33,6 +33,7 @@ import bisq.desktop.main.content.bisq_easy.BisqEasyServiceUtil;
 import bisq.desktop.main.content.bisq_easy.components.TradeDataHeader;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.*;
 import bisq.i18n.Res;
+import bisq.offer.price.spec.PriceSpec;
 import bisq.settings.DontShowAgainService;
 import bisq.support.mediation.MediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
@@ -61,7 +62,7 @@ public class TradeStateController implements Controller {
     private final BisqEasyOpenTradeSelectionService selectionService;
     private final MediationRequestService mediationRequestService;
     private Pin bisqEasyTradeStatePin, errorMessagePin, peersErrorMessagePin, isInMediationPin;
-    private Subscription channelPin;
+    private Subscription channelPin, hasBuyerAcceptedPriceSpecPin;
 
     public TradeStateController(ServiceProvider serviceProvider) {
         this.serviceProvider = serviceProvider;
@@ -145,6 +146,15 @@ public class TradeStateController implements Controller {
                         }
                     }
             );
+
+            hasBuyerAcceptedPriceSpecPin = EasyBind.subscribe(model.getHasBuyerAcceptedSellersPriceSpec(),
+                    hasAccepted -> updateShouldShowSellerPriceApprovalOverlay());
+            updateShouldShowSellerPriceApprovalOverlay();
+            model.getSellerPriceApprovalLabel().set(
+                    Res.get("bisqEasy.tradeState.info.buyer.phase1a.acceptOrRejectPrice",
+                            bisqEasyTrade.getOffer().getPriceSpec().toString(),
+                            bisqEasyTrade.getContract().getAgreedPriceSpec().toString())
+            );
         });
     }
 
@@ -164,6 +174,9 @@ public class TradeStateController implements Controller {
         if (isInMediationPin != null) {
             isInMediationPin.unbind();
             isInMediationPin = null;
+        }
+        if (hasBuyerAcceptedPriceSpecPin != null) {
+            hasBuyerAcceptedPriceSpecPin.unsubscribe();
         }
         model.resetAll();
     }
@@ -231,6 +244,10 @@ public class TradeStateController implements Controller {
         OpenTradesUtils.reportToMediator(model.getChannel().get(),
                 model.getBisqEasyTrade().get().getContract(),
                 mediationRequestService, channelService);
+    }
+
+    void onAcceptSellersPriceButton() {
+        model.getHasBuyerAcceptedSellersPriceSpec().set(true);
     }
 
     private void applyStateInfoVBox(@Nullable BisqEasyTradeState state) {
@@ -444,5 +461,21 @@ public class TradeStateController implements Controller {
             default:
                 log.error("State {} not handled", state.name());
         }
+    }
+
+    private void updateShouldShowSellerPriceApprovalOverlay() {
+        model.getShouldShowSellerPriceApprovalOverlay().set(
+                model.getBisqEasyTrade().get().isBuyer()
+                        && model.getBisqEasyTrade().get().isMaker()
+                        && tradePhaseBox.getPhaseIndex() == 0
+                        && requiresSellerPriceAcceptance()
+                        && !model.getHasBuyerAcceptedSellersPriceSpec().get()
+        );
+    }
+
+    private boolean requiresSellerPriceAcceptance() {
+        PriceSpec buyerPriceSpec = model.getBisqEasyTrade().get().getOffer().getPriceSpec();
+        PriceSpec sellerPriceSpec = model.getBisqEasyTrade().get().getContract().getAgreedPriceSpec();
+        return !buyerPriceSpec.equals(sellerPriceSpec);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -152,8 +152,8 @@ public class TradeStateController implements Controller {
             updateShouldShowSellerPriceApprovalOverlay();
             model.getSellerPriceApprovalLabel().set(
                     Res.get("bisqEasy.tradeState.info.buyer.phase1a.acceptOrRejectPrice",
-                            bisqEasyTrade.getOffer().getPriceSpec().toString(),
-                            bisqEasyTrade.getContract().getAgreedPriceSpec().toString())
+                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getOffer().getPriceSpec()),
+                            BisqEasyServiceUtil.getFormattedPriceSpec(bisqEasyTrade.getContract().getAgreedPriceSpec()))
             );
         });
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateModel.java
@@ -49,6 +49,9 @@ public class TradeStateModel implements Model {
     private final BooleanProperty showReportToMediatorButton = new SimpleBooleanProperty();
     private final StringProperty tradeInterruptedInfo = new SimpleStringProperty();
     private final StringProperty errorMessage = new SimpleStringProperty();
+    private final BooleanProperty shouldShowSellerPriceApprovalOverlay = new SimpleBooleanProperty();
+    private final BooleanProperty hasBuyerAcceptedSellersPriceSpec = new SimpleBooleanProperty();
+    private final StringProperty sellerPriceApprovalLabel = new SimpleStringProperty();
 
     void resetAll() {
         reset();
@@ -65,5 +68,8 @@ public class TradeStateModel implements Model {
         error.set(false);
         showReportToMediatorButton.set(false);
         tradeInterruptedInfo.set(null);
+        shouldShowSellerPriceApprovalOverlay.set(false);
+        hasBuyerAcceptedSellersPriceSpec.set(false);
+        sellerPriceApprovalLabel.set(null);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateModel.java
@@ -20,7 +20,12 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
 import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.desktop.common.view.Model;
 import bisq.trade.bisq_easy.BisqEasyTrade;
-import javafx.beans.property.*;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.scene.layout.VBox;
 import lombok.Getter;
 import lombok.Setter;
@@ -51,7 +56,7 @@ public class TradeStateModel implements Model {
     private final StringProperty errorMessage = new SimpleStringProperty();
     private final BooleanProperty shouldShowSellerPriceApprovalOverlay = new SimpleBooleanProperty();
     private final BooleanProperty hasBuyerAcceptedSellersPriceSpec = new SimpleBooleanProperty();
-    private final StringProperty sellerPriceApprovalLabel = new SimpleStringProperty();
+    private final ObjectProperty<VBox> sellerPriceApprovalContent = new SimpleObjectProperty<>();
 
     void resetAll() {
         reset();
@@ -70,6 +75,6 @@ public class TradeStateModel implements Model {
         tradeInterruptedInfo.set(null);
         shouldShowSellerPriceApprovalOverlay.set(false);
         hasBuyerAcceptedSellersPriceSpec.set(false);
-        sellerPriceApprovalLabel.set(null);
+        sellerPriceApprovalContent.set(null);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -109,7 +109,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         VBox content = new VBox(tradeDataHeader, Layout.hLine(), isInMediationHBox, interruptedHBox, phaseAndInfoHBox);
         content.getStyleClass().add("bisq-easy-container");
 
-        acceptSellersPriceButton = new Button(Res.get("action.close"));
+        acceptSellersPriceButton = new Button(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.button.accept"));
         acceptSellersPriceButton.getStyleClass().add("outlined-button");
         setUpSellerPriceApprovalOverlay();
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -215,18 +215,21 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
 
     private void setUpSellerPriceApprovalOverlay() {
         sellerPriceApprovalOverlay = new VBox();
-        sellerPriceApprovalOverlay.setAlignment(Pos.CENTER);
+        sellerPriceApprovalOverlay.setAlignment(Pos.TOP_LEFT);
         sellerPriceApprovalOverlay.getStyleClass().addAll("trade-wizard-feedback-bg", "seller-price-approval-popup");
-        sellerPriceApprovalOverlay.setPadding(new Insets(30));
         sellerPriceApprovalOverlay.visibleProperty().set(false);
         sellerPriceApprovalOverlay.managedProperty().set(false);
 
+        Label sellerPriceApprovalTitleLabel = new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.title"));
+        sellerPriceApprovalTitleLabel.getStyleClass().addAll("seller-price-approval-title", "large-text", "font-default");
         sellerPriceApprovalLabel = new Label();
+        sellerPriceApprovalLabel.getStyleClass().addAll("seller-price-approval-description", "normal-text", "font-default");
         sellerPriceApprovalLabel.setWrapText(true);
         HBox sellerPriceApprovalButtons = new HBox(10, acceptSellersPriceButton, cancelButton);
         sellerPriceApprovalButtons.setAlignment(Pos.BOTTOM_RIGHT);
 
-        sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalLabel, Spacer.fillVBox(), sellerPriceApprovalButtons);
+        sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalTitleLabel, sellerPriceApprovalLabel,
+                Spacer.fillVBox(), sellerPriceApprovalButtons);
         StackPane.setAlignment(sellerPriceApprovalOverlay, Pos.TOP_CENTER);
         StackPane.setMargin(sellerPriceApprovalOverlay, new Insets(63, 0, 0, 0));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -214,7 +214,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
     }
 
     private void setUpSellerPriceApprovalOverlay() {
-        sellerPriceApprovalOverlay = new VBox(20);
+        sellerPriceApprovalOverlay = new VBox();
         sellerPriceApprovalOverlay.setAlignment(Pos.CENTER);
         sellerPriceApprovalOverlay.getStyleClass().addAll("trade-wizard-feedback-bg", "seller-price-approval-popup");
         sellerPriceApprovalOverlay.setPadding(new Insets(30));
@@ -226,7 +226,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         HBox sellerPriceApprovalButtons = new HBox(10, acceptSellersPriceButton, cancelButton);
         sellerPriceApprovalButtons.setAlignment(Pos.BOTTOM_RIGHT);
 
-        sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalLabel, sellerPriceApprovalButtons);
+        sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalLabel, Spacer.fillVBox(), sellerPriceApprovalButtons);
         StackPane.setAlignment(sellerPriceApprovalOverlay, Pos.TOP_CENTER);
         StackPane.setMargin(sellerPriceApprovalOverlay, new Insets(63, 0, 0, 0));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -40,7 +40,8 @@ import org.fxmisc.easybind.Subscription;
 @Slf4j
 public class TradeStateView extends View<VBox, TradeStateModel, TradeStateController> {
     private final HBox phaseAndInfoHBox, cancelledHBox, interruptedHBox, errorHBox, isInMediationHBox;
-    private final Button cancelButton, closeTradeButton, exportButton, reportToMediatorButton, acceptSellersPriceButton;
+    private final Button cancelButton, closeTradeButton, exportButton, reportToMediatorButton, acceptSellersPriceButton,
+            rejectPriceButton;
     private final Label cancelledInfo, errorMessage;
     private VBox sellerPriceApprovalOverlay;
     private Pane sellerPriceApprovalContent;
@@ -54,6 +55,11 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
 
         cancelButton = new Button();
         cancelButton.setMinWidth(160);
+        cancelButton.getStyleClass().add("outlined-button");
+
+        rejectPriceButton = new Button();
+        rejectPriceButton.setMinWidth(160);
+        rejectPriceButton.setDefaultButton(true);
 
         tradeDataHeader.getChildren().addAll(Spacer.fillHBox(), cancelButton);
 
@@ -140,6 +146,10 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.visibleProperty().bind(model.getCancelButtonVisible());
         cancelButton.managedProperty().bind(model.getCancelButtonVisible());
 
+        rejectPriceButton.textProperty().bind(model.getInterruptTradeButtonText());
+        rejectPriceButton.visibleProperty().bind(model.getCancelButtonVisible());
+        rejectPriceButton.managedProperty().bind(model.getCancelButtonVisible());
+
         stateInfoVBoxPin = EasyBind.subscribe(model.getStateInfoVBox(), stateInfoVBox -> {
             if (phaseAndInfoHBox.getChildren().size() == 2) {
                 phaseAndInfoHBox.getChildren().remove(1);
@@ -152,15 +162,12 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         });
 
         showSellersPriceApprovalOverlayPin = EasyBind.subscribe(model.getShouldShowSellerPriceApprovalOverlay(), shouldShow -> {
-            cancelButton.setDefaultButton(shouldShow);
             if (shouldShow) {
-                cancelButton.getStyleClass().remove("outlined-button");
                 sellerPriceApprovalOverlay.setVisible(true);
                 sellerPriceApprovalOverlay.setManaged(true);
                 Transitions.blurStrong(phaseAndInfoHBox, 0);
                 Transitions.slideInTop(sellerPriceApprovalOverlay, 450);
             } else {
-                cancelButton.getStyleClass().add("outlined-button");
                 sellerPriceApprovalOverlay.setVisible(false);
                 sellerPriceApprovalOverlay.setManaged(false);
                 Transitions.removeEffect(phaseAndInfoHBox);
@@ -177,6 +184,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.setOnAction(e -> controller.onInterruptTrade());
         closeTradeButton.setOnAction(e -> controller.onCloseTrade());
         exportButton.setOnAction(e -> controller.onExportTrade());
+        rejectPriceButton.setOnAction(e -> controller.onInterruptTrade());
         reportToMediatorButton.setOnAction(e -> controller.onReportToMediator());
         acceptSellersPriceButton.setOnAction(e -> controller.onAcceptSellersPriceButton());
     }
@@ -203,6 +211,10 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.visibleProperty().unbind();
         cancelButton.managedProperty().unbind();
 
+        rejectPriceButton.textProperty().unbind();
+        rejectPriceButton.visibleProperty().unbind();
+        rejectPriceButton.managedProperty().unbind();
+
         stateInfoVBoxPin.unsubscribe();
         showSellersPriceApprovalOverlayPin.unsubscribe();
         sellerPriceApprovalContentPin.unsubscribe();
@@ -210,6 +222,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.setOnAction(null);
         closeTradeButton.setOnAction(null);
         exportButton.setOnAction(null);
+        rejectPriceButton.setOnAction(null);
         reportToMediatorButton.setOnAction(null);
         acceptSellersPriceButton.setOnAction(null);
 
@@ -229,11 +242,14 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         sellerPriceApprovalTitleLabel.getStyleClass().addAll("seller-price-approval-title", "large-text", "font-default");
         sellerPriceApprovalContent = new Pane();
         sellerPriceApprovalContent.getStyleClass().addAll("seller-price-approval-description", "normal-text", "font-default");
-        HBox sellerPriceApprovalButtons = new HBox(10, acceptSellersPriceButton, cancelButton);
+        Label sellerPriceApprovalQuestionLabel = new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.description.question"));
+        sellerPriceApprovalQuestionLabel.getStyleClass().addAll("seller-price-approval-description", "normal-text",
+                "font-default", "seller-price-approval-question");
+        HBox sellerPriceApprovalButtons = new HBox(10, acceptSellersPriceButton, rejectPriceButton);
         sellerPriceApprovalButtons.setAlignment(Pos.BOTTOM_RIGHT);
 
         sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalTitleLabel, sellerPriceApprovalContent,
-                Spacer.fillVBox(), sellerPriceApprovalButtons);
+                sellerPriceApprovalQuestionLabel, Spacer.fillVBox(), sellerPriceApprovalButtons);
         StackPane.setAlignment(sellerPriceApprovalOverlay, Pos.TOP_CENTER);
         StackPane.setMargin(sellerPriceApprovalOverlay, new Insets(63, 0, 0, 0));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -29,6 +29,7 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -42,8 +43,8 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
     private final Button cancelButton, closeTradeButton, exportButton, reportToMediatorButton, acceptSellersPriceButton;
     private final Label cancelledInfo, errorMessage;
     private VBox sellerPriceApprovalOverlay;
-    private Label sellerPriceApprovalLabel;
-    private Subscription stateInfoVBoxPin, showSellersPriceApprovalOverlayPin;
+    private Pane sellerPriceApprovalContent;
+    private Subscription stateInfoVBoxPin, showSellersPriceApprovalOverlayPin, sellerPriceApprovalContentPin;
 
     public TradeStateView(TradeStateModel model,
                           TradeStateController controller,
@@ -139,8 +140,6 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.visibleProperty().bind(model.getCancelButtonVisible());
         cancelButton.managedProperty().bind(model.getCancelButtonVisible());
 
-        sellerPriceApprovalLabel.textProperty().bind(model.getSellerPriceApprovalLabel());
-
         stateInfoVBoxPin = EasyBind.subscribe(model.getStateInfoVBox(), stateInfoVBox -> {
             if (phaseAndInfoHBox.getChildren().size() == 2) {
                 phaseAndInfoHBox.getChildren().remove(1);
@@ -165,6 +164,13 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
                 sellerPriceApprovalOverlay.setVisible(false);
                 sellerPriceApprovalOverlay.setManaged(false);
                 Transitions.removeEffect(phaseAndInfoHBox);
+            }
+        });
+
+        sellerPriceApprovalContentPin = EasyBind.subscribe(model.getSellerPriceApprovalContent(), content -> {
+            if (content != null) {
+                content.getStyleClass().setAll("seller-price-approval-content");
+                sellerPriceApprovalContent.getChildren().setAll(content);
             }
         });
 
@@ -197,10 +203,9 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.visibleProperty().unbind();
         cancelButton.managedProperty().unbind();
 
-        sellerPriceApprovalLabel.textProperty().unbind();
-
         stateInfoVBoxPin.unsubscribe();
         showSellersPriceApprovalOverlayPin.unsubscribe();
+        sellerPriceApprovalContentPin.unsubscribe();
 
         cancelButton.setOnAction(null);
         closeTradeButton.setOnAction(null);
@@ -222,13 +227,12 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
 
         Label sellerPriceApprovalTitleLabel = new Label(Res.get("bisqEasy.tradeState.acceptOrRejectSellersPrice.title"));
         sellerPriceApprovalTitleLabel.getStyleClass().addAll("seller-price-approval-title", "large-text", "font-default");
-        sellerPriceApprovalLabel = new Label();
-        sellerPriceApprovalLabel.getStyleClass().addAll("seller-price-approval-description", "normal-text", "font-default");
-        sellerPriceApprovalLabel.setWrapText(true);
+        sellerPriceApprovalContent = new Pane();
+        sellerPriceApprovalContent.getStyleClass().addAll("seller-price-approval-description", "normal-text", "font-default");
         HBox sellerPriceApprovalButtons = new HBox(10, acceptSellersPriceButton, cancelButton);
         sellerPriceApprovalButtons.setAlignment(Pos.BOTTOM_RIGHT);
 
-        sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalTitleLabel, sellerPriceApprovalLabel,
+        sellerPriceApprovalOverlay.getChildren().addAll(sellerPriceApprovalTitleLabel, sellerPriceApprovalContent,
                 Spacer.fillVBox(), sellerPriceApprovalButtons);
         StackPane.setAlignment(sellerPriceApprovalOverlay, Pos.TOP_CENTER);
         StackPane.setMargin(sellerPriceApprovalOverlay, new Insets(63, 0, 0, 0));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
 
 import bisq.desktop.common.Icons;
 import bisq.desktop.common.Layout;
+import bisq.desktop.common.Transitions;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
 import bisq.i18n.Res;
@@ -105,14 +106,14 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         VBox.setMargin(isInMediationHBox, new Insets(20, 30, 0, 30));
         VBox.setMargin(interruptedHBox, new Insets(20, 30, 20, 30));
         VBox.setMargin(phaseAndInfoHBox, new Insets(0, 30, 15, 30));
-        VBox vBox = new VBox(tradeDataHeader, Layout.hLine(), isInMediationHBox, interruptedHBox, phaseAndInfoHBox);
-        vBox.getStyleClass().add("bisq-easy-container");
+        VBox content = new VBox(tradeDataHeader, Layout.hLine(), isInMediationHBox, interruptedHBox, phaseAndInfoHBox);
+        content.getStyleClass().add("bisq-easy-container");
 
         acceptSellersPriceButton = new Button(Res.get("action.close"));
         acceptSellersPriceButton.getStyleClass().add("outlined-button");
         setUpSellerPriceApprovalOverlay();
 
-        StackPane layeredContent = new StackPane(vBox, sellerPriceApprovalOverlay);
+        StackPane layeredContent = new StackPane(content, sellerPriceApprovalOverlay);
         root.getChildren().add(layeredContent);
     }
 
@@ -138,8 +139,6 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.visibleProperty().bind(model.getCancelButtonVisible());
         cancelButton.managedProperty().bind(model.getCancelButtonVisible());
 
-        sellerPriceApprovalOverlay.visibleProperty().bind(model.getShouldShowSellerPriceApprovalOverlay());
-        sellerPriceApprovalOverlay.managedProperty().bind(model.getShouldShowSellerPriceApprovalOverlay());
         sellerPriceApprovalLabel.textProperty().bind(model.getSellerPriceApprovalLabel());
 
         stateInfoVBoxPin = EasyBind.subscribe(model.getStateInfoVBox(), stateInfoVBox -> {
@@ -157,8 +156,15 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
             cancelButton.setDefaultButton(shouldShow);
             if (shouldShow) {
                 cancelButton.getStyleClass().remove("outlined-button");
+                sellerPriceApprovalOverlay.setVisible(true);
+                sellerPriceApprovalOverlay.setManaged(true);
+                Transitions.blurStrong(phaseAndInfoHBox, 0);
+                Transitions.slideInTop(sellerPriceApprovalOverlay, 450);
             } else {
                 cancelButton.getStyleClass().add("outlined-button");
+                sellerPriceApprovalOverlay.setVisible(false);
+                sellerPriceApprovalOverlay.setManaged(false);
+                Transitions.removeEffect(phaseAndInfoHBox);
             }
         });
 
@@ -191,8 +197,6 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.visibleProperty().unbind();
         cancelButton.managedProperty().unbind();
 
-        sellerPriceApprovalOverlay.visibleProperty().unbind();
-        sellerPriceApprovalOverlay.managedProperty().unbind();
         sellerPriceApprovalLabel.textProperty().unbind();
 
         stateInfoVBoxPin.unsubscribe();
@@ -214,6 +218,9 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         sellerPriceApprovalOverlay.setAlignment(Pos.CENTER);
         sellerPriceApprovalOverlay.getStyleClass().addAll("trade-wizard-feedback-bg", "seller-price-approval-popup");
         sellerPriceApprovalOverlay.setPadding(new Insets(30));
+        sellerPriceApprovalOverlay.visibleProperty().set(false);
+        sellerPriceApprovalOverlay.managedProperty().set(false);
+
         sellerPriceApprovalLabel = new Label();
         sellerPriceApprovalLabel.setWrapText(true);
         HBox sellerPriceApprovalButtons = new HBox(10, acceptSellersPriceButton, cancelButton);

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -439,9 +439,9 @@
 
 /* Temporary overlay */
 .seller-price-approval-popup {
-    -fx-min-height: 250;
-    -fx-pref-height: 250;
-    -fx-max-height: 250;
+    -fx-min-height: 300;
+    -fx-pref-height: 300;
+    -fx-max-height: 300;
     -fx-min-width: 800;
     -fx-pref-width: 800;
     -fx-max-width: 800;
@@ -451,13 +451,21 @@
 .seller-price-approval-popup .seller-price-approval-title {
     -fx-fill: -bisq2-green;
     -fx-text-fill: -bisq2-green;
-
 }
 
-.seller-price-approval-popup .seller-price-approval-description {
+.seller-price-approval-popup .seller-price-approval-content {
     -fx-fill: -fx-light-text-color;
     -fx-text-fill: -fx-light-text-color;
-    -fx-padding: 20 0 0 0;
+    -fx-padding: 10 0 0 0;
+    -fx-spacing: 10;
+}
+
+.seller-price-approval-popup .seller-price-approval-content .unordered-list {
+    -fx-padding: 0 0 0 20;
+}
+
+.seller-price-approval-popup .seller-price-approval-description .label {
+    -fx-wrap-text: true;
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -437,6 +437,30 @@
     -fx-font-family: "IBM Plex Sans Light";
 }
 
+/* Temporary overlay */
+.seller-price-approval-popup {
+    -fx-min-height: 250;
+    -fx-pref-height: 250;
+    -fx-max-height: 250;
+    -fx-min-width: 800;
+    -fx-pref-width: 800;
+    -fx-max-width: 800;
+    -fx-padding: 30 60 30 60;
+}
+
+.seller-price-approval-popup .seller-price-approval-title {
+    -fx-fill: -bisq2-green;
+    -fx-text-fill: -bisq2-green;
+
+}
+
+.seller-price-approval-popup .seller-price-approval-description {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-padding: 20 0 0 0;
+}
+
+
 /*******************************************************************************
  * Trade state phase (left side box)                                           *
  ******************************************************************************/
@@ -514,21 +538,6 @@
     -fx-fill: -fx-mid-text-color;
     -fx-text-fill: -fx-mid-text-color;
     -fx-font-size: 1em;
-    -fx-font-family: "IBM Plex Sans Light";
-}
-
-/* Temporary popup in Buyer Phase 1a */
-.seller-price-approval-popup {
-    -fx-min-height: 250;
-    -fx-max-height: 250;
-    -fx-min-width: 500;
-    -fx-max-width: 500;
-}
-
-.seller-price-approval-popup .label {
-    -fx-fill: -fx-light-text-color;
-    -fx-text-fill: -fx-light-text-color;
-    -fx-font-size: 1.2em;
     -fx-font-family: "IBM Plex Sans Light";
 }
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -519,10 +519,17 @@
 
 /* Temporary popup in Buyer Phase 1a */
 .seller-price-approval-popup {
-    -fx-min-height: 200;
-    -fx-max-height: 200;
+    -fx-min-height: 250;
+    -fx-max-height: 250;
     -fx-min-width: 500;
     -fx-max-width: 500;
+}
+
+.seller-price-approval-popup .label {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-font-size: 1.2em;
+    -fx-font-family: "IBM Plex Sans Light";
 }
 
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -438,7 +438,7 @@
 }
 
 /*******************************************************************************
- * Trade state phase (left side box)                                                                  *
+ * Trade state phase (left side box)                                           *
  ******************************************************************************/
 
 .bisq-easy-trade-state-phase {
@@ -493,7 +493,7 @@
 
 
 /*******************************************************************************
- * Trade state phase info (right side box)                                                                *
+ * Trade state phase info (right side box)                                     *
  ******************************************************************************/
 
 .bisq-easy-trade-state-headline {
@@ -517,10 +517,18 @@
     -fx-font-family: "IBM Plex Sans Light";
 }
 
+/* Temporary popup in Buyer Phase 1a */
+.seller-price-approval-popup {
+    -fx-min-height: 200;
+    -fx-max-height: 200;
+    -fx-min-width: 500;
+    -fx-max-width: 500;
+}
+
 
 /*******************************************************************************
  *                                                                             *
- * Trade wizard                                                        *
+ * Trade wizard                                                                *
  *                                                                             *
  ******************************************************************************/
 

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -456,16 +456,16 @@
 .seller-price-approval-popup .seller-price-approval-content {
     -fx-fill: -fx-light-text-color;
     -fx-text-fill: -fx-light-text-color;
-    -fx-padding: 10 0 0 0;
+    -fx-padding: 30 0 0 0;
     -fx-spacing: 10;
-}
-
-.seller-price-approval-popup .seller-price-approval-content .unordered-list {
-    -fx-padding: 0 0 0 20;
 }
 
 .seller-price-approval-popup .seller-price-approval-description .label {
     -fx-wrap-text: true;
+}
+
+.seller-price-approval-popup .seller-price-approval-question {
+    -fx-padding: 30 0 0 0;
 }
 
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -558,10 +558,9 @@ bisqEasy.openTrades.welcome.line3=Make yourself familiar with the trade rules
 
 bisqEasy.tradeState.requestMediation=Request mediation
 bisqEasy.tradeState.reportToMediator=Report to mediator
-bisqEasy.tradeState.acceptOrRejectSellersPrice.title=Attention
-bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice=Your offer price to buy Bitcoin was:
-bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice=However, the seller is offering you this price:
-bisqEasy.tradeState.acceptOrRejectSellersPrice.description.price=- {0}.
+bisqEasy.tradeState.acceptOrRejectSellersPrice.title=Attention!
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice=Your offer price to buy Bitcoin was: {0}.
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice=However, the seller is offering you this price: {0}.
 bisqEasy.tradeState.acceptOrRejectSellersPrice.description.question=Do you want to accept this new price or do you want to cancel/reject the trade?
 bisqEasy.tradeState.acceptOrRejectSellersPrice.button.accept=Accept price
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -557,6 +557,10 @@ bisqEasy.openTrades.welcome.line3=Make yourself familiar with the trade rules
 
 bisqEasy.tradeState.requestMediation=Request mediation
 bisqEasy.tradeState.reportToMediator=Report to mediator
+bisqEasy.tradeState.acceptOrRejectSellersPrice.title=Attention
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description=Your offer price to buy Bitcoin was {0}. \
+  However, the seller has taken this offer with {1}.\n\n\
+  Do you want to accept his price or do you want to cancel/reject the trade?
 
 # Trade State: Header
 bisqEasy.tradeState.header.peer=Trade peer
@@ -594,9 +598,6 @@ bisqEasy.tradeState.info.buyer.phase1a.btcAddress.help=If you have not set up a 
 bisqEasy.tradeState.info.buyer.phase1a.walletHelpButton=Open wallet guide
 bisqEasy.tradeState.info.buyer.phase1a.sendBtcAddress=Send Bitcoin address to the seller
 bisqEasy.tradeState.info.buyer.phase1a.systemMessage={0} has submitted the Bitcoin address to the system
-bisqEasy.tradeState.info.buyer.phase1a.acceptOrRejectPrice=Your offer price to buy Bitcoin was {0}. \
-  However, the seller has taken this offer with {1}.\n\n\
-  Do you want to accept his price or do you want to cancel/reject the trade?
 
 bisqEasy.tradeState.info.buyer.phase1b.headline=Wait for the seller's payment account data
 bisqEasy.tradeState.info.buyer.phase1b.info=You can use the chat below for getting in touch with the seller.

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -595,8 +595,8 @@ bisqEasy.tradeState.info.buyer.phase1a.walletHelpButton=Open wallet guide
 bisqEasy.tradeState.info.buyer.phase1a.sendBtcAddress=Send Bitcoin address to the seller
 bisqEasy.tradeState.info.buyer.phase1a.systemMessage={0} has submitted the Bitcoin address to the system
 bisqEasy.tradeState.info.buyer.phase1a.acceptOrRejectPrice=Your offer price to buy Bitcoin was {0}. \
-  However, the seller has taken this offer at price {1}.\n\
-  Do you want to accept his price or cancel/reject the trade?
+  However, the seller has taken this offer with {1}.\n\n\
+  Do you want to accept his price or do you want to cancel/reject the trade?
 
 bisqEasy.tradeState.info.buyer.phase1b.headline=Wait for the seller's payment account data
 bisqEasy.tradeState.info.buyer.phase1b.info=You can use the chat below for getting in touch with the seller.

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -594,6 +594,9 @@ bisqEasy.tradeState.info.buyer.phase1a.btcAddress.help=If you have not set up a 
 bisqEasy.tradeState.info.buyer.phase1a.walletHelpButton=Open wallet guide
 bisqEasy.tradeState.info.buyer.phase1a.sendBtcAddress=Send Bitcoin address to the seller
 bisqEasy.tradeState.info.buyer.phase1a.systemMessage={0} has submitted the Bitcoin address to the system
+bisqEasy.tradeState.info.buyer.phase1a.acceptOrRejectPrice=Your offer price to buy Bitcoin was {0}. \
+  However, the seller has taken this offer at price {1}.\n\
+  Do you want to accept his price or cancel/reject the trade?
 
 bisqEasy.tradeState.info.buyer.phase1b.headline=Wait for the seller's payment account data
 bisqEasy.tradeState.info.buyer.phase1b.info=You can use the chat below for getting in touch with the seller.

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -225,9 +225,10 @@ bisqEasy.tradeWizard.review.table.baseAmount.buyer=You receive
 bisqEasy.tradeWizard.review.table.baseAmount.seller=You spend
 bisqEasy.tradeWizard.review.table.price=Price in {0}
 bisqEasy.tradeWizard.review.table.reputation=Reputation
-bisqEasy.tradeWizard.review.chatMessage.fixPrice=Price: {0}
-bisqEasy.tradeWizard.review.chatMessage.floatPrice=Price: {0} above market price
-bisqEasy.tradeWizard.review.chatMessage.marketPrice=Price: Market price
+bisqEasy.tradeWizard.review.chatMessage.fixPrice={0}
+bisqEasy.tradeWizard.review.chatMessage.floatPrice={0} above market price
+bisqEasy.tradeWizard.review.chatMessage.marketPrice=Market price
+bisqEasy.tradeWizard.review.chatMessage.price=Price:
 bisqEasy.tradeWizard.review.chatMessage.myMessage=My Offer to {0} Bitcoin\n\
   Amount: {1}\n\
   Payment method(s): {2}\n\
@@ -558,9 +559,10 @@ bisqEasy.openTrades.welcome.line3=Make yourself familiar with the trade rules
 bisqEasy.tradeState.requestMediation=Request mediation
 bisqEasy.tradeState.reportToMediator=Report to mediator
 bisqEasy.tradeState.acceptOrRejectSellersPrice.title=Attention
-bisqEasy.tradeState.acceptOrRejectSellersPrice.description=Your offer price to buy Bitcoin was {0}. \
-  However, the seller has taken this offer with {1}.\n\n\
-  Do you want to accept this new price or do you want to cancel/reject the trade?
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.buyersPrice=Your offer price to buy Bitcoin was:
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.sellersPrice=However, the seller is offering you this price:
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.price=- {0}.
+bisqEasy.tradeState.acceptOrRejectSellersPrice.description.question=Do you want to accept this new price or do you want to cancel/reject the trade?
 bisqEasy.tradeState.acceptOrRejectSellersPrice.button.accept=Accept price
 
 # Trade State: Header

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -560,7 +560,8 @@ bisqEasy.tradeState.reportToMediator=Report to mediator
 bisqEasy.tradeState.acceptOrRejectSellersPrice.title=Attention
 bisqEasy.tradeState.acceptOrRejectSellersPrice.description=Your offer price to buy Bitcoin was {0}. \
   However, the seller has taken this offer with {1}.\n\n\
-  Do you want to accept his price or do you want to cancel/reject the trade?
+  Do you want to accept this new price or do you want to cancel/reject the trade?
+bisqEasy.tradeState.acceptOrRejectSellersPrice.button.accept=Accept price
 
 # Trade State: Header
 bisqEasy.tradeState.header.peer=Trade peer

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandler.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandler.java
@@ -55,8 +55,8 @@ public class BisqEasyTakeOfferRequestHandler extends TradeMessageHandler<BisqEas
         verifyMessage(message);
 
         BisqEasyContract contract = message.getBisqEasyContract();
-        checkArgument(trade.getOffer().getPriceSpec().equals(contract.getAgreedPriceSpec()),
-                "Price spec cannot be changed from the one set in offer since v2.0.3. Update software to take this offer.");
+//        checkArgument(trade.getOffer().getPriceSpec().equals(contract.getAgreedPriceSpec()),
+//                "Price spec cannot be changed from the one set in offer since v2.0.3.");
         ContractSignatureData takersContractSignatureData = message.getContractSignatureData();
         ContractService contractService = serviceProvider.getContractService();
         try {


### PR DESCRIPTION
Towards #1949 

This PR resolves better "Case 2: Buy offer made in 2.0.3 and taken with 2.0.2", as explained in https://github.com/bisq-network/bisq2/pull/1999#issuecomment-2042849307.
Now, instead of throwing when there's a mismatch in price spec, we allow the buyer to decide if he wants to accept or not.

![image](https://github.com/bisq-network/bisq2/assets/145597137/f69a2dee-131b-4c9b-bf55-2605abe39c1c)

Will follow-up with these improvements:
- [ ] Perhaps as it is now, the buyer needs to accept the new price more than once. At the moment, only after he sends the btc address the overlays disappears.
- [ ] Also, if the seller has sent account details, the buyer will receive the warning for violating the contract if cancelling - I will update that too so that it's always a reject for this case.