### PR TITLE
Versioning build short commit hash

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavController.java
@@ -66,8 +66,12 @@ public class LeftNavController implements Controller {
 
         NetworkInfo networkInfo = new NetworkInfo(serviceProvider, this::onNavigationTargetSelected);
         model = new LeftNavModel(serviceProvider.getWalletService().isPresent());
-        model.setVersion("v" + ApplicationVersion.getVersion().toString());
+        model.setVersion(buildVersionString());
         view = new LeftNavView(model, this, networkInfo.getRoot());
+    }
+
+    private static String buildVersionString() {
+        return "v" + ApplicationVersion.getVersion().toString() + " (" + ApplicationVersion.getBuildCommitShortHash() + ")";
     }
 
     @Override

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,11 +17,18 @@ val generateVersionClass by tasks.registering {
         outputDir.mkdirs()
         versionFile.parentFile.mkdirs()
 
+        val gitCommitVersion = try {
+            val process = ProcessBuilder("git", "rev-parse", "--short", "HEAD").start()
+            process.inputStream.bufferedReader().use { it.readText().trim() }
+        } catch (e: Exception) {
+            "unknown"
+        }
         versionFile.writeText("""
             package bisq.common.application;
 
             public final class BuildVersion {
                 public static final String VERSION = "${project.version}";
+                public static final String COMMIT_SHORT_HASH = "$gitCommitVersion";
             }
         """.trimIndent())
     }

--- a/common/src/main/java/bisq/common/application/ApplicationVersion.java
+++ b/common/src/main/java/bisq/common/application/ApplicationVersion.java
@@ -32,4 +32,8 @@ public class ApplicationVersion {
         }
         return version;
     }
+
+    public static String getBuildCommitShortHash() {
+        return BuildVersion.COMMIT_SHORT_HASH;
+    }
 }


### PR DESCRIPTION
 - Implementation for https://github.com/bisq-network/bisq2/issues/2532
 - gradle BuildVersion class generation includes build commit short hash
 - make the build version short hash available through ApplicationVersion
 - Provided usage on bisq logo version
 
 
![Screenshot from 2024-08-08 14-38-20](https://github.com/user-attachments/assets/45db1651-bb6e-4343-9dde-8a22ecd266d4)
