### PR TITLE
Add @ExcludeForHash to inventory in InventoryRequest

### DIFF
--- a/application/src/main/java/bisq/updater/UpdaterService.java
+++ b/application/src/main/java/bisq/updater/UpdaterService.java
@@ -119,14 +119,14 @@ public class UpdaterService implements Service {
             return;
         }
 
-        Version newVersion = releaseNotification.getVersion();
+        Version newVersion = releaseNotification.getReleaseVersion();
         Version installedVersion = ApplicationVersion.getVersion();
         if (newVersion.belowOrEqual(installedVersion)) {
             log.debug("Our installed version is the same or higher as the version of the new releaseNotification.");
             return;
         }
 
-        if (this.releaseNotification.get() != null && newVersion.belowOrEqual(this.releaseNotification.get().getVersion())) {
+        if (this.releaseNotification.get() != null && newVersion.belowOrEqual(this.releaseNotification.get().getReleaseVersion())) {
             log.debug("The version of our existing releaseNotification is the same or higher as the version of the new releaseNotification.");
             return;
         }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
@@ -56,7 +56,7 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
     @EqualsAndHashCode.Exclude  // transient are excluded by default but let's make it more explicit
-    private transient final Version version;
+    private transient final Version releaseVersion;
 
     public ReleaseNotification(String id,
                                long date,
@@ -75,7 +75,7 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
         this.releaseManagerProfileId = releaseManagerProfileId;
         this.staticPublicKeysProvided = staticPublicKeysProvided;
 
-        version = new Version(versionString);
+        releaseVersion = new Version(versionString);
 
         verify();
     }

--- a/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
+++ b/common/src/main/java/bisq/common/annotation/ExcludeForHash.java
@@ -9,4 +9,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExcludeForHash {
+    // If not empty, the field will only be excluded if at least one version matches the value returned from getVersion()
+    int[] excludeOnlyInVersions() default {};
 }

--- a/common/src/main/java/bisq/common/proto/Proto.java
+++ b/common/src/main/java/bisq/common/proto/Proto.java
@@ -78,8 +78,17 @@ public interface Proto {
         return Arrays.stream(getClass().getDeclaredFields())
                 .peek(field -> field.setAccessible(true))
                 .filter(field -> field.isAnnotationPresent(ExcludeForHash.class))
+                .filter(field -> {
+                    int[] excludeOnlyInVersions = field.getAnnotation(ExcludeForHash.class).excludeOnlyInVersions();
+                    return excludeOnlyInVersions.length == 0 ||
+                            Arrays.stream(excludeOnlyInVersions).boxed().anyMatch(version -> version == getVersion());
+                })
                 .map(Field::getName)
                 .collect(Collectors.toSet());
+    }
+
+    default int getVersion() {
+        return 0;
     }
 
     /**

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
@@ -28,11 +28,22 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public final class InventoryResponse implements BroadcastMessage, Response {
+    private static final int VERSION = 1;
+
     @ExcludeForHash
+    private final int version;
+    // After v 2.0.6 version 0 should not be used anymore. Then we can remove the excludeOnlyInVersions param to
+    // not need to maintain future versions. We add though hypothetical versions 2 and 3 for safety
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final Inventory inventory;
     private final int requestNonce;
 
     public InventoryResponse(Inventory inventory, int requestNonce) {
+        this(VERSION, inventory, requestNonce);
+    }
+
+    private InventoryResponse(int version, Inventory inventory, int requestNonce) {
+        this.version = version;
         this.inventory = inventory;
         this.requestNonce = requestNonce;
 
@@ -56,12 +67,13 @@ public final class InventoryResponse implements BroadcastMessage, Response {
     @Override
     public bisq.network.protobuf.InventoryResponse.Builder getValueBuilder(boolean serializeForHash) {
         return bisq.network.protobuf.InventoryResponse.newBuilder()
+                .setVersion(version)
                 .setInventory(inventory.toProto(serializeForHash))
                 .setRequestNonce(requestNonce);
     }
 
     public static InventoryResponse fromProto(bisq.network.protobuf.InventoryResponse proto) {
-        return new InventoryResponse(Inventory.fromProto(proto.getInventory()), proto.getRequestNonce());
+        return new InventoryResponse(proto.getVersion(), Inventory.fromProto(proto.getInventory()), proto.getRequestNonce());
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p.services.data.inventory;
 
+import bisq.common.annotation.ExcludeForHash;
 import bisq.network.p2p.message.Response;
 import bisq.network.p2p.services.data.broadcast.BroadcastMessage;
 import lombok.EqualsAndHashCode;
@@ -27,6 +28,7 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public final class InventoryResponse implements BroadcastMessage, Response {
+    @ExcludeForHash
     private final Inventory inventory;
     private final int requestNonce;
 

--- a/network/network/src/main/proto/network.proto
+++ b/network/network/src/main/proto/network.proto
@@ -157,6 +157,7 @@ message InventoryRequest {
 message InventoryResponse {
   Inventory inventory = 1;
   sint32 requestNonce = 2;
+  sint32 version = 3;
 }
 
 message ExternalNetworkMessage {


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq2/issues/2346

When objects get an update we publish both the old version and the new one, where the new one is considered invalid for old nodes. The Invenotry contains all those data and would become itself invalid if we do not exclude the inventory from the hash creation for the pow check. Note that InventoryResponse is a direct message and its only the pow use case where the hash would cause issues.