### PR TITLE
Improve error handing in connection

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/node/Connection.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Connection.java
@@ -209,7 +209,8 @@ public abstract class Connection {
         if (isStopped) {
             log.warn("Message not sent as connection has been shut down already. Message={}, Connection={}",
                     StringUtils.truncate(envelopePayloadMessage.toString(), 200), this);
-            throw new ConnectionClosedException(this);
+            // We do not throw a ConnectionClosedException here
+            return this;
         }
 
         requestResponseManager.onSent(envelopePayloadMessage);


### PR DESCRIPTION
Don't throw a ConnectionClosedException if connection have been shutdown already, and we get a send call