### PR TITLE
Move JUnit 5 BitcoindExtension to wallets.regtest module

### DIFF
--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindConnectionFailureIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindConnectionFailureIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.regtest.ConnectionFailureIntegrationTests;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
 import bisq.wallets.regtest.process.MultiProcessCoordinator;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameDocumentationIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameDocumentationIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.calls.BitcoindCreateWalletRpcCall;
 import bisq.wallets.json_rpc.RpcConfig;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindCreateWalletNameIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.regtest.AbstractRegtestSetup;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindListDescriptorsIntegrationTest.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindListDescriptorsIntegrationTest.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindDescriptor;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindListDescriptorResponse;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindPsbtMultiSigIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.bitcoind.rpc.calls.requests.BitcoindImportDescriptorRequestEntry;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindReceiveAddrIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindReceiveAddrIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.core.model.AddressType;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSendAndListTxsIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSendAndListTxsIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindListTransactionsResponse;
 import bisq.wallets.core.model.AddressType;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSendAndListUnspentIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSendAndListUnspentIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindListUnspentResponse;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSendIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSendIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.core.model.AddressType;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSigningIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindSigningIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.core.model.AddressType;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindWalletCreationAndListIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/BitcoindWalletCreationAndListIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.json_rpc.RpcConfig;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/zmq/BitcoindZeroMqBlockHashIntegrationIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/zmq/BitcoindZeroMqBlockHashIntegrationIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind.zmq;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;

--- a/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/zmq/BitcoindZeroMqConnectionInfoFinderIntegrationTests.java
+++ b/wallets/bitcoind/src/integrationTest/java/bisq/wallets/bitcoind/zmq/BitcoindZeroMqConnectionInfoFinderIntegrationTests.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.bitcoind.zmq;
 
-import bisq.wallets.bitcoind.regtest.BitcoindExtension;
+import bisq.wallets.regtest.BitcoindExtension;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindGetZmqNotificationsResponse;
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/BitcoindExtension.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/BitcoindExtension.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.wallets.bitcoind.regtest;
+package bisq.wallets.regtest;
 
 import bisq.wallets.regtest.bitcoind.BitcoindRegtestSetup;
 import org.junit.jupiter.api.extension.BeforeAllCallback;

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/Os.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/Os.java
@@ -1,0 +1,62 @@
+package bisq.wallets.regtest;
+
+import lombok.Getter;
+
+import java.util.Locale;
+
+public enum Os {
+    LINUX("linux"),
+    MAC_OS("macos"),
+    WINDOWS("win");
+
+    @Getter
+    private final String canonicalName;
+
+    Os(String canonicalName) {
+        this.canonicalName = canonicalName;
+    }
+
+    public static bisq.common.platform.OS getOS() {
+        String osName = getOsName();
+        if (isLinux(osName)) {
+            return bisq.common.platform.OS.LINUX;
+        } else if (isMacOs(osName)) {
+            return bisq.common.platform.OS.MAC_OS;
+        } else if (isWindows(osName)) {
+            return bisq.common.platform.OS.WINDOWS;
+        }
+        throw new IllegalStateException("Running on unsupported OS: " + osName);
+    }
+
+    public static boolean isLinux() {
+        return isLinux(getOsName());
+    }
+
+    public static boolean isLinux(String osName) {
+        return osName.contains("linux");
+    }
+
+    public static boolean isMacOs() {
+        return isMacOs(getOsName());
+    }
+
+    public static boolean isMacOs(String osName) {
+        return osName.contains("mac") || osName.contains("darwin");
+    }
+
+    public static boolean isWindows() {
+        return isWindows(getOsName());
+    }
+
+    public static boolean isWindows(String osName) {
+        return osName.contains("win");
+    }
+
+    public static String getOsName() {
+        return System.getProperty("os.name").toLowerCase(Locale.US);
+    }
+
+    public static String getOsVersion() {
+        return System.getProperty("os.version");
+    }
+}

--- a/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
+++ b/wallets/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
@@ -17,7 +17,6 @@
 
 package bisq.wallets.regtest.bitcoind;
 
-import bisq.common.platform.OS;
 import bisq.common.util.NetworkUtils;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
@@ -25,6 +24,7 @@ import bisq.wallets.bitcoind.rpc.responses.BitcoindListUnspentResponse;
 import bisq.wallets.bitcoind.zmq.ZmqListeners;
 import bisq.wallets.json_rpc.RpcConfig;
 import bisq.wallets.regtest.AbstractRegtestSetup;
+import bisq.wallets.regtest.Os;
 import bisq.wallets.regtest.process.MultiProcessCoordinator;
 import lombok.Getter;
 
@@ -158,7 +158,7 @@ public class BitcoindRegtestSetup
                 throw new IllegalStateException("Couldn't extract bitcoind binary.");
             }
 
-            if (OS.isLinux() || OS.isMacOs()) {
+            if (Os.isLinux() || Os.isMacOs()) {
                 isSuccess = bitcoindPath.toFile().setExecutable(true);
                 if (!isSuccess) {
                     throw new IllegalStateException("Couldn't set executable bit on bitcoind binary.");


### PR DESCRIPTION
The wallets.regtest can't depend on any Bisq 2 API to be able to re-use
the bitcoind regtest module in Bisq 1. I migrated our BitcoinJ fork to
the upstream version but Bisq 1 uses deprecated/removed BitcoinJ APIs,
and it's too risky to update critical code without testing the changes.
Bisq 1 doesn't have any bitcoind-based integration testing code and
quicker to re-use Bisq 2 bitcoind integration test infrastructure.