### PR TITLE
Reviewed ES translations for user properties

### DIFF
--- a/i18n/src/main/resources/user_es.properties
+++ b/i18n/src/main/resources/user_es.properties
@@ -7,16 +7,16 @@
 user.userProfile.tooltip=Apodo: {0}\nID de Bot: {1}\nID de Perfil: {2}\n{3}
 user.userProfile.tooltip.banned=¡Este perfil está baneado!
 user.userProfile.userName.banned=[Baneado] {0}
-user.userProfile.livenessState=Última actividad del usuario: {0} hace
-user.userProfile.livenessState.ageDisplay={0} hace
+user.userProfile.livenessState=Última actividad del usuario: hace {0} 
+user.userProfile.livenessState.ageDisplay=hace {0}
 user.userProfile.version=Versión: {0}
 # Dynamic values using TransportType.name()
 # suppress inspection "UnusedProperty"
-user.userProfile.addressByTransport.CLEAR=Clear net address: {0}
+user.userProfile.addressByTransport.CLEAR=Dirección clearnet: {0}
 # suppress inspection "UnusedProperty"
-user.userProfile.addressByTransport.TOR=Tor address: {0}
+user.userProfile.addressByTransport.TOR=Dirección Tor: {0}
 # suppress inspection "UnusedProperty"
-user.userProfile.addressByTransport.I2P=I2P address: {0}
+user.userProfile.addressByTransport.I2P=Dirección I2P: {0}
 
 
 ################################################################################
@@ -40,23 +40,23 @@ user.userProfile.comboBox.description=Perfil de usuario
 user.userProfile.nymId=ID de Bot
 user.userProfile.nymId.tooltip=El 'ID de Bot' se genera a partir del hash de la clave pública de la\nidentidad de ese perfil de usuario.\nSe añade al apodo en caso de que haya múltiples perfiles de usuario en\nla red con el mismo apodo para distinguir claramente entre esos perfiles.
 user.userProfile.profileId=ID de Perfil
-user.userProfile.profileId.tooltip=El 'ID de Perfil' es el hash de la clave pública de la identidad de ese perfil de usuario\ncodificado como cadena hexadecimal.
+user.userProfile.profileId.tooltip=El 'ID de Perfil' es el hash de la clave pública de la identidad de ese perfil de usuario\ncodificado como carácteres hexadecimales.
 user.userProfile.profileAge=Edad del perfil
-user.userProfile.profileAge.tooltip=La 'Edad del perfil' es la antigüedad en días de ese perfil de usuario.
+user.userProfile.profileAge.tooltip=La 'edad del perfil' es la antigüedad en días de ese perfil de usuario.
 user.userProfile.livenessState.description=Última actividad del usuario
 user.userProfile.livenessState.tooltip=El tiempo transcurrido desde que el perfil de usuario fue republicado en la red, desencadenado por la actividad del usuario como movimientos del mouse.
 user.userProfile.reputation=Reputación
-user.userProfile.statement=Declaración
-user.userProfile.statement.prompt=Introduzca una declaración opcional
-user.userProfile.statement.tooLong=La declaración no debe ser más larga de {0} caracteres
-user.userProfile.terms=Términos de comercio
-user.userProfile.terms.prompt=Introduzca términos de comercio opcionales
-user.userProfile.terms.tooLong=Los términos de comercio no deben ser más largos de {0} caracteres
+user.userProfile.statement=Estado
+user.userProfile.statement.prompt=Introduzca un estado opcional
+user.userProfile.statement.tooLong=El estado no debe tener más de {0} caracteres
+user.userProfile.terms=Términos de compra-venta
+user.userProfile.terms.prompt=Introduce términos de compra-venta opcionales
+user.userProfile.terms.tooLong=Los términos de compra-venta no deben ocupar más de {0} caracteres
 
 user.userProfile.createNewProfile=Crear nuevo perfil
 user.userProfile.learnMore=¿Por qué crear un nuevo perfil?
 user.userProfile.deleteProfile=Eliminar perfil
-user.userProfile.deleteProfile.popup.warning=¿Realmente desea eliminar {0}? Esta operación no se puede deshacer.
+user.userProfile.deleteProfile.popup.warning=¿Realmente deseas eliminar {0}? Esta operación no se puede deshacer.
 user.userProfile.deleteProfile.popup.warning.yes=Sí, eliminar perfil
 user.userProfile.deleteProfile.cannotDelete=No está permitido eliminar el perfil de usuario\n\nPara eliminar este perfil, primero:\n- Elimine todos los mensajes publicados con este perfil\n- Cierre todos los canales privados para este perfil\n- Asegúrese de tener al menos un perfil más
 
@@ -68,12 +68,12 @@ user.userProfile.save.popup.noChangesToBeSaved=No hay cambios nuevos que guardar
 # Create user profile
 ################################################################################
 
-user.userProfile.new.step2.headline=Complete su perfil
-user.userProfile.new.step2.subTitle=Opcionalmente puede agregar una declaración personalizada a su perfil y establecer sus términos de comercio.
-user.userProfile.new.statement=Declaración
-user.userProfile.new.statement.prompt=Agregar declaración opcional
-user.userProfile.new.terms=Sus términos de comercio
-user.userProfile.new.terms.prompt=Establecer términos de comercio opcionales
+user.userProfile.new.step2.headline=Completa tu perfil
+user.userProfile.new.step2.subTitle=Opcionalmente puedes agregar un estado personalizado en tu perfil y establecer tus términos de compra-venta
+user.userProfile.new.statement=Estado
+user.userProfile.new.statement.prompt=Agregar estado opcional
+user.userProfile.new.terms=Tus términos de compra-venta
+user.userProfile.new.terms.prompt=Establecer términos de compra-venta opcionales
 
 
 ################################################################################
@@ -99,14 +99,14 @@ user.paymentAccounts.headline=Tus cuentas de pago
 user.paymentAccounts.noAccounts.headline=Tus cuentas de pago
 user.paymentAccounts.noAccounts.info=No has configurado ninguna cuenta todavía.
 user.paymentAccounts.noAccounts.whySetup=¿Por qué es útil configurar una cuenta?
-user.paymentAccounts.noAccounts.whySetup.info=Cuando vendes Bitcoin, necesitas proporcionar tus datos de cuenta de pago al comprador para recibir el pago en Fiat. Configurar cuentas con anticipación permite un acceso rápido y conveniente a esta información durante el comercio.
-user.paymentAccounts.noAccounts.whySetup.note=Información de fondo:\nLos datos de tu cuenta se almacenan exclusivamente localmente en tu computadora y se comparten con tu compañero de comercio solo cuando decides compartirlos.
+user.paymentAccounts.noAccounts.whySetup.info=Cuando vendes Bitcoin, necesitas proporcionar tus datos de cuenta de pago al comprador para recibir el pago en Fiat. Configurar cuentas con anticipación permite un acceso rápido y conveniente a esta información durante la compra-venta.
+user.paymentAccounts.noAccounts.whySetup.note=Nota informativa:\nLos datos de tu cuenta se almacenan exclusivamente localmente en tu ordenador y se comparten con tu contraparte solo si tú decides compartirlos.
 user.paymentAccounts.accountData=Información de la cuenta de pago
 user.paymentAccounts.selectAccount=Seleccionar cuenta de pago
 user.paymentAccounts.createAccount=Crear nueva cuenta de pago
 user.paymentAccounts.deleteAccount=Eliminar cuenta de pago
 user.paymentAccounts.createAccount.headline=Agregar nueva cuenta de pago
-user.paymentAccounts.createAccount.subtitle=La cuenta de pago se almacena solo localmente en tu computadora y solo se envía a tu compañero de comercio si decides hacerlo.
+user.paymentAccounts.createAccount.subtitle=La cuenta de pago se almacena exclusivamente localmente en tu ordenador y se comparte con tu contraparte solo si tú decides compartirlos.
 user.paymentAccounts.createAccount.accountName=Nombre de la cuenta de pago
 user.paymentAccounts.createAccount.accountName.prompt=Establece un nombre único para tu cuenta de pago
 user.paymentAccounts.createAccount.accountData.prompt=Introduce la información de la cuenta de pago (por ejemplo, datos bancarios) que quieres compartir con un posible comprador de Bitcoin para que puedan transferirte el importe en moneda nacional.


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the user properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage.