### PR TITLE
Fix Local Tor Network Setup with ControlPort

### DIFF
--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/BaseTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/BaseTorrcGenerator.java
@@ -23,18 +23,19 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-@Builder
 public class BaseTorrcGenerator implements TorrcConfigGenerator {
     private static final String CONTROL_PORT_WRITE_TO_FILE_CONFIG_KEY = "ControlPortWriteToFile";
+    public static final String CONTROL_DIR_NAME = "control";
 
     private final Path dataDirPath;
     private final Path controlPortWriteFile;
     private final String hashedControlPassword;
     private final boolean isTestNetwork;
 
-    public BaseTorrcGenerator(Path dataDirPath, Path controlPortWriteFile, String hashedControlPassword, boolean isTestNetwork) {
+    @Builder
+    public BaseTorrcGenerator(Path dataDirPath, String hashedControlPassword, boolean isTestNetwork) {
         this.dataDirPath = dataDirPath;
-        this.controlPortWriteFile = controlPortWriteFile;
+        this.controlPortWriteFile = dataDirPath.resolve(CONTROL_DIR_NAME).resolve("control");
         this.hashedControlPassword = hashedControlPassword;
         this.isTestNetwork = isTestNetwork;
     }

--- a/network/tor/tor-local-network/src/integrationTest/java/bisq/tor/local_network/DirectoryAuthorityKeyGenerationTests.java
+++ b/network/tor/tor-local-network/src/integrationTest/java/bisq/tor/local_network/DirectoryAuthorityKeyGenerationTests.java
@@ -38,7 +38,6 @@ public class DirectoryAuthorityKeyGenerationTests {
                 .type(TorNode.Type.DIRECTORY_AUTHORITY)
                 .nickname("Nick")
                 .dataDir(dataDir)
-                .controlPort(1)
                 .orPort(2)
                 .dirPort(3)
                 .build();

--- a/network/tor/tor-local-network/src/integrationTest/java/bisq/tor/local_network/DirectoryAuthorityTests.java
+++ b/network/tor/tor-local-network/src/integrationTest/java/bisq/tor/local_network/DirectoryAuthorityTests.java
@@ -43,7 +43,6 @@ public class DirectoryAuthorityTests {
                 .type(TorNode.Type.DIRECTORY_AUTHORITY)
                 .nickname("DA_1")
                 .dataDir(tempDir)
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
                 .build();
@@ -62,7 +61,6 @@ public class DirectoryAuthorityTests {
                 .type(TorNode.Type.DIRECTORY_AUTHORITY)
                 .nickname("DA_1")
                 .dataDir(firstDaDataDir)
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
                 .build();
@@ -73,7 +71,6 @@ public class DirectoryAuthorityTests {
                 .type(TorNode.Type.DIRECTORY_AUTHORITY)
                 .nickname("DA_2")
                 .dataDir(secondDaDataDir)
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
                 .build();
@@ -84,7 +81,6 @@ public class DirectoryAuthorityTests {
                 .type(TorNode.Type.DIRECTORY_AUTHORITY)
                 .nickname("DA_3")
                 .dataDir(thirdDaDataDir)
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
                 .build();

--- a/network/tor/tor-local-network/src/main/java/bisq/tor/local_network/TorNetwork.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/tor/local_network/TorNetwork.java
@@ -60,7 +60,6 @@ public class TorNetwork {
                 .type(TorNode.Type.DIRECTORY_AUTHORITY)
                 .nickname(nickname)
                 .dataDir(nodeDataDir)
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
                 .build();
@@ -81,7 +80,6 @@ public class TorNetwork {
                 .nickname(nickname)
                 .dataDir(nodeDataDir)
 
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
 
@@ -101,7 +99,6 @@ public class TorNetwork {
                 .nickname(nickname)
                 .dataDir(nodeDataDir)
 
-                .controlPort(NetworkUtils.findFreeSystemPort())
                 .orPort(NetworkUtils.findFreeSystemPort())
                 .dirPort(NetworkUtils.findFreeSystemPort())
 

--- a/network/tor/tor-local-network/src/main/java/bisq/tor/local_network/TorNode.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/tor/local_network/TorNode.java
@@ -43,7 +43,6 @@ public class TorNode {
 
     private final Path dataDir;
 
-    private final int controlPort;
     private final int orPort;
     private final int dirPort;
 
@@ -58,11 +57,10 @@ public class TorNode {
     private Optional<String> relayKeyFingerprint = Optional.empty();
 
     @Builder
-    public TorNode(Type type, String nickname, Path dataDir, int controlPort, int orPort, int dirPort) {
+    public TorNode(Type type, String nickname, Path dataDir, int orPort, int dirPort) {
         this.type = type;
         this.nickname = nickname;
         this.dataDir = dataDir;
-        this.controlPort = controlPort;
         this.orPort = orPort;
         this.dirPort = dirPort;
         this.keysPath = dataDir.resolve("keys");

--- a/network/tor/tor-local-network/src/test/java/bisq/tor/local_network/DirectoryAuthorityTorrcGeneratorTests.java
+++ b/network/tor/tor-local-network/src/test/java/bisq/tor/local_network/DirectoryAuthorityTorrcGeneratorTests.java
@@ -48,7 +48,6 @@ public class DirectoryAuthorityTorrcGeneratorTests {
                         .nickname("A")
                         .dataDir(daAPath)
 
-                        .controlPort(1)
                         .orPort(2)
                         .dirPort(3)
 
@@ -69,7 +68,6 @@ public class DirectoryAuthorityTorrcGeneratorTests {
                         .nickname("B")
                         .dataDir(tempDir.resolve("DA_B"))
 
-                        .controlPort(1)
                         .orPort(2)
                         .dirPort(3)
 

--- a/network/tor/tor-local-network/src/test/java/bisq/tor/local_network/RelayTorrcGeneratorTests.java
+++ b/network/tor/tor-local-network/src/test/java/bisq/tor/local_network/RelayTorrcGeneratorTests.java
@@ -47,7 +47,6 @@ public class RelayTorrcGeneratorTests {
                         .nickname("A")
                         .dataDir(relayAPath)
 
-                        .controlPort(1)
                         .orPort(2)
                         .dirPort(3)
 
@@ -68,7 +67,6 @@ public class RelayTorrcGeneratorTests {
                         .nickname("B")
                         .dataDir(tempDir.resolve("DA_B"))
 
-                        .controlPort(1)
                         .orPort(2)
                         .dirPort(3)
 
@@ -92,7 +90,6 @@ public class RelayTorrcGeneratorTests {
                         .nickname("A")
                         .dataDir(tempDir.resolve("dir_auth"))
 
-                        .controlPort(1)
                         .orPort(2)
                         .dirPort(3)
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -20,6 +20,7 @@ package bisq.tor;
 import bisq.common.application.Service;
 import bisq.common.observable.Observable;
 import bisq.common.util.OsUtils;
+import bisq.network.tor.common.torrc.BaseTorrcGenerator;
 import bisq.network.tor.common.torrc.TorrcFileGenerator;
 import bisq.security.keys.TorKeyPair;
 import bisq.tor.controller.NativeTorController;
@@ -82,7 +83,7 @@ public class TorService implements Service {
             torProcess = Optional.of(nativeTorProcess);
             nativeTorProcess.start();
 
-            Path controlDirPath = torDataDirPath.resolve(NativeTorProcess.CONTROL_DIR_NAME);
+            Path controlDirPath = torDataDirPath.resolve(BaseTorrcGenerator.CONTROL_DIR_NAME);
             Path controlPortFilePath = controlDirPath.resolve("control");
 
             return new ControlPortFilePoller(controlPortFilePath)

--- a/network/tor/tor/src/main/java/bisq/tor/TorrcClientConfigFactory.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorrcClientConfigFactory.java
@@ -65,7 +65,6 @@ public class TorrcClientConfigFactory {
     private TorrcConfigGenerator baseTorrcGenerator() {
         return BaseTorrcGenerator.builder()
                 .dataDirPath(dataDir)
-                .controlPortWriteFile(dataDir.resolve(NativeTorProcess.CONTROL_DIR_NAME).resolve("control"))
                 .hashedControlPassword(hashedControlPassword.getHashedPassword())
                 .isTestNetwork(isTestNetwork)
                 .build();

--- a/network/tor/tor/src/main/java/bisq/tor/process/NativeTorProcess.java
+++ b/network/tor/tor/src/main/java/bisq/tor/process/NativeTorProcess.java
@@ -17,6 +17,7 @@
 
 package bisq.tor.process;
 
+import bisq.network.tor.common.torrc.BaseTorrcGenerator;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
@@ -29,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class NativeTorProcess {
     public static final String ARG_OWNER_PID = "__OwningControllerProcess";
-    public static final String CONTROL_DIR_NAME = "control";
 
     private final Path torDataDirPath;
     private final Path torBinaryPath;
@@ -100,7 +100,7 @@ public class NativeTorProcess {
     }
 
     private void createTorControlDirectory() {
-        File controlDirFile = torDataDirPath.resolve(CONTROL_DIR_NAME).toFile();
+        File controlDirFile = torDataDirPath.resolve(BaseTorrcGenerator.CONTROL_DIR_NAME).toFile();
         if (!controlDirFile.exists()) {
             boolean isSuccess = controlDirFile.mkdirs();
             if (!isSuccess) {


### PR DESCRIPTION
Developer can run a private isolated Tor network to develop Bisq. In a recent change, we let Tor pick the control port and connect to it afterward. The private Tor network setup code was not updated.

Ref: #2063