### PR TITLE
Update notification badge when text chat message is removed

### DIFF
--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -261,6 +261,7 @@ public class ChatNotificationService implements PersistenceClient<ChatNotificati
             wasRemoved = candidate.map(notification -> {
                         boolean result = persistableStore.getNotifications().remove(notification);
                         if (result) {
+                            changedNotification.set(null);
                             changedNotification.set(notification);
                         }
                         return result;


### PR DESCRIPTION
This was only working when the chat message was an offer. For text-only chat messages, the number in the notifications badge of the items in the channel selection wasn't updated when the text message was removed.

Fixes #2577