### PR TITLE
Reviewed ES translations for network properties

### DIFF
--- a/i18n/src/main/resources/network_es.properties
+++ b/i18n/src/main/resources/network_es.properties
@@ -2,9 +2,9 @@
 # Network
 ####################################################################
 
-network.myNetworkNode=Mi nodo de red
+network.myNetworkNode=Mi nodo de la red
 network.p2pNetwork=Red P2P
-network.roles=Roles Vinculados
+network.roles=Roles con fianza
 network.nodes=Nodos de infraestructura
 
 network.version.headline=Distribución de versiones
@@ -32,11 +32,11 @@ network.transport.pow.details=Tiempo total gastado: {0}\nTiempo promedio por men
 network.transport.systemLoad.headline=Carga del sistema
 network.transport.systemLoad.details=Tamaño de los datos de red persistidos: {0}\nCarga actual de la red: {1}\nCarga promedio de la red: {2}
 
-network.header.nodeTag=Etiqueta de nodo
+network.header.nodeTag=Etiqueta de identidad
 network.header.nodeTag.tooltip=Etiqueta de identidad: {0}
 
 network.connections.title=Conexiones
-network.connections.header.peer=Compañero de intercambio
+network.connections.header.peer=Usuario
 network.connections.header.address=Dirección
 network.connections.header.connectionDirection=Entrada/Salida
 network.connections.header.rtt=RTT
@@ -45,7 +45,7 @@ network.connections.header.receivedHeader=Recibido
 network.connections.inbound=Entrante
 network.connections.outbound=Saliente
 network.connections.ioData={0} / {1} Mensajes
-network.connections.seed=Seed node
+network.connections.seed=Nodo semilla
 
 network.nodeInfo.myAddress=Mi dirección predeterminada
 network.nodes.title=Mis nodos
@@ -55,5 +55,7 @@ network.nodes.header.numConnections=Número de conexiones
 network.nodes.header.type=Tipo
 network.nodes.type.active=Nodo de usuario (activo)
 network.nodes.type.retired=Nodo de usuario (retirado)
-network.nodes.type.default=Nodo de chismes
+network.nodes.type.default=Nodo Gossip
+
+
 


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the default properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage.
