### PR TITLE
Remove notifications of expired or pruned messages

### DIFF
--- a/chat/src/main/java/bisq/chat/ChatService.java
+++ b/chat/src/main/java/bisq/chat/ChatService.java
@@ -80,6 +80,7 @@ public class ChatService implements Service {
         this.userProfileService = userService.getUserProfileService();
 
         chatNotificationService = new ChatNotificationService(persistenceService,
+                networkService,
                 this,
                 systemNotificationService,
                 settingsService,

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationsStore.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationsStore.java
@@ -86,7 +86,7 @@ public final class ChatNotificationsStore implements PersistableStore<ChatNotifi
 
     Optional<ChatNotification> findNotification(String id) {
         return chatNotifications.stream()
-                .filter(e -> e.getId().equals(id))
+                .filter(chatNotification -> chatNotification.getId().equals(id))
                 .findAny();
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStorageService.java
@@ -18,6 +18,7 @@
 package bisq.network.p2p.services.data.storage;
 
 import bisq.common.data.ByteArray;
+import bisq.common.observable.collection.ObservableSet;
 import bisq.network.p2p.services.data.DataRequest;
 import bisq.network.p2p.services.data.storage.append.AddAppendOnlyDataRequest;
 import bisq.network.p2p.services.data.storage.auth.AddAuthenticatedDataRequest;
@@ -49,6 +50,8 @@ public abstract class DataStorageService<T extends DataRequest> extends RateLimi
     private final String storeKey;
     @Getter
     protected final String subDirectory;
+    @Getter
+    public ObservableSet<DataRequest> prunedAndExpiredDataRequests = new ObservableSet<>();
     protected Optional<Integer> maxMapSize = Optional.empty();
 
     public DataStorageService(PersistenceService persistenceService, String storeName, String storeKey) {
@@ -75,7 +78,14 @@ public abstract class DataStorageService<T extends DataRequest> extends RateLimi
 
         int maxSize = getMaxMapSize();
         Map<ByteArray, T> pruned = map.entrySet().stream()
-                .filter(entry -> !entry.getValue().isExpired())
+                .filter(entry -> {
+                    T dataRequest = entry.getValue();
+                    boolean isExpired = dataRequest.isExpired();
+                    if (isExpired) {
+                        prunedAndExpiredDataRequests.add(dataRequest);
+                    }
+                    return !isExpired;
+                })
                 .sorted((o1, o2) -> Long.compare(o2.getValue().getCreated(), o1.getValue().getCreated()))
                 .limit(maxSize)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageService.java
@@ -510,7 +510,7 @@ public class StorageService {
                 appendOnlyDataStores.values().stream());
     }
 
-    private Stream<DataStorageService<? extends DataRequest>> getStoresByStoreType(StoreType storeType) {
+    public Stream<DataStorageService<? extends DataRequest>> getStoresByStoreType(StoreType storeType) {
         List<DataStorageService<? extends DataRequest>> dataStorageServiceStream;
         switch (storeType) {
             case ALL:

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
@@ -318,7 +318,14 @@ public class AuthenticatedDataStorageService extends DataStorageService<Authenti
 
     private void pruneExpired() {
         Set<Map.Entry<ByteArray, AuthenticatedDataRequest>> expiredEntries = persistableStore.getMap().entrySet().stream()
-                .filter(entry -> entry.getValue().isExpired())
+                .filter(entry -> {
+                    AuthenticatedDataRequest dataRequest = entry.getValue();
+                    boolean isExpired = dataRequest.isExpired();
+                    if (isExpired) {
+                        prunedAndExpiredDataRequests.add(dataRequest);
+                    }
+                    return isExpired;
+                })
                 .collect(Collectors.toSet());
         if (!expiredEntries.isEmpty()) {
             log.info("We remove {} expired entries from our map", expiredEntries.size());

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxDataStorageService.java
@@ -231,7 +231,14 @@ public class MailboxDataStorageService extends DataStorageService<MailboxRequest
 
     private void pruneExpired() {
         Set<Map.Entry<ByteArray, MailboxRequest>> expiredEntries = persistableStore.getMap().entrySet().stream()
-                .filter(entry -> entry.getValue().isExpired())
+                .filter(entry -> {
+                    MailboxRequest dataRequest = entry.getValue();
+                    boolean isExpired = dataRequest.isExpired();
+                    if (isExpired) {
+                        prunedAndExpiredDataRequests.add(dataRequest);
+                    }
+                    return isExpired;
+                })
                 .collect(Collectors.toSet());
         if (!expiredEntries.isEmpty()) {
             log.info("We remove {} expired entries from our map", expiredEntries.size());


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/2682

Add ObservableSet to DataStorageService when data gets expired or pruned at prunePersisted are at periodic expiry check.

ChatNotificationService listens on changes of the set and deletes the notification. This works both for expired messages at startup, and at runtime (we check every minute for expired messages).