### PR TITLE
Handle pending messages at shutdown

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/list_view/ListViewUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/list_view/ListViewUtil.java
@@ -59,7 +59,6 @@ public class ListViewUtil {
                                                AtomicInteger numRecursions,
                                                AtomicInteger delay) {
         UIScheduler.run(() -> {
-            log.error("delayedScrollbarLookup {} {}", numRecursions, delay);
             Optional<ScrollBar> scrollbar = findScrollbar(listView, orientation);
             if (scrollbar.isPresent()) {
                 future.complete(scrollbar);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/BisqEasyOpenTradesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/BisqEasyOpenTradesView.java
@@ -73,6 +73,7 @@ import javafx.stage.Stage;
 import javafx.util.Callback;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
@@ -490,6 +491,7 @@ public final class BisqEasyOpenTradesView extends ChatView<BisqEasyOpenTradesVie
         return (BisqEasyOpenTradesController) controller;
     }
 
+    @ToString
     @Getter
     @EqualsAndHashCode(onlyExplicitlyIncluded = true)
     static class ListItem implements DateTableItem {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -32,7 +32,21 @@ import bisq.desktop.common.view.Controller;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.BisqEasyServiceUtil;
 import bisq.desktop.main.content.bisq_easy.components.TradeDataHeader;
-import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.*;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState1a;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState1b;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState2a;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState2b;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState3a;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState4;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerStateLightning3b;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerStateOnchain3b;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerState1;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerState2a;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerState2b;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerState3a;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerState4;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerStateLightning3b;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.SellerStateOnchain3b;
 import bisq.i18n.Res;
 import bisq.offer.price.spec.PriceSpec;
 import bisq.settings.DontShowAgainService;
@@ -219,7 +233,11 @@ public class TradeStateController implements Controller {
                 .show();
     }
 
-    void doInterruptTrade() {
+    void onRejectPrice() {
+        doInterruptTrade();
+    }
+
+    private void doInterruptTrade() {
         BisqEasyTrade trade = model.getBisqEasyTrade().get();
         String encoded;
         BisqEasyOpenTradeChannel channel = model.getChannel().get();
@@ -243,12 +261,17 @@ public class TradeStateController implements Controller {
     void onCloseTrade() {
         new Popup().warning(Res.get("bisqEasy.openTrades.closeTrade.warning.interrupted"))
                 .actionButtonText(Res.get("confirmation.yes"))
-                .onAction(() -> {
-                    bisqEasyTradeService.removeTrade(model.getBisqEasyTrade().get());
-                    leavePrivateChatManager.leaveChannel(model.getChannel().get());
-                })
+                .onAction(this::doCloseTrade)
                 .closeButtonText(Res.get("confirmation.no"))
                 .show();
+    }
+
+    private void doCloseTrade() {
+        // We need to pin the chatChannel to close as the one in the model would get updated after
+        // bisqEasyTradeService.removeTrade, and then we would close the wrong channel.
+        BisqEasyOpenTradeChannel chatChannel = model.getChannel().get();
+        bisqEasyTradeService.removeTrade(model.getBisqEasyTrade().get());
+        leavePrivateChatManager.leaveChannel(chatChannel);
     }
 
     void onExportTrade() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -183,7 +183,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.setOnAction(e -> controller.onInterruptTrade());
         closeTradeButton.setOnAction(e -> controller.onCloseTrade());
         exportButton.setOnAction(e -> controller.onExportTrade());
-        rejectPriceButton.setOnAction(e -> controller.doInterruptTrade());
+        rejectPriceButton.setOnAction(e -> controller.onRejectPrice());
         reportToMediatorButton.setOnAction(e -> controller.onReportToMediator());
         acceptSellersPriceButton.setOnAction(e -> controller.onAcceptSellersPriceButton());
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/QrCodeListeningServer.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/QrCodeListeningServer.java
@@ -68,13 +68,13 @@ public class QrCodeListeningServer {
     }
 
     public void stopServer() {
-        log.info("stopServer");
         if (isStopped) {
             return;
         }
 
         isStopped = true;
         serverSocket.ifPresent(serverSocket -> {
+            log.info("stopServer");
             try {
                 serverSocket.close();
             } catch (IOException ignore) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLauncher.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLauncher.java
@@ -88,8 +88,8 @@ public class WebcamProcessLauncher {
     }
 
     public CompletableFuture<Boolean> shutdown() {
-        log.info("Process shutdown. runningProcess={}", runningProcess);
         return CompletableFuture.supplyAsync(() -> runningProcess.map(process -> {
+            log.info("Process shutdown. runningProcess={}", runningProcess);
             process.destroy();
             boolean terminatedGraceFully = false;
             try {

--- a/bisq-easy/build.gradle.kts
+++ b/bisq-easy/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(project(":presentation"))
 
     implementation("network:network")
+    implementation("network:network-identity")
     implementation("wallets:core")
     // implementation("wallets:electrum")
     // implementation("wallets:bitcoind")

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
@@ -25,9 +25,11 @@ import bisq.common.application.Service;
 import bisq.common.currency.MarketRepository;
 import bisq.common.observable.Observable;
 import bisq.common.observable.Pin;
+import bisq.common.util.CompletableFutureUtils;
 import bisq.contract.ContractService;
 import bisq.identity.IdentityService;
 import bisq.network.NetworkService;
+import bisq.network.p2p.services.confidential.resend.ResendMessageData;
 import bisq.network.p2p.services.data.BroadcastResult;
 import bisq.offer.OfferService;
 import bisq.persistence.PersistenceService;
@@ -44,8 +46,12 @@ import bisq.wallets.core.WalletService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 @Slf4j
 @Getter
@@ -152,7 +158,9 @@ public class BisqEasyService implements Service {
             mostRecentMinRequiredReputationScoreOrDefaultPin.unbind();
             selectedMarketPin.unbind();
         }
-        return bisqEasyNotificationsService.shutdown();
+
+        return getStorePendingMessagesInMailboxFuture()
+                .thenCompose(e -> bisqEasyNotificationsService.shutdown());
     }
 
     public boolean isDeleteUserIdentityProhibited(UserIdentity userIdentity) {
@@ -165,6 +173,38 @@ public class BisqEasyService implements Service {
             return CompletableFuture.failedFuture(new RuntimeException("Deleting userProfile is not permitted"));
         }
         return userIdentityService.deleteUserIdentity(userIdentity);
+    }
+
+
+    // At shutdown, we store all pending messages (CONNECT, SENT or TRY_ADD_TO_MAILBOX state) in the mailbox.
+    // We wait until all broadcast futures are completed or timeout if it takes longer as expected.
+    private CompletableFuture<Boolean> getStorePendingMessagesInMailboxFuture() {
+        return CompletableFutureUtils.allOf(getStorePendingMessagesInMailboxFutures())
+                .orTimeout(20, TimeUnit.SECONDS)
+                .handle((broadcastResultList, throwable) -> {
+                    if (throwable != null) {
+                        log.error("flushPendingMessagesToMailboxAtShutdown failed", throwable);
+                        return false;
+                    } else {
+                        log.error("All broadcast futures at getStorePendingMessagesInMailboxFuture completed");
+                        return true;
+                    }
+                });
+    }
+
+    private Stream<CompletableFuture<bisq.network.p2p.services.data.broadcast.BroadcastResult>> getStorePendingMessagesInMailboxFutures() {
+        Set<ResendMessageData> pendingResendMessageDataSet = networkService.getPendingResendMessageDataSet();
+        return networkService.getConfidentialMessageServices().stream()
+                .flatMap(confidentialMessageService ->
+                        pendingResendMessageDataSet.stream()
+                                .flatMap(resendMessageData ->
+                                        userIdentityService.findUserIdentity(resendMessageData.getSenderNetworkId().getId())
+                                                .map(userIdentity -> userIdentity.getNetworkIdWithKeyPair().getKeyPair())
+                                                .flatMap(senderKeyPair -> confidentialMessageService.flushPendingMessagesToMailboxAtShutdown(resendMessageData, senderKeyPair)).stream()
+                                )
+                )
+                .flatMap(sendConfidentialMessageResult -> sendConfidentialMessageResult.getMailboxFuture().stream())
+                .flatMap(Collection::stream);
     }
 
     private void applyDifficultyAdjustmentFactor() {

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
@@ -184,10 +184,15 @@ public class BisqEasyService implements Service {
                 .orTimeout(20, TimeUnit.SECONDS)
                 .handle((broadcastResultList, throwable) -> {
                     if (throwable != null) {
-                        log.error("flushPendingMessagesToMailboxAtShutdown failed", throwable);
+                        log.warn("flushPendingMessagesToMailboxAtShutdown failed", throwable);
                         return false;
                     } else {
-                        log.error("All broadcast futures at getStorePendingMessagesInMailboxFuture completed");
+                        log.info("All broadcast futures at getStorePendingMessagesInMailboxFuture completed. broadcastResultList={}", broadcastResultList);
+                        try {
+                            // We delay a bit before continuing shutdown process. Usually we only have 1 pending message...
+                            Thread.sleep(100 + broadcastResultList.size() * 500L);
+                        } catch (InterruptedException ignore) {
+                        }
                         return true;
                     }
                 });

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
@@ -149,6 +149,7 @@ public class BisqEasyService implements Service {
     }
 
     public CompletableFuture<Boolean> shutdown() {
+        log.info("shutdown");
         if (difficultyAdjustmentFactorPin != null) {
             difficultyAdjustmentFactorPin.unbind();
             ignoreDiffAdjustmentFromSecManagerPin.unbind();

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatus.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatus.java
@@ -24,6 +24,9 @@ public enum MessageDeliveryStatus implements ProtoEnum {
         this.received = received;
     }
 
+    public boolean isPending() {
+        return this == CONNECTING || this == SENT || this == TRY_ADD_TO_MAILBOX;
+    }
 
     @Override
     public bisq.network.protobuf.MessageDeliveryStatus toProtoEnum() {


### PR DESCRIPTION
Implements https://github.com/bisq-network/bisq2/issues/2538

At shutdown we store all pending messages in mailbox. This prevent the issue when a user quickly close the app after sending a message. Before only after restart the message would be resent. Now the peer receives the message as mailbox message immediately.