### PR TITLE
Fix connection handshake bannedPeer test

### DIFF
--- a/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
@@ -139,11 +139,10 @@ public class ConnectionHandshakeResponderTest {
 
         when(banList.isBanned(Address.localHost(1234))).thenReturn(true);
 
-        Exception exception = assertThrows(ConnectionException.class, handshakeResponder::verifyAndBuildRespond);
+        ConnectionException exception = assertThrows(ConnectionException.class, handshakeResponder::verifyAndBuildRespond);
 
-        assertThat(exception.getMessage())
-                .containsIgnoringCase("Peer")
-                .containsIgnoringCase("quarantine");
+        assertThat(exception.getReason())
+                .isEqualTo(ConnectionException.Reason.ADDRESS_BANNED);
     }
 
     @Test


### PR DESCRIPTION
PR #2180 broke this test. Before that change, it wasn't possible to know the ConnectionException reason without parsing its message.