### PR TITLE
Prepare support for macos aarch64 tor binary

### DIFF
--- a/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCoreHashFileUrlProvider.kt
+++ b/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCoreHashFileUrlProvider.kt
@@ -6,12 +6,15 @@ class BitcoinCoreHashFileUrlProvider(private val version: String) : PerOsUrlProv
     override val urlPrefix: String
         get() = "https://bitcoincore.org/bin/bitcoin-core-$version/SHA256SUMS"
 
-    override val linuxUrl: String
+    override val LINUX_X86_64_URL: String
         get() = ""
 
-    override val macOsUrl: String
+    override val MACOS_X86_64_URL: String
         get() = ""
 
-    override val windowsUrl: String
+    override val MACOS_ARM_64_URL: String
+        get() = ""
+
+    override val WIN_X86_64_URL: String
         get() = ""
 }

--- a/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCoreHashFileUrlProvider.kt
+++ b/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCoreHashFileUrlProvider.kt
@@ -1,8 +1,8 @@
 package bisq.gradle.bitcoin_core
 
-import bisq.gradle.tasks.PerOsUrlProvider
+import bisq.gradle.tasks.PerPlatformUrlProvider
 
-class BitcoinCoreHashFileUrlProvider(private val version: String) : PerOsUrlProvider {
+class BitcoinCoreHashFileUrlProvider(private val version: String) : PerPlatformUrlProvider {
     override val urlPrefix: String
         get() = "https://bitcoincore.org/bin/bitcoin-core-$version/SHA256SUMS"
 

--- a/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCorePlugin.kt
+++ b/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCorePlugin.kt
@@ -22,7 +22,7 @@ class BitcoinCorePlugin : Plugin<Project> {
             binaryName = "BitcoinCoreSha256Sums",
             version = extension.version,
 
-            perOsUrlProvider = { version -> BitcoinCoreHashFileUrlProvider(version) },
+            perPlatformUrlProvider = { version -> BitcoinCoreHashFileUrlProvider(version) },
             downloadDirectory = DOWNLOADS_DIR,
 
             pgpFingerprintToKeyUrlMap = mapOf(

--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/BisqElectrumPlugin.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/BisqElectrumPlugin.kt
@@ -22,7 +22,7 @@ class BisqElectrumPlugin : Plugin<Project> {
             binaryName = "Electrum",
             version = extension.version,
 
-            perOsUrlProvider = { version -> ElectrumBinaryUrlProvider(version) },
+            perPlatformUrlProvider = { version -> ElectrumBinaryUrlProvider(version) },
             downloadDirectory = DOWNLOADS_DIR,
 
             pgpFingerprintToKeyUrlMap = mapOf(

--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/ElectrumBinaryUrlProvider.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/ElectrumBinaryUrlProvider.kt
@@ -1,8 +1,8 @@
 package bisq.gradle.electrum
 
-import bisq.gradle.tasks.PerOsUrlProvider
+import bisq.gradle.tasks.PerPlatformUrlProvider
 
-class ElectrumBinaryUrlProvider(private val version: String) : PerOsUrlProvider {
+class ElectrumBinaryUrlProvider(private val version: String) : PerPlatformUrlProvider {
     override val urlPrefix: String
         get() = "https://download.electrum.org/$version/"
 

--- a/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/ElectrumBinaryUrlProvider.kt
+++ b/build-logic/electrum-binaries/src/main/kotlin/bisq/gradle/electrum/ElectrumBinaryUrlProvider.kt
@@ -6,12 +6,15 @@ class ElectrumBinaryUrlProvider(private val version: String) : PerOsUrlProvider 
     override val urlPrefix: String
         get() = "https://download.electrum.org/$version/"
 
-    override val linuxUrl: String
+    override val LINUX_X86_64_URL: String
         get() = "electrum-$version-x86_64.AppImage"
 
-    override val macOsUrl: String
+    override val MACOS_X86_64_URL: String
         get() = "electrum-$version.dmg"
 
-    override val windowsUrl: String
+    override val MACOS_ARM_64_URL: String
+        get() = "electrum-$version.dmg" // No ARM_64 version provided
+
+    override val WIN_X86_64_URL: String
         get() = "electrum-$version.exe"
 }

--- a/build-logic/gradle-tasks/build.gradle.kts
+++ b/build-logic/gradle-tasks/build.gradle.kts
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":commons"))
     implementation(libs.bouncycastle.pg)
 }

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerOsUrlProvider.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerOsUrlProvider.kt
@@ -1,20 +1,27 @@
 package bisq.gradle.tasks
 
+import bisq.gradle.common.Platform.*
+import bisq.gradle.common.getPlatform
+
 interface PerOsUrlProvider {
     val urlPrefix: String
 
-    val linuxUrl: String
-    val macOsUrl: String
-    val windowsUrl: String
+    val LINUX_X86_64_URL: String
+    val MACOS_X86_64_URL: String
+    val MACOS_ARM_64_URL: String
+    val WIN_X86_64_URL: String
 
     val url: String
         get() = urlPrefix + getUrlSuffix()
 
     private fun getUrlSuffix() =
-            when (getOS()) {
-                OS.LINUX -> linuxUrl
-                OS.MAC_OS -> macOsUrl
-                OS.WINDOWS -> windowsUrl
-            }
+        when (getPlatform()) {
+            LINUX_X86_64 -> LINUX_X86_64_URL
+            LINUX_ARM_64 -> LINUX_X86_64_URL // No ARM_64 provided
+            MACOS_X86_64 -> MACOS_X86_64_URL
+            MACOS_ARM_64 -> MACOS_ARM_64_URL
+            WIN_X86_64 -> WIN_X86_64_URL
+            WIN_ARM_64 -> WIN_X86_64_URL // No ARM_64 provided
+        }
 
 }

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerPlatformUrlProvider.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PerPlatformUrlProvider.kt
@@ -3,7 +3,7 @@ package bisq.gradle.tasks
 import bisq.gradle.common.Platform.*
 import bisq.gradle.common.getPlatform
 
-interface PerOsUrlProvider {
+interface PerPlatformUrlProvider {
     val urlPrefix: String
 
     val LINUX_X86_64_URL: String

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/download/SignedBinaryDownloader.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/download/SignedBinaryDownloader.kt
@@ -1,6 +1,6 @@
 package bisq.gradle.tasks.download
 
-import bisq.gradle.tasks.PerOsUrlProvider
+import bisq.gradle.tasks.PerPlatformUrlProvider
 import bisq.gradle.tasks.signature.SignatureVerificationTask
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -14,7 +14,7 @@ class SignedBinaryDownloader(
     private val binaryName: String,
     private val version: Property<String>,
 
-    private val perOsUrlProvider: (String) -> PerOsUrlProvider,
+    private val perPlatformUrlProvider: (String) -> PerPlatformUrlProvider,
     private val downloadDirectory: String,
 
     private val pgpFingerprintToKeyUrlMap: Map<String, URL>
@@ -23,7 +23,7 @@ class SignedBinaryDownloader(
     private val downloadTaskFactory = DownloadTaskFactory(project, downloadDirectory)
 
     fun registerTasks() {
-        val binaryDownloadUrl: Provider<String> = version.map { perOsUrlProvider(it).url }
+        val binaryDownloadUrl: Provider<String> = version.map { perPlatformUrlProvider(it).url }
         val binaryDownloadTask =
             downloadTaskFactory.registerDownloadTask("download${binaryName}Binary", binaryDownloadUrl)
 

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/BisqTorBinaryPlugin.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/BisqTorBinaryPlugin.kt
@@ -19,7 +19,7 @@ class BisqTorBinaryPlugin : Plugin<Project> {
             binaryName = "Tor",
             version = extension.version,
 
-            perOsUrlProvider = { version -> TorBinaryUrlProvider(version) },
+            perPlatformUrlProvider = { version -> TorBinaryUrlProvider(version) },
             downloadDirectory = DOWNLOADS_DIR,
 
             pgpFingerprintToKeyUrlMap = mapOf(

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
@@ -6,12 +6,19 @@ class TorBinaryUrlProvider(private val version: String) : PerOsUrlProvider {
     override val urlPrefix: String
         get() = "https://archive.torproject.org/tor-package-archive/torbrowser/$version/"
 
-    override val linuxUrl: String
+    override val LINUX_X86_64_URL: String
         get() = "tor-expert-bundle-linux-x86_64-$version.tar.gz"
 
-    override val macOsUrl: String
+    override val MACOS_X86_64_URL: String
         get() = "tor-expert-bundle-macos-x86_64-$version.tar.gz"
 
-    override val windowsUrl: String
+    override val MACOS_ARM_64_URL: String
+        // Currently the Tor version for aarch64 does not work, thus we use the x64 version.
+        // See: https://github.com/bisq-network/bisq2/issues/2679
+        // Once resolved we can use the line below.
+        // get() = "tor-expert-bundle-macos-aarch64-$version.tar.gz"
+        get() = "tor-expert-bundle-macos-x86_64-$version.tar.gz"
+
+    override val WIN_X86_64_URL: String
         get() = "tor-expert-bundle-windows-x86_64-$version.tar.gz"
 }

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
@@ -1,8 +1,8 @@
 package bisq.gradle.tor_binary
 
-import bisq.gradle.tasks.PerOsUrlProvider
+import bisq.gradle.tasks.PerPlatformUrlProvider
 
-class TorBinaryUrlProvider(private val version: String) : PerOsUrlProvider {
+class TorBinaryUrlProvider(private val version: String) : PerPlatformUrlProvider {
     override val urlPrefix: String
         get() = "https://archive.torproject.org/tor-package-archive/torbrowser/$version/"
 

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
@@ -7,11 +7,11 @@ class TorBinaryUrlProvider(private val version: String) : PerOsUrlProvider {
         get() = "https://archive.torproject.org/tor-package-archive/torbrowser/$version/"
 
     override val linuxUrl: String
-        get() = "tor-expert-bundle-$version-linux-x86_64.tar.gz"
+        get() = "tor-expert-bundle-linux-x86_64-$version.tar.gz"
 
     override val macOsUrl: String
-        get() = "tor-expert-bundle-$version-macos-x86_64.tar.gz"
+        get() = "tor-expert-bundle-macos-x86_64-$version.tar.gz"
 
     override val windowsUrl: String
-        get() = "tor-expert-bundle-$version-windows-x86_64.tar.gz"
+        get() = "tor-expert-bundle-windows-x86_64-$version.tar.gz"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 version=2.1.0
-tor.version=12.0.5
+tor.version=13.5.2
 org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
Preparation for support for MacOs aarch64 tor binaries once https://github.com/bisq-network/bisq2/issues/2679 is resolved.