### PR TITLE
Fixes main branch not compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ hs_err_pid*
 *.spvchain
 *.wallet
 *.ser
+*.sh
 .DS_Store
 .gradle
 build

--- a/trade/src/main/java/bisq/trade/protocol/messages/TradeMessage.java
+++ b/trade/src/main/java/bisq/trade/protocol/messages/TradeMessage.java
@@ -77,12 +77,14 @@ public abstract class TradeMessage implements MailboxMessage, ExternalNetworkMes
             case SUBMARINETRADEMESSAGE: {
                 return SubmarineTradeMessage.fromProto(proto);
             }
-
             case MESSAGE_NOT_SET: {
                 throw new UnresolvableProtobufMessageException(proto);
             }
+            default: {
+                log.error("Invalid protobuf message: {}", proto.getMessageCase());
+                throw new UnresolvableProtobufMessageException(proto);
+            }
         }
-        throw new UnresolvableProtobufMessageException(proto);
     }
 
     public static ProtoResolver<ExternalNetworkMessage> getNetworkMessageResolver() {


### PR DESCRIPTION
 - Fix compilation error on trade module by implementing default case for fromProto method switch
 - Added git ignore for dev .sh scripts
 
 
 Original error:
 
 Task :application:compileJava FAILED []/projects/bisq2/application/src/main/java/bisq/application/ResolverConfig.java:43: error: package bisq.trade.protocol.messages does not exist import bisq.trade.protocol.messages.TradeMessage; ^ 1 error