### PR TITLE
Set -fx-font-smoothing-type to grey

### DIFF
--- a/apps/desktop/desktop/src/main/resources/css/base.css
+++ b/apps/desktop/desktop/src/main/resources/css/base.css
@@ -133,3 +133,8 @@
                 -fx-dark-text-color
         );
 }
+
+/* Avoid color artefacts at antialias */
+.text {
+    -fx-font-smoothing-type: gray;
+}


### PR DESCRIPTION
With ` -fx-font-smoothing-type: gray;`:
![lcdtext=false](https://github.com/bisq-network/bisq/assets/116298498/0922447b-8c4e-4b74-8a65-24aafac89f25)

With ` -fx-font-smoothing-type: lcd;`, which is default set by moderna.css:
![def](https://github.com/bisq-network/bisq/assets/116298498/4bd76025-a4b4-4405-bebd-0b60fa9cb8e1)

