### PR TITLE
Reviewed ES translations for chat properties

### DIFF
--- a/i18n/src/main/resources/chat_es.properties
+++ b/i18n/src/main/resources/chat_es.properties
@@ -4,7 +4,7 @@
 #
 ####################################################################
 
-chat.privateChannel.message.leave={0} dejó el chat
+chat.privateChannel.message.leave={0} ha salido del chat
 
 ####################################################################
 # Notifications
@@ -21,11 +21,11 @@ chat.notifications.offerTaken.message=ID de la transacción: {0}
 # suppress inspection "UnusedProperty"
 chat.channelDomain.BISQ_EASY_OFFERBOOK=Bisq Easy
 # suppress inspection "UnusedProperty"
-chat.channelDomain.BISQ_EASY_OPEN_TRADES=Bisq Easy comercio
+chat.channelDomain.BISQ_EASY_OPEN_TRADES=Compra-venta Bisq Easy
 # suppress inspection "UnusedProperty"
 chat.channelDomain.BISQ_EASY_PRIVATE_CHAT=Bisq Easy
 # suppress inspection "UnusedProperty"
-chat.channelDomain.DISCUSSION=Discusiones
+chat.channelDomain.DISCUSSION=Charlas
 # suppress inspection "UnusedProperty"
 chat.channelDomain.EVENTS=Eventos
 # suppress inspection "UnusedProperty"
@@ -38,21 +38,21 @@ chat.channelDomain.SUPPORT=Soporte
 
 ## Channel id is used for creating dynamically the key
 # suppress inspection "UnusedProperty"
-discussion.bisq.title=Discusiones
+discussion.bisq.title=Charlas
 # suppress inspection "UnusedProperty"
-discussion.bisq.description=Canal público para discusiones
+discussion.bisq.description=Canal público para charlar
 # suppress inspection "UnusedProperty"
 discussion.bitcoin.title=Bitcoin
 # suppress inspection "UnusedProperty"
-discussion.bitcoin.description=Canal para discusiones sobre Bitcoin
+discussion.bitcoin.description=Canal para charlar sobre Bitcoin
 # suppress inspection "UnusedProperty"
 discussion.markets.title=Mercados
 # suppress inspection "UnusedProperty"
-discussion.markets.description=Canal para discusiones sobre mercados y precios
+discussion.markets.description=Canal para charlar sobre mercados y precios
 # suppress inspection "UnusedProperty"
 discussion.offTopic.title=Off-topic
 # suppress inspection "UnusedProperty"
-discussion.offTopic.description=Canal para charlas fuera de tema
+discussion.offTopic.description=Canal para charlas off-topic
 
 # suppress inspection "UnusedProperty"
 events.conferences.title=Conferencias
@@ -67,22 +67,22 @@ events.podcasts.title=Podcasts
 # suppress inspection "UnusedProperty"
 events.podcasts.description=Canal para anuncios de podcasts
 # suppress inspection "UnusedProperty"
-events.tradeEvents.title=Eventos de comercio
+events.tradeEvents.title=Intercambiar
 # suppress inspection "UnusedProperty"
-events.tradeEvents.description=Canal para anuncios de eventos de comercio
+events.tradeEvents.description=Canal para anuncios de eventos de intercambio
 
 # suppress inspection "UnusedProperty"
-support.support.title=Asistencia
+support.support.title=Soporte
 # suppress inspection "UnusedProperty"
 support.support.description=Canal para Soporte
 # suppress inspection "UnusedProperty"
-support.questions.title=Preguntas
+support.questions.title=Soporte
 # suppress inspection "UnusedProperty"
-support.questions.description=Canal para preguntas generales
+support.questions.description=Canal para soporte en compra-ventas
 # suppress inspection "UnusedProperty"
-support.reports.title=Informe de fraude
+support.reports.title=Denunciar
 # suppress inspection "UnusedProperty"
-support.reports.description=Canal para informes de fraude
+support.reports.description=Canal para informar de fraudes
 
 
 ################################################################################
@@ -95,8 +95,8 @@ chat.leave=Haz click aquí para salir
 chat.leave.info=Vas a salir del chat
 chat.leave.confirmLeaveChat=Salir del chat
 chat.messagebox.noChats.placeholder.title=¡Inicia la conversación!
-chat.messagebox.noChats.placeholder.description=Únete a la discusión en {0} para compartir tus pensamientos y hacer preguntas.
-chat.ignoreUser.warn=Seleccionar 'Ignorar usuario' ocultará todos los mensajes de este usuario.\n\nEsta acción tendrá efecto la próxima vez que entres al chat.\n\nPara revertir esto, ve al menú más opciones > Información del canal > Participantes y selecciona 'Deshacer Ignorar' al lado del usuario.
+chat.messagebox.noChats.placeholder.description=Únete a la discusión en {0} para compartir tus ideas y hacer preguntas.
+chat.ignoreUser.warn=Seleccionar 'Ignorar usuario' ocultará todos los mensajes de este usuario.\n\nEsta acción tendrá efecto la próxima vez que entres al chat.\n\nSi quieres deshacer esta acción, ve al menú más opciones > Información del canal > Participantes y selecciona 'Dejar de ignorar' al lado del usuario.
 chat.ignoreUser.confirm=Ignorar usuario
 
 
@@ -107,8 +107,8 @@ chat.ignoreUser.confirm=Ignorar usuario
 chat.private.title=Chats privados
 chat.private.messagebox.noChats.title={0} chats privados
 chat.private.messagebox.noChats.placeholder.title=No tienes conversaciones en curso
-chat.private.messagebox.noChats.placeholder.description=Para chatear de manera privada con un par, pasa el cursor sobre su mensaje en un\nchat público y haz clic en 'Enviar mensaje privado'.
-chat.private.openChatsList.headline=Contactos de chat
+chat.private.messagebox.noChats.placeholder.description=Para chatear de manera privada con otro usario, pasa el cursor sobre su mensaje en un\nchat público y haz clic en 'Enviar mensaje privado'.
+chat.private.openChatsList.headline=Usuarios del chat
 chat.private.leaveChat.confirmation=¿Estás seguro de que quieres abandonar este chat?\nPerderás acceso al chat y toda la información del chat.
 
 
@@ -116,7 +116,7 @@ chat.private.leaveChat.confirmation=¿Estás seguro de que quieres abandonar est
 # Top menu
 ######################################################
 
-chat.topMenu.tradeGuide.tooltip=Abrir guía de comercio
+chat.topMenu.tradeGuide.tooltip=Abrir guía de compra-venta
 chat.topMenu.chatRules.tooltip=Abrir reglas del chat
 
 
@@ -127,7 +127,7 @@ chat.topMenu.chatRules.tooltip=Abrir reglas del chat
 chat.dropdownMenu.tooltip=Más opciones
 chat.dropdownMenu.chatRules=Reglas de chat
 chat.dropdownMenu.channelInfo=Información del canal
-chat.dropdownMenu.tradeGuide=Guía de intercambio
+chat.dropdownMenu.tradeGuide=Guía de compra-venta
 
 
 ######################################################
@@ -135,7 +135,7 @@ chat.dropdownMenu.tradeGuide=Guía de intercambio
 ######################################################
 
 chat.chatRules.headline=Reglas del chat
-chat.chatRules.content=- Sé respetuoso: Trata a los demás con amabilidad, evita lenguaje ofensivo, ataques personales y acoso.- Sé tolerante: Mantén una mente abierta y acepta que otros pueden tener opiniones diferentes, antecedentes culturales y experiencias.- No hagas spam: Evita inundar el chat con mensajes repetitivos o irrelevantes.- No hagas publicidad: Evita promover productos comerciales, servicios o publicar enlaces promocionales.- No seas provocador: El comportamiento disruptivo y la provocación intencional no son bienvenidos.- No te hagas pasar por otra persona: No uses apodos que induzcan a otros a pensar que eres una persona conocida.- Respeta la privacidad: Protege tu privacidad y la de los demás; no compartas detalles de las transacciones.- Informa de comportamientos inadecuados: Informa sobre violaciones de las reglas o comportamientos inapropiados al moderador.- Disfruta del chat: Participa en discusiones significativas, haz amigos y diviértete en una comunidad amigable e inclusiva.\n\nAl participar en el chat, aceptas seguir estas reglas.\nViolaciones graves de las reglas pueden resultar en la prohibición de la red de Bisq.
+chat.chatRules.content=- Sé respetuoso: Trata a los demás con amabilidad, evita el lenguaje ofensivo, los ataques personales y el acoso.- Sé tolerante: Mantén una mente abierta y acepta que otros pueden tener opiniones, culturas y experiencias diferentes.- No hagas spam: Evita inundar el chat con mensajes repetitivos o irrelevantes.- No hagas publicidad: Evita promover productos comerciales, servicios o enlaces promocionales.- No seas provocador: El comportamiento disruptivo y la provocación intencional no son bienvenidos.- No te hagas pasar por otra persona: No uses apodos que induzcan a otros a pensar que eres una persona conocida.- Respeta la privacidad: Protege tu privacidad y la de los demás; no compartas detalles de las transacciones.- Informa de comportamientos inadecuados: Informa sobre violaciones de las reglas o comportamientos inapropiados al moderador.- Disfruta del chat: Participa en discusiones interesantes, haz amigos y diviértete en una comunidad amigable e inclusiva.\n\nAl participar en el chat, aceptas seguir estas reglas.\nLas violaciones graves de las reglas pueden resultar en expulsión de la red Bisq.
 
 
 ####################################################################
@@ -151,11 +151,11 @@ chat.sideBar.userProfile.profileAge=Antigüedad del perfil
 chat.sideBar.userProfile.livenessState=Última actividad del usuario
 chat.sideBar.userProfile.version=Versión
 chat.sideBar.userProfile.statement=Declaración
-chat.sideBar.userProfile.terms=Términos de comercio
+chat.sideBar.userProfile.terms=Términos de compra-venta
 chat.sideBar.userProfile.sendPrivateMessage=Enviar mensaje privado
 chat.sideBar.userProfile.mention=Mencionar
 chat.sideBar.userProfile.ignore=Ignorar
-chat.sideBar.userProfile.undoIgnore=Deshacer ignorar
+chat.sideBar.userProfile.undoIgnore=Dejar de ignorar
 chat.sideBar.userProfile.report=Informar al moderador
 
 
@@ -164,10 +164,10 @@ chat.sideBar.userProfile.report=Informar al moderador
 ####################################################################
 
 chat.sideBar.channelInfo.notification.options=Opciones de notificación
-chat.sideBar.channelInfo.notifications.globalDefault=Usar predeterminado
+chat.sideBar.channelInfo.notifications.globalDefault=Notificaciones por defecto
 chat.sideBar.channelInfo.notifications.all=Todos los mensajes
 chat.sideBar.channelInfo.notifications.mention=Si se menciona
-chat.sideBar.channelInfo.notifications.off=Apagar
+chat.sideBar.channelInfo.notifications.off=Ninguna
 chat.sideBar.channelInfo.participants=Participantes
 
 
@@ -175,11 +175,11 @@ chat.sideBar.channelInfo.participants=Participantes
 # Report to moderator window
 ####################################################################
 
-chat.reportToModerator.headline=Informar al moderador
-chat.reportToModerator.info=Por favor, familiarízate con las reglas de comercio y asegúrate de que la razón para informar sea considerada una violación de esas reglas.\nPuedes leer las reglas de comercio y las reglas del chat haciendo clic en el icono de interrogación en la esquina superior derecha de las pantallas del chat.
+chat.reportToModerator.headline=Denunciar al moderador
+chat.reportToModerator.info=Por favor, familiarízate con las reglas de compra-venta y asegúrate de que la razón para denunciar sea considerada una violación de esas reglas.\nPuedes leer las reglas de comercio y las reglas del chat haciendo clic en el icono de interrogación en la esquina superior derecha de las pantallas del chat.
 chat.reportToModerator.message=Mensaje al moderador
-chat.reportToModerator.message.prompt=Ingresar mensaje al moderador
-chat.reportToModerator.report=Informar al moderador
+chat.reportToModerator.message.prompt=Introducir el mensaje al moderador
+chat.reportToModerator.report=Denunciar al moderador
 
 
 ####################################################################
@@ -196,25 +196,25 @@ chat.message.supportedLanguages=Idiomas admitidos:
 chat.message.supportedLanguages.Tooltip=Idiomas admitidos
 
 # suppress inspection "UnusedProperty"
-chat.message.deliveryState.CONNECTING=Connecting to peer
+chat.message.deliveryState.CONNECTING=Conectando con usuario
 # suppress inspection "UnusedProperty"
-chat.message.deliveryState.SENT=Mensaje enviado (recibo no confirmado aún).
+chat.message.deliveryState.SENT=Mensaje enviado (sin confirmación de recepción).
 # suppress inspection "UnusedProperty"
-chat.message.deliveryState.ACK_RECEIVED=Message receipt acknowledged
+chat.message.deliveryState.ACK_RECEIVED=Recepción confirmada
 # suppress inspection "UnusedProperty"
-chat.message.deliveryState.TRY_ADD_TO_MAILBOX=Try to add message to peer's mailbox
+chat.message.deliveryState.TRY_ADD_TO_MAILBOX=Intentando dejar mensaje en el buzón del usuario
 # suppress inspection "UnusedProperty"
-chat.message.deliveryState.ADDED_TO_MAILBOX=Mensaje agregado al buzón del destinatario
+chat.message.deliveryState.ADDED_TO_MAILBOX=Mensaje entregado al buzón del usuario
 # suppress inspection "UnusedProperty"
-chat.message.deliveryState.MAILBOX_MSG_RECEIVED=Mensaje del buzón recibido por el destinatario
+chat.message.deliveryState.MAILBOX_MSG_RECEIVED=El usuario ha descargado el mensaje de su buzón
 # suppress inspection "UnusedProperty"
 chat.message.deliveryState.FAILED=Error al enviar el mensaje
 chat.message.resendMessage=Haz click para reenviar el mensaje.
 
 chat.message.contextMenu.ignoreUser=Ignorar usuario
-chat.message.contextMenu.reportUser=Informar sobre el usuario al moderador
+chat.message.contextMenu.reportUser=Denunciar sobre el usuario al moderador
 chat.message.takeOffer.myReputationScoreTooLow.warn=Tu puntuación de reputación es demasiado baja para tomar esta oferta.\n\nLa oferta requiere una puntuación mínima de reputación de: {0}.\nTu puntuación de reputación es: {1}.\n\nTen en cuenta que el modelo de seguridad de Bisq Easy está basado en la reputación del vendedor.\n\nPara aprender más acerca del modelo de reputación: [HYPERLINK:https://bisq.wiki/Reputation].\nTambién puedes ir a "Opciones de Usuario/Reputación" para leer más acerca de cómo construir reputación.
-chat.message.takeOffer.makersReputationScoreTooLow.warn=La puntuación de reputación del creador es demasiado baja.\n\nTu puntuación mínima de reputación requerida es: {0}.\nUa puntuación de reputación del tomador es: {1}.\n\nTen en cuenta que el modelo de seguridad de Bisq Easy está basado en la reputación del vendedor.\n\nPara aprender más acerca del modelo de reputación: [HYPERLINK:https://bisq.wiki/Reputation].\nTambién puedes ir a "Opciones de Usuario/Reputación" para leer más acerca de cómo construir reputación.
+chat.message.takeOffer.makersReputationScoreTooLow.warn=La puntuación de reputación del creador es demasiado baja.\n\nTu puntuación mínima de reputación requerida es: {0}.\nUa puntuación de reputación del tomador es: {1}.\n\nTen en cuenta que el modelo de seguridad de Bisq Easy está basado en la reputación del vendedor.\n\nPara aprender más acerca del modelo de reputación: [HYPERLINK:https://bisq.wiki/Reputation].\nPuedes cambiar la puntuación de reputación mínima en "Ajustes/Preferencias".
 
 chat.message.offer.offerAlreadyTaken.warn=Ya has tomado esa oferta.
 chat.message.delete.differentUserProfile.warn=Este mensaje de chat fue creado con otro perfil de usuario.\n\n¿Quieres eliminar el mensaje?
@@ -224,5 +224,5 @@ chat.message.send.offerOnly.warn=Tienes seleccionada la opción 'Solo ofertas'. 
 
 chat.message.citation.headline=Respondiendo a:
 chat.message.reactionPopup=reaccionó con
-chat.listView.scrollDown=Scroll down
-chat.listView.scrollDown.newMessages=Scroll down to read new messages
+chat.listView.scrollDown=Bajar
+chat.listView.scrollDown.newMessages=Bajar para leer nuevos mensajes


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the chat properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage.

Replaces #2777, which had the same contents but commits were not signed.