### PR TITLE
Feature/btc address tx hints

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/BitcoinDataValidator.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/BitcoinDataValidator.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.desktop.components.controls.validator;
+
+import bisq.common.validation.BitcoinDataValidation;
+
+/**
+ * A validator for Bitcoin string format data. Initially thought for txIDs and wallet addresses
+ */
+public abstract class BitcoinDataValidator extends ValidatorBase {
+
+    public enum BitcoinDataType {
+        WALLET_ADDRESS,
+        TX_ID
+    }
+
+    @Override
+    protected void eval() {
+        hasErrors.set(!isValid());
+    }
+
+    /**
+     * @return the data to evaluate at the time of evaluation (eval() gets called)
+     */
+    protected abstract String getData();
+
+    /**
+     *
+     * @return type of validation to use
+     */
+    protected abstract BitcoinDataType getType();
+
+    private boolean isValid() {
+        String data = getData();
+        if (data == null) {
+            return false;
+        }
+        return switch (getType()) {
+            case WALLET_ADDRESS -> BitcoinDataValidation.validateWalletAddressHash(getData());
+            case TX_ID -> BitcoinDataValidation.validateTransactionId(getData());
+        };
+    }
+}

--- a/common/src/main/java/bisq/common/validation/BitcoinDataValidation.java
+++ b/common/src/main/java/bisq/common/validation/BitcoinDataValidation.java
@@ -1,0 +1,58 @@
+package bisq.common.validation;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Pattern;
+
+/*
+ * Copyright 2024 Rodrigo Varela
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility class for Bitcoin identifying if a given string matches the pattern related to a BTC characteristic.
+ * Initially thought to be used for addresses and transaction IDs.
+ *
+ * @author Rodrigo Varela
+ */
+public class BitcoinDataValidation {
+
+    // Regular expressions for different Bitcoin address formats
+    private static final Pattern P2PKH_PATTERN = Pattern.compile("^[1][A-Za-z0-9]{26,34}$");
+    private static final Pattern P2SH_PATTERN = Pattern.compile("^[3][A-Za-z0-9]{26,34}$");
+    private static final Pattern BECH32_PATTERN = Pattern.compile("^(bc1|tb1)[a-z0-9]{25,39}$");
+    private static final Pattern TXID_PATTERN = Pattern.compile("^[a-fA-F0-9]{64}$");
+
+    /**
+     * Checks if the given string is a Bitcoin address.
+     *
+     * @param address The string to be checked.
+     * @return True if it is a Bitcoin address, false otherwise.
+     */
+    public static boolean validateWalletAddressHash(@NotNull String address) {
+        return !address.isBlank() && (P2PKH_PATTERN.matcher(address).matches() ||
+                P2SH_PATTERN.matcher(address).matches() ||
+                BECH32_PATTERN.matcher(address).matches());
+    }
+
+    /**
+     * Checks if the given string is a Bitcoin transaction ID.
+     *
+     * @param txId The string to be checked.
+     * @return True if it is a Bitcoin transaction ID, false otherwise.
+     */
+    public static boolean validateTransactionId(@NotNull String txId) {
+        return TXID_PATTERN.matcher(txId).matches();
+    }
+}

--- a/common/src/test/java/bisq/common/validation/BitcoinDataValidationTest.java
+++ b/common/src/test/java/bisq/common/validation/BitcoinDataValidationTest.java
@@ -1,0 +1,29 @@
+package bisq.common.validation;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BitcoinDataValidationTest {
+
+    @Test
+    public void testValidateWalletAddressHash() {
+        assertTrue(BitcoinDataValidation.validateWalletAddressHash("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")); // P2PKH
+        assertTrue(BitcoinDataValidation.validateWalletAddressHash("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")); // P2SH
+        assertTrue(BitcoinDataValidation.validateWalletAddressHash("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")); // Bech32
+        assertTrue(BitcoinDataValidation.validateWalletAddressHash("bc1qar0srrr7xw7b6gdk9w2v0du8gfpv4p2c5f9l5w")); // Bech32
+        assertFalse(BitcoinDataValidation.validateWalletAddressHash("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t40")); // Invalid Bech32
+        assertFalse(BitcoinDataValidation.validateWalletAddressHash("4A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")); // Invalid address
+        assertFalse(BitcoinDataValidation.validateWalletAddressHash("")); // Empty string
+    }
+
+    @Test
+    public void testValidateTransactionId() {
+        assertTrue(BitcoinDataValidation.validateTransactionId("4b1ecb5cf2b6f254dc2b82c4e6a6c44f11b1e9d35cce63143142b6eae3c721c2")); // Valid TXID
+        assertTrue(BitcoinDataValidation.validateTransactionId("4b1fcb5cf2b6f254dc2b82c4e6a6c14f11b1e9d33cce63143142b6e3e3c721c2")); // Valid TXID
+        assertFalse(BitcoinDataValidation.validateTransactionId("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0")); // Valid TXID
+        assertFalse(BitcoinDataValidation.validateTransactionId("InvalidAddressOrTxId")); // Invalid address or TXID
+        assertFalse(BitcoinDataValidation.validateTransactionId("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t01")); // Invalid TXID
+        assertFalse(BitcoinDataValidation.validateTransactionId("")); // Empty string
+    }
+}

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -314,6 +314,8 @@ bisqEasy.takeOffer.tradeLogMessage={0} has sent a message for taking {1}''s offe
 
 bisqEasy.takeOffer.noMediatorAvailable.warning=There is no mediator available. You have to use the support chat instead.
 bisqEasy.takeOffer.makerBanned.warning=The maker of this offer is banned. Please try to use a different offer.
+bisqEasy.takeOffer.btcAddress.warning=The Bitcoin address that you have entered appears to be invalid. If you are sure the address is valid you can ignore this warning and proceed.
+bisqEasy.takeOffer.btcAddress.warning.proceed=Ignore warning
 
 
 ################################################################################
@@ -755,6 +757,9 @@ bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.paymentProof.LN=Preimage
 bisqEasy.tradeState.info.seller.phase3a.btcSentButton=I confirm to have sent {0}
 bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage={0} initiated the Bitcoin transfer. {1}: ''{2}''
 bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.noProofProvided={0} initiated the Bitcoin transfer.
+
+bisqEasy.tradeState.info.seller.phase3a.txId.warning=The Transaction ID that you have entered appears to be invalid. If you are sure the Transaction ID is valid you can ignore this warning and proceed.
+bisqEasy.tradeState.info.seller.phase3a.txId.warning.proceed=Ignore warning
 
 bisqEasy.tradeState.info.seller.phase3b.headline=Waiting for blockchain confirmation
 bisqEasy.tradeState.info.seller.phase3b.info=The Bitcoin transaction require at least 1 blockchain confirmation to be considered complete.


### PR DESCRIPTION
**Related issues**

 - Implementation of https://github.com/bisq-network/bisq2/issues/1473
 - Implementation of https://github.com/bisq-network/bisq2/issues/1474

**Approach**

 - Pattern based validator for BTC addresses and txIds. Unit test provided
 - Warning pop up on every user input for these strings, allowing to proceed if the user wants to dismiss the warning.