### PR TITLE
Add version and applicationVersion to Capability

### DIFF
--- a/common/src/main/java/bisq/common/util/Version.java
+++ b/common/src/main/java/bisq/common/util/Version.java
@@ -58,6 +58,18 @@ public class Version implements Comparable<Version> {
         return compareTo(other) <= 0;
     }
 
+    public boolean above(String other) {
+        return above(new Version(other));
+    }
+
+    public boolean above(Version other) {
+        return compareTo(other) > 0;
+    }
+
+    public boolean aboveOrEqual(Version other) {
+        return compareTo(other) >= 0;
+    }
+
     @Override
     public int compareTo(Version other) {
         if (other == null) {

--- a/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
+++ b/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.util.FileUtils;
 import bisq.common.util.NetworkUtils;
 import bisq.network.common.Address;
@@ -187,11 +188,11 @@ public class NetworkEnvelopeSocketChannelTests {
         List<TransportType> supportedTransportTypes = new ArrayList<>(1);
         supportedTransportTypes.add(TransportType.CLEAR);
 
-        Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes, new ArrayList<>());
+        Capability peerCapability = createCapability(Address.localHost(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationService authorizationService = createAuthorizationService();
 
-        Capability responderCapability = new Capability(Address.localHost(1234), supportedTransportTypes, new ArrayList<>());
+        Capability responderCapability = createCapability(Address.localHost(1234), supportedTransportTypes);
 
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
@@ -217,4 +218,7 @@ public class NetworkEnvelopeSocketChannelTests {
                 Set.of(Feature.AUTHORIZATION_HASH_CASH));
     }
 
+    private static Capability createCapability(Address address, List<TransportType> supportedTransportTypes) {
+        return new Capability(Capability.VERSION, address, supportedTransportTypes, new ArrayList<>(), ApplicationVersion.getVersion().getVersionAsString());
+    }
 }

--- a/network/network/src/integrationTest/java/bisq/network/p2p/OutboundConnectionsMultiplexerTest.java
+++ b/network/network/src/integrationTest/java/bisq/network/p2p/OutboundConnectionsMultiplexerTest.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.util.FileUtils;
 import bisq.common.util.NetworkUtils;
 import bisq.network.common.Address;
@@ -60,7 +61,7 @@ public class OutboundConnectionsMultiplexerTest {
         supportedTransportTypes.add(TransportType.CLEAR);
 
         Address serverAddress = Address.localHost(NetworkUtils.findFreeSystemPort());
-        Capability serverCapability = new Capability(serverAddress, supportedTransportTypes, new ArrayList<>());
+        Capability serverCapability = createCapability(serverAddress, supportedTransportTypes);
         ServerChannel serverChannel = new ServerChannel(
                 serverCapability,
                 new NetworkLoad(),
@@ -84,7 +85,7 @@ public class OutboundConnectionsMultiplexerTest {
 
                 AuthorizationService authorizationService = createAuthorizationService();
                 Address outboundAddress = Address.localHost(NetworkUtils.findFreeSystemPort());
-                Capability outboundCapability = new Capability(outboundAddress, supportedTransportTypes, new ArrayList<>());
+                Capability outboundCapability = createCapability(outboundAddress, supportedTransportTypes);
                 Selector selector = SelectorProvider.provider().openSelector();
 
                 var outboundConnectionManager = new OutboundConnectionManager(
@@ -132,5 +133,9 @@ public class OutboundConnectionsMultiplexerTest {
                 new HashCashProofOfWorkService(),
                 new EquihashProofOfWorkService(),
                 Set.of(Feature.AUTHORIZATION_HASH_CASH));
+    }
+
+    private static Capability createCapability(Address address, List<TransportType> supportedTransportTypes) {
+        return new Capability(Capability.VERSION, address, supportedTransportTypes, new ArrayList<>(), ApplicationVersion.getVersion().getVersionAsString());
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -40,6 +40,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode
 public final class Capability implements NetworkProto {
     public static final int VERSION = 1;
+
     @ExcludeForHash
     private final int version;
     private final Address address;
@@ -50,6 +51,10 @@ public final class Capability implements NetworkProto {
 
     public static Capability myCapability(Address address, List<TransportType> supportedTransportTypes, List<Feature> features) {
         return new Capability(VERSION, address, supportedTransportTypes, features, ApplicationVersion.getVersion().getVersionAsString());
+    }
+
+    public static Capability withVersion(Capability capability, int version) {
+        return new Capability(version, capability.getAddress(), capability.getSupportedTransportTypes(), capability.getFeatures(), capability.getApplicationVersion());
     }
 
     @VisibleForTesting

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -17,10 +17,14 @@
 
 package bisq.network.p2p.node;
 
+import bisq.common.annotation.ExcludeForHash;
+import bisq.common.application.ApplicationVersion;
 import bisq.common.proto.NetworkProto;
 import bisq.common.util.ProtobufUtils;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.network.common.Address;
 import bisq.network.common.TransportType;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -35,14 +39,26 @@ import static com.google.common.base.Preconditions.checkArgument;
 @ToString
 @EqualsAndHashCode
 public final class Capability implements NetworkProto {
+    public static final int VERSION = 1;
+    @ExcludeForHash
+    private final int version;
     private final Address address;
     private final List<TransportType> supportedTransportTypes;
     private final List<Feature> features;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
+    private final String applicationVersion;
 
-    public Capability(Address address, List<TransportType> supportedTransportTypes, List<Feature> features) {
+    public static Capability myCapability(Address address, List<TransportType> supportedTransportTypes, List<Feature> features) {
+        return new Capability(VERSION, address, supportedTransportTypes, features, ApplicationVersion.getVersion().getVersionAsString());
+    }
+
+    @VisibleForTesting
+    public Capability(int version, Address address, List<TransportType> supportedTransportTypes, List<Feature> features, String applicationVersion) {
+        this.version = version;
         this.address = address;
         this.supportedTransportTypes = supportedTransportTypes;
         this.features = features;
+        this.applicationVersion = applicationVersion;
 
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.supportedTransportTypes);
@@ -55,18 +71,23 @@ public final class Capability implements NetworkProto {
     public void verify() {
         checkArgument(supportedTransportTypes.size() <= TransportType.values().length);
         checkArgument(features.size() <= Feature.values().length);
+        if (version > 0) {
+            NetworkDataValidation.validateVersion(applicationVersion);
+        }
     }
 
     @Override
     public bisq.network.protobuf.Capability.Builder getBuilder(boolean serializeForHash) {
         return bisq.network.protobuf.Capability.newBuilder()
+                .setVersion(version)
                 .setAddress(address.toProto(serializeForHash))
                 .addAllSupportedTransportTypes(supportedTransportTypes.stream()
                         .map(Enum::name)
                         .collect(Collectors.toList()))
                 .addAllFeatures(features.stream()
                         .map(Feature::toProtoEnum)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()))
+                .setApplicationVersion(applicationVersion);
     }
 
     @Override
@@ -78,8 +99,10 @@ public final class Capability implements NetworkProto {
         List<TransportType> supportedTransportTypes = proto.getSupportedTransportTypesList().stream()
                 .map(e -> ProtobufUtils.enumFromProto(TransportType.class, e))
                 .collect(Collectors.toList());
-        return new Capability(Address.fromProto(proto.getAddress()),
+        return new Capability(proto.getVersion(),
+                Address.fromProto(proto.getAddress()),
                 supportedTransportTypes,
-                ProtobufUtils.fromProtoEnumList(Feature.class, proto.getFeaturesList()));
+                ProtobufUtils.fromProtoEnumList(Feature.class, proto.getFeaturesList()),
+                proto.getApplicationVersion());
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/ConnectionException.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/ConnectionException.java
@@ -28,7 +28,8 @@ public class ConnectionException extends CompletionException {
         PROTOBUF_IS_NULL,
         AUTHORIZATION_FAILED,
         ONION_ADDRESS_VERIFICATION_FAILED,
-        ADDRESS_BANNED
+        ADDRESS_BANNED,
+        HANDSHAKE_FAILED
     }
 
     @Getter
@@ -41,6 +42,11 @@ public class ConnectionException extends CompletionException {
 
     public ConnectionException(String message) {
         super(message);
+    }
+
+    public ConnectionException(Reason reason, Throwable throwable) {
+        super(throwable);
+        this.reason = reason;
     }
 
     public ConnectionException(Throwable throwable) {

--- a/network/network/src/main/java/bisq/network/p2p/node/Node.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Node.java
@@ -245,7 +245,7 @@ public class Node implements Connection.Handler {
 
     private void createServerAndListen() {
         ServerSocketResult serverSocketResult = transportService.getServerSocket(networkId, keyBundle);
-        myCapability = Optional.of(new Capability(serverSocketResult.getAddress(), new ArrayList<>(supportedTransportTypes), new ArrayList<>(features)));
+        myCapability = Optional.of(Capability.myCapability(serverSocketResult.getAddress(), new ArrayList<>(supportedTransportTypes), new ArrayList<>(features)));
         server = Optional.of(new Server(serverSocketResult,
                 socket -> onClientSocket(socket, serverSocketResult, myCapability.get()),
                 exception -> {
@@ -268,7 +268,7 @@ public class Node implements Connection.Handler {
             ConnectionHandshake.Result result = connectionHandshake.onSocket(networkLoadSnapshot.getCurrentNetworkLoad()); // Blocking call
             connectionHandshakes.remove(connectionHandshake.getId());
 
-            Address address = result.getCapability().getAddress();
+            Address address = result.getPeersCapability().getAddress();
             log.debug("Inbound handshake completed: Initiated by {} to {}", address, myCapability.getAddress());
 
             // As time passed we check again if connection is still not available
@@ -287,7 +287,7 @@ public class Node implements Connection.Handler {
             ConnectionThrottle connectionThrottle = new ConnectionThrottle(peersNetworkLoadSnapshot, networkLoadSnapshot, config);
             InboundConnection connection = new InboundConnection(socket,
                     serverSocketResult,
-                    result.getCapability(),
+                    result.getPeersCapability(),
                     peersNetworkLoadSnapshot,
                     result.getConnectionMetrics(),
                     connectionThrottle,
@@ -430,7 +430,7 @@ public class Node implements Connection.Handler {
                 // For clearnet this check doesn't make sense because:
                 // - the peer binds to 127.0.0.1, therefore reports 127.0.0.1 in the handshake
                 // - we use the peer's public IP to connect to him
-                checkArgument(address.equals(result.getCapability().getAddress()), "Peers reported address must match address we used to connect");
+                checkArgument(address.equals(result.getPeersCapability().getAddress()), "Peers reported address must match address we used to connect");
             }
 
             // As time passed we check again if connection is still not available
@@ -454,7 +454,7 @@ public class Node implements Connection.Handler {
             ConnectionThrottle connectionThrottle = new ConnectionThrottle(peersNetworkLoadSnapshot, networkLoadSnapshot, config);
             OutboundConnection connection = new OutboundConnection(socket,
                     address,
-                    result.getCapability(),
+                    result.getPeersCapability(),
                     peersNetworkLoadSnapshot,
                     result.getConnectionMetrics(),
                     connectionThrottle,

--- a/network/network/src/main/java/bisq/network/p2p/node/PeerConnectionsManager.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/PeerConnectionsManager.java
@@ -124,7 +124,7 @@ public class PeerConnectionsManager {
         ServerSocketResult serverSocketResult = transportService.getServerSocket(networkId, node.getKeyBundle());
         List<TransportType> supportedTransportTypes = new ArrayList<>(config.getSupportedTransportTypes());
         List<Feature> features = new ArrayList<>(config.getFeatures());
-        Capability serverCapability = new Capability(serverSocketResult.getAddress(), supportedTransportTypes, features);
+        Capability serverCapability = Capability.myCapability(serverSocketResult.getAddress(), supportedTransportTypes, features);
         ServerChannel serverChannel = new ServerChannel(
                 serverCapability,
                 myNetworkLoad,

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
@@ -175,12 +175,12 @@ public final class ConnectionHandshake {
     @ToString
     @EqualsAndHashCode
     public static final class Result {
-        private final Capability capability;
+        private final Capability peersCapability;
         private final NetworkLoad peersNetworkLoad;
         private final ConnectionMetrics connectionMetrics;
 
-        Result(Capability capability, NetworkLoad peersNetworkLoad, ConnectionMetrics connectionMetrics) {
-            this.capability = capability;
+        Result(Capability peersCapability, NetworkLoad peersNetworkLoad, ConnectionMetrics connectionMetrics) {
+            this.peersCapability = peersCapability;
             this.peersNetworkLoad = peersNetworkLoad;
             this.connectionMetrics = connectionMetrics;
         }

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
@@ -327,7 +327,9 @@ public final class ConnectionHandshake {
             log.debug("Clients capability {}, load={}", requestersCapability, request.getNetworkLoad());
             connectionMetrics.onReceived(requestNetworkEnvelope, deserializeTime);
 
-            Response response = new Response(capability, myNetworkLoad);
+            // We reply with the same version as the peer has to avoid pow hash check failures
+            Capability responseCapability = Capability.withVersion(capability, requestersCapability.getVersion());
+            Response response = new Response(responseCapability, myNetworkLoad);
             AuthorizationToken token = authorizationService.createToken(response,
                     request.getNetworkLoad(),
                     peerAddress.getFullAddress(),

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshakeResponder.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshakeResponder.java
@@ -40,18 +40,18 @@ import static bisq.network.p2p.node.ConnectionException.Reason.*;
 @Slf4j
 public class ConnectionHandshakeResponder {
     private final BanList banList;
-    private final Capability capability;
+    private final Capability myCapability;
     private final NetworkLoad myNetworkLoad;
     private final AuthorizationService authorizationService;
     private final NetworkEnvelopeSocketChannel networkEnvelopeSocketChannel;
 
     public ConnectionHandshakeResponder(BanList banList,
-                                        Capability capability,
+                                        Capability myCapability,
                                         NetworkLoad myNetworkLoad,
                                         AuthorizationService authorizationService,
                                         NetworkEnvelopeSocketChannel networkEnvelopeSocketChannel) {
         this.banList = banList;
-        this.capability = capability;
+        this.myCapability = myCapability;
         this.myNetworkLoad = myNetworkLoad;
         this.authorizationService = authorizationService;
         this.networkEnvelopeSocketChannel = networkEnvelopeSocketChannel;
@@ -70,7 +70,7 @@ public class ConnectionHandshakeResponder {
 
         Capability requestersCapability = request.getCapability();
         Address peerAddress = requestersCapability.getAddress();
-        Address myAddress = capability.getAddress();
+        Address myAddress = myCapability.getAddress();
         if (!OnionAddressValidation.verify(myAddress, peerAddress, request.getSignatureDate(), request.getAddressOwnershipProof())) {
             throw new ConnectionException(ONION_ADDRESS_VERIFICATION_FAILED, "Peer couldn't proof its onion address: " + peerAddress.getFullAddress() +
                     ", Proof: " + Hex.encode(request.getAddressOwnershipProof().orElseThrow()));
@@ -96,7 +96,7 @@ public class ConnectionHandshakeResponder {
 
     private void verifyPoW(NetworkEnvelope requestNetworkEnvelope) {
         ConnectionHandshake.Request request = (ConnectionHandshake.Request) requestNetworkEnvelope.getEnvelopePayloadMessage();
-        String myAddress = capability.getAddress().getFullAddress();
+        String myAddress = myCapability.getAddress().getFullAddress();
         // As the request did not know our load at the initial request, they used the NetworkLoad.INITIAL_LOAD for the
         // AuthorizationToken.
         boolean isAuthorized = authorizationService.isAuthorized(
@@ -132,7 +132,7 @@ public class ConnectionHandshakeResponder {
                                                    NetworkLoad peerNetworkLoad,
                                                    Address peerAddress,
                                                    List<Feature> requestersFeatures) {
-        ConnectionHandshake.Response response = new ConnectionHandshake.Response(capability, myNetworkLoad);
+        ConnectionHandshake.Response response = new ConnectionHandshake.Response(myCapability, myNetworkLoad);
         AuthorizationToken token = authorizationService.createToken(response,
                 peerNetworkLoad,
                 peerAddress.getFullAddress(),

--- a/network/network/src/main/proto/network.proto
+++ b/network/network/src/main/proto/network.proto
@@ -29,6 +29,8 @@ message Capability {
   network.common.Address address = 1;
   repeated string supportedTransportTypes = 2;
   repeated Feature features = 3;
+  sint32 version = 4;
+  string applicationVersion = 5;
 }
 
 enum InventoryFilterType{

--- a/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.util.FileUtils;
 import bisq.network.common.Address;
 import bisq.network.common.TransportType;
@@ -58,7 +59,7 @@ public class ConnectionHandshakeResponderTest {
 
     public ConnectionHandshakeResponderTest() throws IOException {
         supportedTransportTypes.add(TransportType.CLEAR);
-        this.responderCapability = new Capability(Address.localHost(1234), supportedTransportTypes, new ArrayList<>());
+        this.responderCapability = createCapability(Address.localHost(1234), supportedTransportTypes);
         this.authorizationService = createAuthorizationService();
         this.handshakeResponder = new ConnectionHandshakeResponder(
                 banList,
@@ -164,7 +165,7 @@ public class ConnectionHandshakeResponderTest {
 
     @Test
     void correctPoW() throws IOException {
-        Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes, new ArrayList<>());
+        Capability peerCapability = createCapability(Address.localHost(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
@@ -182,12 +183,16 @@ public class ConnectionHandshakeResponderTest {
     }
 
     private NetworkEnvelope createValidRequest() {
-        Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes, new ArrayList<>());
+        Capability peerCapability = createCapability(Address.localHost(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 responderCapability.getAddress().getFullAddress(),
                 0, new ArrayList<>());
         return new NetworkEnvelope(token, request);
+    }
+
+    private static Capability createCapability(Address address, List<TransportType> supportedTransportTypes) {
+        return new Capability(Capability.VERSION, address, supportedTransportTypes, new ArrayList<>(), ApplicationVersion.getVersion().getVersionAsString());
     }
 }

--- a/network/network/src/test/java/bisq/network/p2p/InboundConnectionsManagerTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/InboundConnectionsManagerTests.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.util.FileUtils;
 import bisq.common.util.NetworkUtils;
 import bisq.network.common.Address;
@@ -76,7 +77,7 @@ public class InboundConnectionsManagerTests {
         );
         serverSocketChannel.socket().bind(socketAddress);
 
-        Capability myCapability = new Capability(myAddress, supportedTransportTypes, new ArrayList<>());
+        Capability myCapability = createCapability(myAddress, supportedTransportTypes);
 
         Selector selector = SelectorProvider.provider().openSelector();
         InboundConnectionsManager inboundConnectionsManager = new InboundConnectionsManager(
@@ -165,7 +166,7 @@ public class InboundConnectionsManagerTests {
         );
         serverSocketChannel.socket().bind(socketAddress);
 
-        Capability myCapability = new Capability(myAddress, supportedTransportTypes, new ArrayList<>());
+        Capability myCapability = createCapability(myAddress, supportedTransportTypes);
 
         Selector selector = SelectorProvider.provider().openSelector();
         InboundConnectionsManager inboundConnectionsManager = new InboundConnectionsManager(
@@ -246,7 +247,7 @@ public class InboundConnectionsManagerTests {
     private bisq.network.protobuf.NetworkEnvelope createPoWRequest(Address myAddress, Address peerAddress) {
         List<TransportType> supportedTransportTypes = new ArrayList<>(1);
         supportedTransportTypes.add(TransportType.CLEAR);
-        Capability peerCapability = new Capability(peerAddress, supportedTransportTypes, new ArrayList<>());
+        Capability peerCapability = createCapability(peerAddress, supportedTransportTypes);
 
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationService authorizationService = createAuthorizationService();
@@ -262,5 +263,9 @@ public class InboundConnectionsManagerTests {
                 new HashCashProofOfWorkService(),
                 new EquihashProofOfWorkService(),
                 Set.of(Feature.AUTHORIZATION_HASH_CASH));
+    }
+
+    private static Capability createCapability(Address address, List<TransportType> supportedTransportTypes) {
+        return new Capability(Capability.VERSION, address, supportedTransportTypes, new ArrayList<>(), ApplicationVersion.getVersion().getVersionAsString());
     }
 }

--- a/network/network/src/test/java/bisq/network/p2p/ProtoBufMessageLengthTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/ProtoBufMessageLengthTests.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.util.FileUtils;
 import bisq.network.common.Address;
 import bisq.network.common.TransportType;
@@ -110,12 +111,16 @@ public class ProtoBufMessageLengthTests {
     }
 
     private bisq.network.protobuf.NetworkEnvelope createValidRequest() {
-        Capability peerCapability = new Capability(Address.localHost(2345), supportedTransportTypes, new ArrayList<>());
+        Capability peerCapability = createCapability(Address.localHost(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
                 Address.localHost(1234).getFullAddress(),
                 0, new ArrayList<>());
         return new NetworkEnvelope(token, request).completeProto();
+    }
+
+    private static Capability createCapability(Address address, List<TransportType> supportedTransportTypes) {
+        return new Capability(Capability.VERSION, address, supportedTransportTypes, new ArrayList<>(), ApplicationVersion.getVersion().getVersionAsString());
     }
 }


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq2/issues/2350

We use first version 1 when we start the handshake. When connection to an old node it is expected to fail as the pow hash check fails. In that case we retry with version 0.

When we receive a handshake request we check the peers capability version and reply with the same version.

@alvasw 
The changes are not implemented in the new `PeerConnectionsManager` classes as those are not yet used and at time when its used the backward compatibility issue is likely anyway resolved as we dont need to support pre 2.0.5 versions anymore.