### PR TITLE
Add tx id and block height to proof of burn  and bond data [2a]

### DIFF
--- a/application/src/main/java/bisq/updater/UpdaterService.java
+++ b/application/src/main/java/bisq/updater/UpdaterService.java
@@ -119,14 +119,14 @@ public class UpdaterService implements Service {
             return;
         }
 
-        Version newVersion = releaseNotification.getVersion();
+        Version newVersion = releaseNotification.getReleaseVersion();
         Version installedVersion = ApplicationVersion.getVersion();
         if (newVersion.belowOrEqual(installedVersion)) {
             log.debug("Our installed version is the same or higher as the version of the new releaseNotification.");
             return;
         }
 
-        if (this.releaseNotification.get() != null && newVersion.belowOrEqual(this.releaseNotification.get().getVersion())) {
+        if (this.releaseNotification.get() != null && newVersion.belowOrEqual(this.releaseNotification.get().getReleaseVersion())) {
             log.debug("The version of our existing releaseNotification is the same or higher as the version of the new releaseNotification.");
             return;
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/reputation/list/ReputationDetailsPopup.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/reputation/list/ReputationDetailsPopup.java
@@ -69,7 +69,7 @@ public class ReputationDetailsPopup extends VBox {
         Optional.ofNullable(bondedReputationService.getDataSetByHash().get(userProfile.getBondedReputationKey()))
                 .ifPresent(dataSet -> listItems.addAll(dataSet.stream()
                         .map(data -> new ListItem(ReputationSource.BSQ_BOND,
-                                data.getTime(),
+                                data.getBlockTime(),
                                 bondedReputationService.calculateScore(data),
                                 Optional.of(data.getAmount()),
                                 Optional.of(data.getLockTime())))

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/reputation/list/ReputationDetailsPopup.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/reputation/list/ReputationDetailsPopup.java
@@ -60,7 +60,7 @@ public class ReputationDetailsPopup extends VBox {
         Optional.ofNullable(proofOfBurnService.getDataSetByHash().get(userProfile.getProofOfBurnKey()))
                 .ifPresent(dataSet -> listItems.addAll(dataSet.stream()
                         .map(data -> new ListItem(ReputationSource.BURNED_BSQ,
-                                data.getTime(),
+                                data.getBlockTime(),
                                 proofOfBurnService.calculateScore(data),
                                 data.getAmount()))
                         .collect(Collectors.toList())));
@@ -180,25 +180,25 @@ public class ReputationDetailsPopup extends VBox {
         private final long date, age, amount, score, lockTime;
         private final String dateString, timeString, sourceString, ageString, amountString, scoreString, lockTimeString;
 
-        public ListItem(ReputationSource reputationSource, long date, long score) {
-            this(reputationSource, date, score, Optional.empty(), Optional.empty());
+        public ListItem(ReputationSource reputationSource, long blockTime, long score) {
+            this(reputationSource, blockTime, score, Optional.empty(), Optional.empty());
         }
 
-        public ListItem(ReputationSource reputationSource, long date, long score, long amount) {
-            this(reputationSource, date, score, Optional.of(amount), Optional.empty());
+        public ListItem(ReputationSource reputationSource, long blockTime, long score, long amount) {
+            this(reputationSource, blockTime, score, Optional.of(amount), Optional.empty());
         }
 
-        public ListItem(ReputationSource reputationSource, long date, long score, Optional<Long> optionalAmount, Optional<Long> optionalLockTime) {
+        public ListItem(ReputationSource reputationSource, long blockTime, long score, Optional<Long> optionalAmount, Optional<Long> optionalLockTime) {
             this.reputationSource = reputationSource;
-            this.date = date;
-            dateString = DateFormatter.formatDate(date);
-            timeString = DateFormatter.formatTime(date);
+            this.date = blockTime;
+            dateString = DateFormatter.formatDate(blockTime);
+            timeString = DateFormatter.formatTime(blockTime);
             this.amount = optionalAmount.orElse(0L);
             this.score = score;
             this.lockTime = optionalLockTime.orElse(0L);
-            age = TimeFormatter.getAgeInDays(date);
+            age = TimeFormatter.getAgeInDays(blockTime);
             sourceString = reputationSource.getDisplayString();
-            ageString = TimeFormatter.formatAgeInDays(date);
+            ageString = TimeFormatter.formatAgeInDays(blockTime);
             amountString = optionalAmount.map(amount -> AmountFormatter.formatAmountWithCode(Coin.fromValue(amount, "BSQ"))).orElse("-");
             scoreString = String.valueOf(score);
             lockTimeString = optionalLockTime.map(String::valueOf).orElse("-");

--- a/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeService.java
+++ b/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeService.java
@@ -223,7 +223,7 @@ public class Bisq1BridgeService implements Service, ConfidentialMessageService.L
         return CompletableFutureUtils.allOf(proofOfBurnList.stream()
                         .map(dto -> new AuthorizedProofOfBurnData(
                                 dto.getAmount(),
-                                dto.getTime(),
+                                dto.getBlockTime(),
                                 Hex.decode(dto.getHash()),
                                 staticPublicKeysProvided))
                         .map(this::publishAuthorizedData))

--- a/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeService.java
+++ b/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeService.java
@@ -225,50 +225,55 @@ public class Bisq1BridgeService implements Service, ConfidentialMessageService.L
     private CompletableFuture<Boolean> publishProofOfBurnDtoSet(List<ProofOfBurnDto> proofOfBurnList) {
         // After v2.0.6 we can remove support for version 0 data
         Stream<AuthorizedProofOfBurnData> oldVersions = proofOfBurnList.stream()
-                .map(dto -> createAuthorizedProofOfBurnData(dto, 0))
+                .map(dto -> new AuthorizedProofOfBurnData(
+                        0,
+                        dto.getBlockTime(),
+                        dto.getAmount(),
+                        Hex.decode(dto.getHash()),
+                        dto.getBlockHeight(),
+                        dto.getTxId(),
+                        staticPublicKeysProvided))
                 .filter(e -> ApplicationVersion.getVersion().below("2.0.7"));
         Stream<AuthorizedProofOfBurnData> newVersions = proofOfBurnList.stream()
-                .map(dto -> createAuthorizedProofOfBurnData(dto, 1));
+                .map(dto -> new AuthorizedProofOfBurnData(
+                        dto.getBlockTime(),
+                        dto.getAmount(),
+                        Hex.decode(dto.getHash()),
+                        dto.getBlockHeight(),
+                        dto.getTxId(),
+                        staticPublicKeysProvided));
         return CompletableFutureUtils.allOf(Stream.concat(oldVersions, newVersions)
                         .map(this::publishAuthorizedData)
                         .collect(Collectors.toList()))
                 .thenApply(results -> !results.contains(false));
-    }
-
-    private AuthorizedProofOfBurnData createAuthorizedProofOfBurnData(ProofOfBurnDto dto, int version) {
-        return new AuthorizedProofOfBurnData(
-                version,
-                dto.getBlockTime(),
-                dto.getAmount(),
-                Hex.decode(dto.getHash()),
-                dto.getBlockHeight(),
-                dto.getTxId(),
-                staticPublicKeysProvided);
     }
 
     private CompletableFuture<Boolean> publishBondedReputationDtoSet(List<BondedReputationDto> bondedReputationList) {
         // After v2.0.6 we can remove support for version 0 data
         Stream<AuthorizedBondedReputationData> oldVersions = bondedReputationList.stream()
-                .map(dto -> createAuthorizedBondedReputationData(dto, 0))
+                .map(dto -> new AuthorizedBondedReputationData(
+                        0,
+                        dto.getBlockTime(),
+                        dto.getAmount(),
+                        Hex.decode(dto.getHash()),
+                        dto.getLockTime(),
+                        dto.getBlockHeight(),
+                        dto.getTxId(),
+                        staticPublicKeysProvided))
                 .filter(e -> ApplicationVersion.getVersion().below("2.0.7"));
         Stream<AuthorizedBondedReputationData> newVersions = bondedReputationList.stream()
-                .map(dto -> createAuthorizedBondedReputationData(dto, 1));
+                .map(dto -> new AuthorizedBondedReputationData(
+                        dto.getBlockTime(),
+                        dto.getAmount(),
+                        Hex.decode(dto.getHash()),
+                        dto.getLockTime(),
+                        dto.getBlockHeight(),
+                        dto.getTxId(),
+                        staticPublicKeysProvided));
         return CompletableFutureUtils.allOf(Stream.concat(oldVersions, newVersions)
                         .map(this::publishAuthorizedData)
                         .collect(Collectors.toList()))
                 .thenApply(results -> !results.contains(false));
-    }
-
-    private AuthorizedBondedReputationData createAuthorizedBondedReputationData(BondedReputationDto dto, int version) {
-        return new AuthorizedBondedReputationData(
-                version,
-                dto.getBlockTime(),
-                dto.getAmount(),
-                Hex.decode(dto.getHash()),
-                dto.getLockTime(),
-                dto.getBlockHeight(),
-                dto.getTxId(),
-                staticPublicKeysProvided);
     }
 
     private CompletableFuture<Boolean> publishAuthorizedData(AuthorizedDistributedData data) {

--- a/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeService.java
+++ b/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeService.java
@@ -24,6 +24,7 @@ import bisq.bonded_roles.oracle.AuthorizedOracleNode;
 import bisq.bonded_roles.registration.BondedRoleRegistrationRequest;
 import bisq.bonded_roles.security_manager.alert.AlertType;
 import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.encoding.Hex;
 import bisq.common.timer.Scheduler;
@@ -63,6 +64,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -220,14 +223,27 @@ public class Bisq1BridgeService implements Service, ConfidentialMessageService.L
     }
 
     private CompletableFuture<Boolean> publishProofOfBurnDtoSet(List<ProofOfBurnDto> proofOfBurnList) {
-        return CompletableFutureUtils.allOf(proofOfBurnList.stream()
-                        .map(dto -> new AuthorizedProofOfBurnData(
-                                dto.getAmount(),
-                                dto.getBlockTime(),
-                                Hex.decode(dto.getHash()),
-                                staticPublicKeysProvided))
-                        .map(this::publishAuthorizedData))
+        // After v2.0.6 we can remove support for version 0 data
+        Stream<AuthorizedProofOfBurnData> oldVersions = proofOfBurnList.stream()
+                .map(dto -> createAuthorizedProofOfBurnData(dto, 0))
+                .filter(e -> ApplicationVersion.getVersion().below("2.0.7"));
+        Stream<AuthorizedProofOfBurnData> newVersions = proofOfBurnList.stream()
+                .map(dto -> createAuthorizedProofOfBurnData(dto, 1));
+        return CompletableFutureUtils.allOf(Stream.concat(oldVersions, newVersions)
+                        .map(this::publishAuthorizedData)
+                        .collect(Collectors.toList()))
                 .thenApply(results -> !results.contains(false));
+    }
+
+    private AuthorizedProofOfBurnData createAuthorizedProofOfBurnData(ProofOfBurnDto dto, int version) {
+        return new AuthorizedProofOfBurnData(
+                version,
+                dto.getBlockTime(),
+                dto.getAmount(),
+                Hex.decode(dto.getHash()),
+                dto.getBlockHeight(),
+                dto.getTxId(),
+                staticPublicKeysProvided);
     }
 
     private CompletableFuture<Boolean> publishBondedReputationDtoSet(List<BondedReputationDto> bondedReputationList) {

--- a/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/dto/BondedReputationDto.java
+++ b/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/dto/BondedReputationDto.java
@@ -28,8 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 public class BondedReputationDto {
     private long amount;
-    private long time;
+    private long blockTime;
     private String hash;
     private int blockHeight;
     private int lockTime;
+    private String txId;
 }

--- a/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/dto/ProofOfBurnDto.java
+++ b/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/dto/ProofOfBurnDto.java
@@ -31,4 +31,5 @@ public class ProofOfBurnDto {
     private long blockTime;
     private String hash;
     private int blockHeight;
+    private String txId;
 }

--- a/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/dto/ProofOfBurnDto.java
+++ b/apps/oracle-node/oracle-node/src/main/java/bisq/oracle_node/bisq1_bridge/dto/ProofOfBurnDto.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 public class ProofOfBurnDto {
     private long amount;
-    private long time;
+    private long blockTime;
     private String hash;
     private int blockHeight;
 }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
@@ -56,7 +56,7 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
     @EqualsAndHashCode.Exclude  // transient are excluded by default but let's make it more explicit
-    private transient final Version version;
+    private transient final Version releaseVersion;
 
     public ReleaseNotification(String id,
                                long date,
@@ -75,7 +75,7 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
         this.releaseManagerProfileId = releaseManagerProfileId;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
-        version = new Version(versionString);
+        releaseVersion = new Version(versionString);
 
         verify();
     }

--- a/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
+++ b/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
@@ -9,4 +9,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExcludeForHash {
+    // If not empty, the field will only be excluded if at least one version matches the value returned from getVersion()
+    int[] excludeOnlyInVersions() default {};
 }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -78,8 +78,17 @@ public interface Proto {
         return Arrays.stream(getClass().getDeclaredFields())
                 .peek(field -> field.setAccessible(true))
                 .filter(field -> field.isAnnotationPresent(ExcludeForHash.class))
+                .filter(field -> {
+                    int[] excludeOnlyInVersions = field.getAnnotation(ExcludeForHash.class).excludeOnlyInVersions();
+                    return excludeOnlyInVersions.length == 0 ||
+                            Arrays.stream(excludeOnlyInVersions).boxed().anyMatch(version -> version == getVersion());
+                })
                 .map(Field::getName)
                 .collect(Collectors.toSet());
+    }
+
+    default int getVersion() {
+        return 0;
     }
 
     /**

--- a/user/src/main/java/bisq/user/reputation/BondedReputationService.java
+++ b/user/src/main/java/bisq/user/reputation/BondedReputationService.java
@@ -56,6 +56,13 @@ public class BondedReputationService extends SourceReputationService<AuthorizedB
     }
 
     @Override
+    protected boolean isValidVersion(AuthorizedBondedReputationData data) {
+        // We added fields in AuthorizedBondedReputationData in v2.0.5 and increased version in AuthorizedBondedReputationData to 1.
+        // As we publish both version 0 and version 1 objects we ignore the version 0 objects to avoid duplicates.
+        return data.getVersion() > 0;
+    }
+
+    @Override
     protected ByteArray getDataKey(AuthorizedBondedReputationData data) {
         return new ByteArray(data.getHash());
     }

--- a/user/src/main/java/bisq/user/reputation/ProofOfBurnService.java
+++ b/user/src/main/java/bisq/user/reputation/ProofOfBurnService.java
@@ -55,6 +55,13 @@ public class ProofOfBurnService extends SourceReputationService<AuthorizedProofO
     }
 
     @Override
+    protected boolean isValidVersion(AuthorizedProofOfBurnData data) {
+        // We added fields in AuthorizedProofOfBurnData in v2.0.5 and increased version in AuthorizedProofOfBurnData to 1.
+        // As we publish both version 0 and version 1 objects we ignore the version 0 objects to avoid duplicates.
+        return data.getVersion() > 0;
+    }
+
+    @Override
     protected ByteArray getDataKey(AuthorizedProofOfBurnData data) {
         return new ByteArray(data.getHash());
     }

--- a/user/src/main/java/bisq/user/reputation/SourceReputationService.java
+++ b/user/src/main/java/bisq/user/reputation/SourceReputationService.java
@@ -32,6 +32,7 @@ import bisq.user.identity.UserIdentity;
 import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
+import bisq.user.reputation.data.AuthorizedProofOfBurnData;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -93,7 +94,12 @@ public abstract class SourceReputationService<T extends AuthorizedDistributedDat
     public void onAuthorizedDataAdded(AuthorizedData authorizedData) {
         findRelevantData(authorizedData.getAuthorizedDistributedData())
                 .ifPresent(data -> {
-                    if (isAuthorized(authorizedData)) {
+                    if (data instanceof AuthorizedProofOfBurnData) {
+                        if (data.getVersion() == 0) {
+                            return;
+                        }
+                    }
+                    if (isAuthorized(authorizedData) && isValidVersion(data)) {
                         ByteArray providedHash = getDataKey(data);
                         // To avoid ConcurrentModificationException
                         List<UserProfile> userProfiles = new ArrayList<>(userProfileService.getUserProfileById().values());
@@ -110,6 +116,10 @@ public abstract class SourceReputationService<T extends AuthorizedDistributedDat
                                 });
                     }
                 });
+    }
+
+    protected boolean isValidVersion(T data) {
+        return true;
     }
 
     protected abstract Optional<T> findRelevantData(AuthorizedDistributedData authorizedDistributedData);

--- a/user/src/main/java/bisq/user/reputation/SourceReputationService.java
+++ b/user/src/main/java/bisq/user/reputation/SourceReputationService.java
@@ -32,7 +32,6 @@ import bisq.user.identity.UserIdentity;
 import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
-import bisq.user.reputation.data.AuthorizedProofOfBurnData;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -94,11 +93,6 @@ public abstract class SourceReputationService<T extends AuthorizedDistributedDat
     public void onAuthorizedDataAdded(AuthorizedData authorizedData) {
         findRelevantData(authorizedData.getAuthorizedDistributedData())
                 .ifPresent(data -> {
-                    if (data instanceof AuthorizedProofOfBurnData) {
-                        if (data.getVersion() == 0) {
-                            return;
-                        }
-                    }
                     if (isAuthorized(authorizedData) && isValidVersion(data)) {
                         ByteArray providedHash = getDataKey(data);
                         // To avoid ConcurrentModificationException

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
@@ -94,6 +94,7 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
     @Override
     public bisq.user.protobuf.AuthorizedBondedReputationData.Builder getBuilder(boolean serializeForHash) {
         return bisq.user.protobuf.AuthorizedBondedReputationData.newBuilder()
+                .setVersion(version)
                 .setAmount(amount)
                 .setLockTime(lockTime)
                 .setBlockTime(blockTime)

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
@@ -44,6 +44,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode
 @Getter
 public final class AuthorizedBondedReputationData implements AuthorizedDistributedData {
+    private static final int VERSION = 1;
+
     @EqualsAndHashCode.Exclude
     private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
     private final long blockTime;
@@ -58,6 +60,16 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
     private final int blockHeight;
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
+
+    public AuthorizedBondedReputationData(long blockTime,
+                                          long amount,
+                                          byte[] hash,
+                                          long lockTime,
+                                          int blockHeight,
+                                          String txId,
+                                          boolean staticPublicKeysProvided) {
+        this(VERSION, blockTime, amount, hash, lockTime, blockHeight, txId, staticPublicKeysProvided);
+    }
 
     public AuthorizedBondedReputationData(int version,
                                           long blockTime,

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -46,14 +46,14 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     @EqualsAndHashCode.Exclude
     private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
     private final long amount;
-    private final long time;
+    private final long blockTime;
     private final byte[] hash;
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 
-    public AuthorizedProofOfBurnData(long amount, long time, byte[] hash, boolean staticPublicKeysProvided) {
+    public AuthorizedProofOfBurnData(long amount, long blockTime, byte[] hash, boolean staticPublicKeysProvided) {
         this.amount = amount;
-        this.time = time;
+        this.blockTime = blockTime;
         this.hash = hash;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
@@ -62,7 +62,7 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
 
     @Override
     public void verify() {
-        NetworkDataValidation.validateDate(time);
+        NetworkDataValidation.validateDate(blockTime);
         NetworkDataValidation.validateHash(hash);
         checkArgument(amount > 0);
     }
@@ -71,7 +71,7 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     public bisq.user.protobuf.AuthorizedProofOfBurnData.Builder getBuilder(boolean serializeForHash) {
         return bisq.user.protobuf.AuthorizedProofOfBurnData.newBuilder()
                 .setAmount(amount)
-                .setTime(time)
+                .setBlockTime(blockTime)
                 .setHash(ByteString.copyFrom(hash))
                 .setStaticPublicKeysProvided(staticPublicKeysProvided);
     }
@@ -84,7 +84,7 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     public static AuthorizedProofOfBurnData fromProto(bisq.user.protobuf.AuthorizedProofOfBurnData proto) {
         return new AuthorizedProofOfBurnData(
                 proto.getAmount(),
-                proto.getTime(),
+                proto.getBlockTime(),
                 proto.getHash().toByteArray(),
                 proto.getStaticPublicKeysProvided());
     }
@@ -127,7 +127,7 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     public String toString() {
         return "AuthorizedProofOfBurnData{" +
                 ",\r\n                    amount=" + amount +
-                ",\r\n                    time=" + new Date(time) +
+                ",\r\n                    blockTime=" + new Date(blockTime) +
                 ",\r\n                    hash=" + Hex.encode(hash) +
                 ",\r\n                    staticPublicKeysProvided=" + staticPublicKeysProvided() +
                 ",\r\n                    authorizedPublicKeys=" + getAuthorizedPublicKeys() +

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -78,9 +78,13 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
 
     @Override
     public void verify() {
+        checkArgument(amount > 0);
         NetworkDataValidation.validateDate(blockTime);
         NetworkDataValidation.validateHash(hash);
-        checkArgument(amount > 0);
+        if (version > 0) {
+            NetworkDataValidation.validateBtcTxId(txId);
+            checkArgument(blockHeight > 0);
+        }
     }
 
     @Override

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -44,6 +44,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode
 @Getter
 public final class AuthorizedProofOfBurnData implements AuthorizedDistributedData {
+    private static final int VERSION = 1;
+
     @EqualsAndHashCode.Exclude
     private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
     private final long blockTime;
@@ -57,6 +59,15 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     private final int blockHeight;
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
+
+    public AuthorizedProofOfBurnData(long blockTime,
+                                     long amount,
+                                     byte[] hash,
+                                     int blockHeight,
+                                     String txId,
+                                     boolean staticPublicKeysProvided) {
+        this(VERSION, blockTime, amount, hash, blockHeight, txId, staticPublicKeysProvided);
+    }
 
     public AuthorizedProofOfBurnData(int version,
                                      long blockTime,

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -127,7 +127,7 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     public String toString() {
         return "AuthorizedProofOfBurnData{" +
                 ",\r\n                    amount=" + amount +
-                ",\r\n                    blockTime=" + new Date(blockTime) +
+                ",\r\n                    blockTime=" + blockTime + " (" + new Date(blockTime) + ")" +
                 ",\r\n                    hash=" + Hex.encode(hash) +
                 ",\r\n                    staticPublicKeysProvided=" + staticPublicKeysProvided() +
                 ",\r\n                    authorizedPublicKeys=" + getAuthorizedPublicKeys() +

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -18,6 +18,7 @@
 package bisq.user.reputation.data;
 
 import bisq.bonded_roles.AuthorizedPubKeys;
+import bisq.common.annotation.ExcludeForHash;
 import bisq.common.application.DevMode;
 import bisq.common.encoding.Hex;
 import bisq.common.proto.ProtoResolver;
@@ -45,16 +46,31 @@ import static com.google.common.base.Preconditions.checkArgument;
 public final class AuthorizedProofOfBurnData implements AuthorizedDistributedData {
     @EqualsAndHashCode.Exclude
     private final MetaData metaData = new MetaData(TTL_100_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
-    private final long amount;
     private final long blockTime;
+    private final long amount;
     private final byte[] hash;
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
+    @ExcludeForHash
+    private final int version;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
+    private final int blockHeight;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
+    private final String txId;
 
-    public AuthorizedProofOfBurnData(long amount, long blockTime, byte[] hash, boolean staticPublicKeysProvided) {
-        this.amount = amount;
+    public AuthorizedProofOfBurnData(int version,
+                                     long blockTime,
+                                     long amount,
+                                     byte[] hash,
+                                     int blockHeight,
+                                     String txId,
+                                     boolean staticPublicKeysProvided) {
+        this.version = version;
         this.blockTime = blockTime;
+        this.amount = amount;
         this.hash = hash;
+        this.blockHeight = blockHeight;
+        this.txId = txId;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
         verify();
@@ -70,9 +86,12 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     @Override
     public bisq.user.protobuf.AuthorizedProofOfBurnData.Builder getBuilder(boolean serializeForHash) {
         return bisq.user.protobuf.AuthorizedProofOfBurnData.newBuilder()
+                .setVersion(version)
                 .setAmount(amount)
                 .setBlockTime(blockTime)
                 .setHash(ByteString.copyFrom(hash))
+                .setBlockHeight(blockHeight)
+                .setTxId(txId)
                 .setStaticPublicKeysProvided(staticPublicKeysProvided);
     }
 
@@ -83,9 +102,12 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
 
     public static AuthorizedProofOfBurnData fromProto(bisq.user.protobuf.AuthorizedProofOfBurnData proto) {
         return new AuthorizedProofOfBurnData(
-                proto.getAmount(),
+                proto.getVersion(),
                 proto.getBlockTime(),
+                proto.getAmount(),
                 proto.getHash().toByteArray(),
+                proto.getBlockHeight(),
+                proto.getTxId(),
                 proto.getStaticPublicKeysProvided());
     }
 
@@ -126,9 +148,12 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     @Override
     public String toString() {
         return "AuthorizedProofOfBurnData{" +
+                ",\r\n                    version=" + version +
                 ",\r\n                    amount=" + amount +
                 ",\r\n                    blockTime=" + blockTime + " (" + new Date(blockTime) + ")" +
                 ",\r\n                    hash=" + Hex.encode(hash) +
+                ",\r\n                    blockHeight=" + blockHeight +
+                ",\r\n                    txId=" + txId +
                 ",\r\n                    staticPublicKeysProvided=" + staticPublicKeysProvided() +
                 ",\r\n                    authorizedPublicKeys=" + getAuthorizedPublicKeys() +
                 "\r\n}";

--- a/user/src/main/proto/user.proto
+++ b/user/src/main/proto/user.proto
@@ -109,7 +109,7 @@ message AuthorizeTimestampRequest {
 
 message AuthorizedProofOfBurnData {
   sint64 amount = 1;
-  sint64 time = 2;
+  sint64 blockTime = 2;
   bytes hash = 3;
   bool staticPublicKeysProvided = 4;
 }

--- a/user/src/main/proto/user.proto
+++ b/user/src/main/proto/user.proto
@@ -106,12 +106,14 @@ message AuthorizeTimestampRequest {
   string profileId = 1;
 }
 
-
 message AuthorizedProofOfBurnData {
   sint64 amount = 1;
   sint64 blockTime = 2;
   bytes hash = 3;
   bool staticPublicKeysProvided = 4;
+  sint32 version = 5;
+  sint32 blockHeight = 6;
+  string txId = 7;
 }
 
 message AuthorizedBondedReputationData {

--- a/user/src/main/proto/user.proto
+++ b/user/src/main/proto/user.proto
@@ -118,10 +118,13 @@ message AuthorizedProofOfBurnData {
 
 message AuthorizedBondedReputationData {
   sint64 amount = 1;
-  sint64 time = 2;
+  sint64 blockTime = 2;
   bytes hash = 3;
   sint64 lockTime = 4;
   bool staticPublicKeysProvided = 5;
+  sint32 version = 6;
+  sint32 blockHeight = 7;
+  string txId = 8;
 }
 
 message AuthorizedAccountAgeData {


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq2/pull/2345

Fixes https://github.com/bisq-network/bisq2/issues/2262

Oracle nodes using that code need to run the RestApi code based on https://github.com/bisq-network/bisq/pull/7187 


When we deploy it we need to ensure that one seednode runs on the old version and one on the new version.
The oracle node publishes both a version 0 (old) version and a version 1 (new) version.
The newly added `blockHeight` and `txId` fields are annotated with `@ExcludeForHash(excludeOnlyInVersions = {0})`. This means those fields are ignored in version 0 objects, thus creating the same hash as from the old code base.
The `version` field is annotated with `@ExcludeForHash` - thus it is ignored on all versions.

A old seed node will fail with the new data as the hashes are not matching (new fields not excluded in new version, but as old node don't know those fields they are not present).

A new seed node would provide both the old and new version but as in the inventory response all the data are added the hash is different between the receiver and the sender (new node had included the fields). 

Also as long not many of the new nodes are in the network distribution of the version 1 objects will be poor. To mitigate that we can restart the Oracle node frequently.

For the issue with inventory response we can consider to add `@ExcludeForHash`  to the `inventory` field in `InventoryResponse`. As the response is anyway invalid between old nodes and new seed nodes (or other new nodes) we would not cause more harm by adding the annotation which would alter the hash as well.