### PR TITLE
Use JRE instead of JDK Desktop Binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ hs_err_pid*
 *.wallet
 *.ser
 *.sh
+.vscode
 .DS_Store
 .gradle
 build

--- a/apps/desktop/desktop-app-launcher/build.gradle.kts
+++ b/apps/desktop/desktop-app-launcher/build.gradle.kts
@@ -1,5 +1,4 @@
 import java.util.Properties
-import java.io.File
 
 // Function to read properties from a file - TODO find a way to reuse this code instead of copying when needed
 fun readPropertiesFile(filePath: String): Properties {
@@ -12,6 +11,7 @@ plugins {
     id("bisq.java-library")
     id("bisq.gradle.desktop.regtest.BisqDesktopRegtestPlugin")
     application
+    id("org.kordamp.gradle.jdeps") version "0.20.0"
     id("bisq.gradle.packaging.PackagingPlugin")
     alias(libs.plugins.openjfx)
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JLinkTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JLinkTask.kt
@@ -3,14 +3,18 @@ package bisq.gradle.packaging
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
-import java.util.concurrent.TimeUnit
+import org.gradle.api.tasks.*
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+
+//import java.util.regex.Pattern
 
 abstract class JLinkTask : DefaultTask() {
+
+//    companion object {
+//        val pattern: Pattern = Pattern.compile(".*\\b(java\\..*|javax\\..*)\\b.*\$")
+//    }
 
     @get:InputDirectory
     abstract val jdkDirectory: DirectoryProperty
@@ -27,46 +31,105 @@ abstract class JLinkTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        // jlink expects non-existent output directory
+        // Ensure the output directory is clean
         val outputDirectoryFile = outputDirectory.asFile.get()
-        outputDirectoryFile.deleteRecursively()
+        if (outputDirectoryFile.exists() && outputDirectoryFile.listFiles()?.isNotEmpty() == true) {
+            // In case you want to run it manually, this will stop the plugin from running the task
+            logger.lifecycle("custom jre already created, skipping - see: ${jdkDirectory.get()}")
+        } else {
+            if (!outputDirectoryFile.canWrite()) {
+                throw IllegalStateException("Output directory is not writable: ${outputDirectoryFile.absolutePath}")
+            }
+            outputDirectoryFile.deleteRecursively()
 
-        val jLinkPath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jlink")
-        val processBuilder = ProcessBuilder(
+            logger.lifecycle("JDK path: ${jdkDirectory.get()}")
+
+            // Construct the jlink command
+            val jLinkPath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jlink")
+            val processBuilder = ProcessBuilder(
                 jLinkPath.toAbsolutePath().toString(),
-
+                "--verbose",
                 "--add-modules", parseUsedJavaModulesFromJDepsOutput(),
-
+                "--include-locales=en,cs,de,es,it,pcm,pt-BR",
                 "--strip-native-commands",
                 "--no-header-files",
                 "--no-man-pages",
-                "--strip-debug",
-
+                "--compress=2",
+//            "--strip-debug", // makes jlink fail in some platforms like Ubuntu linux
+//            "--add-reads", "java.base=ALL-UNNAMED",
                 "--output", outputDirectoryFile.absolutePath
-        )
+            )
+            logger.lifecycle("Executing jlink command: ${processBuilder.command().joinToString(" ")}")
 
-        if (javaModulesDirectory.isPresent) {
-            val commands = processBuilder.command()
-            commands.add("--module-path")
-            commands.add(javaModulesDirectory.asFile.get().absolutePath)
-        }
+            // Add module path if specified
+            if (javaModulesDirectory.isPresent) {
+                val commands = processBuilder.command()
+                commands.add("--module-path")
+                commands.add(javaModulesDirectory.asFile.get().absolutePath)
+                logger.lifecycle("Executing jlink command: ${commands.joinToString(" ")}")
+            }
 
-        processBuilder.inheritIO()
+            logger.lifecycle("Preparing process builder..")
+            processBuilder.inheritIO()
 
-        val process = processBuilder.start()
-        process.waitFor(2, TimeUnit.MINUTES)
+            logger.lifecycle("Starting process builder..")
+            val process = processBuilder.start()
+            if (System.getProperty("os.name").lowercase().contains("windows")) {
+                val reader =
+                    BufferedReader(InputStreamReader(process.inputStream))
+                while ((reader.readLine()) != null) {
+                    // WORKAROUND: Jlink hangs in windows (11pro) when running from this custom plugin
+                    // This buffer reader is needed jus to get it going and won't affect the rest of the platforms
+                }
+            }
+            logger.lifecycle("Reading errors..")
+            val errorOutput = process.errorStream.bufferedReader().readText()
+            val exitCode = process.waitFor()
 
-        val isSuccess = process.exitValue() == 0
-        if (!isSuccess) {
-            throw IllegalStateException("jlink couldn't create custom runtime.")
+            if (exitCode != 0) {
+                logger.error("jlink error output:\n$errorOutput")
+                throw IllegalStateException("jlink couldn't create custom runtime. Exit code: $exitCode")
+            }
         }
     }
 
     private fun parseUsedJavaModulesFromJDepsOutput(): String {
-        var readLines = jDepsOutputFile.asFile.get().readLines()
-        if (!javaModulesDirectory.isPresent) {
-            readLines = readLines.filter { it.startsWith("java.") }
-        }
-        return readLines.joinToString(",")
+//        TODO instead of hardcoding he modules process the jdeps report and generate the below so we don't need
+//             to touch this code again in case of needed new jmods in the future
+//            readLines.filter { pattern.matcher(it).matches() }
+//            .flatMap { line -> line.split("->").map { it.trim() } }
+//            .filter { it.startsWith("java.") || it == "bisq.desktop_app_launcher" }
+//            .flatMap { line -> line.split(",").map { it.trim() } }
+//            .distinct()
+//            .joinToString(",")
+//        val readLines = jDepsOutputFile.asFile.get().readLines()
+        val modules = listOf(
+            // base
+            "java.base",
+            "java.datatransfer",
+            "java.desktop",
+            "java.logging",
+            "java.xml",
+            "java.naming",
+            "java.net.http",
+            // security
+            "java.se",
+            "java.security.jgss",
+            // javafx
+            "javafx.base",
+            "javafx.controls",
+            "javafx.fxml",
+            "javafx.graphics",
+            "javafx.media",
+            "javafx.swing",
+//            "javafx.web",
+            // jdk
+            "jdk.unsupported",
+            "jdk.localedata",
+            "jdk.crypto.cryptoki",
+            "jdk.crypto.ec"
+        ).joinToString(",")
+        logger.lifecycle("Modules to be included: $modules")
+        return modules
     }
 }


### PR DESCRIPTION
## Purpose

 - Implementation for [JDK/JRE Build Optimization Issue](https://github.com/bisq-network/bisq2/issues/2681)
 
## Approach

 - ~~Use Gradle Java Toolchain~~  --> _Couldn't get it to pick up the JRE_
 - ~~Download JRE manually and use it for runtime~~  --> _Too complicated, increase build times_
 - Build a skimmed JRE out of our dev JDK  --> **Success ! :)**
 
 ## Results
 
  - Reduction on final binary are around **~160MB (30% less)**
  - **new** results after tweaking some unnecessary mods during review are **~245MB (46% less)**
  - This PR is fully  tested in MacOS (M1). Also tested that it will run in Windows and Linux, but for those environments I need help as the binary won't generate in my envs even from main branch (Eventually I need to work why is this happening and submit a PR to fix it  or fix whatever is wrong in my envs) - Please help test this PR!
  
## How to test this PR
  

1.  `$ ./gradlew apps:desktop:desktop-app-launcher:clean  apps:desktop:desktop-app-launcher:generateInstallers --info`  
2. you'll find in in `apps/desktop/desktop-app-launcher/build` folder the `custom-jre` folder with the gerated skimmed JRE, and in `packages/jpackages/package/Bisq2...` the installer corresponding to your env (e.g. Bisq2....dmg) . Install it and run the app. Also check the size of the binary. Please comment your results with details on your environment in this PR.
  
## Known Issues / Future lines of improvement

 - Left TODOs in the code to reference this

## Dev Commit logs

 - approach using jlink to generate a slim jre from our dev jdk
 - generateInstallers depends on jlink task now
 - work out the list of mods needed for the app to function
 - optimize jlink command to trim as much unneded stuff as possible
 - adjust code for windows env
 - cleanup code, leave TODOs for future lines of improvement/optimization