### PR TITLE
Improve error popup

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -953,6 +953,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
                             zipLogLabel.setText("Zipped to: " + uri.toString().replace("%20", " "));
+                            OsUtils.open(baseDir);
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -430,7 +430,7 @@ public abstract class Overlay<T extends Overlay<T>> {
         TextArea errorReportTextArea = new TextArea(errorReport);
         errorReportTextArea.setPrefWidth(width);
         errorReportTextArea.setWrapText(true);
-        errorReportTextArea.getStyleClass().add("error-log");
+        errorReportTextArea.getStyleClass().addAll("code-block", "error-log");
 
         content(errorReportTextArea);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -941,9 +941,6 @@ public abstract class Overlay<T extends Overlay<T>> {
 
         Label zipLogLabel = new Label();
         Button zipLogButton = new Button(Res.get("popup.reportError.zipLogs"));
-//        GridPane.setHalignment(zipLogButton, HPos.LEFT);
-//        GridPane.setRowIndex(zipLogButton, gridPane.getRowCount());
-//        gridPane.getChildren().add(zipLogButton);
         zipLogButton.setOnAction(event -> {
             URI uri = URI.create("jar:file:" + Paths.get(baseDir,"bisq2-logs.zip").toUri().getPath());
             Map<String, String> env = Map.of("create", "true");
@@ -955,7 +952,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     if (logPath.toFile().isFile()) {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
-                            zipLogLabel.setText("Zipped to " + uri);
+                            zipLogLabel.setText("Zipped to: " + uri);
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -949,6 +949,11 @@ public abstract class Overlay<T extends Overlay<T>> {
         MaterialTextField zipTextField = new MaterialTextField(Res.get("popup.reportError.zipNewDirectory"), zipDirectory[0] + "/bisq2-logs.zip");
 
         zipLogButton.setOnAction(event -> {
+            try {
+                Files.createDirectories(Paths.get(zipDirectory[0]));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
             URI uri = URI.create("jar:file:" + Paths.get(zipDirectory[0],"bisq2-logs.zip").toUri().getRawPath());
             Map<String, String> env = Map.of("create", "true");
             List<Path> logPaths = Arrays.asList(

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -964,8 +964,8 @@ public abstract class Overlay<T extends Overlay<T>> {
                     if (logPath.toFile().isFile()) {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
-                            zipLogLabel.setText(Res.get("popup.reportError.zippedTo", baseDir + "/bisq2-logs.zip"));
-                            OsUtils.open(baseDir);
+                            zipLogLabel.setText(Res.get("popup.reportError.zippedTo", zipDirectory[0] + "/bisq2-logs.zip"));
+                            OsUtils.open(zipDirectory[0]);
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -939,7 +939,7 @@ public abstract class Overlay<T extends Overlay<T>> {
         gridPane.getChildren().add(logButton);
         logButton.setOnAction(event -> OsUtils.open(new File(baseDir, "bisq.log")));
 
-        Button zipLogButton = new Button(Res.get("popup.zipLogs.log"));
+        Button zipLogButton = new Button(Res.get("popup.reportError.zipLogs"));
         GridPane.setHalignment(zipLogButton, HPos.LEFT);
         GridPane.setRowIndex(zipLogButton, gridPane.getRowCount());
         gridPane.getChildren().add(zipLogButton);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -939,10 +939,11 @@ public abstract class Overlay<T extends Overlay<T>> {
         gridPane.getChildren().add(logButton);
         logButton.setOnAction(event -> OsUtils.open(new File(baseDir, "bisq.log")));
 
+        Label zipLogLabel = new Label();
         Button zipLogButton = new Button(Res.get("popup.reportError.zipLogs"));
-        GridPane.setHalignment(zipLogButton, HPos.LEFT);
-        GridPane.setRowIndex(zipLogButton, gridPane.getRowCount());
-        gridPane.getChildren().add(zipLogButton);
+//        GridPane.setHalignment(zipLogButton, HPos.LEFT);
+//        GridPane.setRowIndex(zipLogButton, gridPane.getRowCount());
+//        gridPane.getChildren().add(zipLogButton);
         zipLogButton.setOnAction(event -> {
             URI uri = URI.create("jar:file:" + Paths.get(baseDir,"bisq2-logs.zip").toUri().getPath());
             Map<String, String> env = Map.of("create", "true");
@@ -954,6 +955,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     if (logPath.toFile().isFile()) {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
+                            zipLogLabel.setText("Zipped to " + uri);
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
@@ -961,10 +963,18 @@ public abstract class Overlay<T extends Overlay<T>> {
                 });
             } catch (IOException e) {
                 throw new RuntimeException(e);
-        }});
+            }});
+
+        HBox zipLogHbox = new HBox(10);
+        zipLogHbox.setAlignment(Pos.CENTER_LEFT);
+
+        zipLogHbox.getChildren().addAll(zipLogButton, zipLogLabel);
+        GridPane.setHalignment(zipLogHbox, HPos.LEFT);
+        GridPane.setRowIndex(zipLogHbox, gridPane.getRowCount());
+        gridPane.getChildren().add(zipLogHbox);
 
         Button gitHubButton = new Button(Res.get("popup.reportError.gitHub"));
-        GridPane.setHalignment(gitHubButton, HPos.RIGHT);
+        GridPane.setHalignment(gitHubButton, HPos.LEFT);
         GridPane.setRowIndex(gitHubButton, gridPane.getRowCount());
         gridPane.getChildren().add(gitHubButton);
         gitHubButton.setOnAction(event -> {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -944,7 +944,7 @@ public abstract class Overlay<T extends Overlay<T>> {
         GridPane.setRowIndex(zipLogButton, gridPane.getRowCount());
         gridPane.getChildren().add(zipLogButton);
         zipLogButton.setOnAction(event -> {
-            URI uri = URI.create("jar:file:" + baseDir + "/bisq2-logs.zip");
+            URI uri = URI.create("jar:file:" + Paths.get(baseDir,"bisq2-logs.zip").toUri().getPath());
             Map<String, String> env = Map.of("create", "true");
             try (FileSystem zipfs = FileSystems.newFileSystem(uri, env)) {
                 Files.copy(Path.of(baseDir).resolve("bisq.log"), zipfs.getPath("/bisq.log"), StandardCopyOption.REPLACE_EXISTING);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -952,7 +952,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     if (logPath.toFile().isFile()) {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
-                            zipLogLabel.setText("Zipped to: " + baseDir + "/bisq2-logs.zip");
+                            zipLogLabel.setText(Res.get("popup.reportError.zippedTo", baseDir + "/bisq2-logs.zip"));
                             OsUtils.open(baseDir);
                         } catch (IOException e) {
                             throw new RuntimeException(e);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -952,7 +952,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     if (logPath.toFile().isFile()) {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
-                            zipLogLabel.setText("Zipped to: " + uri.toString().replace("%20", " "));
+                            zipLogLabel.setText("Zipped to: " + baseDir + "/bisq2-logs.zip");
                             OsUtils.open(baseDir);
                         } catch (IOException e) {
                             throw new RuntimeException(e);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -942,7 +942,7 @@ public abstract class Overlay<T extends Overlay<T>> {
         Label zipLogLabel = new Label();
         Button zipLogButton = new Button(Res.get("popup.reportError.zipLogs"));
         zipLogButton.setOnAction(event -> {
-            URI uri = URI.create("jar:file:" + Paths.get(baseDir,"bisq2-logs.zip").toUri().getPath());
+            URI uri = URI.create("jar:file:" + Paths.get(baseDir,"bisq2-logs.zip").toUri().getRawPath());
             Map<String, String> env = Map.of("create", "true");
             List<Path> logPaths = Arrays.asList(
                     Path.of(baseDir).resolve("bisq.log"),
@@ -952,7 +952,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     if (logPath.toFile().isFile()) {
                         try {
                             Files.copy(logPath, zipfs.getPath(logPath.toFile().getName()), StandardCopyOption.REPLACE_EXISTING);
-                            zipLogLabel.setText("Zipped to: " + uri);
+                            zipLogLabel.setText("Zipped to: " + uri.toString().replace("%20", " "));
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -31,6 +31,7 @@ import bisq.desktop.components.containers.BisqGridPane;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.BusyAnimation;
+import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
 import bisq.settings.DontShowAgainService;
 import bisq.settings.SettingsService;
@@ -940,9 +941,15 @@ public abstract class Overlay<T extends Overlay<T>> {
         logButton.setOnAction(event -> OsUtils.open(new File(baseDir, "bisq.log")));
 
         Label zipLogLabel = new Label();
+        zipLogLabel.setText(Res.get("popup.reportError.zipCurrentDirectory", baseDir + "/bisq2-logs.zip"));
         Button zipLogButton = new Button(Res.get("popup.reportError.zipLogs"));
+        Button zipChangeDirectoryButton = new Button(Res.get("popup.reportError.zipChangeDirectory"));
+        String[] zipDirectory = new String[1];
+        zipDirectory[0] = baseDir;
+        MaterialTextField zipTextField = new MaterialTextField(Res.get("popup.reportError.zipNewDirectory"), zipDirectory[0] + "/bisq2-logs.zip");
+
         zipLogButton.setOnAction(event -> {
-            URI uri = URI.create("jar:file:" + Paths.get(baseDir,"bisq2-logs.zip").toUri().getRawPath());
+            URI uri = URI.create("jar:file:" + Paths.get(zipDirectory[0],"bisq2-logs.zip").toUri().getRawPath());
             Map<String, String> env = Map.of("create", "true");
             List<Path> logPaths = Arrays.asList(
                     Path.of(baseDir).resolve("bisq.log"),
@@ -966,7 +973,19 @@ public abstract class Overlay<T extends Overlay<T>> {
         HBox zipLogHbox = new HBox(10);
         zipLogHbox.setAlignment(Pos.CENTER_LEFT);
 
-        zipLogHbox.getChildren().addAll(zipLogButton, zipLogLabel);
+        zipChangeDirectoryButton.setOnAction(event -> {
+            if (zipLogHbox.getChildren().contains(zipLogLabel)) {
+                zipLogHbox.getChildren().remove(zipLogLabel);
+                zipLogHbox.getChildren().add(1, zipTextField);
+            } else {
+                zipDirectory[0] = zipTextField.getText();
+                zipLogLabel.setText(Res.get("popup.reportError.zipCurrentDirectory", zipDirectory[0] + "/bisq2-logs.zip"));
+                zipLogHbox.getChildren().remove(zipTextField);
+                zipLogHbox.getChildren().add(zipLogLabel);
+            }
+        });
+
+        zipLogHbox.getChildren().addAll(zipLogButton, zipChangeDirectoryButton, zipLogLabel);
         GridPane.setHalignment(zipLogHbox, HPos.LEFT);
         GridPane.setRowIndex(zipLogHbox, gridPane.getRowCount());
         gridPane.getChildren().add(zipLogHbox);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/PeerOfferMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/PeerOfferMessageBox.java
@@ -106,7 +106,7 @@ public final class PeerOfferMessageBox extends PeerTextMessageBox {
         messageTitle.getStyleClass().addAll("bisq-easy-offer-title", "normal-text", "font-default");
         messageTitle.setPadding(new Insets(0, 0, 0, 7));
         peerNickName = new Label(StringUtils.truncate(item.getNickName(), 28));
-        peerNickName.getStyleClass().addAll("code-block", "hand-cursor");
+        peerNickName.getStyleClass().addAll("code-block", "offerbook-peer-name", "hand-cursor");
         peerNickName.setOnMouseClicked(e -> controller.onShowChatUserDetails(item.getChatMessage()));
         HBox messageTitleBox = new HBox(5, messageTitle, peerNickName);
         messageTitleBox.getStyleClass().add(isBuy ? "bisq-easy-offer-sell-btc-title" : "bisq-easy-offer-buy-btc-title");

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -278,3 +278,21 @@
     -fx-font-size: 1em;
     -fx-font-family: "IBM Plex Sans";
 }
+
+
+/*******************************************************************************
+ * Error popup                                                              *
+ ******************************************************************************/
+
+.error-log {
+    -fx-text-fill: -fx-light-text-color;
+    -fx-font-size: 1em;
+}
+
+.error-log .content {
+    -fx-background-color: -bisq-dark-grey-50;
+}
+
+.error-log:focused .content {
+    -fx-background-color: -bisq-dark-grey-50;
+}

--- a/apps/desktop/desktop/src/main/resources/css/application.css
+++ b/apps/desktop/desktop/src/main/resources/css/application.css
@@ -285,14 +285,13 @@
  ******************************************************************************/
 
 .error-log {
-    -fx-text-fill: -fx-light-text-color;
-    -fx-font-size: 1em;
+    -fx-background-color: -bisq-dark-grey-30;
 }
 
 .error-log .content {
-    -fx-background-color: -bisq-dark-grey-50;
+    -fx-background-color: -bisq-dark-grey-30;
 }
 
 .error-log:focused .content {
-    -fx-background-color: -bisq-dark-grey-50;
+    -fx-background-color: -bisq-dark-grey-30;
 }

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -199,6 +199,15 @@
     -fx-padding: 0 10 0 10;
 }
 
+.offerbook-peer-name {
+    -fx-background-color: -bisq-dark-grey-30;
+    -fx-padding: 1 7;
+    -fx-background-radius: 4;
+    -fx-border-radius: 4;
+    -fx-border-width: 1px;
+    -fx-border-color: -bisq-dark-grey-50;
+}
+
 /* Drop down sort & filter menu */
 .dropdown-menu-popup .dropdown-menu-item .dropdown-menu-item-content .menu-item-icon,
 .dropdown-menu-popup .dropdown-menu-item:hover .dropdown-menu-item-content .menu-item-icon {

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -577,12 +577,6 @@
     -fx-text-fill: -fx-mid-text-color;
     -fx-font-family: "IBM Plex Mono";
     -fx-font-size: 1em;
-    -fx-background-color: -bisq-dark-grey-30;
-    -fx-padding: 1 7;
-    -fx-background-radius: 4;
-    -fx-border-radius: 4;
-    -fx-border-width: 1px;
-    -fx-border-color: -bisq-dark-grey-50;
 }
 
 

--- a/common/src/main/java/bisq/common/logging/LogMaskConverter.java
+++ b/common/src/main/java/bisq/common/logging/LogMaskConverter.java
@@ -1,11 +1,11 @@
 package bisq.common.logging;
 
-import bisq.common.util.OsUtils;
+import bisq.common.util.StringUtils;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.CompositeConverter;
 
 public class LogMaskConverter extends CompositeConverter<ILoggingEvent> {
     public String transform(ILoggingEvent event, String message) {
-        return message.replace(OsUtils.getHomeDirectory(), "<HOME_DIR>");
+        return StringUtils.maskHomeDirectory(message);
     }
 }

--- a/common/src/main/java/bisq/common/util/OsUtils.java
+++ b/common/src/main/java/bisq/common/util/OsUtils.java
@@ -101,6 +101,10 @@ public class OsUtils {
         return System.getProperty("os.version");
     }
 
+    public static String getOsInfo() {
+        return getOSName() + " (" + getOSArchitecture() + ") v." + getVersionString();
+    }
+
     public static Version getVersion() {
         return new Version(getVersionString());
     }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -222,4 +222,8 @@ public class StringUtils {
         min = min % 60;
         return String.format("%02d:%02d:%02.2f", hours, min, sec);
     }
+
+    public static String maskHomeDirectory(String string) {
+        return string.replace(OsUtils.getHomeDirectory(), "<HOME_DIR>");
+    }
 }

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -236,7 +236,7 @@ popup.headline.invalid=Invalid input
 popup.headline.error=Error
 
 popup.reportError.log=Open log file
-popup.zipLogs.log=Zip log files
+popup.reportError.zipLogs=Zip log files
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
 The above error message will be copied to the clipboard when you click any of the buttons below.\n\

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -240,7 +240,7 @@ popup.reportError.zipLogs=Zip log files
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
 The above error message will be copied to the clipboard when you click any of the buttons below.\n\
-It will make debugging easier if you include the bisq.log file by pressing 'Open log file', saving a copy, and attaching it to your bug report.
+It will make debugging easier if you include log files in your bug report by pressing 'Zip log files' and attaching the resulting zip file.
 popup.reportBug=Report bug to Bisq developers
 popup.startup.error=An error occurred at initializing Bisq: {0}.
 popup.shutdown=Shut down is in process.\n\n\

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -236,6 +236,7 @@ popup.headline.invalid=Invalid input
 popup.headline.error=Error
 
 popup.reportError.log=Open log file
+popup.zipLogs.log=Zip log files
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
 The above error message will be copied to the clipboard when you click any of the buttons below.\n\

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -239,7 +239,7 @@ popup.reportError.log=Open log file
 popup.reportError.zipLogs=Zip log files
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
-The above error message will be copied to the clipboard when you click any of the buttons below.\n\
+The above error message will be copied to the clipboard when you click any of the buttons below.\n\n\
 It will make debugging easier if you include log files in your bug report by pressing \"Zip log files\" and attaching the resulting zip file.
 popup.reportBug=Report bug to Bisq developers
 popup.startup.error=An error occurred at initializing Bisq: {0}.

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -237,6 +237,7 @@ popup.headline.error=Error
 
 popup.reportError.log=Open log file
 popup.reportError.zipLogs=Zip log files
+popup.reportError.zippedTo=Zipped to: {0}
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
 The above error message will be copied to the clipboard when you click any of the buttons below.\n\n\

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -234,18 +234,17 @@ popup.headline.information=Information
 popup.headline.warning=Warning
 popup.headline.invalid=Invalid input
 popup.headline.error=Error
-
+popup.reportBug=Report bug to Bisq developers
+popup.reportError=To help us to improve the software please report this bug by opening a new issue at: 'https://github.com/bisq-network/bisq2/issues'.\n\
+  The error message will be copied to the clipboard when you click the 'report' button below.\n\n\
+  It will make debugging easier if you include log files in your bug report. Log files do not contain sensitive data.
+popup.reportBug.report=Bisq version: {0}\n\
+  Operating system: {1}\n\
+  Error message:\n\
+  {2}
 popup.reportError.log=Open log file
 popup.reportError.zipLogs=Zip log files
-popup.reportError.zipChangeDirectory=Change directory
-popup.reportError.zipNewDirectory=New directory
-popup.reportError.zipCurrentDirectory=Logs will be zipped to: {0}
-popup.reportError.zippedTo=Zipped to: {0}
-popup.reportError.gitHub=Report to GitHub issue tracker
-popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
-The above error message will be copied to the clipboard when you click any of the buttons below.\n\n\
-It will make debugging easier if you include log files in your bug report by pressing \"Zip log files\" and attaching the resulting zip file.
-popup.reportBug=Report bug to Bisq developers
+popup.reportError.gitHub=Report to Bisq GitHub repository
 popup.startup.error=An error occurred at initializing Bisq: {0}.
 popup.shutdown=Shut down is in process.\n\n\
   It might take up to {0} seconds until shut down is completed.

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -240,7 +240,7 @@ popup.reportError.zipLogs=Zip log files
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\
 The above error message will be copied to the clipboard when you click any of the buttons below.\n\
-It will make debugging easier if you include log files in your bug report by pressing 'Zip log files' and attaching the resulting zip file.
+It will make debugging easier if you include log files in your bug report by pressing \"Zip log files\" and attaching the resulting zip file.
 popup.reportBug=Report bug to Bisq developers
 popup.startup.error=An error occurred at initializing Bisq: {0}.
 popup.shutdown=Shut down is in process.\n\n\

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -237,6 +237,9 @@ popup.headline.error=Error
 
 popup.reportError.log=Open log file
 popup.reportError.zipLogs=Zip log files
+popup.reportError.zipChangeDirectory=Change directory
+popup.reportError.zipNewDirectory=New directory
+popup.reportError.zipCurrentDirectory=Logs will be zipped to: {0}
 popup.reportError.zippedTo=Zipped to: {0}
 popup.reportError.gitHub=Report to GitHub issue tracker
 popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\n\

--- a/i18n/src/main/resources/application_cs.properties
+++ b/i18n/src/main/resources/application_cs.properties
@@ -218,7 +218,7 @@ popup.headline.error=Chyba
 
 popup.reportError.log=Otevřít soubor protokolu
 popup.reportError.gitHub=Nahlásit na GitHub sledovač problémů
-popup.reportError={0}\n\nAbychom mohli vylepšit software, prosím nahlásit tuto chybu otevřením nového problému na https://github.com/bisq-network/bisq2/issues.\nVýše uvedená chybová zpráva bude zkopírována do schránky, když kliknete na libovolné tlačítko níže.\nLadění bude jednodušší, pokud připojíte soubor bisq.log stisknutím 'Otevřít soubor protokolu', uložíte kopii a připojíte ji k vašemu hlášení o chybě.
+popup.reportError=Abychom mohli vylepšit software, prosím nahlásit tuto chybu otevřením nového problému na https://github.com/bisq-network/bisq2/issues.\nVýše uvedená chybová zpráva bude zkopírována do schránky, když kliknete na libovolné tlačítko níže.\nLadění bude jednodušší, pokud připojíte soubor bisq.log stisknutím 'Otevřít soubor protokolu', uložíte kopii a připojíte ji k vašemu hlášení o chybě.
 popup.reportBug=Nahlásit chybu vývojářům Bisq
 popup.startup.error=Při inicializaci Bisq došlo k chybě: {0}.
 popup.shutdown=Probíhá vypínání.\n\nMůže trvat až {0} sekund, než se vypnutí dokončí.

--- a/i18n/src/main/resources/application_de.properties
+++ b/i18n/src/main/resources/application_de.properties
@@ -221,7 +221,7 @@ popup.headline.error=Fehler
 
 popup.reportError.log=Log-Datei öffnen
 popup.reportError.gitHub=An GitHub-Problemverfolgung melden
-popup.reportError={0}\n\nUm uns bei der Verbesserung der Software zu helfen, melden Sie diesen Fehler, indem Sie ein neues Problem unter https://github.com/bisq-network/bisq2/issues öffnen.\nDie obige Fehlermeldung wird in die Zwischenablage kopiert, wenn Sie auf eine der Schaltflächen unten klicken.\nEs erleichtert das Debuggen, wenn Sie die bisq.log-Datei einbeziehen, indem Sie auf 'Log-Datei öffnen' klicken, eine Kopie speichern und sie Ihrem Fehlerbericht anhängen.
+popup.reportError=Um uns bei der Verbesserung der Software zu helfen, melden Sie diesen Fehler, indem Sie ein neues Problem unter https://github.com/bisq-network/bisq2/issues öffnen.\nDie obige Fehlermeldung wird in die Zwischenablage kopiert, wenn Sie auf eine der Schaltflächen unten klicken.\nEs erleichtert das Debuggen, wenn Sie die bisq.log-Datei einbeziehen, indem Sie auf 'Log-Datei öffnen' klicken, eine Kopie speichern und sie Ihrem Fehlerbericht anhängen.
 popup.reportBug=Problem an Bisq-Entwickler melden
 popup.startup.error=Ein Fehler ist beim Starten von Bisq aufgetreten: {0}.
 popup.shutdown=App wird heruntergefahren.\n\nEs kann bis zu {0} Sekunden dauern, bis das Herunterfahren abgeschlossen ist.

--- a/i18n/src/main/resources/application_es.properties
+++ b/i18n/src/main/resources/application_es.properties
@@ -218,7 +218,7 @@ popup.headline.error=Error
 
 popup.reportError.log=Abrir archivo de registro
 popup.reportError.gitHub=Informar al rastreador de problemas de GitHub
-popup.reportError={0}\n\nPara ayudarnos a mejorar el software, por favor, informa sobre este error abriendo un nuevo problema en https://github.com/bisq-network/bisq2/issues.\nEl mensaje de error anterior se copiará al portapapeles cuando hagas clic en cualquiera de los botones a continuación.\nFacilitará la depuración si incluyes el archivo bisq.log presionando 'Abrir archivo de registro', guardando una copia y adjuntándola a tu informe de error.
+popup.reportError=Para ayudarnos a mejorar el software, por favor, informa sobre este error abriendo un nuevo problema en https://github.com/bisq-network/bisq2/issues.\nEl mensaje de error anterior se copiará al portapapeles cuando hagas clic en cualquiera de los botones a continuación.\nFacilitará la depuración si incluyes el archivo bisq.log presionando 'Abrir archivo de registro', guardando una copia y adjuntándola a tu informe de error.
 popup.reportBug=Informar un error a los desarrolladores de Bisq
 popup.startup.error=Ocurrió un error iniciando Bisq: {0}.
 popup.shutdown=Apagado en progreso.\n\nPuede llevar hasta {0} segundos hasta que se apague.

--- a/i18n/src/main/resources/application_it.properties
+++ b/i18n/src/main/resources/application_it.properties
@@ -218,7 +218,7 @@ popup.headline.error=Errore
 
 popup.reportError.log=Apri file di log
 popup.reportError.gitHub=Segnala al tracker issue di GitHub
-popup.reportError={0}\n\nPer aiutarci a migliorare il software, ti preghiamo di segnalare questo bug aprendo una nuova issue su https://github.com/bisq-network/bisq2/issues.\nIl messaggio di errore sopra verrà copiato negli appunti quando clicchi su uno dei pulsanti qui sotto.\nFacilita il debug se includi il file bisq.log premendo 'Apri file di log', salvandone una copia e allegandola alla segnalazione del bug.
+popup.reportError=Per aiutarci a migliorare il software, ti preghiamo di segnalare questo bug aprendo una nuova issue su https://github.com/bisq-network/bisq2/issues.\nIl messaggio di errore sopra verrà copiato negli appunti quando clicchi su uno dei pulsanti qui sotto.\nFacilita il debug se includi il file bisq.log premendo 'Apri file di log', salvandone una copia e allegandola alla segnalazione del bug.
 popup.reportBug=Segnala bug agli sviluppatori di Bisq
 popup.startup.error=Si è verificato un errore durante l'inizializzazione di Bisq: {0}.
 popup.shutdown=La chiusura è in corso.\n\nPotrebbero essere necessari fino a {0} secondi perché la chiusura sia completata.

--- a/i18n/src/main/resources/application_pcm.properties
+++ b/i18n/src/main/resources/application_pcm.properties
@@ -218,7 +218,7 @@ popup.headline.error=Error
 
 popup.reportError.log=Open log file
 popup.reportError.gitHub=Report to GitHub issue tracker
-popup.reportError={0}\n\nTo help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\nThe above error message go copy to clipboard when you click any of the buttons below.\nE go help for debugging if you include the bisq.log file by pressing 'Open log file', saving a copy, and attaching am to your bug report.
+popup.reportError=To help us to improve the software please report this bug by opening a new issue at https://github.com/bisq-network/bisq2/issues.\nThe above error message go copy to clipboard when you click any of the buttons below.\nE go help for debugging if you include the bisq.log file by pressing 'Open log file', saving a copy, and attaching am to your bug report.
 popup.reportBug=Report bug to Bisq developers
 popup.startup.error=An error occurred at initializing Bisq: {0}.
 popup.shutdown=Shut down is in process.\n\nIt might take up to {0} seconds until shut down is completed.

--- a/i18n/src/main/resources/application_pt_BR.properties
+++ b/i18n/src/main/resources/application_pt_BR.properties
@@ -218,7 +218,7 @@ popup.headline.error=Erro
 
 popup.reportError.log=Abrir arquivo de log
 popup.reportError.gitHub=Reportar ao rastreador de problemas do GitHub
-popup.reportError={0}\n\nPara nos ajudar a melhorar o software, por favor, reporte este bug abrindo uma nova questão em https://github.com/bisq-network/bisq2/issues.\nA mensagem de erro acima será copiada para a área de transferência quando você clicar em qualquer um dos botões abaixo.\nSerá mais fácil para depuração se você incluir o arquivo bisq.log pressionando 'Abrir arquivo de log', salvando uma cópia e anexando-a ao seu relatório de bug.
+popup.reportError=Para nos ajudar a melhorar o software, por favor, reporte este bug abrindo uma nova questão em https://github.com/bisq-network/bisq2/issues.\nA mensagem de erro acima será copiada para a área de transferência quando você clicar em qualquer um dos botões abaixo.\nSerá mais fácil para depuração se você incluir o arquivo bisq.log pressionando 'Abrir arquivo de log', salvando uma cópia e anexando-a ao seu relatório de bug.
 popup.reportBug=Reportar bug aos desenvolvedores do Bisq
 popup.startup.error=Ocorreu um erro ao inicializar o Bisq: {0}.
 popup.shutdown=O processo de desligamento está em andamento.\n\nPode levar até {0} segundos até que o desligamento seja concluído.


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq2/pull/2296
Rebased on Master.


The version at https://github.com/bisq-network/bisq2/pull/2296 had multiple buttons and text display which is not really needed. This version reduce the UX elements to the minimum.
It also improves the display of the error and includes the Bisq Version and OS version to the text which should be used for reporting.

![Screenshot 2024-06-27 at 14 19 23](https://github.com/bisq-network/bisq2/assets/116298498/4724b97d-c621-4c44-9e17-de50922ed09e)

