### PR TITLE
Add version number to user profile [2b]

### DIFF
--- a/application/src/main/java/bisq/updater/UpdaterService.java
+++ b/application/src/main/java/bisq/updater/UpdaterService.java
@@ -119,14 +119,14 @@ public class UpdaterService implements Service {
             return;
         }
 
-        Version newVersion = releaseNotification.getVersion();
+        Version newVersion = releaseNotification.getReleaseVersion();
         Version installedVersion = ApplicationVersion.getVersion();
         if (newVersion.belowOrEqual(installedVersion)) {
             log.debug("Our installed version is the same or higher as the version of the new releaseNotification.");
             return;
         }
 
-        if (this.releaseNotification.get() != null && newVersion.belowOrEqual(this.releaseNotification.get().getVersion())) {
+        if (this.releaseNotification.get() != null && newVersion.belowOrEqual(this.releaseNotification.get().getReleaseVersion())) {
             log.debug("The version of our existing releaseNotification is the same or higher as the version of the new releaseNotification.");
             return;
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/UserProfileSidebar.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/sidebar/UserProfileSidebar.java
@@ -42,12 +42,7 @@ import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
 import de.jensd.fx.fontawesome.AwesomeIcon;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
@@ -145,6 +140,11 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
                     .orElse(Res.get("data.na")));
 
             model.lastSeen.set(TimeFormatter.formatAge(userProfileService.getLastSeen(userProfile)));
+            String version = userProfile.getApplicationVersion();
+            if (version.isEmpty()) {
+                version = Res.get("data.na");
+            }
+            model.version.set(version);
 
             // If we selected our own user we don't show certain features
             model.isPeer.set(!userIdentityService.isUserIdentityPresent(userProfile.getId()));
@@ -204,6 +204,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
         private final ObjectProperty<ReputationScore> reputationScore = new SimpleObjectProperty<>();
         private final StringProperty profileAge = new SimpleStringProperty();
         private final StringProperty lastSeen = new SimpleStringProperty();
+        private final StringProperty version = new SimpleStringProperty();
         private final BooleanProperty ignoreUserSelected = new SimpleBooleanProperty();
         private final BooleanProperty isPeer = new SimpleBooleanProperty();
 
@@ -218,7 +219,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
     public static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
         private final ImageView catIconImageView;
         private final Label nickName, botId, userId, addressByTransport, statement, totalReputationScore,
-                profileAge, lastSeen, terms;
+                profileAge, lastSeen, terms, version;
         private final BisqMenuItem privateMsg, mention, ignore, undoIgnore, report;
         private final VBox botIdBox, userIdBox, addressByTransportBox, statementBox, termsBox, optionsVBox;
         private final ReputationScoreDisplay reputationScoreDisplay;
@@ -288,6 +289,10 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             VBox lastSeenBox = lastSeenTriple.getThird();
             lastSeen = lastSeenTriple.getSecond();
 
+            Triple<Label, Label, VBox> versionTriple = getInfoBox(Res.get("chat.sideBar.userProfile.version"));
+            VBox versionBox = versionTriple.getThird();
+            version = versionTriple.getSecond();
+
             Triple<Label, Label, VBox> statementTriple = getInfoBox(Res.get("chat.sideBar.userProfile.statement"));
             statementBox = statementTriple.getThird();
             statement = statementTriple.getSecond();
@@ -297,7 +302,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             terms = termsTriple.getSecond();
 
             VBox content = new VBox(15, botIdBox, userIdBox, addressByTransportBox,
-                    totalReputationScoreBox, profileAgeBox, lastSeenBox, statementBox, termsBox);
+                    totalReputationScoreBox, profileAgeBox, lastSeenBox, versionBox, statementBox, termsBox);
             content.setMaxWidth(width - 15); // Remove the scrollbar
             content.setPadding(new Insets(0, 10, 20, 20));
             ScrollPane scrollPane = new ScrollPane(content);
@@ -342,6 +347,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             termsBox.managedProperty().bind(model.terms.isEmpty().not());
             profileAge.textProperty().bind(model.profileAge);
             lastSeen.textProperty().bind(model.lastSeen);
+            version.textProperty().bind(model.version);
             ignore.visibleProperty().bind(model.ignoreUserSelected.not());
             ignore.managedProperty().bind(model.ignoreUserSelected.not());
             undoIgnore.visibleProperty().bind(model.ignoreUserSelected);
@@ -397,6 +403,7 @@ public class UserProfileSidebar implements Comparable<UserProfileSidebar> {
             terms.managedProperty().unbind();
             profileAge.textProperty().unbind();
             lastSeen.textProperty().unbind();
+            version.textProperty().unbind();
             ignore.visibleProperty().unbind();
             ignore.managedProperty().unbind();
             undoIgnore.visibleProperty().unbind();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/UserProfileIcon.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/UserProfileIcon.java
@@ -132,7 +132,12 @@ public class UserProfileIcon extends StackPane {
         if (userProfile != null && tooltip != null) {
             String tooltipString = userProfile.getTooltipString();
             String lastSeenString = lastSeenAsString != null ? "\n" + Res.get("user.userProfile.lastSeenAgo", lastSeenAsString) : "";
-            tooltipText = tooltipString + lastSeenString;
+            String version = userProfile.getApplicationVersion();
+            if (version.isEmpty()) {
+                version = Res.get("data.na");
+            }
+            String versionString = lastSeenAsString != null ? "\n" + Res.get("user.userProfile.version", version) : "";
+            tooltipText = tooltipString + lastSeenString + versionString;
             tooltip.setText(tooltipText);
         }
     }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
@@ -56,7 +56,7 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
     @EqualsAndHashCode.Exclude  // transient are excluded by default but let's make it more explicit
-    private transient final Version version;
+    private transient final Version releaseVersion;
 
     public ReleaseNotification(String id,
                                long date,
@@ -75,7 +75,7 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
         this.releaseManagerProfileId = releaseManagerProfileId;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
-        version = new Version(versionString);
+        releaseVersion = new Version(versionString);
 
         verify();
     }

--- a/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
+++ b/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
@@ -9,4 +9,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExcludeForHash {
+    // If not empty, the field will only be excluded if at least one version matches the value returned from getVersion()
+    int[] excludeOnlyInVersions() default {};
 }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -78,8 +78,17 @@ public interface Proto {
         return Arrays.stream(getClass().getDeclaredFields())
                 .peek(field -> field.setAccessible(true))
                 .filter(field -> field.isAnnotationPresent(ExcludeForHash.class))
+                .filter(field -> {
+                    int[] excludeOnlyInVersions = field.getAnnotation(ExcludeForHash.class).excludeOnlyInVersions();
+                    return excludeOnlyInVersions.length == 0 ||
+                            Arrays.stream(excludeOnlyInVersions).boxed().anyMatch(version -> version == getVersion());
+                })
                 .map(Field::getName)
                 .collect(Collectors.toSet());
+    }
+
+    default int getVersion() {
+        return 0;
     }
 
     /**

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -167,6 +167,7 @@ chat.sideBar.userProfile.transportAddress=Transport address
 chat.sideBar.userProfile.totalReputationScore=Total reputation score
 chat.sideBar.userProfile.profileAge=Profile age
 chat.sideBar.userProfile.lastSeen=Last seen
+chat.sideBar.userProfile.version=Version
 chat.sideBar.userProfile.statement=Statement
 chat.sideBar.userProfile.terms=Trade terms
 chat.sideBar.userProfile.sendPrivateMessage=Send private message

--- a/i18n/src/main/resources/user.properties
+++ b/i18n/src/main/resources/user.properties
@@ -8,6 +8,7 @@ user.userProfile.tooltip=Nickname: {0}\nBot ID: {1}\nProfile ID: {2}\n{3}
 user.userProfile.tooltip.banned=This profile is banned!
 user.userProfile.userName.banned=[Banned] {0}
 user.userProfile.lastSeenAgo=Last seen: {0} ago
+user.userProfile.version=Version: {0}
 # Dynamic values using TransportType.name()
 # suppress inspection "UnusedProperty"
 user.userProfile.addressByTransport.CLEAR=Clear net address: {0}

--- a/user/src/main/java/bisq/user/identity/UserIdentityService.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityService.java
@@ -17,6 +17,7 @@
 
 package bisq.user.identity;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.encoding.Hex;
 import bisq.common.observable.Observable;
@@ -201,7 +202,7 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
     public CompletableFuture<BroadcastResult> editUserProfile(UserIdentity oldUserIdentity, String terms, String statement) {
         Identity oldIdentity = oldUserIdentity.getIdentity();
         UserProfile oldUserProfile = oldUserIdentity.getUserProfile();
-        UserProfile newUserProfile = UserProfile.fromEdit(oldUserProfile, terms, statement);
+        UserProfile newUserProfile = UserProfile.forEdit(oldUserProfile, terms, statement);
         UserIdentity newUserIdentity = new UserIdentity(oldIdentity, newUserProfile);
 
         synchronized (lock) {
@@ -296,7 +297,7 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
             rePublishUserProfilesExecutor = Optional.of(ExecutorFactory.newSingleThreadExecutor("rePublishUserProfilesExecutor"));
             rePublishUserProfilesExecutor.get().submit(() -> {
                 userIdentities.forEach(userIdentity -> {
-                    UserProfile userProfile = UserProfile.fromRePublish(userIdentity.getUserProfile());
+                    UserProfile userProfile = UserProfile.forRePublish(userIdentity.getUserProfile());
                     publishUserProfile(userProfile, userIdentity.getNetworkIdWithKeyPair().getKeyPair());
                     try {
                         int republishDelay = 60_000 + new Random().nextInt(180_000);
@@ -316,7 +317,14 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
         log.info("publishUserProfile {}", userProfile.getUserName());
         persistableStore.setLastUserProfilePublishingDate(System.currentTimeMillis());
         persist();
-        return networkService.publishAuthenticatedData(userProfile, keyPair);
+
+        // We publish both the old version and the new version to support old clients
+        if (ApplicationVersion.getVersion().below("2.0.7")) {
+            return networkService.publishAuthenticatedData(UserProfile.withVersion(userProfile, 0), keyPair)
+                    .thenCompose(e -> networkService.publishAuthenticatedData(userProfile, keyPair));
+        } else {
+            return networkService.publishAuthenticatedData(userProfile, keyPair);
+        }
     }
 
     private UserIdentity createUserIdentity(String nickName,
@@ -327,7 +335,7 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
                                             Identity identity) {
         checkArgument(nickName.equals(nickName.trim()) && !nickName.isEmpty(),
                 "Nickname must not have leading or trailing spaces and must not be empty.");
-        UserProfile userProfile = new UserProfile(nickName, proofOfWork, avatarVersion,
+        UserProfile userProfile = UserProfile.createNew(nickName, proofOfWork, avatarVersion,
                 identity.getNetworkIdWithKeyPair().getNetworkId(), terms, statement);
         UserIdentity userIdentity = new UserIdentity(identity, userProfile);
 

--- a/user/src/main/java/bisq/user/identity/UserIdentityService.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityService.java
@@ -17,6 +17,7 @@
 
 package bisq.user.identity;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.encoding.Hex;
 import bisq.common.observable.Observable;
@@ -296,7 +297,8 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
             rePublishUserProfilesExecutor = Optional.of(ExecutorFactory.newSingleThreadExecutor("rePublishUserProfilesExecutor"));
             rePublishUserProfilesExecutor.get().submit(() -> {
                 userIdentities.forEach(userIdentity -> {
-                    publishUserProfile(userIdentity.getUserProfile(), userIdentity.getNetworkIdWithKeyPair().getKeyPair());
+                    UserProfile userProfile = UserProfile.from(userIdentity.getUserProfile(), ApplicationVersion.getVersion().getVersionAsString());
+                    publishUserProfile(userProfile, userIdentity.getNetworkIdWithKeyPair().getKeyPair());
                     try {
                         int republishDelay = 60_000 + new Random().nextInt(180_000);
                         Thread.sleep(republishDelay);
@@ -326,8 +328,8 @@ public class UserIdentityService implements PersistenceClient<UserIdentityStore>
                                             Identity identity) {
         checkArgument(nickName.equals(nickName.trim()) && !nickName.isEmpty(),
                 "Nickname must not have leading or trailing spaces and must not be empty.");
-        UserProfile userProfile = new UserProfile(nickName, proofOfWork, avatarVersion,
-                identity.getNetworkIdWithKeyPair().getNetworkId(), terms, statement);
+        UserProfile userProfile = new UserProfile(1, nickName, proofOfWork, avatarVersion,
+                identity.getNetworkIdWithKeyPair().getNetworkId(), terms, statement, ApplicationVersion.getVersion().getVersionAsString());
         UserIdentity userIdentity = new UserIdentity(identity, userProfile);
 
         synchronized (lock) {

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -57,14 +57,34 @@ public final class UserProfile implements DistributedData {
     public static final int MAX_LENGTH_TERMS = 500;
     public static final int MAX_LENGTH_STATEMENT = 100;
 
-    public static UserProfile fromEdit(UserProfile userProfile, String terms, String statement) {
+    public static UserProfile forEdit(UserProfile userProfile, String terms, String statement) {
         return new UserProfile(userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
                 userProfile.getNetworkId(), terms, statement);
     }
 
-    public static UserProfile fromRePublish(UserProfile userProfile) {
+    public static UserProfile forRePublish(UserProfile userProfile) {
         return new UserProfile(userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
                 userProfile.getNetworkId(), userProfile.getTerms(), userProfile.getStatement());
+    }
+
+    public static UserProfile createNew(String nickName,
+                                        ProofOfWork proofOfWork,
+                                        int avatarVersion,
+                                        NetworkId networkId,
+                                        String terms,
+                                        String statement) {
+        return new UserProfile(nickName,
+                proofOfWork,
+                avatarVersion,
+                networkId,
+                terms,
+                statement);
+    }
+
+    public static UserProfile withVersion(UserProfile userProfile, int version) {
+        return new UserProfile(version, userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
+                userProfile.getNetworkId(), userProfile.getTerms(), userProfile.getStatement(),
+                ApplicationVersion.getVersion().getVersionAsString());
     }
 
     // We give a bit longer TTL than the chat messages to ensure the chat user is available as long the messages are
@@ -88,12 +108,12 @@ public final class UserProfile implements DistributedData {
     private transient ByteArray proofOfBurnHash;
     private transient ByteArray bondedReputationHash;
 
-    public UserProfile(String nickName,
-                       ProofOfWork proofOfWork,
-                       int avatarVersion,
-                       NetworkId networkId,
-                       String terms,
-                       String statement) {
+    private UserProfile(String nickName,
+                        ProofOfWork proofOfWork,
+                        int avatarVersion,
+                        NetworkId networkId,
+                        String terms,
+                        String statement) {
         this(VERSION,
                 nickName,
                 proofOfWork,

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -18,6 +18,7 @@
 package bisq.user.profile;
 
 import bisq.common.annotation.ExcludeForHash;
+import bisq.common.application.ApplicationVersion;
 import bisq.common.data.ByteArray;
 import bisq.common.encoding.Hex;
 import bisq.common.proto.ProtoResolver;
@@ -51,18 +52,19 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 @Slf4j
 @Getter
 public final class UserProfile implements DistributedData {
+    public static final int VERSION = 1;
     public static final int MAX_LENGTH_NICK_NAME = 100;
     public static final int MAX_LENGTH_TERMS = 500;
     public static final int MAX_LENGTH_STATEMENT = 100;
 
-    public static UserProfile from(UserProfile userProfile, String terms, String statement) {
-        return new UserProfile(1, userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
-                userProfile.getNetworkId(), terms, statement, userProfile.applicationVersion);
+    public static UserProfile fromEdit(UserProfile userProfile, String terms, String statement) {
+        return new UserProfile(userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
+                userProfile.getNetworkId(), terms, statement);
     }
 
-    public static UserProfile from(UserProfile userProfile, String version) {
-        return new UserProfile(1, userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
-                userProfile.getNetworkId(), userProfile.getTerms(), userProfile.getStatement(), version);
+    public static UserProfile fromRePublish(UserProfile userProfile) {
+        return new UserProfile(userProfile.getNickName(), userProfile.getProofOfWork(), userProfile.getAvatarVersion(),
+                userProfile.getNetworkId(), userProfile.getTerms(), userProfile.getStatement());
     }
 
     // We give a bit longer TTL than the chat messages to ensure the chat user is available as long the messages are
@@ -86,14 +88,30 @@ public final class UserProfile implements DistributedData {
     private transient ByteArray proofOfBurnHash;
     private transient ByteArray bondedReputationHash;
 
-    public UserProfile(int version,
-                       String nickName,
+    public UserProfile(String nickName,
                        ProofOfWork proofOfWork,
                        int avatarVersion,
                        NetworkId networkId,
                        String terms,
-                       String statement,
-                       String applicationVersion) {
+                       String statement) {
+        this(VERSION,
+                nickName,
+                proofOfWork,
+                avatarVersion,
+                networkId,
+                terms,
+                statement,
+                ApplicationVersion.getVersion().getVersionAsString());
+    }
+
+    private UserProfile(int version,
+                        String nickName,
+                        ProofOfWork proofOfWork,
+                        int avatarVersion,
+                        NetworkId networkId,
+                        String terms,
+                        String statement,
+                        String applicationVersion) {
         this.version = version;
         this.nickName = nickName;
         this.proofOfWork = proofOfWork;

--- a/user/src/main/proto/user.proto
+++ b/user/src/main/proto/user.proto
@@ -31,6 +31,8 @@ message UserProfile {
   string terms = 4;
   string statement = 5;
   sint32 avatarVersion = 6;
+  sint32 version = 7;
+  string applicationVersion = 8;
 }
 
 message UserIdentity {


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq2/pull/2345

Implements https://github.com/bisq-network/bisq2/issues/2289

This feature allows us to get information about the update rate at new releases. Currently there is nothing implemented for that but this could easily be added (as done in https://github.com/bisq-network/bisq2/pull/2348).

Similar as in https://github.com/bisq-network/bisq2/pull/2344 we use the newly added support for version parameter in ExcludeForHash to support an added fields in a backward compatible way.
We publish both the version 0 and the version 1 objects so that both old and new versions can operate with the data. The old version will reject the new data.
 