### PR TITLE
Update tor.version to 13.5.2.

### DIFF
--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
@@ -7,11 +7,11 @@ class TorBinaryUrlProvider(private val version: String) : PerOsUrlProvider {
         get() = "https://archive.torproject.org/tor-package-archive/torbrowser/$version/"
 
     override val linuxUrl: String
-        get() = "tor-expert-bundle-$version-linux-x86_64.tar.gz"
+        get() = "tor-expert-bundle-linux-x86_64-$version.tar.gz"
 
     override val macOsUrl: String
-        get() = "tor-expert-bundle-$version-macos-x86_64.tar.gz"
+        get() = "tor-expert-bundle-macos-x86_64-$version.tar.gz"
 
     override val windowsUrl: String
-        get() = "tor-expert-bundle-$version-windows-x86_64.tar.gz"
+        get() = "tor-expert-bundle-windows-x86_64-$version.tar.gz"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 version=2.1.0
-tor.version=12.0.5
+tor.version=13.5.2
 org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
Adopt change in name patter to put version after platform name.

The previous version did fail with the signature checks.