### PR TITLE
Reviewed ES translations for default properties

### DIFF
--- a/i18n/src/main/resources/default_es.properties
+++ b/i18n/src/main/resources/default_es.properties
@@ -42,7 +42,7 @@ action.cancel=Cancelar
 action.close=Cerrar
 action.save=Guardar
 action.shutDown=Apagar
-action.iUnderstand=Entiendo
+action.iUnderstand=Lo entiendo
 action.goTo=Ir a {0}
 action.copyToClipboard=Copiar al portapapeles
 action.search=Buscar
@@ -51,7 +51,7 @@ action.editable=Editable
 action.delete=Eliminar
 action.learnMore=Más información
 action.dontShowAgain=No mostrar de nuevo
-action.expandOrCollapse=Haga clic para colapsar o expandir
+action.expandOrCollapse=Haga clic para cerrar o expandir
 action.exportAsCsv=Exportar como CSV
 action.react=Reaccionar
 
@@ -72,7 +72,7 @@ offer.buying=comprando
 offer.selling=vendiendo
 offer.seller=Vendedor
 offer.buyer=Comprador
-offer.maker=Fabricante
+offer.maker=Ofertante
 offer.taker=Tomador
 offer.price.above=por encima de
 offer.price.below=por debajo de
@@ -95,28 +95,28 @@ temporal.at=en
 
 # suppress inspection "UnusedProperty"
 validation.invalid=Entrada no válida
-validation.invalidNumber=La entrada no es un número válido
-validation.invalidPercentage=La entrada no es un valor porcentual válido
-validation.empty=No se permite una cadena vacía
-validation.password.tooShort=La contraseña que ingresaste es demasiado corta. Debe contener al menos 8 caracteres.
-validation.password.notMatching=Las 2 contraseñas que ingresaste no coinciden
-validation.tooLong=El texto de entrada no debe ser más largo de {0} caracteres
-validation.invalidBitcoinAddress=La dirección de Bitcoin parece ser inválida
-validation.invalidBitcoinTransactionId=El ID de la transacción de Bitcoin parece ser inválido
-validation.invalidLightningInvoice=La factura de Lightning parece ser inválida
-validation.invalidLightningPreimage=La preimagen de Lightning parece ser inválida
+validation.invalidNumber=No es un número válido
+validation.invalidPercentage=No es un porcentaje válido
+validation.empty=No se permite texto vacío
+validation.password.tooShort=La contraseña que has introducido es demasiado corta. Debe contener al menos 8 caracteres.
+validation.password.notMatching=Las 2 contraseñas no coinciden
+validation.tooLong=El texto no debe ser más largo de {0} caracteres
+validation.invalidBitcoinAddress=La dirección de Bitcoin no parece válida
+validation.invalidBitcoinTransactionId=El ID de la transacción de Bitcoin no parece válido
+validation.invalidLightningInvoice=La factura de Lightning no parece válida
+validation.invalidLightningPreimage=La preimagen de Lightning no parece válida
 
 
 ####################################################################
 # UI components
 ####################################################################
 
-component.priceInput.prompt=Ingrese el precio
+component.priceInput.prompt=Introduce el precio
 component.priceInput.description={0} precio
 component.marketPrice.requesting=Solicitando precio de mercado
 
 # suppress inspection "UnusedProperty"
-component.marketPrice.source.PERSISTED=Datos persistidos
+component.marketPrice.source.PERSISTED=Pendiente de recibir precio de mercado. Usando datos persistidos en su lugar.
 # suppress inspection "UnusedProperty"
 component.marketPrice.source.PROPAGATED_IN_NETWORK=Propagado por el nodo oráculo: {0}
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the default properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage.