### PR TITLE
Improve chat notifications efficiency

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -325,7 +325,6 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     private void updateFilteredMarketChannelItems() {
         model.getFilteredMarketChannelItems().setPredicate(null);
         model.getFilteredMarketChannelItems().setPredicate(marketChannelItemsPredicate);
-        model.getMarketChannelItems().forEach(MarketChannelItem::onActivate);
     }
 
     private void updateFavouriteMarketChannelItems() {
@@ -336,7 +335,6 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         model.getFavouriteMarketChannelItems().setPredicate(favouriteMarketChannelItemsPredicate);
         model.getFavouritesTableViewHeightChanged().set(false);
         model.getFavouritesTableViewHeightChanged().set(true);
-        model.getMarketChannelItems().forEach(MarketChannelItem::onActivate);
     }
 
     private void maybeSelectFirst() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -220,12 +220,11 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         updateFavouriteMarketChannelItems();
         maybeSelectFirst();
 
-        changedNotificationPin = chatNotificationService.getChangedNotification().addObserver(notification ->
-                UIThread.run(() -> {
-                    if (notification != null) {
-                        applyNotification(notification);
-                    }
-                }));
+        changedNotificationPin = chatNotificationService.getChangedNotification().addObserver(notification -> {
+            if (notification != null) {
+                UIThread.run(() -> applyNotification(notification));
+            }
+        });
     }
 
     private void applyNotification(ChatNotification notification) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -230,7 +230,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
 
     private void applyNotification(ChatNotification notification) {
         findMarketChannelItem(notification.getChatChannelId())
-                .ifPresent(marketplaceChannelItem -> marketplaceChannelItem.applyNotification(notification));
+                .ifPresent(MarketChannelItem::refreshNotifications);
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.bisq_easy.offerbook;
 
 import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookChannel;
 import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
-import bisq.chat.notifications.ChatNotification;
 import bisq.chat.notifications.ChatNotificationService;
 import bisq.common.currency.Market;
 import bisq.desktop.common.threading.UIThread;
@@ -73,14 +72,10 @@ public class MarketChannelItem {
 
         channel.getChatMessages().addObserver(new WeakReference<Runnable>(this::updateNumOffers).get());
         updateNumOffers();
-
-        chatNotificationService.getNotConsumedNotifications(channel).forEach(this::applyNotification);
+        refreshNotifications();
     }
 
-    void applyNotification(ChatNotification notification) {
-        if (notification == null) {
-            return;
-        }
+    void refreshNotifications() {
         long numNotifications = chatNotificationService.getNumNotifications(channel);
         String value = "";
         if (numNotifications > 9) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -22,7 +22,6 @@ import bisq.chat.bisqeasy.offerbook.BisqEasyOfferbookMessage;
 import bisq.chat.notifications.ChatNotification;
 import bisq.chat.notifications.ChatNotificationService;
 import bisq.common.currency.Market;
-import bisq.common.observable.Pin;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.components.MarketImageComposition;
@@ -56,7 +55,6 @@ public class MarketChannelItem {
     private final IntegerProperty numOffers = new SimpleIntegerProperty(0);
     private final BooleanProperty isFavourite = new SimpleBooleanProperty(false);
     private final StringProperty numMarketNotifications = new SimpleStringProperty();
-    private Pin changedChatNotificationPin;
 
     MarketChannelItem(BisqEasyOfferbookChannel channel,
                       FavouriteMarketsService favouriteMarketsService,
@@ -77,25 +75,9 @@ public class MarketChannelItem {
         updateNumOffers();
 
         chatNotificationService.getNotConsumedNotifications(channel).forEach(this::applyNotification);
-
-        onActivate();
     }
 
-    void onActivate() {
-        if (changedChatNotificationPin != null) {
-            changedChatNotificationPin.unbind();
-        }
-        changedChatNotificationPin = chatNotificationService.getChangedNotification().addObserver(notification ->
-                UIThread.run(() -> applyNotification(notification)));
-    }
-
-    void onDeactivate() {
-        if (changedChatNotificationPin != null) {
-            changedChatNotificationPin.unbind();
-        }
-    }
-
-    private void applyNotification(ChatNotification notification) {
+    void applyNotification(ChatNotification notification) {
         if (notification == null) {
             return;
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -34,8 +34,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.lang.ref.WeakReference;
-
 @Slf4j
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
@@ -70,8 +68,6 @@ public class MarketChannelItem {
         setUpColorAdjustments();
         marketLogo.setEffect(DEFAULT_COLOR_ADJUST);
 
-        channel.getChatMessages().addObserver(new WeakReference<Runnable>(this::updateNumOffers).get());
-        updateNumOffers();
         refreshNotifications();
     }
 
@@ -86,6 +82,7 @@ public class MarketChannelItem {
             value = String.valueOf(numNotifications);
         }
         numMarketNotifications.set(value);
+        updateNumOffers();
     }
 
     private void setUpColorAdjustments() {

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -370,10 +370,6 @@ public class ChatNotificationService implements PersistenceClient<ChatNotificati
             return;
         }
 
-        if (isConsumed(chatNotification)) {
-            return;
-        }
-
         // At first start-up when user has not setup their profile yet, we set all notifications as consumed
         if (!userIdentityService.hasUserIdentities()) {
             consumeNotification(chatNotification);


### PR DESCRIPTION
Removes all bindings from MarketplaceChannelItem, that were also being re-created per each notification, to create a single binding in BisqEasyOfferbookController. Now each notification is processed only once to update the numbers of the channel where it was produced instead of refreshing all channels.