### PR TITLE
Fix bug with cookie subkey handling

### DIFF
--- a/settings/src/main/java/bisq/settings/CookieKey.java
+++ b/settings/src/main/java/bisq/settings/CookieKey.java
@@ -17,17 +17,10 @@
 
 package bisq.settings;
 
-import bisq.common.util.ProtobufUtils;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.annotation.Nullable;
-
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
-// Used for persistence of Cookie. We use enum name as key.
 public enum CookieKey {
     STAGE_X,
     STAGE_Y,
@@ -50,10 +43,7 @@ public enum CookieKey {
     MARKET_SORT_TYPE,
     SELECTED_MARKET_CODES;
 
-    @Setter
     @Getter
-    @Nullable
-    private String subKey;
     private final boolean useSubKey;
 
     CookieKey(boolean useSubKey) {
@@ -62,37 +52,5 @@ public enum CookieKey {
 
     CookieKey() {
         this(false);
-    }
-
-    public boolean isUseSubKey() {
-        if (useSubKey) {
-            checkArgument(subKey != null,
-                    "If the enum has useSubKey set the subKey must not be null. CookieKey=" + this);
-        }
-        return useSubKey;
-    }
-
-    // We do not use protobuf for the enum for more flexibility
-    String getKeyForProto() {
-        String key = name();
-        if (isUseSubKey()) {
-            key = key + "." + subKey;
-        }
-        return key;
-    }
-
-    @Nullable
-    static CookieKey fromProto(String key) {
-        String[] tokens = key.split("\\.");
-        String name = tokens[0];
-        CookieKey cookieKey = ProtobufUtils.enumFromProto(CookieKey.class, name);
-        if (cookieKey != null && tokens.length > 1) {
-            String subKey = tokens[1];
-            checkArgument(cookieKey.useSubKey,
-                    "If the subKey is not null, the enum must have useSubKey set to true. CookieKey=" +
-                            cookieKey + ". subKey=" + subKey);
-            cookieKey.setSubKey(subKey);
-        }
-        return cookieKey;
     }
 }

--- a/settings/src/main/java/bisq/settings/CookieMapKey.java
+++ b/settings/src/main/java/bisq/settings/CookieMapKey.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.settings;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Wrapper for CookieKey and sub key
+ */
+@EqualsAndHashCode
+@Getter
+class CookieMapKey {
+    private final CookieKey cookieKey;
+
+    @Getter
+    private final Optional<String> subKey;
+
+    CookieMapKey(CookieKey cookieKey, @Nullable String subKey) {
+        this(cookieKey, Optional.ofNullable(subKey));
+    }
+
+    private CookieMapKey(CookieKey cookieKey, Optional<String> subKey) {
+        this.cookieKey = cookieKey;
+        this.subKey = subKey;
+
+        if (subKey.isPresent()) {
+            checkArgument(cookieKey.isUseSubKey(),
+                    "If the subKey is not null, the enum must have useSubKey set to true. CookieKey=" +
+                            cookieKey + ". subKey=" + subKey);
+        }
+    }
+
+    static CookieMapKey fromProto(String key, Optional<String> subKey) {
+        CookieKey cookieKey = CookieKey.valueOf(CookieKey.class, key);
+        return new CookieMapKey(cookieKey, subKey);
+    }
+}

--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -237,8 +237,7 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
     }
 
     public void setCookie(CookieKey key, String subKey, boolean value) {
-        key.setSubKey(subKey);
-        setCookie(key, value);
+        setCookie(key, subKey, value);
     }
 
     public void setCookie(CookieKey key, double value) {
@@ -248,12 +247,15 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
     }
 
     public void setCookie(CookieKey key, String subKey, double value) {
-        key.setSubKey(subKey);
-        setCookie(key, value);
+        setCookie(key, subKey, value);
     }
 
     public void setCookie(CookieKey key, String value) {
-        getCookie().putAsString(key, value);
+        setCookie(key, null, value);
+    }
+
+    public void setCookie(CookieKey key, @Nullable String subKey, String value) {
+        getCookie().putAsString(key, subKey, value);
         persist();
         updateCookieChangedFlag();
     }
@@ -263,15 +265,9 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
     }
 
     public void removeCookie(CookieKey key, @Nullable String subKey) {
-        key.setSubKey(subKey);
-        getCookie().remove(key);
+        getCookie().remove(key, subKey);
         persist();
         updateCookieChangedFlag();
-    }
-
-    public void setCookie(CookieKey key, String subKey, String value) {
-        key.setSubKey(subKey);
-        setCookie(key, value);
     }
 
     private void updateCookieChangedFlag() {

--- a/settings/src/main/proto/settings.proto
+++ b/settings/src/main/proto/settings.proto
@@ -23,8 +23,9 @@ option java_multiple_files = true;
 import "common.proto";
 
 message CookieMapEntry {
-  string cookieKey = 1;
+  string key = 1;
   string value = 2;
+  optional string subKey = 3;
 }
 message Cookie {
   repeated CookieMapEntry cookieMapEntries = 1;


### PR DESCRIPTION
We have overwritten the map entry when using different subkeys because enum identity does not consider the values of fields. We now wrap the key and the subkey in a new object and use that as map key. We also store the subkey in proto in a new field instead of encoding it in the key.