### PR TITLE
Add ExcludeForHash annotation

### DIFF
--- a/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
+++ b/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
@@ -1,0 +1,12 @@
+package bisq.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExcludeForHash {
+}


### PR DESCRIPTION
Add getBuilder method to Proto
Add serializeForHash method

When serializeForHash is used we clear all fields annotated with `ExcludeForHash`. This allows more flexibility for not identity-defining fields in use cases where we use the hash like in: data storage, pow, signatures The getBuilder default method is just temporary to avoid the need to update all implementations of Proto. Follow up commits will apply the new interface to the code base