### PR TITLE
Fix Kotlin DSL warning

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    `kotlin-dsl` apply false
+}


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/2530

https://youtrack.jetbrains.com/issue/KT-64210/False-positive-warning-that-Kotlin-Gradle-plugin-was-loaded-multiple-times-in-different-subprojects-is-displayed