### PR TITLE
Dont use MacOS aarch64 tor binaries

### DIFF
--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
@@ -12,8 +12,11 @@ class TorBinaryUrlProvider(private val version: String) : PerOsUrlProvider {
     override val macOsUrl: String
         get() = "tor-expert-bundle-$version-macos-x86_64.tar.gz"
 
+    // Tor binary for macOsAarch64 does not work yet, so we use still the x86 version
+    /* override val macOsAarch64Url: String
+         get() = "tor-expert-bundle-$version-macos-aarch64.tar.gz"*/
     override val macOsAarch64Url: String
-        get() = "tor-expert-bundle-$version-macos-aarch64.tar.gz"
+        get() = "tor-expert-bundle-$version-macos-x86_64.tar.gz"
 
     override val windowsUrl: String
         get() = "tor-expert-bundle-$version-windows-x86_64.tar.gz"


### PR DESCRIPTION
The aarch64 tor binary seems to have issues as tor cannot get started up. We temporarily disable it and use the x86 instead on MacOS with aarch64 (M1,M2,M3)