### PR TITLE
Reviewed ES translations for settings properties

### DIFF
--- a/i18n/src/main/resources/payment_method_es.properties
+++ b/i18n/src/main/resources/payment_method_es.properties
@@ -10,9 +10,9 @@ SAME_BANK=Transferencia con el mismo banco
 # suppress inspection "UnusedProperty"
 SPECIFIC_BANKS=Transferencias con bancos específicos
 # suppress inspection "UnusedProperty"
-US_POSTAL_MONEY_ORDER=Orden de dinero postal de EE. UU.
+US_POSTAL_MONEY_ORDER=Giro postal de EE. UU.
 # suppress inspection "UnusedProperty"
-CASH_DEPOSIT=Depósito en efectivo
+CASH_DEPOSIT=Ingreso de efectivo
 # suppress inspection "UnusedProperty"
 CASH_BY_MAIL=Efectivo por correo
 # suppress inspection "UnusedProperty"
@@ -36,9 +36,9 @@ SAME_BANK_SHORT=Mismo banco
 # suppress inspection "UnusedProperty"
 SPECIFIC_BANKS_SHORT=Bancos específicos
 # suppress inspection "UnusedProperty"
-US_POSTAL_MONEY_ORDER_SHORT=Orden de dinero de EE. UU.
+US_POSTAL_MONEY_ORDER_SHORT=Giro postal de EE. UU.
 # suppress inspection "UnusedProperty"
-CASH_DEPOSIT_SHORT=Depósito en efectivo
+CASH_DEPOSIT_SHORT=Ingreso de efectivo
 # suppress inspection "UnusedProperty"
 CASH_BY_MAIL_SHORT=Efectivo por correo
 # suppress inspection "UnusedProperty"
@@ -70,7 +70,7 @@ WECHAT_PAY=WeChat Pay
 # suppress inspection "UnusedProperty"
 SEPA=SEPA
 # suppress inspection "UnusedProperty"
-SEPA_INSTANT=SEPA Instant
+SEPA_INSTANT=SEPA Instantánea
 # suppress inspection "UnusedProperty"
 FASTER_PAYMENTS=Faster Payments
 # suppress inspection "UnusedProperty"
@@ -112,7 +112,7 @@ BIZUM=Bizum
 # suppress inspection "UnusedProperty"
 PIX=Pix
 # suppress inspection "UnusedProperty"
-AMAZON_GIFT_CARD=Amazon eGift Card
+AMAZON_GIFT_CARD=Tarjeta regalo de Amazon
 # suppress inspection "UnusedProperty"
 CAPITUAL=Capitual
 # suppress inspection "UnusedProperty"
@@ -128,15 +128,15 @@ VERSE=Verse
 # suppress inspection "UnusedProperty"
 STRIKE=Strike
 # suppress inspection "UnusedProperty"
-SWIFT=SWIFT International Wire Transfer
+SWIFT=Transferencia internacional SWIFT
 # suppress inspection "UnusedProperty"
 SWIFT_SHORT=SWIFT
 # suppress inspection "UnusedProperty"
-ACH_TRANSFER=ACH Transfer
+ACH_TRANSFER=Transferencia ACH
 # suppress inspection "UnusedProperty"
 ACH_TRANSFER_SHORT=ACH
 # suppress inspection "UnusedProperty"
-DOMESTIC_WIRE_TRANSFER=Domestic Wire Transfer
+DOMESTIC_WIRE_TRANSFER=Transferencia Wire Doméstica
 # suppress inspection "UnusedProperty"
 DOMESTIC_WIRE_TRANSFER_SHORT=Wire
 # suppress inspection "UnusedProperty"
@@ -160,15 +160,15 @@ LN=BTC a través de Lightning Network
 # suppress inspection "UnusedProperty"
 LN_SHORT=Lightning
 # suppress inspection "UnusedProperty"
-LBTC=L-BTC (BTC con la cadena lateral Liquid)
+LBTC=L-BTC (BTC pegged en la side chain Liquid)
 # suppress inspection "UnusedProperty"
 LBTC_SHORT=Liquid
 # suppress inspection "UnusedProperty"
-RBTC=RBTC (BTC con la cadena lateral RSK)
+RBTC=RBTC (BTC pegged en la side chain RSK)
 # suppress inspection "UnusedProperty"
 RBTC_SHORT=RSK
 # suppress inspection "UnusedProperty"
-WBTC=WBTC (BTC envuelto como token ERC20)
+WBTC=WBTC (BTC wrapped como token ERC20)
 # suppress inspection "UnusedProperty"
 WBTC_SHORT=WBTC
 # suppress inspection "UnusedProperty"

--- a/i18n/src/main/resources/settings_es.properties
+++ b/i18n/src/main/resources/settings_es.properties
@@ -4,25 +4,25 @@
 
 settings.language=Idioma
 settings.notifications=Notificaciones
-settings.trade=Oferta y comercio
+settings.trade=Oferta y compra-venta
 settings.display=Visualización
 settings.network=Red
 
 settings.language.headline=Selección de Idioma
 settings.language.select=Seleccionar idioma
-settings.language.select.invalid=Por favor, seleccione un idioma de la lista
-settings.language.restart=Para aplicar el nuevo idioma, necesita reiniciar la aplicación
-settings.language.supported.headline=Agregar idiomas soportados
-settings.language.supported.subHeadLine=Idiomas en los que es fluido
+settings.language.select.invalid=Por favor, selecciona un idioma de la lista
+settings.language.restart=Para aplicar el nuevo idioma debes reiniciar la aplicación
+settings.language.supported.headline=Agregar tus idiomas aceptados
+settings.language.supported.subHeadLine=Idiomas que hablas con fluidez
 settings.language.supported.select=Seleccionar idioma
 settings.language.supported.addButton.tooltip=Agregar idioma seleccionado a la lista
-settings.language.supported.list.subHeadLine=Fluidez en:
+settings.language.supported.list.subHeadLine=Hablas en:
 settings.language.supported.invalid=Por favor, seleccione un idioma de la lista
 
 settings.notification.options=Opciones de notificación
 settings.notification.option.all=Todos los mensajes de chat
-settings.notification.option.mention=Si se menciona
-settings.notification.option.off=Desactivado
+settings.notification.option.mention=Si me mencionan
+settings.notification.option.off=Ninguna
 settings.notification.notifyForPreRelease=Notificar sobre actualizaciones de software en pre-lanzamiento
 settings.notification.useTransientNotifications=Usar notificaciones transitorias
 settings.notification.clearNotifications=Limpiar notificaciones
@@ -34,11 +34,11 @@ settings.display.resetDontShowAgain=Restablecer todos los indicadores de 'No mos
 
 settings.trade.headline=Configuraciones de oferta e intercambio
 settings.trade.maxTradePriceDeviation=Tolerancia máxima de precio de operación
-settings.trade.maxTradePriceDeviation.help=Diferencia máxima de precio de operación que un creador de oferta tolera cuando su oferta es aceptada.
+settings.trade.maxTradePriceDeviation.help=Diferencia máxima de precio de operación que un ofertante tolera cuando su oferta es aceptada.
 settings.trade.requiredTotalReputationScore=Puntuación mínima de reputación requerida
-settings.trade.requiredTotalReputationScore.help=Restringir el intercambio a comerciantes con una puntuación mínima de reputación
+settings.trade.requiredTotalReputationScore.help=Restringir el intercambio a usuarios con una puntuación mínima de reputación
 settings.trade.minReputationScore.description.self=Puntuación de reputación mínima requerida personalizada
-settings.trade.minReputationScore.description.fromSecManager=Puntuación de reputación mínima requerida  por el Mánager de Seguridad de Bisq
+settings.trade.minReputationScore.description.fromSecManager=Puntuación de reputación mínima requerida por el Mánager de Seguridad de Bisq
 settings.trade.minReputationScore.invalid=Debe ser un número entre 0 y {0}
 settings.trade.minReputationScore.ignoreValueFromSecManager=Ignorar el valor proporcionado por el Mánager de Seguridad de Bisq
 settings.trade.maxTradePriceDeviation.invalid=Debe ser un valor entre 1 y {0}%


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the settings properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage.