### PR TITLE
Reviewed ES translations for payment method properties

### DIFF
--- a/i18n/src/main/resources/payment_method_es.properties
+++ b/i18n/src/main/resources/payment_method_es.properties
@@ -10,9 +10,9 @@ SAME_BANK=Transferencia con el mismo banco
 # suppress inspection "UnusedProperty"
 SPECIFIC_BANKS=Transferencias con bancos específicos
 # suppress inspection "UnusedProperty"
-US_POSTAL_MONEY_ORDER=Orden de dinero postal de EE. UU.
+US_POSTAL_MONEY_ORDER=Giro postal de EE. UU.
 # suppress inspection "UnusedProperty"
-CASH_DEPOSIT=Depósito en efectivo
+CASH_DEPOSIT=Ingreso de efectivo
 # suppress inspection "UnusedProperty"
 CASH_BY_MAIL=Efectivo por correo
 # suppress inspection "UnusedProperty"
@@ -36,9 +36,9 @@ SAME_BANK_SHORT=Mismo banco
 # suppress inspection "UnusedProperty"
 SPECIFIC_BANKS_SHORT=Bancos específicos
 # suppress inspection "UnusedProperty"
-US_POSTAL_MONEY_ORDER_SHORT=Orden de dinero de EE. UU.
+US_POSTAL_MONEY_ORDER_SHORT=Giro postal de EE. UU.
 # suppress inspection "UnusedProperty"
-CASH_DEPOSIT_SHORT=Depósito en efectivo
+CASH_DEPOSIT_SHORT=Ingreso de efectivo
 # suppress inspection "UnusedProperty"
 CASH_BY_MAIL_SHORT=Efectivo por correo
 # suppress inspection "UnusedProperty"
@@ -70,7 +70,7 @@ WECHAT_PAY=WeChat Pay
 # suppress inspection "UnusedProperty"
 SEPA=SEPA
 # suppress inspection "UnusedProperty"
-SEPA_INSTANT=SEPA Instant
+SEPA_INSTANT=SEPA Instantánea
 # suppress inspection "UnusedProperty"
 FASTER_PAYMENTS=Faster Payments
 # suppress inspection "UnusedProperty"
@@ -112,7 +112,7 @@ BIZUM=Bizum
 # suppress inspection "UnusedProperty"
 PIX=Pix
 # suppress inspection "UnusedProperty"
-AMAZON_GIFT_CARD=Amazon eGift Card
+AMAZON_GIFT_CARD=Tarjeta regalo de Amazon
 # suppress inspection "UnusedProperty"
 CAPITUAL=Capitual
 # suppress inspection "UnusedProperty"
@@ -128,15 +128,15 @@ VERSE=Verse
 # suppress inspection "UnusedProperty"
 STRIKE=Strike
 # suppress inspection "UnusedProperty"
-SWIFT=SWIFT International Wire Transfer
+SWIFT=Transferencia internacional SWIFT
 # suppress inspection "UnusedProperty"
 SWIFT_SHORT=SWIFT
 # suppress inspection "UnusedProperty"
-ACH_TRANSFER=ACH Transfer
+ACH_TRANSFER=Transferencia ACH
 # suppress inspection "UnusedProperty"
 ACH_TRANSFER_SHORT=ACH
 # suppress inspection "UnusedProperty"
-DOMESTIC_WIRE_TRANSFER=Domestic Wire Transfer
+DOMESTIC_WIRE_TRANSFER=Transferencia Wire Doméstica
 # suppress inspection "UnusedProperty"
 DOMESTIC_WIRE_TRANSFER_SHORT=Wire
 # suppress inspection "UnusedProperty"
@@ -160,15 +160,15 @@ LN=BTC a través de Lightning Network
 # suppress inspection "UnusedProperty"
 LN_SHORT=Lightning
 # suppress inspection "UnusedProperty"
-LBTC=L-BTC (BTC con la cadena lateral Liquid)
+LBTC=L-BTC (BTC pegged en la side chain Liquid)
 # suppress inspection "UnusedProperty"
 LBTC_SHORT=Liquid
 # suppress inspection "UnusedProperty"
-RBTC=RBTC (BTC con la cadena lateral RSK)
+RBTC=RBTC (BTC pegged en la side chain RSK)
 # suppress inspection "UnusedProperty"
 RBTC_SHORT=RSK
 # suppress inspection "UnusedProperty"
-WBTC=WBTC (BTC envuelto como token ERC20)
+WBTC=WBTC (BTC wrapped como token ERC20)
 # suppress inspection "UnusedProperty"
 WBTC_SHORT=WBTC
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the default properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage.
