### PR TITLE
Get SOCKS5 port from Tor daemon

### DIFF
--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -53,7 +53,6 @@ public class TorService implements Service {
     private final AtomicBoolean isRunning = new AtomicBoolean();
 
     private Optional<NativeTorProcess> torProcess = Optional.empty();
-    private Optional<Integer> socksPort = Optional.empty();
     private Optional<TorSocksProxyFactory> torSocksProxyFactory = Optional.empty();
 
     public TorService(TorTransportConfig transportConfig) {
@@ -92,7 +91,7 @@ public class TorService implements Service {
                     nativeTorController.enableTorNetworking();
                     nativeTorController.waitUntilBootstrapped();
 
-                    int port = socksPort.orElseThrow();
+                    int port = nativeTorController.getSocksPort().orElseThrow();
                     torSocksProxyFactory = Optional.of(new TorSocksProxyFactory(port));
                 })
                 .thenApply(unused -> true);
@@ -153,13 +152,10 @@ public class TorService implements Service {
     }
 
     private void createTorrcConfigFile(Path dataDir, PasswordDigest hashedControlPassword) {
-        int socksPort = NetworkUtils.findFreeSystemPort();
-        this.socksPort = Optional.of(socksPort);
-
         TorrcClientConfigFactory torrcClientConfigFactory = TorrcClientConfigFactory.builder()
                 .isTestNetwork(transportConfig.isTestNetwork())
                 .dataDir(dataDir)
-                .socksPort(socksPort)
+                .socksPort(NetworkUtils.findFreeSystemPort())
                 .hashedControlPassword(hashedControlPassword)
                 .build();
 

--- a/network/tor/tor/src/main/java/bisq/tor/controller/NativeTorController.java
+++ b/network/tor/tor/src/main/java/bisq/tor/controller/NativeTorController.java
@@ -139,6 +139,30 @@ public class NativeTorController implements BootstrapEventListener, HsDescUpload
         }
     }
 
+    public Optional<Integer> getSocksPort() {
+        try {
+            TorControlConnection controlConnection = torControlConnection.orElseThrow();
+            String socksListenersString = controlConnection.getInfo("net/listeners/socks");
+
+            String socksListener;
+            if (socksListenersString.contains(" ")) {
+                String[] socksPorts = socksListenersString.split(" ");
+                socksListener = socksPorts[0];
+            } else {
+                socksListener = socksListenersString;
+            }
+
+            // "127.0.0.1:12345"
+            socksListener = socksListener.replace("\"", "");
+            String portString = socksListener.split(":")[1];
+
+            int port = Integer.parseInt(portString);
+            return Optional.of(port);
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
     public void waitUntilBootstrapped() {
         try {
             while (true) {


### PR DESCRIPTION
We don't know the SOCKS5 port when we're using to a running Tor daemon. This change is needed to support external Tor instances.

Ref: #1894