### PR TITLE
Proguard integration for jars optimization

### DIFF
--- a/.github/workflows/build_bisq_module.yml
+++ b/.github/workflows/build_bisq_module.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Gradle Build Action
         uses: gradle/gradle-build-action@v3.5.0
         with:
-          arguments: build --scan
+          arguments: clean build --scan
           build-root-directory: ${{ inputs.build-root-dir }}
           gradle-executable: ./gradlew
-          gradle-version: 8.8
+          gradle-version: 8.9

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ hs_err_pid*
 *.wallet
 *.ser
 *.sh
+*.py
 .DS_Store
 .gradle
 build

--- a/apps/build.gradle.kts
+++ b/apps/build.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+    id("bisq.gradle.packaging.ProGuardPlugin") version "0.1.0"
+}
+
+proguardConfig {
+    rulesFileRelativePath = "../../"
+}
+
 extensions.findByName("buildScan")?.withGroovyBuilder {
     setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
     setProperty("termsOfServiceAgree", "yes")

--- a/apps/desktop/desktop-app/build.gradle.kts
+++ b/apps/desktop/desktop-app/build.gradle.kts
@@ -78,8 +78,18 @@ tasks {
     }
 
     named<ShadowJar>("shadowJar") {
+        // Directory where the JARs are located
+        val inputDir = file("${project.layout.buildDirectory.get()}/install/desktop-app/lib")
+
+        // Configure the task to include only JARs that do not have `-unobfuscated` in their names
+        from(fileTree(inputDir).matching {
+            include("*.jar")
+            exclude { file ->
+                file.name.contains("-unobfuscated")
+            }
+        })
         val platformName = getPlatform().platformName
-        archiveClassifier.set(platformName + "-all")
+        archiveClassifier.set("$platformName-all")
     }
 
     distZip {

--- a/apps/seed-node-app/build.gradle.kts
+++ b/apps/seed-node-app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("bisq.java-library")
+    id("bisq.gradle.packaging.ProGuardPlugin") version "0.1.0"
     application
 }
 
@@ -24,6 +25,9 @@ dependencies {
 }
 
 tasks {
+    installDist {
+        dependsOn("proguardTask") // Ensure that ProGuard runs before installation
+    }
     distZip {
         enabled = false
     }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,3 +1,8 @@
 plugins {
     `kotlin-dsl` apply false
+    java
+}
+
+tasks.named("clean") {
+    dependsOn(subprojects.map { it.tasks.named("clean") })
 }

--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
         testAnnotationProcessor(it)
         testCompileOnly(it)
     }
+    // needed for proguard
+    implementation("org.projectlombok:lombok:1.18.34")
 
     versionCatalog.findLibrary("slf4j-api").ifPresent {
         implementation(it)

--- a/build-logic/commons/src/main/kotlin/bisq.java-library.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-library.gradle.kts
@@ -4,5 +4,10 @@ plugins {
 
 dependencies {
     api(platform("bisq:platform"))
+    implementation("com.guardsquare:proguard-gradle:7.5.0") {
+        exclude(group = "com.guardsquare", module = "proguard-base")
+        exclude(group = "com.guardsquare", module = "proguard-gradle")
+    }
     implementation("bisq:common")
+    testImplementation("bisq:common")
 }

--- a/build-logic/commons/src/main/kotlin/bisq.protobuf.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.protobuf.gradle.kts
@@ -10,13 +10,37 @@ repositories {
 
 val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
-    versionCatalog.findLibrary("protobuf-java").ifPresent {
-        implementation(it)
-    }
+    implementation("com.google.protobuf:protobuf-java:4.27.3")
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.19.4"
+        artifact = "com.google.protobuf:protoc:4.27.3"
+    }
+//    generateProtoTasks {
+//        all().forEach { task ->
+//            task.builtins {
+//                create("java") {
+//                    option("lite")
+//                }
+//            }
+//        }
+//    }
+}
+
+tasks.withType<JavaCompile> {
+    dependsOn(tasks.named("generateProto"))
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir("build/generated/source/proto/main/java")
+        }
+    }
+    test {
+        java {
+            srcDir("build/generated/source/proto/test/java")
+        }
     }
 }

--- a/build-logic/packaging/build.gradle.kts
+++ b/build-logic/packaging/build.gradle.kts
@@ -13,6 +13,10 @@ gradlePlugin {
             id = "bisq.gradle.packaging.PackagingPlugin"
             implementationClass = "bisq.gradle.packaging.PackagingPlugin"
         }
+        create("ProGuardPlugin") {
+            id = "bisq.gradle.packaging.ProGuardPlugin"
+            implementationClass = "bisq.gradle.packaging.ProGuardPlugin"
+        }
     }
 }
 
@@ -20,4 +24,11 @@ dependencies {
     implementation(project(":gradle-tasks"))
     implementation(project(":commons"))
     implementation(libs.commons.codec)
+    implementation("com.guardsquare:proguard-gradle:7.5.0") {
+        exclude(group = "com.guardsquare", module = "proguard-base")
+        exclude(group = "com.guardsquare", module = "proguard-gradle")
+    }
 }
+
+group = "bisq.gradle"
+version = "0.1.0"

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -34,7 +34,9 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         val installDistTask: TaskProvider<Sync> = project.tasks.named("installDist", Sync::class.java)
 
         val generateHashesTask = project.tasks.register<Sha256HashTask>("generateHashes") {
-            inputDirFile.set(installDistTask.map { File(it.destinationDir, "lib") })
+            inputFiles.set(installDistTask.map { File(it.destinationDir, "lib").listFiles()?.filter { file ->
+                !file.name.contains("unobfuscated")
+            }?.toList() ?: emptyList() })
             outputFile.set(getHashFileForOs(project, extension))
         }
 

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/ProGuardPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/ProGuardPlugin.kt
@@ -1,0 +1,329 @@
+package bisq.gradle.packaging
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.JavaExec
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.*
+import java.io.File
+import java.nio.file.Paths
+import java.util.Properties
+import java.util.jar.JarFile
+import java.util.zip.ZipFile
+
+/**
+ * Allows to configure relativity to proguard config file (root) from any composite submodule build.gradle.kts
+ */
+open class ProGuardExtension {
+    var rulesFileRelativePath: String? = null
+    var enabled: Boolean = true
+}
+/**
+ * A Gradle plugin that applies ProGuard to obfuscate Java bytecode in leaf projects.
+ *
+ * This plugin is designed to be applied to a Gradle root and will configure ProGuard tasks for each leaf project.
+ * The plugin will only apply ProGuard to leaf projects that have no subprojects and are not blacklisted.
+ * On gradle composite setups like the one we use, you need to apply it to each composite "root"
+ *
+ * The plugin will create a "proguardTask" for each leaf project and configure it to run ProGuard on the project's JAR files.
+ * The plugin will also configure the "jar" task to depend on the "proguardTask", ensuring that the obfuscated JAR is generated.
+ *
+ * The plugin will log information about the leaf projects it applies ProGuard to and will provide warnings for any leaf projects
+ * that are blacklisted or have subprojects.
+ *
+ * The plugin will also provide a "listJars" task that can be used to list the JAR files in the "build/libs" directory of each leaf project.
+ *
+ * @author Rodrigo Varela
+ */
+class ProGuardPlugin : Plugin<Project> {
+    companion object {
+        val BLACKLISTED = listOf("platform", "i2p")
+        const val UNPROGUARDED_KEY = "unproguarded"
+    }
+
+    override fun apply(project: Project) {
+        val extension = project.extensions.create("proguardConfig", ProGuardExtension::class.java)
+
+        if (extension.rulesFileRelativePath == null) {
+            project.logger.warn("WARNING: rules file path not configured, using ${project.rootDir.path}")
+            extension.rulesFileRelativePath = project.rootDir.path
+            // Fix for build servers (github)
+            if (project.rootDir.path.endsWith("/apps")) {
+                extension.rulesFileRelativePath = project.rootDir.path.replace("/apps", "")
+            }
+        }
+        val propertiesFile = File(extension.rulesFileRelativePath, "gradle.properties")
+        if (propertiesFile.exists()) {
+            val properties = Properties().apply { load(propertiesFile.inputStream()) }
+            extension.enabled = properties.getProperty("proguard.enable", "true").toBoolean()
+        } else {
+            project.logger.warn("gradle.properties not found at: ${extension.rulesFileRelativePath}")
+        }
+
+        val configured = mutableSetOf<String>()
+        setupListJars(project)
+        project.afterEvaluate {
+            project.allprojects {
+                configureProGuardForLeafProjects(project, extension, configured)
+            }
+        }
+    }
+
+    private fun configureProGuardForLeafProjects(project: Project,
+                                                 extension: ProGuardExtension,
+                                                 configured: MutableSet<String>) {
+        if (project.subprojects.isEmpty()
+            && !BLACKLISTED.contains(project.name)) {
+
+            if (!configured.contains(project.name)) {
+                setupListJars(project)
+                configured.add(project.name)
+            }
+//            println("${project.name} is a leaf project.")
+
+
+            var proguardTask = project.tasks.findByName("proguardTask")
+            if (proguardTask == null) {
+                project.tasks.register<JavaExec>("proguardTask") {
+
+                }
+                proguardTask = project.tasks.findByName("proguardTask")
+            }
+            (proguardTask as JavaExec).apply {
+                //            dependsOn("build") // Ensure JARs are built before running ProGuard
+                mainClass.set("proguard.ProGuard")
+                group = "build"
+                description = "Runs ProGuard to obfuscate the code."
+                enabled = extension.enabled
+
+                val classpathConfig = project.configurations.findByName("runtimeClasspath")
+                    ?: project.configurations.findByName("compileClasspath")
+                    ?: project.configurations.findByName("default")
+
+                if (classpathConfig != null) {
+                    classpath = classpathConfig
+//                    println("Using classpath ${classpathConfig.name} for project ${project.name}")
+                } else {
+//                    println("WARNING: No suitable classpath found for project ${project.name}")
+                }
+
+                doFirst {
+                    var inputDir = File("${project.layout.buildDirectory.get()}/libs")
+                    var outputDir = File("${project.layout.buildDirectory.get()}/libs/${UNPROGUARDED_KEY}")
+                    val originalFiles =
+                        inputDir.listFiles { file -> file.extension == "jar" }
+                            ?.filter { hasClasses(it) } ?: emptyList()
+                    // original jar task output dir
+
+                    if (!outputDir.exists()) {
+                        outputDir.mkdirs()
+                    }
+                    originalFiles.forEach { jarFile ->
+                        val targetFile = File(outputDir, "${jarFile.nameWithoutExtension}.jar")
+                        try {
+                            jarFile.copyTo(targetFile, overwrite = true)
+                            println("Copied ${jarFile.absolutePath} to ${targetFile.absolutePath}")
+                        } catch (e: Exception) {
+                            println("WARNING: Failed to copy ${jarFile.absolutePath} to ${targetFile.absolutePath} : ${e.message}")
+                        }
+                    }
+
+                    // Configure ProGuard task for this leaf project
+                    inputDir = File("${project.layout.buildDirectory.get()}/libs/${UNPROGUARDED_KEY}")
+                    outputDir = File("${project.layout.buildDirectory.get()}/libs")
+                    val rulesFile = File("${extension.rulesFileRelativePath}/proguard-rules.pro".replace("//", "/"))
+
+                    // Collect library JARs from runtimeClasspath - needed for tests to pass
+                    val myClasspath = project.configurations.findByName("runtimeClasspath")
+                        ?: project.configurations.findByName("compileClasspath")
+                        ?: project.configurations.findByName("default")
+                    val libraryJars = myClasspath?.filter { it.name.endsWith(".jar") && hasClasses(it) }
+                        ?.map { it.absolutePath } ?: emptyList()
+
+
+                    // Detect the Java runtime library path
+                    // this is very important to avoid proguard "Cannot find symbol" nightmare warnings
+                    val javaHome = System.getProperty("java.home")
+                    val javaRuntimeJars = listOf(
+                        Paths.get(javaHome, "jmods", "java.base.jmod").toFile(),
+                        Paths.get(javaHome, "jmods", "jdk.management.jmod").toFile(),  // For java.lang.management
+                        Paths.get(javaHome, "jmods", "jdk.unsupported.jmod").toFile(),  // For sun.nio and other internal classes
+                        Paths.get(javaHome, "jmods", "jdk.httpserver.jmod").toFile(),  // For sun.nio and other internal classes
+                        Paths.get(javaHome, "jmods", "java.desktop.jmod").toFile(),   // For javax and swing and other internal classes
+                    )
+
+                    val libClasspathLogWhitelist = listOf("protobuf", "common")
+
+                    libraryJars.forEach { libName ->
+                        if (libClasspathLogWhitelist.any { libName.contains(it) })
+                            println("library used: $libName")
+                    }
+
+                    // Prepare arguments for ProGuard
+                    // use the original targe dir to get jar names
+                    val inputJars =
+                        outputDir.listFiles { file -> file.extension == "jar" }?.filter { hasClasses(it) } ?: emptyList()
+
+                    // Prepare arguments for ProGuard
+                    args = inputJars.flatMap { jarFile ->
+                        listOf(
+                            "-injars", "${inputDir}/${jarFile.nameWithoutExtension}.jar",
+                            "-outjars", "${outputDir}/${jarFile.nameWithoutExtension}.jar",
+                        )
+                    } + libraryJars.flatMap { jarPath ->
+                        listOf(
+                            "-libraryjars", jarPath
+                        )
+                    } + javaRuntimeJars.flatMap { jarPath ->
+                        listOf(
+                            "-libraryjars", jarPath.absolutePath
+                        )
+                    } + listOf(
+                        "@${rulesFile}" // Path to ProGuard rules file
+                    )
+                }
+                onlyIf {
+                    // use output dir because files haven't been moved at this point
+                    (File("${project.layout.buildDirectory.get()}/libs").listFiles { file -> file.extension == "jar" }?.filter { hasClasses(it) } ?: emptyList()).isNotEmpty()
+                }
+            }
+
+            if (extension.enabled) {
+                project.apply(plugin = "java")
+
+                project.repositories {
+                    mavenCentral()
+                }
+                // Ensure the ProGuard task is finalized by the build task
+                val jarTask = project.tasks.findByName("jar")
+                if (jarTask != null) {
+                    // Ensure the ProGuard task is finalized by the build task
+                    project.tasks.named<Jar>("jar") {
+                        finalizedBy("proguardTask")
+                        //project.subprojects.forEach {
+                        //    mustRunAfter(it.tasks.named("proguardTask"))
+                        //}
+                    }
+
+                    setupTestDependencies(project)
+                } else {
+                    println("WARNING: No 'build' task found in ${project.name}. Cannot bind proguard task to build for this case")
+                }
+            }
+        } else {
+            // Recursive case: Iterate over subprojects
+            for (subproject in project.subprojects) {
+                configureProGuardForLeafProjects(subproject, extension, configured)
+            }
+        }
+    }
+
+    /**
+     * Sets up test dependencies for the given project.
+     *
+     * This function is specifically designed to handle the "persistence" project and its dependency on the "common" project.
+     * If the given project is named "persistence", it configures the "test" task to run after the "proguardTask" of the "common" project.
+     * Additionally, it optionally ensures that the "test" task waits for the entire build process of the "common" module.
+     *
+     * IMPORTANT NOTE: persistence:test won't pass in default multi-thread gradle setup without this tweak
+     *
+     * @param project The Gradle project for which to set up test dependencies
+     */
+    private fun setupTestDependencies(project: Project) {
+        try {
+            if (!BLACKLISTED.contains(project.name)) {
+                project.tasks.named("test") {
+                    val commonProject = project.rootProject.findProject(":common")
+                    if (commonProject != null && project.name != "common") {
+                        // Ensure persistence:test starts after common:proguardTask
+                        mustRunAfter(commonProject.tasks.named("proguardTask"))
+
+                        // Optionally ensure it also waits for the entire build process of the common module
+                        dependsOn(commonProject.tasks.named("build"))
+                    }
+                    //mustRunAfter(project.tasks.named("proguardTask"))
+                }
+
+            }
+        } catch (e: Exception) {
+            println("WARNING: Project ${project.name} doesn't have common dependency")
+        }
+    }
+
+    private fun setupListJars(project: Project) {
+        val listJarsTask = project.tasks.findByName("listJars")
+        if (listJarsTask == null) {
+            project.tasks.register("listJars") {
+                doLast {
+                    printJarWithSize(project)
+                }
+            }
+        } else {
+            project.tasks.named("listJars").configure {
+                doLast {
+                    printJarWithSize(project)
+                }
+            }
+        }
+    }
+
+    private fun hasClasses(jarFile: File): Boolean {
+        try {
+            verifyReadableZip(jarFile)
+            JarFile(jarFile).use { jar ->
+                return jar.entries().asSequence().any { it.name.endsWith(".class") }
+            }
+        } catch (e: Exception) {
+            println("ERROR: Error checking for classes in ${jarFile.absolutePath}: ${e.message}")
+            return false
+        }
+    }
+
+    private fun verifyReadableZip(jarFile: File) {
+        if (!jarFile.exists()) {
+            println("File does not exist.")
+            throw IllegalArgumentException("File does not exist")
+        }
+
+        try {
+            ZipFile(jarFile).use { zip ->
+                zip.entries().asSequence().filter { !it.isDirectory }.forEach { entry ->
+                    zip.getInputStream(entry).use { inputStream ->
+                        inputStream.readBytes() // Read the bytes to ensure the entry is readable
+                    }
+                }
+            }
+            //println("ZIP file is intact.")
+        } catch (e: Exception) {
+            println("ZIP file is corrupted or cannot be opened.")
+            throw e
+        }
+    }
+
+    private fun printJarWithSize(project: Project) {
+        var size = 0.0
+        var unproguardSize = 0.0
+        project.file("build/libs").listFiles()?.forEach { file ->
+            try {
+                var fileToPrint = file
+                var unobfuscated = false
+                if (fileToPrint.absolutePath.contains(UNPROGUARDED_KEY)) {
+                    unobfuscated = true
+                    fileToPrint = File(file.absolutePath).listFiles()?.ifEmpty { arrayOf(file) }?.first() ?: file
+                }
+                val fileSizeInMB = fileToPrint.length() / (1024.0)
+                if (unobfuscated) {
+                    unproguardSize = fileSizeInMB;
+                } else {
+                    size = fileSizeInMB;
+                }
+                println("${project.name}: ${if (unobfuscated) "${UNPROGUARDED_KEY}/" else ""}${fileToPrint.name} (${String.format("%.2f", fileSizeInMB)} KB)")
+            } catch (e: Exception) {
+                println("ERROR: Error printing ${e.message}")
+            }
+        }
+        if (unproguardSize > 0.0) {
+            println("${project.name}: Size optimization: ${String.format("%.2f", 100 * (unproguardSize - size) / unproguardSize )}%")
+        }
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Sha256HashTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/Sha256HashTask.kt
@@ -5,8 +5,10 @@ import bisq.gradle.common.getOS
 import org.apache.commons.codec.binary.Hex
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -15,8 +17,8 @@ import java.security.MessageDigest
 
 abstract class Sha256HashTask : DefaultTask() {
 
-    @get:InputDirectory
-    abstract val inputDirFile: Property<File>
+    @get:InputFiles
+    abstract val inputFiles: ListProperty<File>
 
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
@@ -25,11 +27,10 @@ abstract class Sha256HashTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        val fileHashes = inputDirFile.get().listFiles()!!
-            .map { file ->
-                val hash = digest.digest(file.readBytes())
-                Pair(file.name, Hex.encodeHexString(hash))
-            }
+        val fileHashes = inputFiles.get().map { file ->
+            val hash = digest.digest(file.readBytes())
+            Pair(file.name, Hex.encodeHexString(hash))
+        }
 
         // linux:file_name:sha256_hash
         val osName = getOsName()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,64 @@
+plugins {
+    java
+    id("bisq.gradle.packaging.ProGuardPlugin") version "0.1.0"
+}
+
+repositories {
+    mavenCentral()
+}
+
+tasks.register("buildAll") {
+    group = "build"
+    description = "Build the entire project leaving it ready to work with."
+
+    doLast {
+        listOf(
+            "build",
+            ":apps:seed-node-app:build",
+            ":apps:seed-node-app:installDist",
+            ":apps:desktop:desktop-app:build",
+            ":apps:desktop:desktop-app:installDist",
+            ":apps:desktop:desktop-app-launcher:generateInstallers",
+//            ":REPLACEME:build",
+        ).forEach {
+            exec {
+                println("Executing Build: $it")
+                commandLine("./gradlew", it)
+            }
+        }
+    }
+}
+
+tasks.register("cleanAll") {
+    group = "build"
+    description = "Cleans the entire project."
+
+    doLast {
+        listOf(
+            ":apps:seed-node-app:clean",
+            ":apps:oracle-node-app:clean",
+            ":apps:rest-api-app:clean",
+            ":apps:desktop:desktop-app:clean",
+            ":apps:desktop:desktop:clean",
+            ":apps:desktop:desktop-app-launcher:clean",
+            ":apps:desktop:webcam-app:clean",
+            ":bisq-easy:clean",
+            ":persistence:clean",
+            ":build-logic:clean", // not really necessary
+            ":network:clean",
+            ":application:clean",
+            ":wallets:clean",
+            "clean",
+//            ":REPLACEME:clean",
+        ).forEach {
+            exec {
+                println("Executing Clean: $it")
+                commandLine("./gradlew", it)
+            }
+        }
+    }
+}
+
 group = "bisq"
 
 extensions.findByName("buildScan")?.withGroovyBuilder {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     id("bisq.protobuf")
 }
 
+dependencies {
+    // TODO figure out why this is needed (it shouldn't, the custom proguard plugin already has the dependency..)
+    implementation("com.guardsquare:proguard-gradle:7.5.0")
+}
 
 val torVersion: String? = project.findProperty("tor.version") as String?
 if (torVersion == null) {

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id("bisq.java-library")
     id("bisq.grpc")
     id 'application'
+    id("bisq.gradle.packaging.ProGuardPlugin") version "0.1.0"
 }
 
 dependencies {
@@ -11,7 +12,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.19.1"
+        artifact = "com.google.protobuf:protoc:4.27.3"
     }
 
     plugins {

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -11,15 +11,30 @@
 
    On macOS and Linux, execute:
    ```sh
-   ./gradlew build
+   ./gradlew clean build
    ```
 
    On Windows:
    ```cmd
-   gradlew.bat build
+   gradlew.bat clean build
    ```
 
-   If you prefer to skip tests to speed up the building process, just append `-x test` to the previous commands.
+   If you prefer to skip proguard (use non proguarded jars) to speed up the building process, add `-x proguardTask` to the previous commands.
+   If you prefer to skip tests to speed up the building process, add `-x test` to the previous commands.
+
+3. **Generate Seed Node & Desktop App Binaries**
+
+   Seed Node:
+   ```sh
+   ./gradlew :apps:seed-node-app:clean :apps:seed-node-app:installDist
+   ```
+   Desktop:
+   ```sh
+   ./gradlew :apps:desktop:desktop-app:clean :apps:desktop:desktop-app:installDist
+   ```
+   
+   **For Windows environments**: replace ./gradlew with gradle.bat as the previous example shows
+
 
 ### Important notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4096M
+proguard.enable=true
 version=2.1.0
 tor.version=13.5.2
-org.gradle.jvmargs=-Xmx4096M

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 # Convention: mark all versions using 'strictly'. This ensures only one version is allowed in the dependency tree, even
 # when multiple versions are attempted to be brought in as transitive dependencies of other requirements.
 [versions]
-annotations-lib = { strictly = '23.0.0' }
+annotations-lib = { strictly = '24.0.0' }
 
 apache-commons-lang-lib = { strictly = '3.14.0' }
 apache-httpcomponents-core-lib = { strictly = '4.4.13' }
@@ -52,7 +52,7 @@ mockito-lib = { strictly = '4.11.0' }
 openjfx-plugin = { strictly = '0.0.13' }
 openjfx-monocle-lib = { strictly = 'jdk-12.0.1+2'}
 
-protobuf-java-lib = { strictly = '3.19.4' }
+protobuf-java-lib = { strictly = '4.27.3' }
 protobuf-gradle-plugin-lib = { strictly = '0.9.4' }
 
 sarxos-lib = { strictly = '0.3.12' }

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+    java
+}
+
+tasks.named("clean") {
+    dependsOn(subprojects.map { it.tasks.named("clean") })
+}
+
 extensions.findByName("buildScan")?.withGroovyBuilder {
     setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
     setProperty("termsOfServiceAgree", "yes")

--- a/persistence/src/test/java/bisq/persistence/TimestampStore.java
+++ b/persistence/src/test/java/bisq/persistence/TimestampStore.java
@@ -29,9 +29,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@Getter
 @Slf4j
 public final class TimestampStore implements PersistableStore<TimestampStore> {
-    @Getter
     private final Map<String, Long> timestampsByProfileId = new ConcurrentHashMap<>();
 
     public TimestampStore() {

--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 dependencies {
     constraints {
+        api("com.guardsquare:proguard-gradle") {
+            version { require("7.5.0") }
+        }
         api("org.checkerframework:checker-qual") {
             version { require("3.13.0") }
         }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,321 @@
+# Filter manifirst
+#-injars  my.jar(!META-INF/MANIFEST.MF)
+
+# careful when using dontwarn..
+#-dontwarn javax.**
+#-dontwarn java.**
+#-dontwarn org.**
+#-dontwarn bisq.**
+#-dontwarn com.google.protobuf.**
+#-dontwarn bisq.common.proto.**
+
+#----------------------------------------------------------------
+#Warning: bisq.common.jvm.JvmUtils: can't find referenced class java.lang.management.ManagementFactory
+#Warning: bisq.common.jvm.JvmUtils: can't find referenced class java.lang.management.ManagementFactory
+#Warning: bisq.common.jvm.JvmUtils: can't find referenced class java.lang.management.RuntimeMXBean
+#Warning: bisq.common.jvm.JvmUtils: can't find referenced class java.lang.management.RuntimeMXBean
+# found these the only acceptable warnings to just skip
+-dontwarn java.lang.management.**
+#----------------------------------------------------------------
+
+#-printmapping build/libs/mapping.txt
+#-printseeds build/libs/out.seeds
+
+#-addconfigurationdebugging
+#-verbose
+
+-adaptresourcefilenames **.properties,**.gif,**.jpg,**.svg,**.png
+-adaptresourcefilecontents **.properties,META-INF/MANIFEST.MF
+
+## GENERAL RULES
+-verbose
+-allowaccessmodification
+-dontusemixedcaseclassnames
+-dontskipnonpubliclibraryclasses
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+-keepclasseswithmembers public class * {
+    public static void main(java.lang.String[]);
+}
+-keep public class * {
+    public protected *;
+}
+
+-keepattributes *Annotation*
+-keepattributes EnclosingMethod
+-keepparameternames
+-renamesourcefileattribute SourceFile
+-keepattributes Signature,Exceptions,*Annotation*,
+                InnerClasses,PermittedSubclasses,EnclosingMethod,
+                Deprecated,SourceFile,LineNumberTable
+
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+-keepclassmembers,allowoptimization enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+## **IMPORTANT** During the first addition of proguard, Optimization and preverification failed due to not finding the
+## protobuf classes used as parent of our classes ()
+## removing preverification helped to avoid but problems came down the line when testing final builds.
+## uncomment the following lines only if you know what and why are you doing it.
+## More information: https://community.guardsquare.com/t/facing-an-error-with-cant-find-common-super-class-of-while-obfuscating-a-maven-based-java-application/1437/3
+
+# Controls for debugging
+
+#-dontpreverify
+#-dontshrink
+#-dontoptimize
+## Decision has been made to do not use obfuscation for security and deterministic size reasons.
+## Keep rules will still be kept below but doesn't really serve much purpose until this gets commented out
+-dontobfuscate
+
+# 1 is the default - On the first attempt to setup proguard effort was invested in raising this number unsuccessfully
+# as it would cause cause problems on the generated desktop app (with javafx)
+-optimizationpasses 1
+#-optimizations !code/allocation/variable
+
+## BISQ MODULES
+# PERSISTANCE
+# As a general rule, we don't wont to obfuscate bisq. modules code. This could be improved but on the first attempt it proved to be very challenging
+# If this were to be removed, its recommended to leave the specific keeps below in this file.
+#-keep class bisq.** { *; }
+
+# specific keeps on common
+-keep class bisq.common.util.** { *; }
+-keep class bisq.common.util.StringUtils { *; }
+-keep class bisq.common.util.ClassUtils { *; }
+-keep class bisq.common.logging.LogMaskConverter {
+    public <methods>;
+    *;
+}
+
+# General rules to keep Java core classes
+-keep class java.lang.** { *; }
+-keep class java.util.** { *; }
+-keep class java.io.** { *; }
+-keep class java.nio.** { *; }
+-keep class java.lang.management.ManagementFactory { *; }
+-keep class java.lang.management.RuntimeMXBean { *; }
+# Add specific rules for referenced classes
+-keep class bisq.user.reputation.requests.AuthorizeTimestampRequest { *; }
+
+-keepclassmembers class bisq.common.util.ClassUtils {
+    public static ** getEnclosingClass();
+}
+
+#Protobuf
+-keepclassmembers class * {
+    ** ADAPTER; ** Schema; ** Protobuf;
+}
+-keepclasseswithmembers class * {
+    ** ADAPTER; ** Schema; ** Protobuf;
+}
+-keep class com.google.protobuf.** { *; }
+-keep class com.google.protobuf.GeneratedMessageLite { *; }
+-keepclassmembers class com.google.protobuf.GeneratedMessageLite$Builder { *; }
+-keepclassmembers class com.google.protobuf.GeneratedMessageLite {
+    public static <fields>;
+}
+-keepclassmembers class ** {
+    public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite);
+}
+-keepclassmembers class **$Builder {
+    public ** build();
+}
+-keep class bisq.common.proto.** { *; }
+# MacOS persistence tests would fail without the following specific keep
+-keep class bisq.common.protobuf.** { *; }
+-keep class bisq.common.protobuf.StringLongPair { *; }
+-keep class bisq.common.protobuf.StringLongPair$1 { *; }
+-keep class bisq.common.protobuf.StringLongPair$Builder { *; }
+
+# Keep the interface and its methods
+-keep interface bisq.common.proto.PersistableProto { *; }
+# Keep all implementations of PersistableProto
+-keep class * implements bisq.common.proto.PersistableProto { *; }
+# Ensure that ProGuard does not strip any fields or methods of classes implementing PersistableProto
+-keepclassmembers class * implements bisq.common.proto.PersistableProto {
+    <fields>;
+    <methods>;
+}
+
+-keep interface bisq.common.proto.Proto { *; }
+-keep class * implements bisq.common.proto.Proto { *; }
+-keep class bisq.persistence.TimestampStore { *; }
+-keep class bisq.persistence.PersistableStoreReaderWriter { *; }
+-keep class bisq.persistence.PersistableStoreReaderWriterTests { *; }
+-keep public class * extends com.google.protobuf.GeneratedMessageLite { *; }
+-keep public class * extends com.google.protobuf.GeneratedMessage { *; }
+-keep class **.protobuf.** { *; }
+-keep class **.protobuf.**$Builder { *; }
+-keepclassmembers class **.protobuf.** { *; }
+-keepclassmembers class **.protobuf.**$Builder { *; }
+
+# Guava
+-dontwarn javax.lang.model.element.Modifier
+-dontnote sun.misc.SharedSecrets
+-keep class sun.misc.** { *; }
+-dontwarn java.lang.SafeVarargs
+-keep class com.google.common.base.Joiner {
+    public static Joiner on(java.lang.String);
+    public ** join(...);
+}
+
+-keep class java.lang.Throwable {
+    void addSuppressed(...);
+}
+
+-keepclassmembers class com.google.common.util.concurrent.AbstractFuture** {
+    java.util.concurrent.atomic.AtomicReferenceFieldUpdater waiters;
+    java.util.concurrent.atomic.AtomicReferenceFieldUpdater value;
+    java.util.concurrent.atomic.AtomicReferenceFieldUpdater listeners;
+    java.util.concurrent.atomic.AtomicReferenceFieldUpdater thread;
+    java.util.concurrent.atomic.AtomicReferenceFieldUpdater next;
+}
+
+-keepclassmembers class com.google.common.util.concurrent.AtomicDouble {
+    double value;
+}
+
+-keepclassmembers class com.google.common.util.concurrent.AggregateFutureState {
+    int remaining;
+    java.util.concurrent.atomic.AtomicReferenceFieldUpdater seenExceptions;
+}
+
+-dontwarn java.lang.ClassValue
+-dontnote com.google.appengine.api.ThreadManager
+-keep class com.google.appengine.api.ThreadManager {
+    static java.util.concurrent.ThreadFactory currentRequestThreadFactory(...);
+}
+
+-dontnote com.google.apphosting.api.ApiProxy
+-keep class com.google.apphosting.api.ApiProxy {
+    static com.google.apphosting.api.ApiProxy.Environment getCurrentEnvironment(...);
+}
+
+# OkHttp
+-dontwarn okhttp3.**
+-keep class okhttp3.** { *; }
+-dontwarn okio.**
+-keep class okio.** { *; }
+
+#Spring
+
+#-keepclassmembers class * {
+#    @org.springframework.beans.factory.annotation.Autowired *;
+#}
+#-keep class * implements java.lang.reflect.InvocationHandler { *; }
+#-keep class org.springframework.beans.factory.annotation.**
+#-dontwarn org.springframework.beans.factory.annotation.**
+
+-keepclassmembers class * {
+    @javax.annotation.Resource *;
+}
+-keep class javax.annotation.**
+-dontwarn javax.annotation.**
+
+-keepattributes *Annotation*, Signature, EnclosingMethod
+-keep class * extends java.lang.annotation.Annotation { *; }
+
+# Gson
+-keep class com.google.gson.** { *; }
+-dontwarn com.google.gson.**
+-keep class com.google.gson.annotations.**
+-dontwarn com.google.gson.annotations.**
+-keepclasseswithmembers,allowobfuscation,includedescriptorclasses class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+-keepclassmembers enum * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Jackson
+-keep class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.**
+
+# JUnit
+-keepattributes *Annotation*
+-keep class org.junit.** { *; }
+-dontwarn org.junit.**
+
+# Apache HttpComponents
+-dontwarn org.apache.http.**
+-keep class org.apache.http.** { *; }
+
+# BouncyCastle & security
+-dontwarn org.bouncycastle.**
+-keep class org.bouncycastle.** { *; }
+
+# Commons Codec
+-dontwarn org.apache.commons.codec.**
+-keep class org.apache.commons.codec.** { *; }
+
+# Typesafe Config
+-dontwarn com.typesafe.config.**
+-keep class com.typesafe.config.** { *; }
+
+# Tests
+
+# very important for persistance tests
+-keepattributes StackMapTable,LocalVariableTable
+
+-keep class *Test { *; }
+-keepclassmembers class * {
+    @org.junit.** <methods>;
+}
+
+-keep class org.gradle.** { *; }
+-keep class org.junit.** { *; }
+-keep class org.testng.** { *; }
+-keep class ch.qos.logback.** { *; }
+-keep class org.slf4j.** { *; }
+-keepclassmembers class * {
+    @org.junit.jupiter.api.Test <methods>;
+    @org.junit.jupiter.api.BeforeEach <methods>;
+    @org.junit.jupiter.api.AfterEach <methods>;
+    void set*();
+}
+
+# Desktop app
+
+-keep class bisq.user.identity.UserIdentityStore {
+    *;
+}
+-keep class bisq.security.AesSecretKey {
+    *;
+}
+-keepclassmembers,allowshrinking class * {
+    *** lambda*(...);
+}
+
+# Java Fx
+
+-keep class javafx.** { *; }
+-keep class com.sun.** { *; }
+
+# Proto
+-keep class com.google.protobuf.** { *; }
+-keep class bisq.common.proto.Proto {
+    public <methods>;
+}
+-keep class bisq.common.proto.PersistableProtoResolverMap { *; }
+-keep class bisq.common.proto.ProtobufUtils { *; }
+
+# Rest-API
+
+-keep class com.sun.net.httpserver.** { *; }
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        mavenCentral()
     }
     includeBuild("build-logic")
 }
@@ -22,11 +23,11 @@ toolchainManagement {
 rootProject.name = "bisq"
 
 include("account")
+include("common")
 include("application")
 include("bisq-easy")
 include("bonded-roles")
 include("chat")
-include("common")
 include("contract")
 include("daemon")
 include("identity")

--- a/wallets/build.gradle.kts
+++ b/wallets/build.gradle.kts
@@ -1,4 +1,12 @@
+plugins {
+    java
+}
+
 extensions.findByName("buildScan")?.withGroovyBuilder {
     setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
     setProperty("termsOfServiceAgree", "yes")
+}
+
+tasks.named("clean") {
+    dependsOn(subprojects.map { it.tasks.named("clean") })
 }


### PR DESCRIPTION
## Reason

 - This is an implementation of issue  https://github.com/bisq-network/bisq2/issues/2522

## Approach

Significant effort has been made to be able to seamlessly integrate Proguard into our build project. This implementation followed the following guidelines:

 - no modifications needed on the current way of building the project (e.g. git clean build works as it used to), and same goes for all the important commands to generate apps packaging.
 - enable as much optimizations as possible (currently, all 4 stages or proguard are being used: preverify, shrink, obfuscate, optimize)
 - Tests with proguarded jars passing as well as the current unproguarded state, no skip tests was needed (after hours of work to set it up right)

## Output

 - jar sizes reduction of average ~7%
 - `installDist` and `generateInstallers` use the integration and proguarded jars are used in the packaging
 - unobfuscated jars are keept in the corresponding build directories on a subdir called `unobfuscated`
 - a handy `listJars` task is provided that allows to quickly compare jars and their size

## Known issues / future lines of improvement

 - the current implementation is not playing well with gradle parallelism. IMHE most of the times is fine, but sometimes you'll get a proguardTask failing because it tried to use a jar that was being proguarded simultaneously. To have a deterministic result when testing just use the `--max-workers=1` parameter. E.g. `./gradlew clean build --max-workers=1`
 - Even thought obfuscation is enabled, a significant portion (specially in common) has been configured (proguard-rules.pro ) to be kept as not doing so would cause different issues either in tests or in the apps itself (specially related to security and persistence modules).
 - Optimization passes have been left to the current proguard stable version default (1). Trying to elevate this number resulted in builds, this could be a future project.
 - After nailing the basics, a refactor was done into a reusable custom gradle plugin for future integration
 - webcam project has been left aside in the context of this first integration, should be easily integrated thanks to the usage of gradle custom plugins.
 - Final proguard-rules.pro config file might have more rules than what is actually needed, this will be clean up in future optimization PRs after this first integration merge.
 - listJars has a bug where in certain modules it will print the jars more than once :-P
 - `gradlew apps:desktop:desktop-app-launcher:generateInstallers` only works for me in MacOS (M1). This is `not` an issue of this PR, as I have the same problem in `main`. So users with Linux and Windows systems that already have this working would be really appreacited to test the installers. In my tests installer works great in MacOS, and I even did real life trades in prod whilst testing the proguarded installed app.

## How to test this PR

 - once branch downloaded and checked out, first do `./gradlew clean build` . If everything is fine you should be able to do `gradlew listJars` and see 2 jars per proguarded module. 
 - then you can test the apps in the different ways you normally work. Run the seed node, run the oracle node, run the desktop and with 2 users and trade. Run the app in prod mode, etc.
 - generate installers, install and do a trade in prod.

### Dev's commit logs:

 - define global proguard config file in root
 - define global setup of proguard in root build.gradle.kts, excluding special sub project platform
 - add task to list generated jar files
 - add useful listJars gradle task to print involved jars with size
 - clean and build logic for wallets included submodule
 - configuration of proguard linked to root on leaf projects only, using the main proguard rules file from root
 - persistance module generates proguard jar
 - generic java app rules for proguard, fix proguard not finding java classpaths
 - avoid shas of non proguard jars
 - move proguard logic into custom gradle plugin for reuse in composite modules
 - added proguard to daemon module
 - added handy cleanAll buildAll root tasks to completely wipe jars and regenerate
 - allow configure relative path to proguard config per module
 - include into installDist the proguardTask needs to run after jar instead of build
 - better inclusion of proguard in build cycle by executing right after jar and keeping jar orginal name fix plugin sometimes not finding jar files, copying jar into unobfuscated subdir
 - avoid configuring already configured subprojects/modules
 - added docs to explain how to use proguard in the dev docs
 - fix dependencies to avoid loss of protobuf classes on proguarded builds (tests pass)
 - upgraded protobuf and protobuf gradle plugin to latest stable versions
 - cleanup and docs
 - add python scripts to gitignore


Thanks for taking time to help testing this PR !