### PR TITLE
Show amount step before price in trade wizard

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/SmallAmountInput.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/SmallAmountInput.java
@@ -32,10 +32,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SmallAmountInput extends AmountInput {
-
     private static final double ICON_SCALE = 0.8;
     private static final double ICON_OPACITY = 0.5;
-    private static final String DEFAULT_TOOLTIP = "bisqEasy.component.amount.baseSide.tooltip.marketPrice";
+    private static final String DEFAULT_TOOLTIP = "bisqEasy.component.amount.baseSide.tooltip.btcAmount.marketPrice";
     private static final String QUOTE_AMOUNT_ID = "quote-amount-text-field";
 
     public SmallAmountInput(boolean isBaseCurrency) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
@@ -20,7 +20,6 @@ package bisq.desktop.main.content.bisq_easy.take_offer.amount;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.currency.Market;
 import bisq.common.monetary.Monetary;
-import bisq.common.monetary.PriceQuote;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.main.content.bisq_easy.components.AmountComponent;
@@ -31,7 +30,6 @@ import bisq.offer.amount.OfferAmountUtil;
 import bisq.offer.amount.spec.AmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.offer.price.PriceUtil;
-import bisq.offer.price.spec.PriceSpec;
 import bisq.presentation.formatters.PriceFormatter;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import lombok.Getter;
@@ -78,11 +76,6 @@ public class TakeOfferAmountController implements Controller {
                 OfferAmountFormatter.formatQuoteSideMinAmount(marketPriceService, bisqEasyOffer, false),
                 OfferAmountFormatter.formatQuoteSideMaxAmount(marketPriceService, bisqEasyOffer)));
 
-        if (takersDirection.isBuy()) {
-            // If taker is buyer we set the sellers price from the offer
-            PriceUtil.findQuote(marketPriceService, bisqEasyOffer).ifPresent(amountComponent::setQuote);
-        }
-
         takersAmountSpec.ifPresent(amountSpec -> {
             OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, amountSpec, bisqEasyOffer.getPriceSpec(), market)
                     .ifPresent(amountComponent::setQuoteSideAmount);
@@ -96,19 +89,6 @@ public class TakeOfferAmountController implements Controller {
             String btcAmount = Res.get("bisqEasy.component.amount.baseSide.tooltip.seller.btcAmount") + "\n";
             PriceUtil.findQuote(marketPriceService, model.getBisqEasyOffer()).ifPresent(priceQuote ->
                     amountComponent.setTooltip(btcAmount + Res.get("bisqEasy.component.amount.baseSide.tooltip.taker.offerPrice", PriceFormatter.formatWithCode(priceQuote))));
-        }
-    }
-
-    public void setTradePriceSpec(PriceSpec priceSpec) {
-        // priceSpec from price view in case we are the seller
-        if (priceSpec != null && model.getBisqEasyOffer() != null && model.getBisqEasyOffer().getTakersDirection().isSell()) {
-            Market market = model.getBisqEasyOffer().getMarket();
-            Optional<PriceQuote> priceQuote = PriceUtil.findQuote(marketPriceService, priceSpec, market);
-            if (priceQuote.isPresent()) {
-                amountComponent.setQuote(priceQuote.get());
-            } else {
-                log.warn("Could not find price quote for market {}", market);
-            }
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
@@ -82,14 +82,13 @@ public class TakeOfferAmountController implements Controller {
             OfferAmountUtil.findBaseSideMaxOrFixedAmount(marketPriceService, amountSpec, bisqEasyOffer.getPriceSpec(), market)
                     .ifPresent(amountComponent::setBaseSideAmount);
         });
-        if (model.getBisqEasyOffer().getTakersDirection().isSell()) {
-            String btcAmount = Res.get("bisqEasy.component.amount.baseSide.tooltip.seller.btcAmount") + "\n";
-            amountComponent.setTooltip(btcAmount + Res.get("bisqEasy.component.amount.baseSide.tooltip.price"));
-        } else {
-            String btcAmount = Res.get("bisqEasy.component.amount.baseSide.tooltip.seller.btcAmount") + "\n";
-            PriceUtil.findQuote(marketPriceService, model.getBisqEasyOffer()).ifPresent(priceQuote ->
-                    amountComponent.setTooltip(btcAmount + Res.get("bisqEasy.component.amount.baseSide.tooltip.taker.offerPrice", PriceFormatter.formatWithCode(priceQuote))));
-        }
+
+        String btcAmount = takersDirection.isBuy()
+                ? Res.get("bisqEasy.component.amount.baseSide.tooltip.buyer.btcAmount")
+                : Res.get("bisqEasy.component.amount.baseSide.tooltip.seller.btcAmount");
+        Optional<String> priceQuoteOptional = PriceUtil.findQuote(marketPriceService, model.getBisqEasyOffer())
+                .map(priceQuote -> "\n" + Res.get("bisqEasy.component.amount.baseSide.tooltip.taker.offerPrice", PriceFormatter.formatWithCode(priceQuote)));
+        priceQuoteOptional.ifPresent(priceQuote -> amountComponent.setTooltip(String.format("%s%s", btcAmount, priceQuote)));
     }
 
     public ReadOnlyObjectProperty<Monetary> getTakersQuoteSideAmount() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardController.java
@@ -136,7 +136,7 @@ public class TradeWizardController extends NavigationController implements InitW
         ));
 
         if (model.getPriceProgressItemVisible().get()) {
-            model.getChildTargets().add(2, NavigationTarget.TRADE_WIZARD_PRICE);
+            model.getChildTargets().add(3, NavigationTarget.TRADE_WIZARD_PRICE);
         } else {
             model.getChildTargets().remove(NavigationTarget.TRADE_WIZARD_PRICE);
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardController.java
@@ -156,14 +156,9 @@ public class TradeWizardController extends NavigationController implements InitW
             updateNextButtonDisabledState();
         });
         amountSpecPin = EasyBind.subscribe(tradeWizardAmountController.getAmountSpec(),
-                amountSpec -> {
-                    tradeWizardSelectOfferController.setAmountSpec(amountSpec);
-                });
+                amountSpec -> tradeWizardSelectOfferController.setAmountSpec(amountSpec));
         priceSpecPin = EasyBind.subscribe(tradeWizardPriceController.getPriceSpec(),
-                priceSpec -> {
-                    tradeWizardAmountController.setPriceSpec(priceSpec);
-                    tradeWizardSelectOfferController.setPriceSpec(priceSpec);
-                });
+                priceSpec -> tradeWizardSelectOfferController.setPriceSpec(priceSpec));
         selectedBisqEasyOfferPin = EasyBind.subscribe(tradeWizardSelectOfferController.getSelectedBisqEasyOffer(),
                 selectedBisqEasyOffer -> {
                     tradeWizardReviewController.setSelectedBisqEasyOffer(selectedBisqEasyOffer);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardView.java
@@ -146,13 +146,13 @@ public class TradeWizardView extends NavigationView<VBox, TradeWizardModel, Trad
         priceProgressItemVisiblePin = EasyBind.subscribe(model.getPriceProgressItemVisible(), isVisible -> {
             if (isVisible) {
                 if (!progressItemsBox.getChildren().contains(priceProgressItemLine)) {
-                    progressItemsBox.getChildren().add(5, priceProgressItemLine);
+                    progressItemsBox.getChildren().add(7, priceProgressItemLine);
                 }
                 if (!progressItemsBox.getChildren().contains(priceProgressItemLabel)) {
-                    progressItemsBox.getChildren().add(5, priceProgressItemLabel);
+                    progressItemsBox.getChildren().add(7, priceProgressItemLabel);
                 }
                 if (!progressLabelList.contains(priceProgressItemLabel)) {
-                    progressLabelList.add(2, priceProgressItemLabel);
+                    progressLabelList.add(3, priceProgressItemLabel);
                 }
             } else {
                 progressItemsBox.getChildren().remove(priceProgressItemLine);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount/TradeWizardAmountModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount/TradeWizardAmountModel.java
@@ -24,8 +24,6 @@ import bisq.common.monetary.PriceQuote;
 import bisq.desktop.common.view.Model;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.AmountSpec;
-import bisq.offer.price.spec.MarketPriceSpec;
-import bisq.offer.price.spec.PriceSpec;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -48,8 +46,6 @@ public class TradeWizardAmountModel implements Model {
     @Setter
     private List<FiatPaymentMethod> fiatPaymentMethods = new ArrayList<>();
     @Setter
-    private PriceSpec priceSpec = new MarketPriceSpec();
-    @Setter
     private String headline;
     @Setter
     private boolean isCreateOfferMode;
@@ -64,7 +60,6 @@ public class TradeWizardAmountModel implements Model {
         direction = null;
         market = MarketRepository.getDefault();
         fiatPaymentMethods = new ArrayList<>();
-        priceSpec = new MarketPriceSpec();
         headline = null;
         isCreateOfferMode = false;
         bestOffersPrice = Optional.empty();

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -119,7 +119,7 @@ bisqEasy.price.feedback.learnWhySection.openButton=Why?
 bisqEasy.price.feedback.learnWhySection.closeButton=Back to Trade Price
 bisqEasy.price.feedback.learnWhySection.title=Why should I pay a higher price to the seller?
 bisqEasy.price.feedback.learnWhySection.description.intro=The reason for that is that the seller has to cover extra expenses \
-  and compensate for the seller's service specifically:
+  and compensate for the seller's service, specifically:
 bisqEasy.price.feedback.learnWhySection.description.exposition=\
   - Build up reputation which can be costly.\
   - The seller has to pay for miner fees.\

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -144,14 +144,14 @@ bisqEasy.tradeWizard.amount.addMinAmountOption=Add min/max range for amount
 bisqEasy.tradeWizard.amount.removeMinAmountOption=Use fix value amount
 bisqEasy.component.amount.minRangeValue=Min {0}
 bisqEasy.component.amount.maxRangeValue=Max {0}
-bisqEasy.component.amount.baseSide.tooltip.price=Calculated with the seller's trade price.
-bisqEasy.component.amount.baseSide.tooltip.marketPrice=Calculated with current market price.\n\
-  Sellers may ask for a higher price as they have costs for acquiring reputation.\n\
+bisqEasy.component.amount.baseSide.tooltip.btcAmount.marketPrice=This is the Bitcoin amount with current market price.
+bisqEasy.component.amount.baseSide.tooltip.buyerInfo=Sellers may ask for a higher price as they have costs for acquiring reputation.\n\
   5-15% price premium is common.
-bisqEasy.component.amount.baseSide.tooltip.buyer.btcAmount=The expected Bitcoin amount to receive.
-bisqEasy.component.amount.baseSide.tooltip.seller.btcAmount=The expected Bitcoin amount to spend.
-bisqEasy.component.amount.baseSide.tooltip.bestOfferPrice=Calculated with the best price from matching offers: {0}
-bisqEasy.component.amount.baseSide.tooltip.taker.offerPrice=Calculated with the offer price: {0}
+bisqEasy.component.amount.baseSide.tooltip.bestOfferPrice=This is the Bitcoin amount with the best price\n\
+  from matching offers: {0}
+bisqEasy.component.amount.baseSide.tooltip.buyer.btcAmount=This is the Bitcoin amount to receive
+bisqEasy.component.amount.baseSide.tooltip.seller.btcAmount=This is the Bitcoin amount to spend
+bisqEasy.component.amount.baseSide.tooltip.taker.offerPrice=with the offer price: {0}
 
 
 ################################################################################


### PR DESCRIPTION
Towards #2033

Show amount step before price in trade wizard, which:
* Relaxes the min/max amounts that are allowed for trading, since price spec is not taken into consideration.
* Allows for trade price recommendation/decision making based on the amount.