### PR TITLE
wallets: Remove dependency to Bisq 2 FileUtils Class

### DIFF
--- a/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/BitcoindRawTxProcessor.java
+++ b/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/BitcoindRawTxProcessor.java
@@ -17,9 +17,9 @@
 
 package bisq.wallets.bitcoind.zmq;
 
-import bisq.common.encoding.Hex;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindDecodeRawTransactionResponse;
+import com.google.common.io.BaseEncoding;
 
 public class BitcoindRawTxProcessor implements ZmqRawTxProcessor {
 
@@ -33,7 +33,7 @@ public class BitcoindRawTxProcessor implements ZmqRawTxProcessor {
 
     @Override
     public void processRawTx(byte[] serializedTx, byte[] sequenceNumber) {
-        String txInHex = Hex.encode(serializedTx);
+        String txInHex = BaseEncoding.base16().lowerCase().encode(serializedTx);
         BitcoindDecodeRawTransactionResponse.Result rawTransaction = daemon.decodeRawTransaction(txInHex).getResult();
         listeners.fireTxOutputAddressesListeners(rawTransaction);
         listeners.fireTxIdInputListeners(rawTransaction);

--- a/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/ZmqConnection.java
+++ b/wallets/bitcoind/bitcoind/src/main/java/bisq/wallets/bitcoind/zmq/ZmqConnection.java
@@ -17,10 +17,10 @@
 
 package bisq.wallets.bitcoind.zmq;
 
-import bisq.common.threading.ExecutorFactory;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindGetZmqNotificationsResponse;
 import bisq.wallets.bitcoind.zmq.exceptions.CannotFindZmqAddressException;
 import bisq.wallets.bitcoind.zmq.exceptions.CannotFindZmqTopicException;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.zeromq.SocketType;
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -45,8 +47,8 @@ public class ZmqConnection implements AutoCloseable {
     @Getter
     private final ZmqListeners listeners;
 
-    private final ExecutorService executorService = ExecutorFactory
-            .newFixedThreadPool("wallet-zeromq-notification-thread-pool", 2);
+    private final ExecutorService executorService =
+            newFixedThreadPool("wallet-zeromq-notification-thread-pool", 2);
 
     private ZContext context;
 
@@ -150,5 +152,13 @@ public class ZmqConnection implements AutoCloseable {
 
     private boolean isZeroMqContextTerminated(int errorCode) {
         return errorCode == ERROR_CODE_CONTEXT_TERMINATED;
+    }
+
+    public ExecutorService newFixedThreadPool(String name, int numThreads) {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat(name + "-%d")
+                .setDaemon(true)
+                .build();
+        return Executors.newFixedThreadPool(numThreads, threadFactory);
     }
 }

--- a/wallets/bitcoind/bitcoind/src/test/java/bisq/wallets/bitcoind/WalletNotRunningTest.java
+++ b/wallets/bitcoind/bitcoind/src/test/java/bisq/wallets/bitcoind/WalletNotRunningTest.java
@@ -17,21 +17,23 @@
 
 package bisq.wallets.bitcoind;
 
-import bisq.common.util.NetworkUtils;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
-import bisq.wallets.json_rpc.RpcConfig;
-import bisq.wallets.json_rpc.RpcClientFactory;
 import bisq.wallets.json_rpc.JsonRpcClient;
+import bisq.wallets.json_rpc.RpcClientFactory;
+import bisq.wallets.json_rpc.RpcConfig;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.net.ConnectException;
+import java.net.ServerSocket;
+import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class WalletNotRunningTest {
     @Test
     void notRunningTest() {
-        int freePort = NetworkUtils.findFreeSystemPort();
+        int freePort = findFreeSystemPort();
 
         RpcConfig rpcConfig = RpcConfig.builder()
                 .hostname("127.0.0.1")
@@ -45,5 +47,16 @@ public class WalletNotRunningTest {
 
         assertThatThrownBy(minerChainBackend::listWallets)
                 .hasCauseInstanceOf(ConnectException.class);
+    }
+
+    public static int findFreeSystemPort() {
+        try {
+            ServerSocket server = new ServerSocket(0);
+            int port = server.getLocalPort();
+            server.close();
+            return port;
+        } catch (IOException ignored) {
+            return new Random().nextInt(10000) + 50000;
+        }
     }
 }

--- a/wallets/bitcoind/json-rpc/src/main/java/bisq/wallets/json_rpc/JsonRpcCall.java
+++ b/wallets/bitcoind/json-rpc/src/main/java/bisq/wallets/json_rpc/JsonRpcCall.java
@@ -17,7 +17,7 @@
 
 package bisq.wallets.json_rpc;
 
-import bisq.common.util.StringUtils;
+import java.util.UUID;
 
 @SuppressWarnings("ALL")
 public class JsonRpcCall {
@@ -27,7 +27,7 @@ public class JsonRpcCall {
     private final Object params;
 
     public JsonRpcCall(String method, Object params) {
-        this.id = StringUtils.createUid();
+        this.id = UUID.randomUUID().toString();
         this.method = method;
         this.params = params;
     }

--- a/wallets/bitcoind/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestProcess.java
+++ b/wallets/bitcoind/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestProcess.java
@@ -17,7 +17,6 @@
 
 package bisq.wallets.regtest.bitcoind;
 
-import bisq.common.util.NetworkUtils;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.json_rpc.JsonRpcClient;
 import bisq.wallets.json_rpc.RpcCallFailureException;
@@ -53,7 +52,7 @@ public class BitcoindRegtestProcess extends DaemonProcess {
 
     @Override
     public ProcessConfig createProcessConfig() {
-        int zmqPort = NetworkUtils.findFreeSystemPort();
+        int zmqPort = BitcoindRegtestSetup.findFreeSystemPort();
         return ProcessConfig.builder()
                 .name(binaryPath.toAbsolutePath().toString())
                 .args(List.of(
@@ -61,7 +60,7 @@ public class BitcoindRegtestProcess extends DaemonProcess {
                         "-datadir=" + dataDir.toAbsolutePath(),
                         "-debug=1",
 
-                        "-bind=127.0.0.1:" + NetworkUtils.findFreeSystemPort(),
+                        "-bind=127.0.0.1:" + BitcoindRegtestSetup.findFreeSystemPort(),
                         "-whitelist=127.0.0.1",
 
                         "-rpcbind=127.0.0.1:" + rpcConfig.getPort(),

--- a/wallets/bitcoind/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
+++ b/wallets/bitcoind/regtest/src/main/java/bisq/wallets/regtest/bitcoind/BitcoindRegtestSetup.java
@@ -17,7 +17,6 @@
 
 package bisq.wallets.regtest.bitcoind;
 
-import bisq.common.util.NetworkUtils;
 import bisq.wallets.bitcoind.rpc.BitcoindDaemon;
 import bisq.wallets.bitcoind.rpc.BitcoindWallet;
 import bisq.wallets.bitcoind.rpc.responses.BitcoindListUnspentResponse;
@@ -31,11 +30,13 @@ import lombok.Getter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 
 public class BitcoindRegtestSetup
         extends AbstractRegtestSetup<MultiProcessCoordinator> {
@@ -101,7 +102,7 @@ public class BitcoindRegtestSetup
     }
 
     private RpcConfig createRpcConfig() {
-        int port = NetworkUtils.findFreeSystemPort();
+        int port = findFreeSystemPort();
         return createRpcConfig("127.0.0.1", port);
     }
 
@@ -166,6 +167,17 @@ public class BitcoindRegtestSetup
             }
 
             return bitcoindPath;
+        }
+    }
+
+    public static int findFreeSystemPort() {
+        try {
+            ServerSocket server = new ServerSocket(0);
+            int port = server.getLocalPort();
+            server.close();
+            return port;
+        } catch (IOException ignored) {
+            return new Random().nextInt(10000) + 50000;
         }
     }
 }

--- a/wallets/bitcoind/regtest/src/main/java/bisq/wallets/regtest/process/DaemonProcess.java
+++ b/wallets/bitcoind/regtest/src/main/java/bisq/wallets/regtest/process/DaemonProcess.java
@@ -17,12 +17,12 @@
 
 package bisq.wallets.regtest.process;
 
-import bisq.common.file.FileUtils;
 import bisq.common.file.LogScanner;
 import bisq.common.threading.ThreadName;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -48,7 +48,7 @@ public abstract class DaemonProcess implements BisqProcess {
     @Override
     public void start() {
         try {
-            FileUtils.makeDirs(dataDir.toFile());
+            makeDirs(dataDir.toFile());
             process = createAndStartProcess();
             waitUntilReady();
         } catch (IOException e) {
@@ -118,6 +118,12 @@ public abstract class DaemonProcess implements BisqProcess {
             String processName = process.info().command().orElse("<unknown process>");
             log.error("{} didn't start correctly.", processName, e);
             throw new CannotStartProcessException(processName, e);
+        }
+    }
+
+    private static void makeDirs(File dir) throws IOException {
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IOException("Could not make dir " + dir);
         }
     }
 }


### PR DESCRIPTION
We can't depend on Bisq 2's FileUtils class to be able to reuse the
wallets library in Bisq 1.