### PR TITLE
Gradle: Support SHA256 hash verification

### DIFF
--- a/build-logic/bitcoin-core-binaries/build.gradle.kts
+++ b/build-logic/bitcoin-core-binaries/build.gradle.kts
@@ -18,4 +18,5 @@ gradlePlugin {
 
 dependencies {
     implementation(project(":gradle-tasks"))
+    implementation(libs.google.guava)
 }

--- a/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCoreBinaryUrlProvider.kt
+++ b/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCoreBinaryUrlProvider.kt
@@ -1,0 +1,20 @@
+package bisq.gradle.bitcoin_core
+
+import bisq.gradle.tasks.PerPlatformUrlProvider
+
+class BitcoinCoreBinaryUrlProvider(private val version: String) : PerPlatformUrlProvider {
+    override val urlPrefix: String
+        get() = "https://bitcoincore.org/bin/bitcoin-core-$version/bitcoin-$version-"
+
+    override val LINUX_X86_64_URL: String
+        get() = "x86_64-linux-gnu.tar.gz"
+
+    override val MACOS_X86_64_URL: String
+        get() = "x86_64-apple-darwin.tar.gz"
+
+    override val MACOS_ARM_64_URL: String
+        get() = "arm64-apple-darwin.tar.gz"
+
+    override val WIN_X86_64_URL: String
+        get() = "win64.zip"
+}

--- a/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCorePlugin.kt
+++ b/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/BitcoinCorePlugin.kt
@@ -1,9 +1,11 @@
 package bisq.gradle.bitcoin_core
 
 import bisq.gradle.tasks.PgpFingerprint
+import bisq.gradle.tasks.download.DownloadTaskFactory
 import bisq.gradle.tasks.download.SignedBinaryDownloader
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.create
 
 
@@ -58,6 +60,10 @@ class BitcoinCorePlugin : Plugin<Project> {
             )
         )
         hashFileDownloader.registerTasks()
+
+        val binaryDownloadUrl: Provider<String> = extension.version.map { BitcoinCoreBinaryUrlProvider(it).url }
+        val downloadTaskFactory = DownloadTaskFactory(project, DOWNLOADS_DIR)
+        downloadTaskFactory.registerDownloadTask("downloadBitcoinCore", binaryDownloadUrl)
     }
 
     private fun filenameAndFingerprint(filename: String, fingerprint: String) =

--- a/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/HashVerificationTask.kt
+++ b/build-logic/bitcoin-core-binaries/src/main/kotlin/bisq/gradle/bitcoin_core/HashVerificationTask.kt
@@ -1,0 +1,50 @@
+package bisq.gradle.bitcoin_core
+
+import com.google.common.hash.Hashing
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class HashVerificationTask : DefaultTask() {
+    @get:InputFile
+    abstract val inputFile: RegularFileProperty
+
+    @get:InputFile
+    abstract val sha256File: RegularFileProperty
+
+    @get:OutputFile
+    abstract val resultFile: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val input = inputFile.get().asFile.readBytes()
+        val hash: String = Hashing.sha256()
+            .hashBytes(input)
+            .toString()
+
+        val expectedHash = getExpectedHash()
+        if (hash != expectedHash) {
+            throw GradleException(
+                "Hash verification failed for `${inputFile.get().asFile.absolutePath}`. " +
+                        "Expected: `$expectedHash, Actual: `$hash`"
+            )
+        }
+
+        resultFile.get().asFile.writeText(hash)
+    }
+
+    private fun getExpectedHash(): String {
+        val inputFileName = inputFile.get().asFile.name
+        for (line in sha256File.get().asFile.readLines()) {
+            if (line.endsWith(inputFileName)) {
+                // '<sha256hash> filename.tar.gz'
+                return line.split(" ").first()
+            }
+        }
+
+        throw GradleException("Couldn't find expected hash for `$inputFile`.")
+    }
+}


### PR DESCRIPTION
- [bitcoin-core-binaries: Download Bitcoin Core](https://github.com/bisq-network/bisq2/commit/68ac51f51d4a8db3fb9bccf17a2f0fd601418926)
- [bitcoin-core-binaries: Support SHA256 hash verification](https://github.com/bisq-network/bisq2/commit/b5be65de33146f1a52b9557ab60a5fafc0dc5633)
  - The hash verification task looks up the expected hash and verifies that the provided file has that hash. To look up the expected hash, the Gradle task parses the input hash list file of the format '<sha256hash> filename.tar.gz' (per line). Most projects use this format.