### PR TITLE
bitcoind: Use project bitcoind in tests

### DIFF
--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
@@ -38,20 +38,16 @@ public class BitcoindDaemon {
     }
 
     public void createOrLoadWallet(String walletName, Optional<String> passphrase) {
-        createOrLoadWallet(walletName, passphrase, true, false, false);
-    }
-
-    public void createOrLoadLegacyWallet(String walletName, Optional<String> passphrase) {
-        createOrLoadWallet(walletName, passphrase, false, false, false);
+        createOrLoadWallet(walletName, passphrase, false, false);
     }
 
     public void createOrLoadWatchOnlyWallet(String walletName) {
-        createOrLoadWallet(walletName, Optional.empty(), true, true, true);
+        createOrLoadWallet(walletName, Optional.empty(), true, true);
     }
 
-    private void createOrLoadWallet(String walletName, Optional<String> passphrase, boolean descriptors, boolean disablePrivateKeys, boolean blank) {
+    private void createOrLoadWallet(String walletName, Optional<String> passphrase, boolean disablePrivateKeys, boolean blank) {
         try {
-            createWallet(walletName, passphrase.orElse(""), descriptors, disablePrivateKeys, blank);
+            createWallet(walletName, passphrase.orElse(""), disablePrivateKeys, blank);
         } catch (RpcCallFailureException e) {
             if (doesWalletExist(e)) {
                 List<String> loadedWallets = listWallets();
@@ -151,10 +147,9 @@ public class BitcoindDaemon {
         return e.getMessage().contains("Database already exists.");
     }
 
-    private void createWallet(String walletName, String passphrase, boolean descriptors, boolean disablePrivateKeys, boolean blank) {
+    private void createWallet(String walletName, String passphrase, boolean disablePrivateKeys, boolean blank) {
         var request = BitcoindCreateWalletRpcCall.Request.builder()
                 .walletName(walletName)
-                .descriptors(descriptors)
                 .disablePrivateKeys(disablePrivateKeys)
                 .blank(blank)
                 .passphrase(passphrase)

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/BitcoindDaemon.java
@@ -117,7 +117,11 @@ public class BitcoindDaemon {
     }
 
     public String sendRawTransaction(String hexString) {
-        var request = new BitcoindSendRawTransactionRpcCall.Request(hexString);
+        return sendRawTransaction(hexString, null);
+    }
+
+    public String sendRawTransaction(String hexString, String maxBurnAmount) {
+        var request = new BitcoindSendRawTransactionRpcCall.Request(hexString, maxBurnAmount);
         var rpcCall = new BitcoindSendRawTransactionRpcCall(request);
         return rpcClient.call(rpcCall).getResult();
     }

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindCreateWalletRpcCall.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindCreateWalletRpcCall.java
@@ -39,7 +39,6 @@ public class BitcoindCreateWalletRpcCall
         private String passphrase;
         @Json(name = "avoid_reuse")
         private Boolean avoidReuse;
-        private boolean descriptors;
     }
 
     public BitcoindCreateWalletRpcCall(Request request) {

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindSendRawTransactionRpcCall.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/calls/BitcoindSendRawTransactionRpcCall.java
@@ -32,9 +32,12 @@ public class BitcoindSendRawTransactionRpcCall extends DaemonRpcCall<BitcoindSen
     public static final class Request {
         @Json(name = "hexstring")
         private final String hexString;
+        @Json(name = "maxburnamount")
+        private final String maxBurnAmount;
 
-        public Request(String hexString) {
+        public Request(String hexString, String maxBurnAmount) {
             this.hexString = hexString;
+            this.maxBurnAmount = maxBurnAmount;
         }
     }
 

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindDescriptor.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindDescriptor.java
@@ -17,6 +17,7 @@
 
 package bisq.wallets.bitcoind.rpc.responses;
 
+import com.squareup.moshi.Json;
 import lombok.Getter;
 
 import java.util.List;
@@ -29,4 +30,6 @@ public class BitcoindDescriptor {
     private boolean internal;
     private List<Integer> range;
     private Integer next;
+    @Json(name = "next_index")
+    private Integer nextIndex;
 }

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindGetBalancesResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindGetBalancesResponse.java
@@ -27,5 +27,7 @@ public class BitcoindGetBalancesResponse extends JsonRpcResponse<BitcoindGetBala
         private BitcoindGetMineBalancesResponse mine;
         @Json(name = "watchonly")
         private BitcoindGetMineBalancesResponse watchOnly;
+        @Json(name = "lastprocessedblock")
+        private BitcoindGetLastProcessedBlockBalancesResponse lastProcessedBlock;
     }
 }

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindGetLastProcessedBlockBalancesResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindGetLastProcessedBlockBalancesResponse.java
@@ -1,0 +1,9 @@
+package bisq.wallets.bitcoind.rpc.responses;
+
+import lombok.Getter;
+
+@Getter
+public class BitcoindGetLastProcessedBlockBalancesResponse {
+    private String hash;
+    long height;
+}

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindListTransactionsResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindListTransactionsResponse.java
@@ -32,6 +32,8 @@ public class BitcoindListTransactionsResponse extends JsonRpcResponse<List<Bitco
     public static class Entry implements TransactionInfo {
         private boolean involvesWatchonly;
         private String address;
+        @Json(name = "parent_descs")
+        private List<String> parentDescs;
         private String category;
         private double amount;
         private String label;

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindListTransactionsResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindListTransactionsResponse.java
@@ -46,6 +46,8 @@ public class BitcoindListTransactionsResponse extends JsonRpcResponse<List<Bitco
         private int blocktime;
         @Json(name = "txid")
         private String txId;
+        @Json(name = "wtxid")
+        private String wtxId;
         private String[] walletconflicts;
         private int time;
         private int timereceived;

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindWalletProcessPsbtResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindWalletProcessPsbtResponse.java
@@ -26,5 +26,6 @@ public class BitcoindWalletProcessPsbtResponse extends JsonRpcResponse<BitcoindW
     public static class Result {
         private String psbt;
         private boolean complete;
+        private String hex;
     }
 }

--- a/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindWarningResponse.java
+++ b/wallets/bitcoind/src/main/java/bisq/wallets/bitcoind/rpc/responses/BitcoindWarningResponse.java
@@ -20,13 +20,16 @@ package bisq.wallets.bitcoind.rpc.responses;
 import bisq.wallets.json_rpc.JsonRpcResponse;
 import lombok.Getter;
 
+import java.util.Collections;
+import java.util.List;
+
 public class BitcoindWarningResponse extends JsonRpcResponse<BitcoindWarningResponse.Result> {
     @Getter
     public static class Result {
-        protected String warning;
+        protected List<String> warnings = Collections.emptyList();
 
         public boolean hasWarning() {
-            return !warning.isEmpty();
+            return !warnings.isEmpty();
         }
     }
 }

--- a/wallets/elementsd/src/integrationTest/java/bisq/wallets/elementsd/regtest/ElementsdRegtestProcess.java
+++ b/wallets/elementsd/src/integrationTest/java/bisq/wallets/elementsd/regtest/ElementsdRegtestProcess.java
@@ -37,7 +37,7 @@ public class ElementsdRegtestProcess extends BitcoindRegtestProcess {
     private final ElementsdConfig elementsdConfig;
 
     public ElementsdRegtestProcess(ElementsdConfig elementsdConfig, Path dataDir) {
-        super(elementsdConfig.elementsdRpcConfig(), dataDir);
+        super(null, elementsdConfig.elementsdRpcConfig(), dataDir);
         this.elementsdConfig = elementsdConfig;
     }
 

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/ElementsdDaemon.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/rpc/ElementsdDaemon.java
@@ -38,7 +38,7 @@ public class ElementsdDaemon {
     }
 
     public void createOrLoadWallet(String walletName, Optional<String> passphrase) {
-        bitcoindDaemon.createOrLoadLegacyWallet(walletName, passphrase);
+        throw new UnsupportedOperationException("Bitcoin Core 25.0 removed legacy wallet support.");
     }
 
     public ElementsdDecodeRawTransactionResponse decodeRawTransaction(String txInHex) {

--- a/wallets/regtest/build.gradle.kts
+++ b/wallets/regtest/build.gradle.kts
@@ -1,5 +1,18 @@
 plugins {
     id("bisq.java-library")
+    id("bisq.gradle.bitcoin_core.BitcoinCorePlugin")
+}
+
+bitcoin_core {
+    version.set("27.1")
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDir(layout.buildDirectory.file("generated/src/main/resources"))
+        }
+    }
 }
 
 dependencies {

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestProcess.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestProcess.java
@@ -38,12 +38,14 @@ import java.util.List;
 @Slf4j
 public class BitcoindRegtestProcess extends DaemonProcess {
 
+    private final Path binaryPath;
     @Getter
     protected final RpcConfig rpcConfig;
     private final BitcoindDaemon bitcoindDaemon;
 
-    public BitcoindRegtestProcess(RpcConfig rpcConfig, Path dataDir) {
+    public BitcoindRegtestProcess(Path binaryPath, RpcConfig rpcConfig, Path dataDir) {
         super(dataDir);
+        this.binaryPath = binaryPath;
         this.rpcConfig = rpcConfig;
         JsonRpcClient rpcClient = RpcClientFactory.createDaemonRpcClient(rpcConfig);
         bitcoindDaemon = new BitcoindDaemon(rpcClient);
@@ -53,7 +55,7 @@ public class BitcoindRegtestProcess extends DaemonProcess {
     public ProcessConfig createProcessConfig() {
         int zmqPort = NetworkUtils.findFreeSystemPort();
         return ProcessConfig.builder()
-                .name("bitcoind")
+                .name(binaryPath.toAbsolutePath().toString())
                 .args(List.of(
                         "-regtest",
                         "-datadir=" + dataDir.toAbsolutePath(),

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
@@ -65,7 +65,7 @@ public class BitcoindRegtestSetup
         return mineBlocks(1);
     }
 
-    public List<String> mineBlocks(int numberOfBlocks) throws InterruptedException {
+    public List<String> mineBlocks(int numberOfBlocks) {
         return remoteBitcoind.mineBlocks(numberOfBlocks);
     }
 


### PR DESCRIPTION
The tests use the installed bitcoind binary. To make the test failures
reproducible it's better to run the tests with the officially supported
Bitcoin Core version.