### PR TITLE
Improve chat messages' active reactions display

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -395,7 +395,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                     Optional<UserProfile> userProfile = userProfileService.findUserProfile(element.getUserProfileId());
                     userProfile.ifPresent(profile -> {
                         if (!userProfileService.isChatUserIgnored(profile)) {
-                            userReactions.get(reaction).addUser(element, profile);
+                            userReactions.get(reaction).addUser(element, profile, isMyUser(profile));
                         }
                     });
                 }
@@ -407,7 +407,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                 Reaction reaction = getReactionFromOrdinal(chatMessageReaction.getReactionId());
                 if (userReactions.containsKey(reaction)) {
                     Optional<UserProfile> userProfile = userProfileService.findUserProfile(chatMessageReaction.getUserProfileId());
-                    userProfile.ifPresent(profile -> userReactions.get(reaction).removeUser(profile));
+                    userProfile.ifPresent(profile -> userReactions.get(reaction).removeUser(profile, isMyUser(profile)));
                 }
             }
 
@@ -421,5 +421,10 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
     private static Reaction getReactionFromOrdinal(int ordinal) {
         checkArgument(ordinal >= 0 && ordinal < Reaction.values().length, "Invalid reaction id: " + ordinal);
         return Reaction.values()[ordinal];
+    }
+
+    private boolean isMyUser(UserProfile profile) {
+        UserProfile myProfile = userIdentityService.getSelectedUserIdentity().getUserProfile();
+        return myProfile.equals(profile);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -60,11 +60,9 @@ import com.google.common.base.Joiner;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.HBox;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -121,7 +119,6 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
     // Reactions
     private Optional<Pin> userReactionsPin = Optional.empty();
     private final HashMap<Reaction, ReactionItem> userReactions = new HashMap<>();
-    private final SimpleObjectProperty<Node> reactionsNode = new SimpleObjectProperty<>();
 
     public ChatMessageListItem(M chatMessage,
                                C chatChannel,
@@ -293,26 +290,6 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                 .orElse("");
     }
 
-    private void setupDisplayReactionsNode() {
-        HBox reactions = new HBox(5);
-        reactions.setAlignment(Pos.BOTTOM_LEFT);
-        // TODO: order here should be defined by time when this was added
-        REACTION_DISPLAY_ORDER.forEach(reaction -> {
-            if (userReactions.containsKey(reaction) && !userReactions.get(reaction).getUsers().isEmpty()) {
-                reactions.getChildren().add(new Label("", ImageUtil.getImageViewById(reaction.toString().replace("_", "").toLowerCase())));
-            }
-        });
-        reactionsNode.set(reactions);
-    }
-
-    private void logReactionsCount() {
-//        StringBuilder reactionsCount = new StringBuilder("\n");
-//        REACTION_DISPLAY_ORDER.forEach(reaction ->
-//                reactionsCount.append(String.format("%s: %s\n", reaction,
-//                        userReactions.containsKey(reaction) ? userReactions.get(reaction).size() : 0)));
-//        log.info(reactionsCount.toString());
-    }
-
     private String getLocalizedOfferBookMessage(BisqEasyOfferbookMessage chatMessage) {
         BisqEasyOffer bisqEasyOffer = chatMessage.getBisqEasyOffer().orElseThrow();
         String btcPaymentMethods = PaymentMethodSpecFormatter.fromPaymentMethodSpecs(bisqEasyOffer.getBaseSidePaymentMethodSpecs());
@@ -422,9 +399,6 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                         }
                     });
                 }
-
-                setupDisplayReactionsNode();
-                logReactionsCount();
             }
 
             @Override
@@ -435,17 +409,11 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                     Optional<UserProfile> userProfile = userProfileService.findUserProfile(chatMessageReaction.getUserProfileId());
                     userProfile.ifPresent(profile -> userReactions.get(reaction).removeUser(profile));
                 }
-
-                setupDisplayReactionsNode();
-                logReactionsCount();
             }
 
             @Override
             public void clear() {
                 userReactions.clear();
-
-                setupDisplayReactionsNode();
-                logReactionsCount();
             }
         }));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
@@ -36,7 +36,7 @@ public class ReactionItem {
     private final Reaction reaction;
     private final String iconId;
     private long firstAdded;
-    private final SimpleIntegerProperty count = new SimpleIntegerProperty();
+    private final SimpleIntegerProperty count = new SimpleIntegerProperty(0);
     private final SimpleBooleanProperty selected = new SimpleBooleanProperty(false);
     Set<UserProfile> users = new HashSet<>();
 
@@ -45,7 +45,7 @@ public class ReactionItem {
         this.iconId = reaction.toString().replace("_", "").toLowerCase();
     }
 
-    void addUser(ChatMessageReaction chatMessageReaction, UserProfile userProfile) {
+    void addUser(ChatMessageReaction chatMessageReaction, UserProfile userProfile, boolean isMyUser) {
         if (hasReactionBeenRemoved(chatMessageReaction)) {
             return;
         }
@@ -54,11 +54,13 @@ public class ReactionItem {
             firstAdded = chatMessageReaction.getDate();
         }
 
+        selected.set(isMyUser);
         users.add(userProfile);
         count.set(users.size());
     }
 
-    void removeUser(UserProfile userProfile) {
+    void removeUser(UserProfile userProfile, boolean isMyUser) {
+        selected.set(!isMyUser);
         users.remove(userProfile);
         count.set(users.size());
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
@@ -22,23 +22,21 @@ import bisq.chat.reactions.PrivateChatMessageReaction;
 import bisq.chat.reactions.Reaction;
 import bisq.user.profile.UserProfile;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleStringProperty;
-import lombok.EqualsAndHashCode;
+import javafx.beans.property.SimpleIntegerProperty;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
 @Slf4j
 @Getter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class ReactionItem {
-    @EqualsAndHashCode.Include
     private final Reaction reaction;
     private final String iconId;
     private final long firstAdded = 0;
-    private final SimpleStringProperty count = new SimpleStringProperty();
+    private final SimpleIntegerProperty count = new SimpleIntegerProperty();
     private final SimpleBooleanProperty selected = new SimpleBooleanProperty(false);
     Set<UserProfile> users = new HashSet<>();
 
@@ -53,15 +51,19 @@ public class ReactionItem {
         }
 
         users.add(userProfile);
-        count.set(getCount());
+        count.set(users.size());
     }
 
     void removeUser(UserProfile userProfile) {
         users.remove(userProfile);
-        count.set(getCount());
+        count.set(users.size());
     }
 
-    private String getCount() {
+    public boolean hasActiveReactions() {
+        return !users.isEmpty();
+    }
+
+    public String getCountAsString() {
         long count = users.size();
         return count < 100 ? String.valueOf(count) : "+99";
     }
@@ -69,5 +71,9 @@ public class ReactionItem {
     private boolean hasReactionBeenRemoved(ChatMessageReaction chatMessageReaction) {
         return (chatMessageReaction instanceof PrivateChatMessageReaction
                 && ((PrivateChatMessageReaction) chatMessageReaction).isRemoved());
+    }
+
+    public static Comparator<ReactionItem> firstAddedComparator() {
+        return Comparator.comparing(ReactionItem::getFirstAdded);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
@@ -69,6 +69,9 @@ public class ReactionItem {
 
     public String getCountAsString() {
         long count = users.size();
+        if (count == 1) {
+            return "";
+        }
         return count < 100 ? String.valueOf(count) : "+99";
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list;
+
+import bisq.chat.reactions.ChatMessageReaction;
+import bisq.chat.reactions.PrivateChatMessageReaction;
+import bisq.chat.reactions.Reaction;
+import bisq.user.profile.UserProfile;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ReactionItem {
+    @EqualsAndHashCode.Include
+    private final Reaction reaction;
+    private final String iconId;
+    private final long firstAdded = 0;
+    private final SimpleStringProperty count = new SimpleStringProperty();
+    private final SimpleBooleanProperty selected = new SimpleBooleanProperty(false);
+    Set<UserProfile> users = new HashSet<>();
+
+    ReactionItem(Reaction reaction) {
+        this.reaction = reaction;
+        this.iconId = reaction.toString().replace("_", "").toLowerCase();
+    }
+
+    void addUser(ChatMessageReaction chatMessageReaction, UserProfile userProfile) {
+        if (hasReactionBeenRemoved(chatMessageReaction)) {
+            return;
+        }
+
+        users.add(userProfile);
+        count.set(getCount());
+    }
+
+    void removeUser(UserProfile userProfile) {
+        users.remove(userProfile);
+        count.set(getCount());
+    }
+
+    private String getCount() {
+        long count = users.size();
+        return count < 100 ? String.valueOf(count) : "+99";
+    }
+
+    private boolean hasReactionBeenRemoved(ChatMessageReaction chatMessageReaction) {
+        return (chatMessageReaction instanceof PrivateChatMessageReaction
+                && ((PrivateChatMessageReaction) chatMessageReaction).isRemoved());
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public class ReactionItem {
     private final Reaction reaction;
     private final String iconId;
-    private final long firstAdded = 0;
+    private long firstAdded;
     private final SimpleIntegerProperty count = new SimpleIntegerProperty();
     private final SimpleBooleanProperty selected = new SimpleBooleanProperty(false);
     Set<UserProfile> users = new HashSet<>();
@@ -48,6 +48,10 @@ public class ReactionItem {
     void addUser(ChatMessageReaction chatMessageReaction, UserProfile userProfile) {
         if (hasReactionBeenRemoved(chatMessageReaction)) {
             return;
+        }
+
+        if (firstAdded == 0) {
+            firstAdded = chatMessageReaction.getDate();
         }
 
         users.add(userProfile);
@@ -74,6 +78,6 @@ public class ReactionItem {
     }
 
     public static Comparator<ReactionItem> firstAddedComparator() {
-        return Comparator.comparing(ReactionItem::getFirstAdded);
+        return Comparator.comparingLong(ReactionItem::getFirstAdded);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
@@ -22,7 +22,6 @@ import bisq.chat.ChatMessage;
 import bisq.chat.Citation;
 import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
 import bisq.chat.reactions.Reaction;
-import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.controls.BisqMenuItem;
@@ -31,6 +30,7 @@ import bisq.desktop.components.controls.DrawerMenu;
 import bisq.desktop.components.controls.DropdownMenu;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
+import bisq.desktop.main.content.chat.message_container.list.reactions_box.ActiveReactionsDisplayBox;
 import bisq.desktop.main.content.components.UserProfileIcon;
 import bisq.i18n.Res;
 import javafx.css.PseudoClass;
@@ -61,13 +61,13 @@ public abstract class BubbleMessageBox extends MessageBox {
     private static final List<Reaction> REACTIONS = Arrays.asList(Reaction.THUMBS_UP, Reaction.THUMBS_DOWN, Reaction.HAPPY,
             Reaction.LAUGH, Reaction.HEART, Reaction.PARTY);
 
-    private final Subscription showHighlightedPin, reactionsPin, hasFailedDeliveryStatusPin;
+    private final Subscription showHighlightedPin, hasFailedDeliveryStatusPin;
     protected final ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item;
     protected final ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list;
     protected final ChatMessagesListController controller;
     protected final UserProfileIcon userProfileIcon = new UserProfileIcon(60);
     protected final HBox actionsHBox = new HBox(5);
-    protected final HBox addedReactions = new HBox();
+    protected final ActiveReactionsDisplayBox activeReactionsDisplayHBox;
     protected final VBox quotedMessageVBox, contentVBox;
     protected final BisqMenuItem deleteAction = new BisqMenuItem("delete-t-grey", "delete-t-red");
     protected DrawerMenu reactMenu;
@@ -92,6 +92,7 @@ public abstract class BubbleMessageBox extends MessageBox {
         addActionsHandlers();
         addOnMouseEventHandlers();
 
+        activeReactionsDisplayHBox = createAndGetActiveReactionsDisplayBox();
         supportedLanguages = createAndGetSupportedLanguagesLabel();
         quotedMessageVBox = createAndGetQuotedMessageVBox();
         handleQuoteMessageBox();
@@ -113,12 +114,6 @@ public abstract class BubbleMessageBox extends MessageBox {
                 messageBgHBox.getStyleClass().add(HIGHLIGHTED_MESSAGE_BG_STYLE_CLASS);
             } else {
                 messageBgHBox.getStyleClass().remove(HIGHLIGHTED_MESSAGE_BG_STYLE_CLASS);
-            }
-        });
-
-        reactionsPin = EasyBind.subscribe(item.getReactionsNode(), node -> {
-            if (node != null) {
-                UIThread.run(() -> addedReactions.getChildren().setAll(node));
             }
         });
 
@@ -194,9 +189,10 @@ public abstract class BubbleMessageBox extends MessageBox {
         reactionMenuItems.forEach(menuItem -> menuItem.setOnAction(null));
 
         showHighlightedPin.unsubscribe();
-        reactionsPin.unsubscribe();
         reactMenuPin.unsubscribe();
         hasFailedDeliveryStatusPin.unsubscribe();
+
+        activeReactionsDisplayHBox.dispose();
     }
 
     private void showDateTimeAndActionsMenu(boolean shouldShow) {
@@ -214,6 +210,11 @@ public abstract class BubbleMessageBox extends MessageBox {
                 actionsHBox.setVisible(false);
             }
         }
+    }
+
+    private ActiveReactionsDisplayBox createAndGetActiveReactionsDisplayBox() {
+        ActiveReactionsDisplayBox displayBox = new ActiveReactionsDisplayBox(item.getUserReactions().values());
+        return displayBox;
     }
 
     private Label createAndGetSupportedLanguagesLabel() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
@@ -31,6 +31,7 @@ import bisq.desktop.components.controls.DropdownMenu;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
 import bisq.desktop.main.content.chat.message_container.list.reactions_box.ActiveReactionsDisplayBox;
+import bisq.desktop.main.content.chat.message_container.list.reactions_box.ToggleReaction;
 import bisq.desktop.main.content.components.UserProfileIcon;
 import bisq.i18n.Res;
 import javafx.css.PseudoClass;
@@ -213,8 +214,10 @@ public abstract class BubbleMessageBox extends MessageBox {
     }
 
     private ActiveReactionsDisplayBox createAndGetActiveReactionsDisplayBox() {
-        ActiveReactionsDisplayBox displayBox = new ActiveReactionsDisplayBox(item.getUserReactions().values());
-        return displayBox;
+        ToggleReaction toggleReactionFunction = reactionItem -> {
+            controller.onReactMessage(item.getChatMessage(), reactionItem.getReaction(), item.getChatChannel());
+        };
+        return new ActiveReactionsDisplayBox(item.getUserReactions().values(), toggleReactionFunction);
     }
 
     private Label createAndGetSupportedLanguagesLabel() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -95,7 +95,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         });
 
         editInputField.maxWidthProperty().bind(message.widthProperty());
-        messageHBox.getChildren().setAll(Spacer.fillHBox(), addedReactions, messageBgHBox);
+        messageHBox.getChildren().setAll(Spacer.fillHBox(), activeReactionsDisplayHBox, messageBgHBox);
         contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, actionsHBox);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/PeerTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/PeerTextMessageBox.java
@@ -47,7 +47,7 @@ public class PeerTextMessageBox extends BubbleMessageBox {
 
         setUpPeerMessage();
         setMargin(userNameAndDateHBox, new Insets(-5, 0, -5, 10));
-        messageHBox.getChildren().setAll(messageBgHBox, addedReactions, Spacer.fillHBox());
+        messageHBox.getChildren().setAll(messageBgHBox, activeReactionsDisplayHBox, Spacer.fillHBox());
         actionsHBox.getChildren().setAll(replyAction, openPrivateChatAction, copyAction, reactMenu, moreActionsMenu, Spacer.fillHBox());
 
         contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, actionsHBox);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list.reactions_box;
+
+import bisq.desktop.components.controls.BisqMenuItem;
+import bisq.desktop.main.content.chat.message_container.list.ReactionItem;
+import javafx.beans.value.ChangeListener;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
+import javafx.scene.layout.HBox;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ActiveReactionsDisplayBox extends HBox {
+    private final ObservableList<ReactionItem> reactionItems = FXCollections.observableArrayList();
+    private final FilteredList<ReactionItem> filteredReactionItems = new FilteredList<>(reactionItems, ReactionItem::hasActiveReactions);
+    private final SortedList<ReactionItem> sortedReactionItems = new SortedList<>(filteredReactionItems);
+    private final Map<ReactionItem, ChangeListener<Number>> itemChangeListeners = new HashMap<>();
+    private final ListChangeListener<ReactionItem> listChangeListener;
+
+    public ActiveReactionsDisplayBox(Collection<ReactionItem> reactionItems) {
+        this.reactionItems.addAll(reactionItems);
+        listChangeListener = change -> updateItems();
+        sortedReactionItems.setComparator(ReactionItem.firstAddedComparator());
+        initialize();
+        updateItems();
+    }
+
+    private void initialize() {
+        reactionItems.forEach(this::addItemListeners);
+        sortedReactionItems.addListener(listChangeListener);
+    }
+
+    public void dispose() {
+        removeItemListeners();
+        sortedReactionItems.removeListener(listChangeListener);
+    }
+
+    private void addItemListeners(ReactionItem item) {
+        ChangeListener<Number> listener = (obs, oldValue, newValue) -> {
+            int idx = reactionItems.indexOf(item);
+            if (idx >= 0) {
+                reactionItems.set(idx, item);
+            }
+        };
+        item.getCount().addListener(listener);
+        itemChangeListeners.put(item, listener);
+    }
+
+    private void removeItemListeners() {
+        itemChangeListeners.forEach((item, listener) -> {
+            item.getCount().removeListener(listener);
+        });
+    }
+
+    private void updateItems() {
+        getChildren().clear();
+        getChildren().addAll(sortedReactionItems.stream()
+                .map(ActiveReactionMenuItem::new)
+                .collect(Collectors.toList()));
+    }
+
+    @Getter
+    private static final class ActiveReactionMenuItem extends BisqMenuItem {
+        private ReactionItem reactionItem;
+
+        public ActiveReactionMenuItem(ReactionItem reactionItem) {
+            this(reactionItem.getIconId());
+
+            this.reactionItem = reactionItem;
+            getStyleClass().add("active-reaction-menu-item");
+        }
+
+        private ActiveReactionMenuItem(String iconId) {
+            super(iconId, iconId);
+        }
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.chat.message_container.list.reactions_box;
 
+import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.main.content.chat.message_container.list.ReactionItem;
 import javafx.beans.value.ChangeListener;
@@ -46,6 +47,7 @@ public class ActiveReactionsDisplayBox extends HBox {
         sortedReactionItems.setComparator(ReactionItem.firstAddedComparator());
         initialize();
         updateItems();
+        getStyleClass().add("active-reactions-display-box");
     }
 
     private void initialize() {
@@ -76,10 +78,12 @@ public class ActiveReactionsDisplayBox extends HBox {
     }
 
     private void updateItems() {
-        getChildren().clear();
-        getChildren().addAll(sortedReactionItems.stream()
-                .map(ActiveReactionMenuItem::new)
-                .collect(Collectors.toList()));
+        UIThread.run(() -> {
+            getChildren().clear();
+            getChildren().addAll(sortedReactionItems.stream()
+                    .map(ActiveReactionMenuItem::new)
+                    .collect(Collectors.toList()));
+        });
     }
 
     @Getter
@@ -90,6 +94,8 @@ public class ActiveReactionsDisplayBox extends HBox {
             this(reactionItem.getIconId());
 
             this.reactionItem = reactionItem;
+            setText(reactionItem.getCountAsString());
+            setGraphicTextGap(4);
             getStyleClass().add("active-reaction-menu-item");
         }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
@@ -40,9 +40,11 @@ public class ActiveReactionsDisplayBox extends HBox {
     private final SortedList<ReactionItem> sortedReactionItems = new SortedList<>(filteredReactionItems);
     private final Map<ReactionItem, ChangeListener<Number>> itemChangeListeners = new HashMap<>();
     private final ListChangeListener<ReactionItem> listChangeListener;
+    private final ToggleReaction toggleReaction;
 
-    public ActiveReactionsDisplayBox(Collection<ReactionItem> reactionItems) {
+    public ActiveReactionsDisplayBox(Collection<ReactionItem> reactionItems, ToggleReaction toggleReaction) {
         this.reactionItems.addAll(reactionItems);
+        this.toggleReaction = toggleReaction;
         listChangeListener = change -> updateItems();
         sortedReactionItems.setComparator(ReactionItem.firstAddedComparator());
         initialize();
@@ -81,7 +83,7 @@ public class ActiveReactionsDisplayBox extends HBox {
         UIThread.run(() -> {
             getChildren().clear();
             getChildren().addAll(sortedReactionItems.stream()
-                    .map(ActiveReactionMenuItem::new)
+                    .map(item -> new ActiveReactionMenuItem(item, toggleReaction))
                     .collect(Collectors.toList()));
         });
     }
@@ -89,14 +91,17 @@ public class ActiveReactionsDisplayBox extends HBox {
     @Getter
     private static final class ActiveReactionMenuItem extends BisqMenuItem {
         private ReactionItem reactionItem;
+        private ToggleReaction toggleReaction;
 
-        public ActiveReactionMenuItem(ReactionItem reactionItem) {
+        public ActiveReactionMenuItem(ReactionItem reactionItem, ToggleReaction toggleReaction) {
             this(reactionItem.getIconId());
 
             this.reactionItem = reactionItem;
+            this.toggleReaction = toggleReaction;
             setText(reactionItem.getCountAsString());
             setGraphicTextGap(4);
             addStyleClasses();
+            setOnAction(e -> toggleReaction.execute(reactionItem));
         }
 
         private ActiveReactionMenuItem(String iconId) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ActiveReactionsDisplayBox.java
@@ -96,11 +96,20 @@ public class ActiveReactionsDisplayBox extends HBox {
             this.reactionItem = reactionItem;
             setText(reactionItem.getCountAsString());
             setGraphicTextGap(4);
-            getStyleClass().add("active-reaction-menu-item");
+            addStyleClasses();
         }
 
         private ActiveReactionMenuItem(String iconId) {
             super(iconId, iconId);
+        }
+
+        private void addStyleClasses() {
+            getStyleClass().add("active-reaction-menu-item");
+            if (reactionItem.getSelected().get()) {
+                getStyleClass().add("active-reaction-selected");
+            } else {
+                getStyleClass().remove("active-reaction-selected");
+            }
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ToggleReaction.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/reactions_box/ToggleReaction.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list.reactions_box;
+
+import bisq.desktop.main.content.chat.message_container.list.ReactionItem;
+
+@FunctionalInterface
+public interface ToggleReaction {
+    void execute(ReactionItem reactionItem);
+}

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -546,15 +546,14 @@
     -fx-background-color: -bisq-mid-grey-10 !important;
 }
 
-.button.bisq-menu-item.reaction-menu-item.icon-only:hover {
+.button.bisq-menu-item.reaction-menu-item.icon-only:hover,
+.button.bisq-menu-item.active-reaction-menu-item:hover{
     -fx-background-color: -bisq-mid-grey-10 !important;
 }
 
 .chat-message-content-box .drawer-menu-items {
     -fx-spacing: 4;
 }
-
-/* Active Reactions Display */
 
 .active-reactions-display-box {
     -fx-spacing: 5;
@@ -567,5 +566,12 @@
     -fx-font-family: "IBM Plex Sans SemiBold";
     -fx-background-color: -bisq-dark-grey-40;
     -fx-background-radius: 15;
-    -fx-padding: 5;
+    -fx-padding: 6;
+}
+
+.button.bisq-menu-item.active-reaction-menu-item.active-reaction-selected {
+    -fx-border-width: 1px;
+    -fx-border-color: -bisq-mid-grey-20;
+    -fx-border-radius: 15;
+    -fx-padding: 5 !important;
 }

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -542,10 +542,7 @@
  * Reactions                                                                   *
  ******************************************************************************/
 
-.reaction-menu-item:selected {
-    -fx-background-color: -bisq-mid-grey-10 !important;
-}
-
+.reaction-menu-item:selected,
 .button.bisq-menu-item.reaction-menu-item.icon-only:hover,
 .button.bisq-menu-item.active-reaction-menu-item:hover{
     -fx-background-color: -bisq-mid-grey-10 !important;

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -553,3 +553,19 @@
 .chat-message-content-box .drawer-menu-items {
     -fx-spacing: 4;
 }
+
+/* Active Reactions Display */
+
+.active-reactions-display-box {
+    -fx-spacing: 5;
+    -fx-alignment: bottom-center;
+}
+
+.button.bisq-menu-item.active-reaction-menu-item {
+    -fx-font-size: 10;
+    -fx-text-fill: -bisq-white;
+    -fx-font-family: "IBM Plex Sans SemiBold";
+    -fx-background-color: -bisq-dark-grey-40;
+    -fx-background-radius: 15;
+    -fx-padding: 5;
+}


### PR DESCRIPTION
* Add a new menu to display the active reactions that a message has. This now includes the count, and also serves as a toggle to add/remove a reaction.
* Add a new class `ReactionItem` to encapsulate the representation of a reaction.
   Will follow-up aligning the already existing reactions menu to use this same reference.