### PR TITLE
Detect filtered Tor controller commands

### DIFF
--- a/network/tor/tor/src/main/java/bisq/tor/controller/TorCommandFilteredException.java
+++ b/network/tor/tor/src/main/java/bisq/tor/controller/TorCommandFilteredException.java
@@ -1,0 +1,4 @@
+package bisq.tor.controller;
+
+public class TorCommandFilteredException extends RuntimeException {
+}

--- a/network/tor/tor/src/main/java/bisq/tor/controller/WhonixTorController.java
+++ b/network/tor/tor/src/main/java/bisq/tor/controller/WhonixTorController.java
@@ -1,0 +1,41 @@
+package bisq.tor.controller;
+
+import bisq.security.keys.TorKeyPair;
+
+import java.io.*;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+public class WhonixTorController implements AutoCloseable {
+    private final Socket controlSocket;
+    private final BufferedReader bufferedReader;
+    private final OutputStream outputStream;
+
+    public WhonixTorController() throws IOException {
+        controlSocket = new Socket("127.0.0.1", 9051);
+
+        InputStream inputStream = controlSocket.getInputStream();
+        bufferedReader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.US_ASCII));
+
+        outputStream = controlSocket.getOutputStream();
+    }
+
+    @Override
+    public void close() throws IOException {
+        controlSocket.close();
+    }
+
+    public void addOnion(TorKeyPair torKeyPair, int onionPort, int localPort) throws IOException {
+        String base64SecretScalar = torKeyPair.getBase64SecretScalar();
+        String command = "ADD_ONION " + "ED25519-V3:" + base64SecretScalar + " Port=" + onionPort + "," + localPort + "\r\n";
+        byte[] commandBytes = command.getBytes(StandardCharsets.US_ASCII);
+
+        outputStream.write(commandBytes);
+        outputStream.flush();
+
+        String reply = bufferedReader.readLine();
+        if (reply.equals("510 Command filtered")) {
+            throw new TorCommandFilteredException();
+        }
+    }
+}

--- a/security/src/main/java/bisq/security/keys/TorKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyPair.java
@@ -50,16 +50,19 @@ public class TorKeyPair implements PersistableProto {
                 proto.getOnionAddress());
     }
 
+    public String getBase64SecretScalar() {
+        // Key Format definition:
+        // https://gitlab.torproject.org/tpo/core/torspec/-/blob/main/control-spec.txt
+        byte[] secretScalar = generateSecretScalar(privateKey);
+        return java.util.Base64.getEncoder().encodeToString(secretScalar);
+    }
+
     /**
      * The format how the private key is stored in the tor directory
      */
     public String getPrivateKeyInOpenSshFormat() {
-        // Key Format definition:
-        // https://gitlab.torproject.org/tpo/core/torspec/-/blob/main/control-spec.txt
-        byte[] secretScalar = generateSecretScalar(privateKey);
-        String encoded = java.util.Base64.getEncoder().encodeToString(secretScalar);
         return "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
-                encoded + "\n" +
+                getBase64SecretScalar() + "\n" +
                 "-----END OPENSSH PRIVATE KEY-----\n";
     }
 


### PR DESCRIPTION
Tails and Whonix use onion-grater to filter dangerous Tor control
protocol commands. Therefore, users need to enable the Bisq onion-grater
profile on those operating systems. We should detect filtered commands
and help users to setup their operating system.

Ref: https://github.com/bisq-network/bisq2/issues/1894

Changes:
- [Add getBase64SecretScalar() to TorKeyPair](https://github.com/bisq-network/bisq2/commit/afe249a6e955544aaedb73f826d8692d0fdd031b)
- [Detect filtered Tor controller commands](https://github.com/bisq-network/bisq2/commit/126f04486c2401b1010b682055bb65925ec09061)