### PR TITLE
Fix application version in user profile bug

### DIFF
--- a/user/src/main/java/bisq/user/profile/UserProfileService.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileService.java
@@ -154,7 +154,10 @@ public class UserProfileService implements PersistenceClient<UserProfileStore>, 
 
     private void processUserProfileAddedOrRefreshed(UserProfile userProfile) {
         Optional<UserProfile> existingUserProfile = findUserProfile(userProfile.getId());
-        if (existingUserProfile.isEmpty() || !existingUserProfile.get().equals(userProfile)) {
+        // ApplicationVersion is excluded in equals check, so we check manually for it.
+        if (existingUserProfile.isEmpty() ||
+                !existingUserProfile.get().equals(userProfile)
+                || !existingUserProfile.get().getApplicationVersion().equals(userProfile.getApplicationVersion())) {
             if (verifyUserProfile(userProfile)) {
                 ObservableHashMap<String, UserProfile> userProfileById = getUserProfileById();
                 synchronized (persistableStore) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/2641

Unfortunately the application version is currently only set to 2.1.0 for newly registered user profiles as the republishing use the user profile from the user identity and that does not get updated. Also we have been missing a check for a changed applicationVersion as that is excluded in the equals check.
The app version distribution is used for the preferred version number at handshakes and other messages where we send currently 2 messages with version 0 and 1 if the first fails. To look at the app version distribution would be an optimization that the chances for the matching version is higher.
All that is not a critical problem, but it would be good to not have a very long delay to the next update where we can fix/adjust those issues.
 