### PR TITLE
Let Tor pick SOCKS5 port

### DIFF
--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/ClientTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/ClientTorrcGenerator.java
@@ -24,17 +24,15 @@ import java.util.Map;
 @Builder
 public class ClientTorrcGenerator implements TorrcConfigGenerator {
     private final TorrcConfigGenerator baseTorrcConfigGenerator;
-    private final int socksPort;
 
-    public ClientTorrcGenerator(TorrcConfigGenerator baseTorrcConfigGenerator, int socksPort) {
+    public ClientTorrcGenerator(TorrcConfigGenerator baseTorrcConfigGenerator) {
         this.baseTorrcConfigGenerator = baseTorrcConfigGenerator;
-        this.socksPort = socksPort;
     }
 
     @Override
     public Map<String, String> generate() {
         Map<String, String> torConfigMap = baseTorrcConfigGenerator.generate();
-        torConfigMap.put("SocksPort", String.valueOf(socksPort));
+        torConfigMap.put("SocksPort", "auto");
         return torConfigMap;
     }
 }

--- a/network/tor/tor-local-network/src/main/java/bisq/tor/local_network/torrc/TestNetworkTorrcGeneratorFactory.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/tor/local_network/torrc/TestNetworkTorrcGeneratorFactory.java
@@ -17,7 +17,6 @@
 
 package bisq.tor.local_network.torrc;
 
-import bisq.common.util.NetworkUtils;
 import bisq.network.tor.common.torrc.*;
 import bisq.tor.local_network.TorNode;
 
@@ -38,7 +37,6 @@ public class TestNetworkTorrcGeneratorFactory {
         var testNetworkTorrcGenerator = testNetworkTorrcGenerator(clientNode);
         return ClientTorrcGenerator.builder()
                 .baseTorrcConfigGenerator(testNetworkTorrcGenerator)
-                .socksPort(NetworkUtils.findFreeSystemPort())
                 .build();
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -53,7 +53,6 @@ public class TorService implements Service {
     private final AtomicBoolean isRunning = new AtomicBoolean();
 
     private Optional<NativeTorProcess> torProcess = Optional.empty();
-    private Optional<Integer> socksPort = Optional.empty();
     private Optional<TorSocksProxyFactory> torSocksProxyFactory = Optional.empty();
 
     public TorService(TorTransportConfig transportConfig) {
@@ -92,7 +91,7 @@ public class TorService implements Service {
                     nativeTorController.enableTorNetworking();
                     nativeTorController.waitUntilBootstrapped();
 
-                    int port = socksPort.orElseThrow();
+                    int port = nativeTorController.getSocksPort().orElseThrow();
                     torSocksProxyFactory = Optional.of(new TorSocksProxyFactory(port));
                 })
                 .thenApply(unused -> true);
@@ -153,13 +152,10 @@ public class TorService implements Service {
     }
 
     private void createTorrcConfigFile(Path dataDir, PasswordDigest hashedControlPassword) {
-        int socksPort = NetworkUtils.findFreeSystemPort();
-        this.socksPort = Optional.of(socksPort);
-
         TorrcClientConfigFactory torrcClientConfigFactory = TorrcClientConfigFactory.builder()
                 .isTestNetwork(transportConfig.isTestNetwork())
                 .dataDir(dataDir)
-                .socksPort(socksPort)
+                .socksPort(NetworkUtils.findFreeSystemPort())
                 .hashedControlPassword(hashedControlPassword)
                 .build();
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -19,7 +19,6 @@ package bisq.tor;
 
 import bisq.common.application.Service;
 import bisq.common.observable.Observable;
-import bisq.common.util.NetworkUtils;
 import bisq.network.tor.common.torrc.TorrcFileGenerator;
 import bisq.tor.controller.NativeTorController;
 import bisq.tor.controller.events.events.BootstrapEvent;
@@ -155,7 +154,6 @@ public class TorService implements Service {
         TorrcClientConfigFactory torrcClientConfigFactory = TorrcClientConfigFactory.builder()
                 .isTestNetwork(transportConfig.isTestNetwork())
                 .dataDir(dataDir)
-                .socksPort(NetworkUtils.findFreeSystemPort())
                 .hashedControlPassword(hashedControlPassword)
                 .build();
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorrcClientConfigFactory.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorrcClientConfigFactory.java
@@ -34,16 +34,13 @@ public class TorrcClientConfigFactory {
 
     private final boolean isTestNetwork;
     private final Path dataDir;
-    private final int socksPort;
     private final PasswordDigest hashedControlPassword;
 
     public TorrcClientConfigFactory(boolean isTestNetwork,
                                     Path dataDir,
-                                    int socksPort,
                                     PasswordDigest hashedControlPassword) {
         this.isTestNetwork = isTestNetwork;
         this.dataDir = dataDir;
-        this.socksPort = socksPort;
         this.hashedControlPassword = hashedControlPassword;
     }
 
@@ -62,7 +59,6 @@ public class TorrcClientConfigFactory {
 
         return ClientTorrcGenerator.builder()
                 .baseTorrcConfigGenerator(baseTorrcGenerator)
-                .socksPort(socksPort)
                 .build();
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/controller/NativeTorController.java
+++ b/network/tor/tor/src/main/java/bisq/tor/controller/NativeTorController.java
@@ -139,6 +139,30 @@ public class NativeTorController implements BootstrapEventListener, HsDescUpload
         }
     }
 
+    public Optional<Integer> getSocksPort() {
+        try {
+            TorControlConnection controlConnection = torControlConnection.orElseThrow();
+            String socksListenersString = controlConnection.getInfo("net/listeners/socks");
+
+            String socksListener;
+            if (socksListenersString.contains(" ")) {
+                String[] socksPorts = socksListenersString.split(" ");
+                socksListener = socksPorts[0];
+            } else {
+                socksListener = socksListenersString;
+            }
+
+            // "127.0.0.1:12345"
+            socksListener = socksListener.replace("\"", "");
+            String portString = socksListener.split(":")[1];
+
+            int port = Integer.parseInt(portString);
+            return Optional.of(port);
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
     public void waitUntilBootstrapped() {
         try {
             while (true) {


### PR DESCRIPTION
To select the Tor SOCKS5 port, we bind to a random port, close it and pass the port number to Tor. It can happen that Tor tries to bind to the port before it is closed. In this case, the Tor startup will fail.

Ref: https://github.com/bisq-network/bisq2/issues/1798