### PR TITLE
Compute Tor bootstrap timeout from last event

### DIFF
--- a/network/tor/tor/src/main/java/bisq/tor/controller/events/events/BootstrapEvent.java
+++ b/network/tor/tor/src/main/java/bisq/tor/controller/events/events/BootstrapEvent.java
@@ -21,6 +21,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.Instant;
+
 @Builder
 @Getter
 @ToString
@@ -31,6 +33,8 @@ public class BootstrapEvent {
     private final int progress;
     private final String tag;
     private final String summary;
+
+    private final Instant timestamp = Instant.now();
 
     public BootstrapEvent(int progress, String tag, String summary) {
         if (progress < 0 || tag.isEmpty() || summary.isEmpty()) {


### PR DESCRIPTION
When the Tor network is under load, the bootstrap process takes multiple minutes. Tor informs us about the progress with BootstrapEvent's until Tor is ready.

Fixes #1798