### PR TITLE
wallets: Remove dependency to Bisq 2 Threading Class

### DIFF
--- a/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/BitcoindRawTxProcessor.java
+++ b/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/BitcoindRawTxProcessor.java
@@ -17,9 +17,9 @@
 
 package bisq.wallets.bitcoind.zmq;
 
-import bisq.common.encoding.Hex;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindDecodeRawTransactionResponse;
+import com.google.common.io.BaseEncoding;
 
 public class BitcoindRawTxProcessor implements ZmqRawTxProcessor {
 
@@ -33,7 +33,7 @@ public class BitcoindRawTxProcessor implements ZmqRawTxProcessor {
 
     @Override
     public void processRawTx(byte[] serializedTx, byte[] sequenceNumber) {
-        String txInHex = Hex.encode(serializedTx);
+        String txInHex = BaseEncoding.base16().lowerCase().encode(serializedTx);
         BitcoindDecodeRawTransactionResponse.Result rawTransaction = daemon.decodeRawTransaction(txInHex).getResult();
         listeners.fireTxOutputAddressesListeners(rawTransaction);
         listeners.fireTxIdInputListeners(rawTransaction);

--- a/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/ZmqConnection.java
+++ b/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/ZmqConnection.java
@@ -17,10 +17,10 @@
 
 package bisq.wallets.bitcoind.zmq;
 
-import bisq.common.threading.ExecutorFactory;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindGetZmqNotificationsResponse;
 import bisq.wallets.bitcoind.zmq.exceptions.CannotFindZmqAddressException;
 import bisq.wallets.bitcoind.zmq.exceptions.CannotFindZmqTopicException;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.zeromq.SocketType;
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -45,8 +47,8 @@ public class ZmqConnection implements AutoCloseable {
     @Getter
     private final ZmqListeners listeners;
 
-    private final ExecutorService executorService = ExecutorFactory
-            .newFixedThreadPool("wallet-zeromq-notification-thread-pool", 2);
+    private final ExecutorService executorService =
+            newFixedThreadPool("wallet-zeromq-notification-thread-pool", 2);
 
     private ZContext context;
 
@@ -150,5 +152,13 @@ public class ZmqConnection implements AutoCloseable {
 
     private boolean isZeroMqContextTerminated(int errorCode) {
         return errorCode == ERROR_CODE_CONTEXT_TERMINATED;
+    }
+
+    public ExecutorService newFixedThreadPool(String name, int numThreads) {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat(name + "-%d")
+                .setDaemon(true)
+                .build();
+        return Executors.newFixedThreadPool(numThreads, threadFactory);
     }
 }


### PR DESCRIPTION
We can't depend on Bisq 2's Threading class to be able to reuse the wallets library in Bisq 1.