### PR TITLE
Prepare for exclude for hash annotation

### DIFF
--- a/account/src/main/java/bisq/account/protocol_type/LoanProtocolType.java
+++ b/account/src/main/java/bisq/account/protocol_type/LoanProtocolType.java
@@ -24,7 +24,7 @@ public enum LoanProtocolType implements ProtocolType {
     REPUTATION;
 
     @Override
-    public bisq.account.protobuf.LoanProtocolType toProto() {
+    public bisq.account.protobuf.LoanProtocolType toProtoEnum() {
         return bisq.account.protobuf.LoanProtocolType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/account/src/main/java/bisq/account/protocol_type/TradeProtocolType.java
+++ b/account/src/main/java/bisq/account/protocol_type/TradeProtocolType.java
@@ -31,7 +31,7 @@ public enum TradeProtocolType implements ProtocolType {
     MONERO_SWAP;
 
     @Override
-    public bisq.account.protobuf.TradeProtocolType toProto() {
+    public bisq.account.protobuf.TradeProtocolType toProtoEnum() {
         return bisq.account.protobuf.TradeProtocolType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/BondedRoleType.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/BondedRoleType.java
@@ -52,7 +52,7 @@ public enum BondedRoleType implements ProtoEnum {
     }
 
     @Override
-    public bisq.bonded_roles.protobuf.BondedRoleType toProto() {
+    public bisq.bonded_roles.protobuf.BondedRoleType toProtoEnum() {
         return bisq.bonded_roles.protobuf.BondedRoleType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
@@ -90,7 +90,7 @@ public final class AuthorizedBondedRole implements AuthorizedDistributedData {
         bisq.bonded_roles.protobuf.AuthorizedBondedRole.Builder builder = bisq.bonded_roles.protobuf.AuthorizedBondedRole.newBuilder()
                 .setProfileId(profileId)
                 .setAuthorizedPublicKey(authorizedPublicKey)
-                .setBondedRoleType(bondedRoleType.toProto())
+                .setBondedRoleType(bondedRoleType.toProtoEnum())
                 .setBondUserName(bondUserName)
                 .setSignatureBase64(signatureBase64)
                 .setNetworkId(networkId.toProto())

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPrice.java
@@ -68,7 +68,7 @@ public final class MarketPrice implements NetworkProto {
         return bisq.bonded_roles.protobuf.MarketPrice.newBuilder()
                 .setPriceQuote(priceQuote.toProto())
                 .setTimestamp(timestamp)
-                .setMarketPriceProvider(marketPriceProvider.toProto())
+                .setMarketPriceProvider(marketPriceProvider.toProtoEnum())
                 .build();
     }
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProvider.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProvider.java
@@ -43,7 +43,7 @@ public enum MarketPriceProvider implements ProtoEnum {
     }
 
     @Override
-    public bisq.bonded_roles.protobuf.MarketPriceProvider toProto() {
+    public bisq.bonded_roles.protobuf.MarketPriceProvider toProtoEnum() {
         return bisq.bonded_roles.protobuf.MarketPriceProvider.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/registration/BondedRoleRegistrationRequest.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/registration/BondedRoleRegistrationRequest.java
@@ -94,7 +94,7 @@ public final class BondedRoleRegistrationRequest implements MailboxMessage {
         var builder = bisq.bonded_roles.protobuf.BondedRoleRegistrationRequest.newBuilder()
                 .setProfileId(profileId)
                 .setAuthorizedPublicKey(authorizedPublicKey)
-                .setBondedRoleType(bondedRoleType.toProto())
+                .setBondedRoleType(bondedRoleType.toProtoEnum())
                 .setBondUserName(bondUserName)
                 .setSignatureBase64(signatureBase64)
                 .setNetworkId(networkId.toProto())

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AlertType.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AlertType.java
@@ -27,7 +27,7 @@ public enum AlertType implements ProtoEnum {
     BAN;
 
     @Override
-    public bisq.bonded_roles.protobuf.AlertType toProto() {
+    public bisq.bonded_roles.protobuf.AlertType toProtoEnum() {
         return bisq.bonded_roles.protobuf.AlertType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
@@ -100,7 +100,7 @@ public final class AuthorizedAlertData implements AuthorizedDistributedData {
         bisq.bonded_roles.protobuf.AuthorizedAlertData.Builder builder = bisq.bonded_roles.protobuf.AuthorizedAlertData.newBuilder()
                 .setId(id)
                 .setDate(date)
-                .setAlertType(alertType.toProto())
+                .setAlertType(alertType.toProtoEnum())
                 .setHaltTrading(haltTrading)
                 .setRequireVersionForTrading(requireVersionForTrading)
                 .setSecurityManagerProfileId(securityManagerProfileId)

--- a/chat/src/main/java/bisq/chat/ChatChannel.java
+++ b/chat/src/main/java/bisq/chat/ChatChannel.java
@@ -58,8 +58,8 @@ public abstract class ChatChannel<M extends ChatMessage> implements PersistableP
     public bisq.chat.protobuf.ChatChannel.Builder getChatChannelBuilder() {
         return bisq.chat.protobuf.ChatChannel.newBuilder()
                 .setId(id)
-                .setChatChannelDomain(chatChannelDomain.toProto())
-                .setChatChannelNotificationType(chatChannelNotificationType.get().toProto());
+                .setChatChannelDomain(chatChannelDomain.toProtoEnum())
+                .setChatChannelNotificationType(chatChannelNotificationType.get().toProtoEnum());
     }
 
     public abstract bisq.chat.protobuf.ChatChannel toProto();

--- a/chat/src/main/java/bisq/chat/ChatChannelDomain.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelDomain.java
@@ -30,7 +30,7 @@ public enum ChatChannelDomain implements ProtoEnum {
     SUPPORT;
 
     @Override
-    public bisq.chat.protobuf.ChatChannelDomain toProto() {
+    public bisq.chat.protobuf.ChatChannelDomain toProtoEnum() {
         return bisq.chat.protobuf.ChatChannelDomain.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/chat/src/main/java/bisq/chat/ChatChannelNotificationType.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelNotificationType.java
@@ -28,7 +28,7 @@ public enum ChatChannelNotificationType implements ProtoEnum {
     OFF;
 
     @Override
-    public bisq.chat.protobuf.ChatChannelNotificationType toProto() {
+    public bisq.chat.protobuf.ChatChannelNotificationType toProtoEnum() {
         return bisq.chat.protobuf.ChatChannelNotificationType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/chat/src/main/java/bisq/chat/ChatMessage.java
+++ b/chat/src/main/java/bisq/chat/ChatMessage.java
@@ -89,12 +89,12 @@ public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessag
     public bisq.chat.protobuf.ChatMessage.Builder getChatMessageBuilder() {
         bisq.chat.protobuf.ChatMessage.Builder builder = bisq.chat.protobuf.ChatMessage.newBuilder()
                 .setId(id)
-                .setChatChannelDomain(chatChannelDomain.toProto())
+                .setChatChannelDomain(chatChannelDomain.toProtoEnum())
                 .setChannelId(channelId)
                 .setAuthorUserProfileId(authorUserProfileId)
                 .setDate(date)
                 .setWasEdited(wasEdited)
-                .setChatMessageType(chatMessageType.toProto());
+                .setChatMessageType(chatMessageType.toProtoEnum());
         citation.ifPresent(citation -> builder.setCitation(citation.toProto()));
         text.ifPresent(builder::setText);
         return builder;

--- a/chat/src/main/java/bisq/chat/ChatMessageType.java
+++ b/chat/src/main/java/bisq/chat/ChatMessageType.java
@@ -27,7 +27,7 @@ public enum ChatMessageType implements ProtoEnum {
     PROTOCOL_LOG_MESSAGE;
 
     @Override
-    public bisq.chat.protobuf.ChatMessageType toProto() {
+    public bisq.chat.protobuf.ChatMessageType toProtoEnum() {
         return bisq.chat.protobuf.ChatMessageType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
@@ -108,7 +108,7 @@ public class ChatNotification implements Notification, PersistableProto {
                 .setMessage(message)
                 .setDate(date)
                 .setChatChannelId(chatChannelId)
-                .setChatChannelDomain(chatChannelDomain.toProto())
+                .setChatChannelDomain(chatChannelDomain.toProtoEnum())
                 .setChatMessageId(chatMessageId)
                 .setIsConsumed(isConsumed.get());
         tradeId.ifPresent(builder::setTradeId);

--- a/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
+++ b/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
@@ -1,0 +1,12 @@
+package bisq.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExcludeForHash {
+}

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -17,7 +17,16 @@
 
 package bisq.common.proto;
 
+import bisq.common.annotation.ExcludeForHash;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Interface for any object which gets serialized using protobuf.
@@ -32,16 +41,57 @@ import com.google.protobuf.Message;
 public interface Proto {
     Message toProto();
 
+    default Message.Builder getBuilder(boolean ignoreAnnotation) {
+        return null;
+    }
+
+    default Message toProto(boolean ignoreAnnotation) {
+        return buildProto(ignoreAnnotation);
+    }
+
+    default <T extends Message> T buildProto(boolean ignoreAnnotation) {
+        var builder = ignoreAnnotation ? getBuilder(true) : clearAnnotatedFields(getBuilder(false));
+        return (T) builder.build();
+    }
+
     default byte[] serialize() {
-        return toProto().toByteArray();
+        return buildProto(true).toByteArray();
     }
 
     default byte[] serializeForHash() {
-        // TODO
-        return toProto().toByteArray();
+        return buildProto(false).toByteArray();
     }
 
     default int getSerializedSize() {
-        return toProto().getSerializedSize();
+        return buildProto(true).getSerializedSize();
+    }
+
+    default Set<String> getExcludedFields() {
+        return Arrays.stream(getClass().getDeclaredFields())
+                .peek(field -> field.setAccessible(true))
+                .filter(field -> field.isAnnotationPresent(ExcludeForHash.class))
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Requires that the name of the java fields is the same as the name of the proto definition.
+     *
+     * @param builder The builder we transform by clearing the ExcludeForHash annotated fields.
+     * @return Builder with the fields annotated with ExcludeForHash cleared.
+     */
+    default <B extends Message.Builder> B clearAnnotatedFields(B builder) {
+        Set<String> excludedFields = getExcludedFields();
+        getLogger().info("Clear fields in builder annotated with @ExcludeForHash: {}", excludedFields);
+        for (Descriptors.FieldDescriptor fieldDesc : builder.getAllFields().keySet()) {
+            if (excludedFields.contains(fieldDesc.getName())) {
+                builder.clearField(fieldDesc);
+            }
+        }
+        return (B) builder;
+    }
+
+    private Logger getLogger() {
+        return LoggerFactory.getLogger(getClass().getSimpleName());
     }
 }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -23,6 +23,8 @@ import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Set;
@@ -64,6 +66,10 @@ public interface Proto {
 
     default int getSerializedSize() {
         return buildProto(true).getSerializedSize();
+    }
+
+    default void writeDelimitedTo(OutputStream outputStream) throws IOException {
+        toProto(true).writeDelimitedTo(outputStream);
     }
 
     default Set<String> getExcludedFields() {

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -36,6 +36,11 @@ public interface Proto {
         return toProto().toByteArray();
     }
 
+    default byte[] serializeForHash() {
+        // TODO
+        return toProto().toByteArray();
+    }
+
     default int getSerializedSize() {
         return toProto().getSerializedSize();
     }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -35,4 +35,8 @@ public interface Proto {
     default byte[] serialize() {
         return toProto().toByteArray();
     }
+
+    default int getSerializedSize() {
+        return toProto().getSerializedSize();
+    }
 }

--- a/common/src/main/java/bisq/common/proto/ProtoEnum.java
+++ b/common/src/main/java/bisq/common/proto/ProtoEnum.java
@@ -24,7 +24,7 @@ import com.google.protobuf.ProtocolMessageEnum;
  * Interface for any enum which gets serialized using protobuf
  */
 public interface ProtoEnum {
-    ProtocolMessageEnum toProto();
+    ProtocolMessageEnum toProtoEnum();
 
     default String getProtobufEnumPrefix() {
         return getProtobufEnumPrefix(this.getClass());

--- a/common/src/main/java/bisq/common/util/ProtobufUtils.java
+++ b/common/src/main/java/bisq/common/util/ProtobufUtils.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -73,13 +72,6 @@ public class ProtobufUtils {
     public static String getProtoType(Any any) {
         String[] tokens = any.getTypeUrl().split("/");
         return tokens.length > 1 ? tokens[1] : "";
-    }
-
-    public static byte[] getByteArrayFromProto(com.google.protobuf.Message proto) throws IOException {
-        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
-            proto.writeDelimitedTo(byteArrayOutputStream);
-            return byteArrayOutputStream.toByteArray();
-        }
     }
 
     public static Any toAny(byte[] bytes) throws IOException {

--- a/common/src/test/java/bisq/common/proto/ExcludeForHashTest.java
+++ b/common/src/test/java/bisq/common/proto/ExcludeForHashTest.java
@@ -1,0 +1,81 @@
+package bisq.common.proto;
+
+import bisq.common.encoding.Hex;
+import bisq.common.proto.mocks.*;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Slf4j
+public class ExcludeForHashTest {
+
+    @Test
+    public void testExcludeForHash() {
+        String serialized, serializeNonExcluded;
+        Child child;
+        Parent parent;
+
+        // No annotations
+        child = new ChildMock("childValue");
+        parent = new ParentMock("parentValue", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertEquals(serialized, serializeNonExcluded);
+
+        // ParentMockWithExcludedValue
+        child = new ChildMock("childValue");
+        parent = new ParentMockWithExcludedValue("parentValue", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertNotEquals(serialized, serializeNonExcluded);
+
+        // If annotated field is set to default value (empty string) we get same results
+        parent = new ParentMockWithExcludedValue("", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertEquals(serialized, serializeNonExcluded);
+
+        // ParentMockWithExcludedChild
+        child = new ChildMock("childValue");
+        parent = new ParentMockWithExcludedChild("parentValue", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertNotEquals(serialized, serializeNonExcluded);
+
+        // ParentMockWithExcludedChild and ChildMockWithExcludedValue
+        child = new ChildMockWithExcludedValue("childValue");
+        parent = new ParentMockWithExcludedChild("parentValue", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertNotEquals(serialized, serializeNonExcluded);
+
+
+        // If child is excluded it does not matter what actual child impl is
+        child = new ChildMockWithExcludedValue("childValue");
+        parent = new ParentMockWithExcludedChild("parentValue", child);
+        var serialized1 = Hex.encode(parent.serializeForHash());
+
+        child = new ChildMock("childValue");
+        parent = new ParentMockWithExcludedChild("parentValue", child);
+        var serialized2 = Hex.encode(parent.serializeForHash());
+        assertEquals(serialized1, serialized2);
+
+
+        // ChildMockWithExcludedValue
+        child = new ChildMockWithExcludedValue("childValue");
+        parent = new ParentMock("parentValue", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertNotEquals(serialized, serializeNonExcluded);
+
+
+        // ChildMockWithExcludedValue and ParentMockWithExcludedValue
+        child = new ChildMockWithExcludedValue("childValue");
+        parent = new ParentMockWithExcludedValue("parentValue", child);
+        serialized = Hex.encode(parent.serialize());
+        serializeNonExcluded = Hex.encode(parent.serializeForHash());
+        assertNotEquals(serialized, serializeNonExcluded);
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/Child.java
+++ b/common/src/test/java/bisq/common/proto/mocks/Child.java
@@ -1,0 +1,16 @@
+package bisq.common.proto.mocks;
+
+import bisq.common.proto.Proto;
+
+public interface Child extends Proto {
+    String getChildValue();
+
+    bisq.common.test.protobuf.Child toProto(boolean ignoreAnnotation);
+
+    bisq.common.test.protobuf.Child.Builder getBuilder(boolean ignoreAnnotation);
+
+    @Override
+    default bisq.common.test.protobuf.Parent toProto() {
+        return buildProto(true);
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/ChildMock.java
+++ b/common/src/test/java/bisq/common/proto/mocks/ChildMock.java
@@ -1,0 +1,25 @@
+package bisq.common.proto.mocks;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public class ChildMock implements Child {
+    private final String childValue;
+
+    public ChildMock(String childValue) {
+        this.childValue = childValue;
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Child toProto(boolean ignoreAnnotation) {
+        return buildProto(ignoreAnnotation);
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Child.Builder getBuilder(boolean ignoreAnnotation) {
+        return bisq.common.test.protobuf.Child.newBuilder()
+                .setChildValue(childValue);
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/ChildMockWithExcludedValue.java
+++ b/common/src/test/java/bisq/common/proto/mocks/ChildMockWithExcludedValue.java
@@ -1,0 +1,27 @@
+package bisq.common.proto.mocks;
+
+import bisq.common.annotation.ExcludeForHash;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public class ChildMockWithExcludedValue implements Child {
+    @ExcludeForHash
+    private final String childValue;
+
+    public ChildMockWithExcludedValue(String childValue) {
+        this.childValue = childValue;
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Child toProto(boolean ignoreAnnotation) {
+        return buildProto(ignoreAnnotation);
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Child.Builder getBuilder(boolean ignoreAnnotation) {
+        return bisq.common.test.protobuf.Child.newBuilder()
+                .setChildValue(childValue);
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/Parent.java
+++ b/common/src/test/java/bisq/common/proto/mocks/Parent.java
@@ -1,0 +1,18 @@
+package bisq.common.proto.mocks;
+
+import bisq.common.proto.Proto;
+
+public interface Parent extends Proto {
+    String getParentValue();
+
+    Child getChild();
+
+    bisq.common.test.protobuf.Parent toProto(boolean ignoreAnnotation);
+
+    bisq.common.test.protobuf.Parent.Builder getBuilder(boolean ignoreAnnotation);
+
+    @Override
+    default bisq.common.test.protobuf.Parent toProto() {
+        return buildProto(true);
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/ParentMock.java
+++ b/common/src/test/java/bisq/common/proto/mocks/ParentMock.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.proto.mocks;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public final class ParentMock implements Parent {
+    private final String parentValue;
+    private final Child child;
+
+    public ParentMock(String parentValue, Child child) {
+        this.parentValue = parentValue;
+        this.child = child;
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Parent toProto(boolean ignoreAnnotation) {
+        return buildProto(ignoreAnnotation);
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Parent.Builder getBuilder(boolean ignoreAnnotation) {
+        return bisq.common.test.protobuf.Parent.newBuilder()
+                .setParentValue(parentValue)
+                .setChild(child.toProto(ignoreAnnotation));
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/ParentMockWithExcludedChild.java
+++ b/common/src/test/java/bisq/common/proto/mocks/ParentMockWithExcludedChild.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.proto.mocks;
+
+import bisq.common.annotation.ExcludeForHash;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public final class ParentMockWithExcludedChild implements Parent {
+    private final String parentValue;
+    @ExcludeForHash
+    private final Child child;
+
+    public ParentMockWithExcludedChild(String parentValue, Child child) {
+        this.parentValue = parentValue;
+        this.child = child;
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Parent toProto(boolean ignoreAnnotation) {
+        return buildProto(ignoreAnnotation);
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Parent.Builder getBuilder(boolean ignoreAnnotation) {
+        return bisq.common.test.protobuf.Parent.newBuilder()
+                .setParentValue(parentValue)
+                .setChild(child.toProto(ignoreAnnotation));
+    }
+}

--- a/common/src/test/java/bisq/common/proto/mocks/ParentMockWithExcludedValue.java
+++ b/common/src/test/java/bisq/common/proto/mocks/ParentMockWithExcludedValue.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.proto.mocks;
+
+import bisq.common.annotation.ExcludeForHash;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public final class ParentMockWithExcludedValue implements Parent {
+    @ExcludeForHash
+    private final String parentValue;
+    private final Child child;
+
+    public ParentMockWithExcludedValue(String parentValue, Child child) {
+        this.parentValue = parentValue;
+        this.child = child;
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Parent toProto(boolean ignoreAnnotation) {
+        return buildProto(ignoreAnnotation);
+    }
+
+    @Override
+    public bisq.common.test.protobuf.Parent.Builder getBuilder(boolean ignoreAnnotation) {
+        return bisq.common.test.protobuf.Parent.newBuilder()
+                .setParentValue(parentValue)
+                .setChild(child.toProto(ignoreAnnotation));
+    }
+}

--- a/common/src/test/proto/common.proto
+++ b/common/src/test/proto/common.proto
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+syntax = "proto3";
+
+package common;
+option java_package = "bisq.common.test.protobuf";
+option java_multiple_files = true;
+
+message Child {
+  string childValue = 1;
+}
+
+message Parent {
+  string parentValue = 1;
+  Child child = 2;
+}

--- a/contract/src/main/java/bisq/contract/Contract.java
+++ b/contract/src/main/java/bisq/contract/Contract.java
@@ -58,7 +58,7 @@ public abstract class Contract<T extends Offer<?, ?>> implements NetworkProto {
         return bisq.contract.protobuf.Contract.newBuilder()
                 .setTakeOfferDate(takeOfferDate)
                 .setOffer(offer.toProto())
-                .setTradeProtocolType(protocolType.toProto());
+                .setTradeProtocolType(protocolType.toProtoEnum());
     }
 
     public static Contract<?> fromProto(bisq.contract.protobuf.Contract proto) {

--- a/contract/src/main/java/bisq/contract/Contract.java
+++ b/contract/src/main/java/bisq/contract/Contract.java
@@ -78,16 +78,4 @@ public abstract class Contract<T extends Offer<?, ?>> implements NetworkProto {
     }
 
     public abstract Party getTaker();
-
-    /**
-     * We need to provide a deterministic serialisation of our data (including all child objects).
-     * Any collection must be deterministically sorted.
-     * To use protobuf serialisation comes with some risks, but it can be assumed that version updates will
-     * not break byte representation even protobuf does not provide such guarantees. Worst case, we need to stick with
-     * the version before a breaking change happens or implement our own serialisation format (which comes with
-     * considerable effort as it need to cover all the object path downwards).
-     */
-    public byte[] getHashForSignature() {
-        return toProto().toByteArray();
-    }
 }

--- a/contract/src/main/java/bisq/contract/ContractService.java
+++ b/contract/src/main/java/bisq/contract/ContractService.java
@@ -75,7 +75,7 @@ public class ContractService implements Service {
     }
 
     private <T extends Offer<?, ?>> byte[] getContractHash(Contract<T> contract) {
-        return DigestUtil.hash(contract.getHashForSignature());
+        return DigestUtil.hash(contract.serializeForHash());
     }
 
 }

--- a/contract/src/main/java/bisq/contract/Party.java
+++ b/contract/src/main/java/bisq/contract/Party.java
@@ -44,7 +44,7 @@ public final class Party implements NetworkProto {
     @Override
     public bisq.contract.protobuf.Party toProto() {
         return bisq.contract.protobuf.Party.newBuilder()
-                .setRole(role.toProto())
+                .setRole(role.toProtoEnum())
                 .setNetworkId(networkId.toProto())
                 .build();
     }

--- a/contract/src/main/java/bisq/contract/Role.java
+++ b/contract/src/main/java/bisq/contract/Role.java
@@ -26,7 +26,7 @@ public enum Role implements ProtoEnum {
     ESCROW_AGENT;
 
     @Override
-    public bisq.contract.protobuf.Role toProto() {
+    public bisq.contract.protobuf.Role toProtoEnum() {
         return bisq.contract.protobuf.Role.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
+++ b/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
@@ -91,7 +91,7 @@ public class NetworkEnvelopeSocketChannelTests {
         NetworkEnvelope requestNetworkEnvelope = createHandshakeRequestMessage();
 
         OutputStream outputStream = Channels.newOutputStream(serverToClientSocketChannel);
-        requestNetworkEnvelope.toProto().writeDelimitedTo(outputStream);
+        requestNetworkEnvelope.writeDelimitedTo(outputStream);
 
         List<NetworkEnvelope> receivedNetworkEnvelopes = networkEnvelopeSocketChannel.receiveNetworkEnvelopes();
         assertThat(receivedNetworkEnvelopes).containsExactly(requestNetworkEnvelope);
@@ -102,8 +102,8 @@ public class NetworkEnvelopeSocketChannelTests {
         NetworkEnvelope requestNetworkEnvelope = createHandshakeRequestMessage();
 
         OutputStream outputStream = Channels.newOutputStream(serverToClientSocketChannel);
-        requestNetworkEnvelope.toProto().writeDelimitedTo(outputStream);
-        requestNetworkEnvelope.toProto().writeDelimitedTo(outputStream);
+        requestNetworkEnvelope.writeDelimitedTo(outputStream);
+        requestNetworkEnvelope.writeDelimitedTo(outputStream);
 
         List<NetworkEnvelope> receivedNetworkEnvelopes = networkEnvelopeSocketChannel.receiveNetworkEnvelopes();
         assertThat(receivedNetworkEnvelopes)
@@ -116,7 +116,7 @@ public class NetworkEnvelopeSocketChannelTests {
         NetworkEnvelope requestNetworkEnvelope = createHandshakeRequestMessage();
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        requestNetworkEnvelope.toProto().writeDelimitedTo(byteArrayOutputStream);
+        requestNetworkEnvelope.writeDelimitedTo(byteArrayOutputStream);
 
         byte[] messageInBytes = byteArrayOutputStream.toByteArray();
         // 176 bytes
@@ -137,7 +137,7 @@ public class NetworkEnvelopeSocketChannelTests {
         NetworkEnvelope requestNetworkEnvelope = createHandshakeRequestMessage();
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        requestNetworkEnvelope.toProto().writeDelimitedTo(byteArrayOutputStream);
+        requestNetworkEnvelope.writeDelimitedTo(byteArrayOutputStream);
 
         byte[] messageInBytes = byteArrayOutputStream.toByteArray();
         // 176 bytes
@@ -172,7 +172,7 @@ public class NetworkEnvelopeSocketChannelTests {
         NetworkEnvelope requestNetworkEnvelope = createHandshakeRequestMessage();
 
         OutputStream outputStream = Channels.newOutputStream(serverToClientSocketChannel);
-        requestNetworkEnvelope.toProto().writeDelimitedTo(outputStream);
+        requestNetworkEnvelope.writeDelimitedTo(outputStream);
 
         // read first 100 bytes
         List<NetworkEnvelope> receivedNetworkEnvelopes = networkEnvelopeSocketChannel.receiveNetworkEnvelopes();

--- a/network/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/network/src/main/java/bisq/network/NetworkService.java
@@ -308,7 +308,7 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
                                                                     PublicKey authorizedPublicKey) {
         checkArgument(dataService.isPresent(), "DataService must be supported when addData is called.");
         try {
-            byte[] signature = SignatureUtil.sign(authorizedDistributedData.serialize(), authorizedPrivateKey);
+            byte[] signature = SignatureUtil.sign(authorizedDistributedData.serializeForHash(), authorizedPrivateKey);
             AuthorizedData authorizedData = new AuthorizedData(authorizedDistributedData, Optional.of(signature), authorizedPublicKey);
             return dataService.get().addAuthorizedData(authorizedData, keyPair);
         } catch (GeneralSecurityException e) {

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -65,7 +65,7 @@ public final class Capability implements NetworkProto {
                         .map(Enum::name)
                         .collect(Collectors.toList()))
                 .addAllFeatures(features.stream()
-                        .map(Feature::toProto)
+                        .map(Feature::toProtoEnum)
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/network/network/src/main/java/bisq/network/p2p/node/Feature.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Feature.java
@@ -14,7 +14,7 @@ public enum Feature implements ProtoEnum {
     AUTHORIZATION_EQUI_HASH;
 
     @Override
-    public bisq.network.protobuf.Feature toProto() {
+    public bisq.network.protobuf.Feature toProtoEnum() {
         return bisq.network.protobuf.Feature.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
@@ -33,7 +33,7 @@ public abstract class AuthorizationToken implements NetworkProto {
 
     public bisq.network.protobuf.AuthorizationToken.Builder getAuthorizationTokenBuilder() {
         return bisq.network.protobuf.AuthorizationToken.newBuilder()
-                .setAuthorizationTokenType(authorizationTokenType.toProto());
+                .setAuthorizationTokenType(authorizationTokenType.toProtoEnum());
     }
 
     public static AuthorizationToken fromProto(bisq.network.protobuf.AuthorizationToken proto) {

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationTokenType.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationTokenType.java
@@ -22,7 +22,7 @@ public enum AuthorizationTokenType implements ProtoEnum {
     }
 
     @Override
-    public bisq.network.protobuf.AuthorizationTokenType toProto() {
+    public bisq.network.protobuf.AuthorizationTokenType toProtoEnum() {
         return bisq.network.protobuf.AuthorizationTokenType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash/HashCashTokenService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash/HashCashTokenService.java
@@ -215,7 +215,7 @@ public class HashCashTokenService extends AuthorizationTokenService<HashCashToke
     }
 
     private byte[] getPayload(EnvelopePayloadMessage message) {
-        return message.serialize();
+        return message.serializeForHash();
     }
 
     private byte[] getChallenge(String peerAddress, int messageCounter) {

--- a/network/network/src/main/java/bisq/network/p2p/node/envelope/NetworkEnvelopeSocket.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/envelope/NetworkEnvelopeSocket.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 @Slf4j
 public class NetworkEnvelopeSocket implements Closeable {
     private final PeerSocket socket;
@@ -41,9 +39,7 @@ public class NetworkEnvelopeSocket implements Closeable {
     }
 
     public void send(NetworkEnvelope networkEnvelope) throws IOException {
-        bisq.network.protobuf.NetworkEnvelope proto = checkNotNull(networkEnvelope.toProto(),
-                "networkEnvelope.toProto() must not be null");
-        proto.writeDelimitedTo(outputStream);
+        networkEnvelope.writeDelimitedTo(outputStream);
         outputStream.flush();
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/ConnectionMetrics.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/ConnectionMetrics.java
@@ -63,7 +63,7 @@ public class ConnectionMetrics {
 
         int ageInMinutes = getAgeInMinutes(now);
         sentBytesPerMinute.putIfAbsent(ageInMinutes, new AtomicLong());
-        sentBytesPerMinute.get(ageInMinutes).getAndAdd(networkEnvelope.toProto().getSerializedSize());
+        sentBytesPerMinute.get(ageInMinutes).getAndAdd(networkEnvelope.getSerializedSize());
 
         numMessagesSentPerMinute.putIfAbsent(ageInMinutes, new AtomicLong());
         numMessagesSentPerMinute.get(ageInMinutes).incrementAndGet();
@@ -78,7 +78,7 @@ public class ConnectionMetrics {
 
         int ageInMinutes = getAgeInMinutes(now);
         receivedBytesPerMinute.putIfAbsent(ageInMinutes, new AtomicLong());
-        receivedBytesPerMinute.get(ageInMinutes).getAndAdd(networkEnvelope.toProto().getSerializedSize());
+        receivedBytesPerMinute.get(ageInMinutes).getAndAdd(networkEnvelope.getSerializedSize());
 
         numMessagesReceivedPerMinute.putIfAbsent(ageInMinutes, new AtomicLong());
         numMessagesReceivedPerMinute.get(ageInMinutes).incrementAndGet();

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoadService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/NetworkLoadService.java
@@ -110,7 +110,7 @@ public class NetworkLoadService {
                 .map(ConnectionMetrics::getNumMessagesReceivedOfLastHour)
                 .mapToLong(e -> e)
                 .sum();
-        long networkDatabaseSize = dataRequests.stream().mapToLong(e -> e.toProto().getSerializedSize()).sum();
+        long networkDatabaseSize = dataRequests.stream().mapToLong(e -> e.getSerializedSize()).sum();
 
         StringBuilder sb = new StringBuilder("\n\n////////////////////////////////////////////////////////////////////////////////////////////////////");
         sb.append("\nNetwork statistics").append(("\n////////////////////////////////////////////////////////////////////////////////////////////////////"))

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatus.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatus.java
@@ -26,7 +26,7 @@ public enum MessageDeliveryStatus implements ProtoEnum {
 
 
     @Override
-    public bisq.network.protobuf.MessageDeliveryStatus toProto() {
+    public bisq.network.protobuf.MessageDeliveryStatus toProtoEnum() {
         return bisq.network.protobuf.MessageDeliveryStatus.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusStore.java
@@ -50,7 +50,7 @@ public final class MessageDeliveryStatusStore implements PersistableStore<Messag
     public bisq.network.protobuf.MessageDeliveryStatusStore toProto() {
         return bisq.network.protobuf.MessageDeliveryStatusStore.newBuilder()
                 .putAllMessageDeliveryStatusByMessageId(messageDeliveryStatusByMessageId.entrySet().stream()
-                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get().toProto())))
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get().toProtoEnum())))
                 .putAllCreationDateByMessageId(creationDateByMessageId.entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
                 .build();

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/resend/ResendMessageData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/resend/ResendMessageData.java
@@ -99,7 +99,7 @@ public class ResendMessageData implements NetworkProto {
                 .setReceiverNetworkId(receiverNetworkId.toProto())
                 .setSenderKeyPair(KeyPairProtoUtil.toProto(senderKeyPair))
                 .setSenderNetworkId(senderNetworkId.toProto())
-                .setMessageDeliveryStatus(messageDeliveryStatus.toProto())
+                .setMessageDeliveryStatus(messageDeliveryStatus.toProtoEnum())
                 .setDate(date)
                 .build();
     }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
@@ -55,7 +55,7 @@ public final class Inventory implements NetworkProto {
         // We need to sort deterministically as the data is used in the proof of work check
         // TODO (optimize, low prio) dataRequest.serialize() is expensive. We have the hash of the data in most DataRequest implementations.
         //  This could be used and combined with the other remaining data, like signature and pubkey
-        this.entries.sort(Comparator.comparing((DataRequest dataRequest) -> new ByteArray(dataRequest.serialize())));
+        this.entries.sort(Comparator.comparing((DataRequest dataRequest) -> new ByteArray(dataRequest.serializeForHash())));
 
         verify();
     }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
@@ -41,16 +41,16 @@ public final class Inventory implements NetworkProto {
 
     private final List<? extends DataRequest> entries;
     private final boolean maxSizeReached;
-    private transient final Optional<Integer> serializedSize;
+    private transient final Optional<Integer> cachedSerializedSize;
 
     public Inventory(Collection<? extends DataRequest> entries, boolean maxSizeReached) {
         this(entries, maxSizeReached, Optional.empty());
     }
 
-    private Inventory(Collection<? extends DataRequest> entries, boolean maxSizeReached, Optional<Integer> serializedSize) {
+    private Inventory(Collection<? extends DataRequest> entries, boolean maxSizeReached, Optional<Integer> cachedSerializedSize) {
         this.entries = new ArrayList<>(entries);
         this.maxSizeReached = maxSizeReached;
-        this.serializedSize = serializedSize;
+        this.cachedSerializedSize = cachedSerializedSize;
 
         // We need to sort deterministically as the data is used in the proof of work check
         // TODO (optimize, low prio) dataRequest.serialize() is expensive. We have the hash of the data in most DataRequest implementations.
@@ -63,7 +63,7 @@ public final class Inventory implements NetworkProto {
     @Override
     public void verify() {
         // We tolerate up to double of our max size
-        serializedSize.ifPresent(size -> checkArgument(size <= maxSize * 2));
+        cachedSerializedSize.ifPresent(size -> checkArgument(size <= maxSize * 2));
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryHandler.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryHandler.java
@@ -117,7 +117,7 @@ class InventoryHandler implements Connection.Listener {
             report = "No items received";
         }
         String maxSizeReached = inventory.isMaxSizeReached() ? "; \nResponse got truncated because max size was reached" : "";
-        String size = ByteUnit.BYTE.toKB((double) inventory.getSerializedSize().orElse(0)) + " KB";
+        String size = ByteUnit.BYTE.toKB((double) inventory.getCachedSerializedSize().orElse(0)) + " KB";
         log.info("\n##########################################################################################\n" +
                 "Received " + size + " of inventory data from: " + connection.getPeerAddress().getFullAddress() +
                 maxSizeReached +

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponseService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponseService.java
@@ -71,7 +71,7 @@ public class InventoryResponseService implements Node.Listener {
 
     private void handleInventoryRequest(InventoryRequest request, Connection connection) {
         InventoryFilter inventoryFilter = request.getInventoryFilter();
-        double size = ByteUnit.BYTE.toKB(inventoryFilter.toProto().getSerializedSize());
+        double size = ByteUnit.BYTE.toKB(inventoryFilter.getSerializedSize());
         log.info("Received an InventoryRequest from peer {}. Size: {} kb. Filter details: {}",
                 connection.getPeerAddress(), size, inventoryFilter.getDetails());
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/FilterService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/FilterService.java
@@ -101,7 +101,7 @@ public abstract class FilterService<T extends InventoryFilter> {
                         o1.getAuthenticatedSequentialData().getAuthenticatedData().getDistributedData().getMetaData().getPriority()))
                 .filter(request -> {
                     if (!maxSizeReached.get()) {
-                        maxSizeReached.set(accumulatedSize.addAndGet(request.toProto().getSerializedSize()) > maxSize);
+                        maxSizeReached.set(accumulatedSize.addAndGet(request.getSerializedSize()) > maxSize);
                     }
                     return !maxSizeReached.get();
                 })
@@ -113,7 +113,7 @@ public abstract class FilterService<T extends InventoryFilter> {
                     .sorted((o1, o2) -> Integer.compare(o2.getMetaData().getPriority(), o1.getMetaData().getPriority()))
                     .filter(request -> {
                         if (!maxSizeReached.get()) {
-                            maxSizeReached.set(accumulatedSize.addAndGet(request.toProto().getSerializedSize()) > maxSize);
+                            maxSizeReached.set(accumulatedSize.addAndGet(request.getSerializedSize()) > maxSize);
                         }
                         return !maxSizeReached.get();
                     })
@@ -152,7 +152,7 @@ public abstract class FilterService<T extends InventoryFilter> {
                         o1.getMailboxSequentialData().getMailboxData().getMetaData().getPriority()))
                 .filter(request -> {
                     if (!maxSizeReached.get()) {
-                        maxSizeReached.set(accumulatedSize.addAndGet(request.toProto().getSerializedSize()) > maxSize);
+                        maxSizeReached.set(accumulatedSize.addAndGet(request.getSerializedSize()) > maxSize);
                     }
                     return !maxSizeReached.get();
                 })
@@ -163,7 +163,7 @@ public abstract class FilterService<T extends InventoryFilter> {
                     .sorted((o1, o2) -> Integer.compare(o2.getMetaData().getPriority(), o1.getMetaData().getPriority()))
                     .filter(request -> {
                         if (!maxSizeReached.get()) {
-                            maxSizeReached.set(accumulatedSize.addAndGet(request.toProto().getSerializedSize()) > maxSize);
+                            maxSizeReached.set(accumulatedSize.addAndGet(request.getSerializedSize()) > maxSize);
                         }
                         return !maxSizeReached.get();
                     })
@@ -183,7 +183,7 @@ public abstract class FilterService<T extends InventoryFilter> {
                         o1.getAppendOnlyData().getMetaData().getPriority()))
                 .filter(request -> {
                     if (!maxSizeReached.get()) {
-                        maxSizeReached.set(accumulatedSize.addAndGet(request.toProto().getSerializedSize()) > maxSize);
+                        maxSizeReached.set(accumulatedSize.addAndGet(request.getSerializedSize()) > maxSize);
                     }
                     return !maxSizeReached.get();
                 })

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/InventoryFilter.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/InventoryFilter.java
@@ -33,7 +33,7 @@ public abstract class InventoryFilter implements NetworkProto {
 
     public bisq.network.protobuf.InventoryFilter.Builder getInventoryFilterBuilder() {
         return bisq.network.protobuf.InventoryFilter.newBuilder()
-                .setInventoryFilterType(inventoryFilterType.toProto());
+                .setInventoryFilterType(inventoryFilterType.toProtoEnum());
     }
 
     public static InventoryFilter fromProto(bisq.network.protobuf.InventoryFilter proto) {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/InventoryFilterType.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/InventoryFilterType.java
@@ -39,7 +39,7 @@ public enum InventoryFilterType implements ProtoEnum {
     }
 
     @Override
-    public bisq.network.protobuf.InventoryFilterType toProto() {
+    public bisq.network.protobuf.InventoryFilterType toProtoEnum() {
         return bisq.network.protobuf.InventoryFilterType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/append/AppendOnlyDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/append/AppendOnlyDataStorageService.java
@@ -65,7 +65,7 @@ public class AppendOnlyDataStorageService extends DataStorageService<AddAppendOn
                 return new DataStorageResult(false).maxMapSizeReached();
             }
 
-            byte[] hash = DigestUtil.hash(appendOnlyData.serialize());
+            byte[] hash = DigestUtil.hash(appendOnlyData.serializeForHash());
             ByteArray byteArray = new ByteArray(hash);
             if (map.containsKey(byteArray)) {
                 return new DataStorageResult(false).payloadAlreadyStored();

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AddAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AddAuthenticatedDataRequest.java
@@ -47,11 +47,11 @@ public final class AddAuthenticatedDataRequest implements AuthenticatedDataReque
     public static AddAuthenticatedDataRequest from(AuthenticatedDataStorageService store, AuthenticatedData authenticatedData, KeyPair keyPair)
             throws GeneralSecurityException {
 
-        byte[] hash = DigestUtil.hash(authenticatedData.serialize());
+        byte[] hash = DigestUtil.hash(authenticatedData.serializeForHash());
         byte[] pubKeyHash = DigestUtil.hash(keyPair.getPublic().getEncoded());
         int sequenceNumber = store.getSequenceNumber(hash) + 1;
         AuthenticatedSequentialData data = new AuthenticatedSequentialData(authenticatedData, sequenceNumber, pubKeyHash, System.currentTimeMillis());
-        byte[] serialized = data.serialize();
+        byte[] serialized = data.serializeForHash();
         byte[] signature = SignatureUtil.sign(serialized, keyPair.getPrivate());
          /*  log.error("hash={}", Hex.encode(hash));
         log.error("keyPair.getPublic().getEncoded()={}", Hex.encode(keyPair.getPublic().getEncoded()));
@@ -133,7 +133,7 @@ public final class AddAuthenticatedDataRequest implements AuthenticatedDataReque
 
     public boolean isSignatureInvalid() {
         try {
-            return !SignatureUtil.verify(authenticatedSequentialData.serialize(), signature, getOwnerPublicKey());
+            return !SignatureUtil.verify(authenticatedSequentialData.serializeForHash(), signature, getOwnerPublicKey());
         } catch (Exception e) {
             log.warn(e.toString(), e);
             return true;

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
@@ -72,7 +72,7 @@ public class AuthenticatedDataStorageService extends DataStorageService<Authenti
     public DataStorageResult add(AddAuthenticatedDataRequest request) {
         AuthenticatedSequentialData authenticatedSequentialData = request.getAuthenticatedSequentialData();
         AuthenticatedData authenticatedData = authenticatedSequentialData.getAuthenticatedData();
-        byte[] hash = DigestUtil.hash(authenticatedData.serialize());
+        byte[] hash = DigestUtil.hash(authenticatedData.serializeForHash());
         ByteArray byteArray = new ByteArray(hash);
         AuthenticatedDataRequest requestFromMap;
         Map<ByteArray, AuthenticatedDataRequest> map = persistableStore.getMap();

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RefreshAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RefreshAuthenticatedDataRequest.java
@@ -43,7 +43,7 @@ public final class RefreshAuthenticatedDataRequest implements DataRequest {
                                                        AuthenticatedData authenticatedData,
                                                        KeyPair keyPair)
             throws GeneralSecurityException {
-        byte[] hash = DigestUtil.hash(authenticatedData.serialize());
+        byte[] hash = DigestUtil.hash(authenticatedData.serializeForHash());
         byte[] signature = SignatureUtil.sign(hash, keyPair.getPrivate());
         int newSequenceNumber = store.getSequenceNumber(hash) + 1;
         return new RefreshAuthenticatedDataRequest(authenticatedData.getMetaData(),

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
@@ -42,7 +42,7 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
 
     public static RemoveAuthenticatedDataRequest from(AuthenticatedDataStorageService store, AuthenticatedData authenticatedData, KeyPair keyPair)
             throws GeneralSecurityException {
-        byte[] hash = DigestUtil.hash(authenticatedData.serialize());
+        byte[] hash = DigestUtil.hash(authenticatedData.serializeForHash());
         byte[] signature = SignatureUtil.sign(hash, keyPair.getPrivate());
         int newSequenceNumber = store.getSequenceNumber(hash) + 1;
         return new RemoveAuthenticatedDataRequest(authenticatedData.getMetaData(),

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
@@ -122,7 +122,7 @@ public final class AuthorizedData extends AuthenticatedData {
     public boolean isNotAuthorized() {
         try {
             AuthorizedDistributedData authorizedDistributedData = getAuthorizedDistributedData();
-            if (!SignatureUtil.verify(distributedData.serialize(), signature.orElseThrow(), authorizedPublicKey)) {
+            if (!SignatureUtil.verify(distributedData.serializeForHash(), signature.orElseThrow(), authorizedPublicKey)) {
                 return true;
             }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/AddMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/AddMailboxRequest.java
@@ -51,7 +51,7 @@ public final class AddMailboxRequest implements MailboxRequest, AddDataRequest {
                 receiverPublicKeyHash,
                 receiverPublicKey,
                 1);
-        byte[] serialized = mailboxSequentialData.serialize();
+        byte[] serialized = mailboxSequentialData.serializeForHash();
         byte[] signature = SignatureUtil.sign(serialized, senderKeyPair.getPrivate());
         return new AddMailboxRequest(mailboxSequentialData, signature, senderPublicKey);
     }
@@ -122,7 +122,7 @@ public final class AddMailboxRequest implements MailboxRequest, AddDataRequest {
 
     public boolean isSignatureInvalid() {
         try {
-            return !SignatureUtil.verify(mailboxSequentialData.serialize(), signature, getOwnerPublicKey());
+            return !SignatureUtil.verify(mailboxSequentialData.serializeForHash(), signature, getOwnerPublicKey());
         } catch (Exception e) {
             log.warn(e.toString(), e);
             return true;

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxDataStorageService.java
@@ -57,7 +57,7 @@ public class MailboxDataStorageService extends DataStorageService<MailboxRequest
     public DataStorageResult add(AddMailboxRequest request) {
         MailboxSequentialData mailboxSequentialData = request.getMailboxSequentialData();
         MailboxData mailboxData = mailboxSequentialData.getMailboxData();
-        byte[] hash = DigestUtil.hash(mailboxData.serialize());
+        byte[] hash = DigestUtil.hash(mailboxData.serializeForHash());
         ByteArray byteArray = new ByteArray(hash);
         MailboxRequest requestFromMap;
         Map<ByteArray, MailboxRequest> map = persistableStore.getMap();
@@ -201,7 +201,7 @@ public class MailboxDataStorageService extends DataStorageService<MailboxRequest
     }
 
     boolean canAddMailboxMessage(MailboxData mailboxData) {
-        byte[] hash = DigestUtil.hash(mailboxData.serialize());
+        byte[] hash = DigestUtil.hash(mailboxData.serializeForHash());
         return getSequenceNumber(hash) < Integer.MAX_VALUE;
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
@@ -47,7 +47,7 @@ public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataReq
 
     public static RemoveMailboxRequest from(MailboxData mailboxData, KeyPair receiverKeyPair)
             throws GeneralSecurityException {
-        byte[] hash = DigestUtil.hash(mailboxData.serialize());
+        byte[] hash = DigestUtil.hash(mailboxData.serializeForHash());
         byte[] signature = SignatureUtil.sign(hash, receiverKeyPair.getPrivate());
         return new RemoveMailboxRequest(mailboxData.getMetaData(), hash, receiverKeyPair.getPublic(), signature);
     }

--- a/offer/src/main/java/bisq/offer/Direction.java
+++ b/offer/src/main/java/bisq/offer/Direction.java
@@ -26,7 +26,7 @@ public enum Direction implements ProtoEnum {
     SELL;
 
     @Override
-    public bisq.offer.protobuf.Direction toProto() {
+    public bisq.offer.protobuf.Direction toProtoEnum() {
         return bisq.offer.protobuf.Direction.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/offer/src/main/java/bisq/offer/Offer.java
+++ b/offer/src/main/java/bisq/offer/Offer.java
@@ -108,11 +108,11 @@ public abstract class Offer<B extends PaymentMethodSpec<?>, Q extends PaymentMet
                 .setId(id)
                 .setDate(date)
                 .setMakerNetworkId(makerNetworkId.toProto())
-                .setDirection(direction.toProto())
+                .setDirection(direction.toProtoEnum())
                 .setMarket(market.toProto())
                 .setAmountSpec(amountSpec.toProto())
                 .setPriceSpec(priceSpec.toProto())
-                .addAllProtocolTypes(protocolTypes.stream().map(TradeProtocolType::toProto).collect(Collectors.toList()))
+                .addAllProtocolTypes(protocolTypes.stream().map(TradeProtocolType::toProtoEnum).collect(Collectors.toList()))
                 .addAllBaseSidePaymentSpecs(baseSidePaymentMethodSpecs.stream().map(PaymentMethodSpec::toProto).collect(Collectors.toList()))
                 .addAllQuoteSidePaymentSpecs(quoteSidePaymentMethodSpecs.stream().map(PaymentMethodSpec::toProto).collect(Collectors.toList()))
                 .addAllOfferOptions(offerOptions.stream().map(OfferOption::toProto).collect(Collectors.toList()));

--- a/offer/src/main/java/bisq/offer/options/FeeOption.java
+++ b/offer/src/main/java/bisq/offer/options/FeeOption.java
@@ -33,7 +33,7 @@ public final class FeeOption implements OfferOption {
         BSQ;
 
         @Override
-        public bisq.offer.protobuf.FeeOption.FeeType toProto() {
+        public bisq.offer.protobuf.FeeOption.FeeType toProtoEnum() {
             return bisq.offer.protobuf.FeeOption.FeeType.valueOf(getProtobufEnumPrefix() + name());
         }
 
@@ -62,7 +62,7 @@ public final class FeeOption implements OfferOption {
     @Override
     public bisq.offer.protobuf.OfferOption toProto() {
         return getOfferOptionBuilder().setFeeOption(bisq.offer.protobuf.FeeOption.newBuilder()
-                        .setFeeType(feeType.toProto())
+                        .setFeeType(feeType.toProtoEnum())
                         .setBlockHeightAtFeePayment(blockHeightAtFeePayment)
                         .setFeeTxId(feeTxId))
                 .build();

--- a/settings/src/main/java/bisq/settings/ChatNotificationType.java
+++ b/settings/src/main/java/bisq/settings/ChatNotificationType.java
@@ -26,7 +26,7 @@ public enum ChatNotificationType implements ProtoEnum {
     OFF;
 
     @Override
-    public bisq.settings.protobuf.ChatNotificationType toProto() {
+    public bisq.settings.protobuf.ChatNotificationType toProtoEnum() {
         return bisq.settings.protobuf.ChatNotificationType.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -127,7 +127,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 .setMinRequiredReputationScore(minRequiredReputationScore.get())
                 .setOffersOnly(offersOnly.get())
                 .setTradeRulesConfirmed(tradeRulesConfirmed.get())
-                .setChatNotificationType(chatNotificationType.get().toProto())
+                .setChatNotificationType(chatNotificationType.get().toProtoEnum())
                 .setIsTacAccepted(isTacAccepted.get())
                 .addAllConsumedAlertIds(new ArrayList<>(consumedAlertIds))
                 .setCloseMyOfferWhenTaken(closeMyOfferWhenTaken.get())

--- a/support/src/main/java/bisq/support/moderator/ReportToModeratorMessage.java
+++ b/support/src/main/java/bisq/support/moderator/ReportToModeratorMessage.java
@@ -85,7 +85,7 @@ public final class ReportToModeratorMessage implements MailboxMessage {
                 .setReporterUserProfileId(reporterUserProfileId)
                 .setAccusedUserProfile(accusedUserProfile.toProto())
                 .setMessage(message)
-                .setChatChannelDomain(chatChannelDomain.toProto());
+                .setChatChannelDomain(chatChannelDomain.toProtoEnum());
         return builder.build();
     }
 

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -103,7 +103,7 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
     protected bisq.trade.protobuf.Trade.Builder getTradeBuilder() {
         bisq.trade.protobuf.Trade.Builder builder = bisq.trade.protobuf.Trade.newBuilder()
                 .setId(id)
-                .setTradeRole(tradeRole.toProto())
+                .setTradeRole(tradeRole.toProtoEnum())
                 .setMyIdentity(myIdentity.toProto())
                 .setTaker(taker.toProto())
                 .setMaker(maker.toProto())

--- a/trade/src/main/java/bisq/trade/TradeRole.java
+++ b/trade/src/main/java/bisq/trade/TradeRole.java
@@ -37,7 +37,7 @@ public enum TradeRole implements ProtoEnum {
     }
 
     @Override
-    public bisq.trade.protobuf.TradeRole toProto() {
+    public bisq.trade.protobuf.TradeRole toProtoEnum() {
         return bisq.trade.protobuf.TradeRole.valueOf(getProtobufEnumPrefix() + name());
     }
 

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -87,7 +87,7 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
         Optional.ofNullable(paymentAccountData.get()).ifPresent(builder::setPaymentAccountData);
         Optional.ofNullable(btcAddress.get()).ifPresent(builder::setBtcAddress);
         Optional.ofNullable(txId.get()).ifPresent(builder::setTxId);
-        Optional.ofNullable(interruptTradeInitiator.get()).ifPresent(e -> builder.setInterruptTradeInitiator(e.toProto()));
+        Optional.ofNullable(interruptTradeInitiator.get()).ifPresent(e -> builder.setInterruptTradeInitiator(e.toProtoEnum()));
         return getTradeBuilder().setBisqEasyTrade(builder).build();
     }
 

--- a/user/src/main/java/bisq/user/identity/UserIdentityStore.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityStore.java
@@ -384,11 +384,11 @@ public final class UserIdentityStore implements PersistableStore<UserIdentitySto
 
     private EncryptedData encryptPlainTextProto(bisq.user.protobuf.UserIdentityStore plainTextProto) {
         try {
-            byte[] plainText = ProtobufUtils.getByteArrayFromProto(Any.pack(plainTextProto));
+            byte[] plainText = Any.pack(plainTextProto).toByteArray();
             byte[] iv = AesGcm.generateIv().getIV();
             byte[] cipherText = AesGcm.encrypt(aesSecretKey.orElseThrow(), iv, plainText);
             return new EncryptedData(iv, cipherText);
-        } catch (IOException | GeneralSecurityException e) {
+        } catch (GeneralSecurityException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
This add the `@ExcludeForHash` annotation to provide more flexibility with updates.

We use the serialized data from protobuf data for various use cases.
- Hash for data storage
- Hash for Inventory request
- Payload for Pow  
- Input for signature of AuthenticatedData
- ...

Changing or adding any of that data would break the hash and is a limitation for updates.

With the `@ExcludeForHash` annotation we can mark fields in those classes which should not be included for serialisation. The fields get cleared in the builder and thus are set to the default value.

As we need to traverse the hierarchical data structure we need to pass a flag if the serialisation is triggered from a use case where we want to exclude annotated fields or not.
To accomplish that we add a `getBuilder` method and change all classes implementing `Proto` to support that new framework.

This PR only add the annotation, methods, tests and has some refactorings and cleanups. It does not apply the changes yet.  




