### PR TITLE
packaging: Add Windows MSI support

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/PackageFormat.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/PackageFormat.kt
@@ -4,5 +4,6 @@ enum class PackageFormat(val fileExtension: String) {
     DEB("deb"),
     DMG("dmg"),
     EXE("exe"),
+    MSI("msi"),
     RPM("rpm")
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/WindowsPackage.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/WindowsPackage.kt
@@ -3,7 +3,7 @@ package bisq.gradle.packaging.jpackage.package_formats
 import java.nio.file.Path
 
 class WindowsPackage(private val resourcesPath: Path) : JPackagePackageFormatConfigs {
-    override val packageFormats = setOf(PackageFormat.EXE)
+    override val packageFormats = setOf(PackageFormat.EXE, PackageFormat.MSI)
 
     override fun createArgumentsForJPackage(packageFormat: PackageFormat): List<String> =
             mutableListOf(


### PR DESCRIPTION
Users have to manually update Bisq and to support auto-updates we need to ship msi files. We can't use the existing exe file because it requires user interaction during installation or updating.