### PR TITLE
Improvements in Offer List

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -70,7 +70,8 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     private final SetChangeListener<Market> favouriteMarketsListener;
     private final ReputationService reputationService = serviceProvider.getUserService().getReputationService();
     private Pin offerOnlySettingsPin, bisqEasyPrivateTradeChatChannelsPin, selectedChannelPin,
-            marketPriceByCurrencyMapPin, favouriteMarketsPin, offerMessagesPin;
+            marketPriceByCurrencyMapPin, favouriteMarketsPin, offerMessagesPin, showBuyFromOffersSettingsPin,
+            showOfferListExpandedSettingsPin, showMarketSelectionListExpandedSettingsPin;
     private Subscription marketSelectorSearchPin, selectedMarketFilterPin, selectedOfferDirectionOrOwnerFilterPin,
             selectedPeerReputationFilterPin, selectedMarketSortTypePin, showBuyFromOfferMessageItemsPin;
 
@@ -123,6 +124,9 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         model.getMarketSelectorSearchText().set("");
 
         offerOnlySettingsPin = FxBindings.bindBiDir(model.getOfferOnly()).to(settingsService.getOffersOnly());
+        showBuyFromOffersSettingsPin = FxBindings.bindBiDir(model.getShowBuyFromOfferMessageItems()).to(settingsService.getShowBuyFromOffers());
+        showOfferListExpandedSettingsPin = FxBindings.bindBiDir(model.getShowOfferListExpanded()).to(settingsService.getShowOfferListExpanded());
+        showMarketSelectionListExpandedSettingsPin = FxBindings.bindBiDir(model.getShowMarketSelectionListExpanded()).to(settingsService.getShowMarketSelectionListExpanded());
 
         ObservableArray<BisqEasyOpenTradeChannel> bisqEasyOpenTradeChannels = chatService.getBisqEasyOpenTradeChannelService().getChannels();
         bisqEasyPrivateTradeChatChannelsPin = bisqEasyOpenTradeChannels.addObserver(() ->
@@ -244,6 +248,9 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         }
 
         offerOnlySettingsPin.unbind();
+        showBuyFromOffersSettingsPin.unbind();
+        showOfferListExpandedSettingsPin.unbind();
+        showMarketSelectionListExpandedSettingsPin.unbind();
         bisqEasyPrivateTradeChatChannelsPin.unbind();
         selectedChannelPin.unbind();
         marketSelectorSearchPin.unsubscribe();
@@ -335,6 +342,14 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
 
     void toggleMarketSelectionList() {
         model.getShowMarketSelectionListExpanded().set(!model.getShowMarketSelectionListExpanded().get());
+    }
+
+    void onSelectBuyFromFilter() {
+        model.getShowBuyFromOfferMessageItems().set(true);
+    }
+
+    void onSelectSellToFilter() {
+        model.getShowBuyFromOfferMessageItems().set(false);
     }
 
     private void createMarketChannels() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookModel.java
@@ -68,9 +68,9 @@ public final class BisqEasyOfferbookModel extends ChatModel {
     private final List<StandardTable.FilterMenuItem<OfferMessageItem>> filterOfferMessageItems = new ArrayList<>();
     private final ToggleGroup filterOfferMessageMenuItemToggleGroup = new ToggleGroup();
     private final StringProperty fiatAmountTitle = new SimpleStringProperty();
-    private final BooleanProperty showBuyFromOfferMessageItems = new SimpleBooleanProperty(true); // TODO: save user pref in settings
-    private final BooleanProperty showOfferListExpanded = new SimpleBooleanProperty(true); // TODO: save user pref in settings
-    private final BooleanProperty showMarketSelectionListExpanded = new SimpleBooleanProperty(true); // TODO: save user pref in settings
+    private final BooleanProperty showBuyFromOfferMessageItems = new SimpleBooleanProperty();
+    private final BooleanProperty showOfferListExpanded = new SimpleBooleanProperty();
+    private final BooleanProperty showMarketSelectionListExpanded = new SimpleBooleanProperty();
 
     @Setter
     private Predicate<MarketChannelItem> marketPricePredicate = marketChannelItem -> true;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -794,12 +794,16 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     }
 
     private void configOffersTableView(BisqTableView<OfferMessageItem> tableView) {
+        Comparator<OfferMessageItem> userProfileComparator = Comparator
+                .comparingLong(OfferMessageItem::getTotalScore).reversed()
+                .thenComparing(OfferMessageItem::getUserNickname);
+
         BisqTableColumn<OfferMessageItem> userProfileTableColumn = new BisqTableColumn.Builder<OfferMessageItem>()
                 .title(Res.get("bisqEasy.offerbook.offerList.table.columns.peerProfile"))
                 .left()
                 .fixWidth(170)
                 .setCellFactory(BisqEasyOfferbookUtil.getOfferMessageUserProfileCellFactory())
-                .comparator(Comparator.comparing(OfferMessageItem::getUserNickname))
+                .comparator(userProfileComparator)
                 .isSortable(true)
                 .build();
 
@@ -830,6 +834,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         tableView.getColumns().add(priceTableColumn);
         tableView.getColumns().add(spacerColumn);
         tableView.getColumns().add(fiatAmountTableColumn);
+        tableView.getSortOrder().add(userProfileTableColumn);
     }
 
     private static final class DropdownFilterMenuItem<T> extends DropdownMenuItem {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -227,8 +227,8 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
 
         createOfferButton.setOnAction(e -> getController().onCreateOffer());
 
-        buyFromOffers.setOnAction(e -> getModel().getShowBuyFromOfferMessageItems().set(true));
-        sellToOffers.setOnAction(e -> getModel().getShowBuyFromOfferMessageItems().set(false));
+        buyFromOffers.setOnAction(e -> getController().onSelectBuyFromFilter());
+        sellToOffers.setOnAction(e -> getController().onSelectSellToFilter());
 
         removeWithOffersFilter.setOnMouseClicked(e -> getModel().getSelectedMarketsFilter().set(Filters.Markets.ALL));
         withOffersDisplayHint.setOnMouseEntered(e -> removeWithOffersFilter.setGraphic(withOffersRemoveFilterActiveIcon));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/OfferMessageItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/OfferMessageItem.java
@@ -47,6 +47,7 @@ public class OfferMessageItem {
     private final Pair<Monetary, Monetary> minMaxAmount;
     private final String minMaxAmountAsString;
     private final ReputationScore reputationScore;
+    private final long totalScore;
 
     private Pin marketPriceByCurrencyMapPin;
     private double priceSpecAsPercent;
@@ -62,6 +63,7 @@ public class OfferMessageItem {
         this.marketPriceService = marketPriceService;
         userNickname = userProfile.getNickName();
         reputationScore = reputationService.findReputationScore(userProfile.getId()).orElse(ReputationScore.NONE);
+        totalScore = reputationScore.getTotalScore();
         minMaxAmount = retrieveMinMaxAmount();
         minMaxAmountAsString = OfferAmountFormatter.formatQuoteAmount(marketPriceService, offer, false);
 

--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -81,6 +81,9 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
         getFavouriteMarkets().addObserver(this::persist);
         getIgnoreMinRequiredReputationScoreFromSecManager().addObserver(value -> persist());
         getMaxTradePriceDeviation().addObserver(value -> persist());
+        getShowBuyFromOffers().addObserver(value -> persist());
+        getShowOfferListExpanded().addObserver(value -> persist());
+        getShowMarketSelectionListExpanded().addObserver(value -> persist());
         isInitialized = true;
 
         if (DevMode.isDevMode() && getMinRequiredReputationScore().get() == DEFAULT_MIN_REQUIRED_REPUTATION_SCORE) {
@@ -189,6 +192,18 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
 
     public ObservableSet<Market> getFavouriteMarkets() {
         return persistableStore.favouriteMarkets;
+    }
+
+    public Observable<Boolean> getShowBuyFromOffers() {
+        return persistableStore.showBuyFromOffers;
+    }
+
+    public Observable<Boolean> getShowOfferListExpanded() {
+        return persistableStore.showOfferListExpanded;
+    }
+
+    public Observable<Boolean> getShowMarketSelectionListExpanded() {
+        return persistableStore.showMarketSelectionListExpanded;
     }
 
 

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -54,6 +54,9 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
     final ObservableSet<Market> favouriteMarkets = new ObservableSet<>();
     final Observable<Boolean> ignoreMinRequiredReputationScoreFromSecManager = new Observable<>();
     final Observable<Double> maxTradePriceDeviation = new Observable<>();
+    final Observable<Boolean> showBuyFromOffers = new Observable<>();
+    final Observable<Boolean> showOfferListExpanded = new Observable<>();
+    final Observable<Boolean> showMarketSelectionListExpanded = new Observable<>();
 
     public SettingsStore() {
         this(new Cookie(),
@@ -74,7 +77,10 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 false,
                 new HashSet<>(),
                 false,
-                SettingsService.DEFAULT_MAX_TRADE_PRICE_DEVIATION);
+                SettingsService.DEFAULT_MAX_TRADE_PRICE_DEVIATION,
+                true,
+                false,
+                true);
     }
 
     public SettingsStore(Cookie cookie,
@@ -95,7 +101,10 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                          boolean ignoreDiffAdjustmentFromSecManager,
                          Set<Market> favouriteMarkets,
                          boolean ignoreMinRequiredReputationScoreFromSecManager,
-                         double maxTradePriceDeviation) {
+                         double maxTradePriceDeviation,
+                         boolean showBuyFromOffers,
+                         boolean showOfferListExpanded,
+                         boolean showMarketSelectionListExpanded) {
         this.cookie = cookie;
         this.dontShowAgainMap.putAll(dontShowAgainMap);
         this.useAnimations.set(useAnimations);
@@ -115,6 +124,9 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
         this.favouriteMarkets.setAll(favouriteMarkets);
         this.ignoreMinRequiredReputationScoreFromSecManager.set(ignoreMinRequiredReputationScoreFromSecManager);
         this.maxTradePriceDeviation.set(maxTradePriceDeviation);
+        this.showBuyFromOffers.set(showBuyFromOffers);
+        this.showOfferListExpanded.set(showOfferListExpanded);
+        this.showMarketSelectionListExpanded.set(showMarketSelectionListExpanded);
     }
 
     @Override
@@ -138,7 +150,10 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 .setIgnoreDiffAdjustmentFromSecManager(ignoreDiffAdjustmentFromSecManager.get())
                 .addAllFavouriteMarkets(favouriteMarkets.stream().map(market -> market.toProto(serializeForHash)).collect(Collectors.toList()))
                 .setIgnoreMinRequiredReputationScoreFromSecManager(ignoreMinRequiredReputationScoreFromSecManager.get())
-                .setMaxTradePriceDeviation(maxTradePriceDeviation.get());
+                .setMaxTradePriceDeviation(maxTradePriceDeviation.get())
+                .setShowBuyFromOffers(showBuyFromOffers.get())
+                .setShowOfferListExpanded(showOfferListExpanded.get())
+                .setShowMarketSelectionListExpanded(showMarketSelectionListExpanded.get());
     }
 
     @Override
@@ -174,7 +189,10 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 new HashSet<>(proto.getFavouriteMarketsList().stream()
                         .map(Market::fromProto).collect(Collectors.toSet())),
                 proto.getIgnoreMinRequiredReputationScoreFromSecManager(),
-                maxTradePriceDeviation);
+                maxTradePriceDeviation,
+                proto.getShowBuyFromOffers(),
+                proto.getShowOfferListExpanded(),
+                proto.getShowMarketSelectionListExpanded());
     }
 
     @Override
@@ -208,7 +226,10 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 ignoreDiffAdjustmentFromSecManager.get(),
                 new HashSet<>(favouriteMarkets),
                 ignoreMinRequiredReputationScoreFromSecManager.get(),
-                maxTradePriceDeviation.get());
+                maxTradePriceDeviation.get(),
+                showBuyFromOffers.get(),
+                showOfferListExpanded.get(),
+                showMarketSelectionListExpanded.get());
     }
 
     @Override
@@ -233,6 +254,9 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
             favouriteMarkets.setAll(persisted.favouriteMarkets);
             ignoreMinRequiredReputationScoreFromSecManager.set(persisted.ignoreMinRequiredReputationScoreFromSecManager.get());
             maxTradePriceDeviation.set(persisted.maxTradePriceDeviation.get());
+            showBuyFromOffers.set(persisted.showBuyFromOffers.get());
+            showOfferListExpanded.set(persisted.showOfferListExpanded.get());
+            showMarketSelectionListExpanded.set(persisted.showMarketSelectionListExpanded.get());
         } catch (Exception e) {
             log.error("Exception at applyPersisted", e);
         }

--- a/settings/src/main/proto/settings.proto
+++ b/settings/src/main/proto/settings.proto
@@ -57,4 +57,7 @@ message SettingsStore {
   repeated common.Market favouriteMarkets = 17;
   bool ignoreMinRequiredReputationScoreFromSecManager = 18;
   double maxTradePriceDeviation = 19;
+  bool showBuyFromOffers = 20;
+  bool showOfferListExpanded = 21;
+  bool showMarketSelectionListExpanded = 22;
 }


### PR DESCRIPTION
* Persist user preference for the offers list filter and collapsible settings.
* Use reputation score and user nickname as default sorting method for offers list.

![image](https://github.com/bisq-network/bisq2/assets/145597137/ad8f8b75-f91f-4102-8efb-49bf679f404f)
