### PR TITLE
Revert changes of meta data

### DIFF
--- a/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
@@ -43,7 +43,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 @EqualsAndHashCode
 @Getter
 public final class AuthorizedBondedRole implements AuthorizedDistributedData {
-    private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGHEST_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_1000);
+    private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGHEST_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
     private final String profileId;
     private final String authorizedPublicKey;
     private final BondedRoleType bondedRoleType;

--- a/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
@@ -40,7 +40,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 @EqualsAndHashCode
 @Getter
 public final class AuthorizedOracleNode implements AuthorizedDistributedData {
-    private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGHEST_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_1000);
+    private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGHEST_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
     private final NetworkId networkId;
     private final String profileId;
     private final String authorizedPublicKey;

--- a/bonded-roles/src/main/java/bisq/bonded_roles/registration/BondedRoleRegistrationRequest.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/registration/BondedRoleRegistrationRequest.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 
-import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_1000;
+import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 
 @Slf4j
@@ -44,7 +44,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 @ToString
 @EqualsAndHashCode
 public final class BondedRoleRegistrationRequest implements MailboxMessage {
-    private final MetaData metaData = new MetaData(TTL_10_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_1000);
+    private final MetaData metaData = new MetaData(TTL_10_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
     private final String profileId;
     private final String authorizedPublicKey;
     private final BondedRoleType bondedRoleType;

--- a/chat/src/main/java/bisq/chat/bisqeasy/open_trades/BisqEasyOpenTradeMessage.java
+++ b/chat/src/main/java/bisq/chat/bisqeasy/open_trades/BisqEasyOpenTradeMessage.java
@@ -61,7 +61,7 @@ public final class BisqEasyOpenTradeMessage extends PrivateChatMessage implement
                 bisqEasyOffer);
     }
 
-    private final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_5000);
+    private final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     private final String tradeId;
     private final Optional<UserProfile> mediator;

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatMessage.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatMessage.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 
-import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_5000;
+import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
 
 @Slf4j
@@ -41,7 +41,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class TwoPartyPrivateChatMessage extends PrivateChatMessage {
-    private final MetaData metaData = new MetaData(TTL_30_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_5000);
+    private final MetaData metaData = new MetaData(TTL_30_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     public TwoPartyPrivateChatMessage(String messageId,
                                       ChatChannelDomain chatChannelDomain,

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/AckMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/AckMessage.java
@@ -18,7 +18,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 @EqualsAndHashCode
 @ToString
 public final class AckMessage implements MailboxMessage, Response {
-    private final MetaData metaData = new MetaData(TTL_2_DAYS, LOW_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_1000);
+    private final MetaData metaData = new MetaData(TTL_2_DAYS, LOW_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     private final String id;
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
@@ -90,7 +90,7 @@ public abstract class DataStorageService<T extends DataRequest> extends RateLimi
             return maxMapSize.get();
         }
         maxMapSize = persistableStore.getMap().values().stream().map(DataRequest::getMaxMapSize).findFirst();
-        return maxMapSize.orElse(MetaData.MAX_MAP_SIZE_50_000);
+        return maxMapSize.orElse(MetaData.MAX_MAP_SIZE_10_000);
     }
 
     protected boolean isExceedingMapSize() {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
@@ -90,7 +90,7 @@ public abstract class DataStorageService<T extends DataRequest> extends RateLimi
             return maxMapSize.get();
         }
         maxMapSize = persistableStore.getMap().values().stream().map(DataRequest::getMaxMapSize).findFirst();
-        return maxMapSize.orElse(MetaData.MAX_MAP_SIZE_10_000);
+        return maxMapSize.orElse(MetaData.MAX_MAP_SIZE_50_000);
     }
 
     protected boolean isExceedingMapSize() {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
@@ -43,7 +43,9 @@ public final class MetaData implements NetworkProto {
 
     public static final int MAX_MAP_SIZE_100 = 100;
     public static final int MAX_MAP_SIZE_1000 = 1000;
+    public static final int MAX_MAP_SIZE_5000 = 5000;
     public static final int MAX_MAP_SIZE_10_000 = 10_000;
+    public static final int MAX_MAP_SIZE_50_000 = 50_000;
 
     public static final int LOW_PRIORITY = -1;
     public static final int DEFAULT_PRIORITY = 0;

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
@@ -41,10 +41,9 @@ public final class MetaData implements NetworkProto {
     public static final long TTL_30_DAYS = TimeUnit.DAYS.toMillis(30);
     public static final long TTL_100_DAYS = TimeUnit.DAYS.toMillis(100);
 
+    public static final int MAX_MAP_SIZE_100 = 100;
     public static final int MAX_MAP_SIZE_1000 = 1000;
-    public static final int MAX_MAP_SIZE_5000 = 5000;
     public static final int MAX_MAP_SIZE_10_000 = 10_000;
-    public static final int MAX_MAP_SIZE_50_000 = 50_000;
 
     public static final int LOW_PRIORITY = -1;
     public static final int DEFAULT_PRIORITY = 0;
@@ -61,11 +60,11 @@ public final class MetaData implements NetworkProto {
     }
 
     public MetaData(long ttl, String className) {
-        this(ttl, className, MAX_MAP_SIZE_10_000);
+        this(ttl, className, MAX_MAP_SIZE_1000);
     }
 
     public MetaData(long ttl, int priority, String className) {
-        this(ttl, priority, className, MAX_MAP_SIZE_10_000);
+        this(ttl, priority, className, MAX_MAP_SIZE_1000);
     }
 
     public MetaData(long ttl, String className, int maxMapSize) {
@@ -102,7 +101,7 @@ public final class MetaData implements NetworkProto {
 
     public double getCostFactor() {
         double ttlImpact = MathUtils.bounded(0, 1, ttl / (double) TTL_100_DAYS);
-        double mapSizeImpact = MathUtils.bounded(0, 1, maxMapSize / (double) MAX_MAP_SIZE_50_000);
+        double mapSizeImpact = MathUtils.bounded(0, 1, maxMapSize / (double) MAX_MAP_SIZE_10_000);
         double impact = ttlImpact + mapSizeImpact;
         return MathUtils.bounded(0, 1, impact);
     }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
@@ -170,6 +170,7 @@ public class AuthenticatedDataStorageService extends DataStorageService<Authenti
                     "requestFromMap expected be type of AddProtectedDataRequest");
             AddAuthenticatedDataRequest addRequestFromMap = (AddAuthenticatedDataRequest) requestFromMap;
 
+            // We skip that check for a while because we plan updates of the map size values
             if (new Date().after(IGNORE_MAX_MAP_SIZE_UNTIL)) {
                 // The metaData provided in the RemoveAuthenticatedDataRequest must be the same as we had in the AddAuthenticatedDataRequest
                 // The AddAuthenticatedDataRequest does use the metaData from the code base, not one provided by the message, thus it is trusted.

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -60,7 +60,7 @@ public final class UserProfile implements DistributedData {
     }
 
     // We give a bit longer TTL than the chat messages to ensure the chat user is available as long the messages are 
-    private final MetaData metaData = new MetaData(TTL_15_DAYS, DEFAULT_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_50_000);
+    private final MetaData metaData = new MetaData(TTL_15_DAYS, DEFAULT_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_10_000);
     private final String nickName;
     // We need the proofOfWork for verification of the nym and cathash icon
     private final ProofOfWork proofOfWork;

--- a/user/src/main/java/bisq/user/reputation/requests/AuthorizeAccountAgeRequest.java
+++ b/user/src/main/java/bisq/user/reputation/requests/AuthorizeAccountAgeRequest.java
@@ -31,7 +31,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_1000;
+import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 
 @Slf4j
@@ -39,7 +39,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 @ToString
 @EqualsAndHashCode
 public final class AuthorizeAccountAgeRequest implements MailboxMessage {
-    private final MetaData metaData = new MetaData(TTL_10_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_1000);
+    private final MetaData metaData = new MetaData(TTL_10_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
     private final String profileId;
     private final String hashAsHex;
     private final long date;

--- a/user/src/main/java/bisq/user/reputation/requests/AuthorizeSignedWitnessRequest.java
+++ b/user/src/main/java/bisq/user/reputation/requests/AuthorizeSignedWitnessRequest.java
@@ -31,7 +31,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_1000;
+import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 
 @Slf4j
@@ -39,7 +39,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 @ToString
 @EqualsAndHashCode
 public final class AuthorizeSignedWitnessRequest implements MailboxMessage {
-    private final MetaData metaData = new MetaData(TTL_10_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_1000);
+    private final MetaData metaData = new MetaData(TTL_10_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
     private final String profileId;
     private final String hashAsHex;
     private final long accountAgeWitnessDate;


### PR DESCRIPTION
Revert the changes of map size in MetaData to not break compatibility (e.g. remove from storage is broken).

We need to add first support to ignore fields for the hash creation before we can apply those changes. In the meantime we ignore the check or the max size to avoid the problems caused by it that mailbox messages are dropped because the map is full.