### PR TITLE
Remove legacy external Tor key generation

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/node/transport/TorTransportService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/transport/TorTransportService.java
@@ -81,7 +81,8 @@ public class TorTransportService implements TransportService {
             bootstrapInfo.getBootstrapProgress().set(0.25);
             bootstrapInfo.getBootstrapDetails().set("Create Onion service for node ID '" + networkId + "'");
 
-            CreateOnionServiceResponse response = torService.createOnionService(port, keyBundle.getTorKeyPair(), keyBundle.getTorKeyPair().getOnionAddress()).get(2, TimeUnit.MINUTES);
+            CreateOnionServiceResponse response = torService.createOnionService(port, keyBundle.getTorKeyPair())
+                    .get(2, TimeUnit.MINUTES);
 
             bootstrapInfo.getBootstrapState().set(BootstrapState.SERVICE_PUBLISHED);
             bootstrapInfo.getBootstrapProgress().set(0.5);

--- a/network/network/src/main/java/bisq/network/p2p/node/transport/TorTransportService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/transport/TorTransportService.java
@@ -7,7 +7,6 @@ import bisq.network.common.TransportType;
 import bisq.network.identity.NetworkId;
 import bisq.network.p2p.node.ConnectionException;
 import bisq.security.keys.KeyBundle;
-import bisq.security.keys.TorKeyGeneration;
 import bisq.tor.TorService;
 import bisq.tor.TorTransportConfig;
 import bisq.tor.onionservice.CreateOnionServiceResponse;
@@ -82,8 +81,7 @@ public class TorTransportService implements TransportService {
             bootstrapInfo.getBootstrapProgress().set(0.25);
             bootstrapInfo.getBootstrapDetails().set("Create Onion service for node ID '" + networkId + "'");
 
-            String privateOpenSshKey = TorKeyGeneration.getPrivateKeyInOpenSshFormat(keyBundle.getTorKeyPair().getPrivateKey());
-            CreateOnionServiceResponse response = torService.createOnionService(port, privateOpenSshKey, keyBundle.getTorKeyPair().getOnionAddress()).get(2, TimeUnit.MINUTES);
+            CreateOnionServiceResponse response = torService.createOnionService(port, keyBundle.getTorKeyPair(), keyBundle.getTorKeyPair().getOnionAddress()).get(2, TimeUnit.MINUTES);
 
             bootstrapInfo.getBootstrapState().set(BootstrapState.SERVICE_PUBLISHED);
             bootstrapInfo.getBootstrapProgress().set(0.5);

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -21,6 +21,7 @@ import bisq.common.application.Service;
 import bisq.common.observable.Observable;
 import bisq.common.util.OsUtils;
 import bisq.network.tor.common.torrc.TorrcFileGenerator;
+import bisq.security.keys.TorKeyPair;
 import bisq.tor.controller.NativeTorController;
 import bisq.tor.controller.events.events.BootstrapEvent;
 import bisq.tor.installer.TorInstaller;
@@ -110,13 +111,13 @@ public class TorService implements Service {
         return nativeTorController.getBootstrapEvent();
     }
 
-    public CompletableFuture<CreateOnionServiceResponse> createOnionService(int port, String privateOpenSshKey, String onionAddressString) {
+    public CompletableFuture<CreateOnionServiceResponse> createOnionService(int port, TorKeyPair torKeyPair, String onionAddressString) {
         log.info("Start hidden service with port {}", port);
         long ts = System.currentTimeMillis();
         try {
             @SuppressWarnings("resource") ServerSocket localServerSocket = new ServerSocket(RANDOM_PORT);
             int localPort = localServerSocket.getLocalPort();
-            return onionServicePublishService.publish(privateOpenSshKey, onionAddressString, port, localPort)
+            return onionServicePublishService.publish(torKeyPair, onionAddressString, port, localPort)
                     .thenApply(onionAddress -> {
                                 log.info("Tor hidden service Ready. Took {} ms. Onion address={}",
                                         System.currentTimeMillis() - ts, onionAddress);

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -111,13 +111,13 @@ public class TorService implements Service {
         return nativeTorController.getBootstrapEvent();
     }
 
-    public CompletableFuture<CreateOnionServiceResponse> createOnionService(int port, TorKeyPair torKeyPair, String onionAddressString) {
+    public CompletableFuture<CreateOnionServiceResponse> createOnionService(int port, TorKeyPair torKeyPair) {
         log.info("Start hidden service with port {}", port);
         long ts = System.currentTimeMillis();
         try {
             @SuppressWarnings("resource") ServerSocket localServerSocket = new ServerSocket(RANDOM_PORT);
             int localPort = localServerSocket.getLocalPort();
-            return onionServicePublishService.publish(torKeyPair, onionAddressString, port, localPort)
+            return onionServicePublishService.publish(torKeyPair, port, localPort)
                     .thenApply(onionAddress -> {
                                 log.info("Tor hidden service Ready. Took {} ms. Onion address={}",
                                         System.currentTimeMillis() - ts, onionAddress);

--- a/network/tor/tor/src/main/java/bisq/tor/controller/NativeTorController.java
+++ b/network/tor/tor/src/main/java/bisq/tor/controller/NativeTorController.java
@@ -18,6 +18,7 @@
 package bisq.tor.controller;
 
 import bisq.common.observable.Observable;
+import bisq.security.keys.TorKeyPair;
 import bisq.tor.TorrcClientConfigFactory;
 import bisq.tor.controller.events.ControllerEventHandler;
 import bisq.tor.controller.events.events.BootstrapEvent;
@@ -102,18 +103,15 @@ public class NativeTorController implements BootstrapEventListener, HsDescUpload
     }
 
     public TorControlConnection.CreateHiddenServiceResult createHiddenService(
-            int hiddenServicePort, int localPort, String privateKey) throws IOException {
+            int hiddenServicePort, int localPort, TorKeyPair torKeyPair) throws IOException {
         TorControlConnection controlConnection = torControlConnection.orElseThrow();
 
         controllerEventHandler.addHsDescUploadedListener(this);
         setEventSubscriptionsOnConnection(controlConnection, List.of("HS_DESC"));
 
         TorControlConnection.CreateHiddenServiceResult result;
-        if (privateKey.isEmpty()) {
-            result = controlConnection.createHiddenService(hiddenServicePort, localPort);
-        } else {
-            result = controlConnection.createHiddenService(hiddenServicePort, localPort, privateKey);
-        }
+        result = controlConnection.createHiddenService(hiddenServicePort, localPort,
+                torKeyPair.getPrivateKeyInOpenSshFormat());
         hiddenServiceAddress.complete(result.serviceID);
 
         try {

--- a/network/tor/tor/src/main/java/bisq/tor/onionservice/OnionServicePublishService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/onionservice/OnionServicePublishService.java
@@ -39,7 +39,8 @@ public class OnionServicePublishService {
         this.nativeTorController = nativeTorController;
     }
 
-    public synchronized CompletableFuture<OnionAddress> publish(TorKeyPair torKeyPair, String onionAddressString, int onionServicePort, int localPort) {
+    public synchronized CompletableFuture<OnionAddress> publish(TorKeyPair torKeyPair, int onionServicePort, int localPort) {
+        String onionAddressString = torKeyPair.getOnionAddress();
         if (onionAddressMap.containsKey(onionAddressString)) {
             return onionAddressMap.get(onionAddressString);
         }

--- a/network/tor/tor/src/main/java/bisq/tor/onionservice/OnionServicePublishService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/onionservice/OnionServicePublishService.java
@@ -17,6 +17,7 @@
 
 package bisq.tor.onionservice;
 
+import bisq.security.keys.TorKeyPair;
 import bisq.tor.controller.NativeTorController;
 import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.TorControlConnection;
@@ -38,7 +39,7 @@ public class OnionServicePublishService {
         this.nativeTorController = nativeTorController;
     }
 
-    public synchronized CompletableFuture<OnionAddress> publish(String privateOpenSshKey, String onionAddressString, int onionServicePort, int localPort) {
+    public synchronized CompletableFuture<OnionAddress> publish(TorKeyPair torKeyPair, String onionAddressString, int onionServicePort, int localPort) {
         if (onionAddressMap.containsKey(onionAddressString)) {
             return onionAddressMap.get(onionAddressString);
         }
@@ -48,7 +49,7 @@ public class OnionServicePublishService {
 
         try {
             TorControlConnection.CreateHiddenServiceResult jTorResult =
-                    nativeTorController.createHiddenService(onionServicePort, localPort, privateOpenSshKey);
+                    nativeTorController.createHiddenService(onionServicePort, localPort, torKeyPair);
 
             var onionAddress = new OnionAddress(jTorResult.serviceID + ".onion", onionServicePort);
             completableFuture.complete(onionAddress);

--- a/security/src/main/java/bisq/security/keys/TorKeyGeneration.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyGeneration.java
@@ -94,34 +94,5 @@ public class TorKeyGeneration {
                 hashedByteArray[1]
         };
     }
-
-    /**
-     * The format how the private key is stored in the tor directory
-     */
-    public static String getPrivateKeyInOpenSshFormat(byte[] privateKey) {
-        // Key Format definition:
-        // https://gitlab.torproject.org/tpo/core/torspec/-/blob/main/control-spec.txt
-        byte[] secretScalar = generateSecretScalar(privateKey);
-        String encoded = java.util.Base64.getEncoder().encodeToString(secretScalar);
-        return "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
-                encoded + "\n" +
-                "-----END OPENSSH PRIVATE KEY-----\n";
-    }
-
-    private static byte[] generateSecretScalar(byte[] privateKey) {
-        // https://www.rfc-editor.org/rfc/rfc8032#section-5.1
-
-        SHA512Digest sha512Digest = new SHA512Digest();
-        sha512Digest.update(privateKey, 0, privateKey.length);
-
-        byte[] secretScalar = new byte[64];
-        sha512Digest.doFinal(secretScalar, 0);
-
-        secretScalar[0] &= (byte) 248;
-        secretScalar[31] &= 127;
-        secretScalar[31] |= 64;
-
-        return secretScalar;
-    }
 }
 

--- a/security/src/main/java/bisq/security/keys/TorKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyPair.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.crypto.digests.SHA512Digest;
 
 @Slf4j
 @Getter
@@ -47,5 +48,33 @@ public class TorKeyPair implements PersistableProto {
         return new TorKeyPair(proto.getPrivateKey().toByteArray(),
                 proto.getPublicKey().toByteArray(),
                 proto.getOnionAddress());
+    }
+
+    /**
+     * The format how the private key is stored in the tor directory
+     */
+    public String getPrivateKeyInOpenSshFormat() {
+        // Key Format definition:
+        // https://gitlab.torproject.org/tpo/core/torspec/-/blob/main/control-spec.txt
+        byte[] secretScalar = generateSecretScalar(privateKey);
+        String encoded = java.util.Base64.getEncoder().encodeToString(secretScalar);
+        return "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+                encoded + "\n" +
+                "-----END OPENSSH PRIVATE KEY-----\n";
+    }
+
+    private static byte[] generateSecretScalar(byte[] privateKey) {
+        // https://www.rfc-editor.org/rfc/rfc8032#section-5.1
+        SHA512Digest sha512Digest = new SHA512Digest();
+        sha512Digest.update(privateKey, 0, privateKey.length);
+
+        byte[] secretScalar = new byte[64];
+        sha512Digest.doFinal(secretScalar, 0);
+
+        secretScalar[0] &= (byte) 248;
+        secretScalar[31] &= 127;
+        secretScalar[31] |= 64;
+
+        return secretScalar;
     }
 }


### PR DESCRIPTION
- [Remove legacy external Tor key generation](https://github.com/bisq-network/bisq2/commit/0a4759850153cbf91f0f6345da2cc01b17a397e5)
  - In the past, we didn't create the Tor onion keys ourselves. Back then,
we let Tor create the keys and persist those in Bisq.
- [OnionServicePublishService: Remove redundant onionAddress argument](https://github.com/bisq-network/bisq2/commit/729cab97d281a2139c493218560a3ccaf716f886)