### PR TITLE
Shut down orphaned connections.

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/node/CloseReason.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/CloseReason.java
@@ -40,6 +40,7 @@ public enum CloseReason {
     TOO_MANY_INBOUND_CONNECTIONS(true),
     TOO_MANY_CONNECTIONS(true),
     BANNED(false),
+    ORPHANED_CONNECTION(false),
     EXCEPTION(false);
 
     private final boolean isGraceful;

--- a/network/network/src/main/java/bisq/network/p2p/node/Connection.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Connection.java
@@ -272,7 +272,8 @@ public abstract class Connection {
         }
         log.info("Close {}; \ncloseReason: {}", this, closeReason);
         shutdownStarted = true;
-        requestResponseManager.onClosed();
+        requestResponseManager.dispose();
+        connectionMetrics.clear();
         if (inputHandlerFuture != null) {
             inputHandlerFuture.cancel(true);
         }

--- a/network/network/src/main/java/bisq/network/p2p/node/ConnectionThrottle.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/ConnectionThrottle.java
@@ -45,7 +45,7 @@ public class ConnectionThrottle {
     private static final long MAX_LOG_FREQUENCY = TimeUnit.SECONDS.toMillis(30);
 
     // We apply the log throttle globally, so we use static fields
-    private static AtomicLong lastLoggedTs = new AtomicLong();
+    private static final AtomicLong lastLoggedTs = new AtomicLong();
     private static final List<String> LAST_LOGS = new CopyOnWriteArrayList<>();
 
     private final NetworkLoadSnapshot peersNetworkLoadSnapshot;

--- a/network/network/src/main/java/bisq/network/p2p/node/RequestResponseManager.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/RequestResponseManager.java
@@ -63,7 +63,7 @@ public class RequestResponseManager {
         maybeRemoveExpired();
     }
 
-    void onClosed() {
+    void dispose() {
         pendingRequests.clear();
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/ConnectionMetrics.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/ConnectionMetrics.java
@@ -175,6 +175,18 @@ public class ConnectionMetrics {
         return sumOfLastMinute(deserializeTimePerMinute, lastMinutes);
     }
 
+    public void clear() {
+        numMessagesSentPerMinute.clear();
+        sentBytesPerMinute.clear();
+        spentSendMessageTimePerMinute.clear();
+        deserializeTimePerMinute.clear();
+        numMessagesReceivedPerMinute.clear();
+        receivedBytesPerMinute.clear();
+        numSentMessagesByMessageClassName.clear();
+        numReceivedMessagesByMessageClassName.clear();
+        rrtList.clear();
+    }
+
     private long sumOf(TreeMap<Integer, AtomicLong> treeMap) {
         return treeMap.values().stream().mapToLong(AtomicLong::get).sum();
     }


### PR DESCRIPTION
Add clear method to ConnectionMetrics.

We got handleNetworkMessage called from an orphaned connection which is not managed by our outboundConnectionsByAddress or inboundConnectionsByAddress maps. We close after a short delay that connection to avoid memory leaks. We still notify listeners as its is unclear yet if there are valid listeners in that case.