### PR TITLE
Fix file chooser cookie setting logic

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
@@ -42,7 +42,7 @@ public class FileChooserUtil {
     private static Optional<File> openFile(Scene scene, Optional<String> initialFileName) {
         FileChooser fileChooser = getFileChooser(initialFileName);
         Optional<File> result = Optional.ofNullable(fileChooser.showOpenDialog(scene.getWindow()));
-        result.ifPresent(FileChooserUtil::persistFielChooserDirectory);
+        result.ifPresent(FileChooserUtil::persistFileChooserDirectory);
         return result;
     }
 
@@ -57,7 +57,7 @@ public class FileChooserUtil {
     private static Optional<File> saveFile(Scene scene, Optional<String> initialFileName) {
         FileChooser fileChooser = getFileChooser(initialFileName);
         Optional<File> result = Optional.ofNullable(fileChooser.showSaveDialog(scene.getWindow()));
-        result.ifPresent(FileChooserUtil::persistFielChooserDirectory);
+        result.ifPresent(FileChooserUtil::persistFileChooserDirectory);
         return result;
     }
 
@@ -80,7 +80,7 @@ public class FileChooserUtil {
         }
         directoryChooser.setTitle(title);
         Optional<File> result = Optional.ofNullable(directoryChooser.showDialog(scene.getWindow()));
-        result.ifPresent(FileChooserUtil::persistFielChooserDirectory);
+        result.ifPresent(FileChooserUtil::persistFileChooserDirectory);
         return result;
     }
 
@@ -96,7 +96,7 @@ public class FileChooserUtil {
         return fileChooser;
     }
 
-    private static void persistFielChooserDirectory(File file) {
+    private static void persistFileChooserDirectory(File file) {
         SettingsService.getInstance().setCookie(CookieKey.FILE_CHOOSER_DIR, Paths.get(file.getAbsolutePath()).getParent().toString());
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
@@ -32,8 +32,8 @@ import java.util.Optional;
 @Slf4j
 public class FileChooserUtil {
 
-    private static final boolean DIRECTORY_CHOOSER = true;
-    private static final boolean FILE_CHOOSER = false;
+    private static final boolean IS_DIRECTORY_CHOOSER = true;
+    private static final boolean IS_FILE_CHOOSER = false;
 
     public static Optional<File> openFile(Scene scene) {
         return openFile(scene, Optional.empty());
@@ -46,7 +46,7 @@ public class FileChooserUtil {
     private static Optional<File> openFile(Scene scene, Optional<String> initialFileName) {
         FileChooser fileChooser = getFileChooser(initialFileName);
         Optional<File> result = Optional.ofNullable(fileChooser.showOpenDialog(scene.getWindow()));
-        result.ifPresent(file -> persistFileChooserDirectory(file, FILE_CHOOSER));
+        result.ifPresent(file -> persistFileChooserDirectory(file, IS_FILE_CHOOSER));
         return result;
     }
 
@@ -61,7 +61,7 @@ public class FileChooserUtil {
     private static Optional<File> saveFile(Scene scene, Optional<String> initialFileName) {
         FileChooser fileChooser = getFileChooser(initialFileName);
         Optional<File> result = Optional.ofNullable(fileChooser.showSaveDialog(scene.getWindow()));
-        result.ifPresent(file -> persistFileChooserDirectory(file, FILE_CHOOSER));
+        result.ifPresent(file -> persistFileChooserDirectory(file, IS_FILE_CHOOSER));
         return result;
     }
 
@@ -84,7 +84,7 @@ public class FileChooserUtil {
         }
         directoryChooser.setTitle(title);
         Optional<File> result = Optional.ofNullable(directoryChooser.showDialog(scene.getWindow()));
-        result.ifPresent(file -> persistFileChooserDirectory(file, DIRECTORY_CHOOSER));
+        result.ifPresent(file -> persistFileChooserDirectory(file, IS_DIRECTORY_CHOOSER));
         return result;
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
@@ -31,6 +31,10 @@ import java.util.Optional;
 
 @Slf4j
 public class FileChooserUtil {
+
+    private static final boolean DIRECTORY_CHOOSER = true;
+    private static final boolean FILE_CHOOSER = false;
+
     public static Optional<File> openFile(Scene scene) {
         return openFile(scene, Optional.empty());
     }
@@ -42,7 +46,7 @@ public class FileChooserUtil {
     private static Optional<File> openFile(Scene scene, Optional<String> initialFileName) {
         FileChooser fileChooser = getFileChooser(initialFileName);
         Optional<File> result = Optional.ofNullable(fileChooser.showOpenDialog(scene.getWindow()));
-        result.ifPresent(FileChooserUtil::persistFileChooserDirectory);
+        result.ifPresent(file -> persistFileChooserDirectory(file, FILE_CHOOSER));
         return result;
     }
 
@@ -57,7 +61,7 @@ public class FileChooserUtil {
     private static Optional<File> saveFile(Scene scene, Optional<String> initialFileName) {
         FileChooser fileChooser = getFileChooser(initialFileName);
         Optional<File> result = Optional.ofNullable(fileChooser.showSaveDialog(scene.getWindow()));
-        result.ifPresent(FileChooserUtil::persistFileChooserDirectory);
+        result.ifPresent(file -> persistFileChooserDirectory(file, FILE_CHOOSER));
         return result;
     }
 
@@ -80,7 +84,7 @@ public class FileChooserUtil {
         }
         directoryChooser.setTitle(title);
         Optional<File> result = Optional.ofNullable(directoryChooser.showDialog(scene.getWindow()));
-        result.ifPresent(FileChooserUtil::persistFileChooserDirectory);
+        result.ifPresent(file -> persistFileChooserDirectory(file, DIRECTORY_CHOOSER));
         return result;
     }
 
@@ -96,7 +100,8 @@ public class FileChooserUtil {
         return fileChooser;
     }
 
-    private static void persistFileChooserDirectory(File file) {
-        SettingsService.getInstance().setCookie(CookieKey.FILE_CHOOSER_DIR, Paths.get(file.getAbsolutePath()).getParent().toString());
+    private static void persistFileChooserDirectory(File file, boolean isDirectoryChooser) {
+        String directoryToPersist = isDirectoryChooser ? file.getAbsolutePath() : Paths.get(file.getAbsolutePath()).getParent().toString();
+        SettingsService.getInstance().setCookie(CookieKey.FILE_CHOOSER_DIR, directoryToPersist);
     }
 }


### PR DESCRIPTION
Fixes #2664

Persist chosen dir if the flow is about choosing a directory, persist its parent if the flow is about choosing a file.