### PR TITLE
Fix bug at DropdownMenuItem

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenuItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenuItem.java
@@ -17,6 +17,8 @@
 
 package bisq.desktop.components.controls;
 
+import javafx.event.ActionEvent;
+import javafx.event.Event;
 import javafx.scene.control.CustomMenuItem;
 import lombok.Getter;
 
@@ -28,6 +30,12 @@ public class DropdownMenuItem extends CustomMenuItem {
         bisqMenuItem = new BisqMenuItem(defaultIconId, activeIconId, text);
         bisqMenuItem.getStyleClass().add("dropdown-menu-item-content");
         setContent(bisqMenuItem);
+
+        // Using DropdownMenuItem.setOnAction leads to duplicate execution of the handler on MacOS 14.5 / M3.
+        // Might be a bug in the MacOS specific JavaFX libraries as other devs could not reproduce the issue.
+        // Using an eventFilter and consuming the event solves the issue.
+        // This happens only when bisqMenuItem is used inside the DropdownMenuItem
+        bisqMenuItem.addEventFilter(ActionEvent.ANY, Event::consume);
     }
 
     public DropdownMenuItem(String text) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
@@ -121,10 +121,7 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             }
         });
 
-        // Using leaveChatButton.setOnAction leads to duplicate execution of the handler on MacOS 14.5 / M3.
-        // Might be a bug in the MacOS specific JavaFX libraries as other devs could not reproduce the issue.
-        // Using the BisqMenuItem for the event handler works.
-        leaveChatButton.getBisqMenuItem().setOnAction(e -> getController().onLeaveChat());
+        leaveChatButton.setOnAction(e -> getController().onLeaveChat());
 
         headerDropdownMenu.visibleProperty().bind(model.getNoOpenChats().not());
         headerDropdownMenu.managedProperty().bind(model.getNoOpenChats().not());


### PR DESCRIPTION
Using DropdownMenuItem.setOnAction leads to duplicate execution of the handler on MacOS 14.5 / M3. Might be a bug in the MacOS specific JavaFX libraries as other devs could not reproduce the issue. Using an eventFilter and consuming the event solves the issue.