### PR TITLE
gradle-tasks: Remove dependency to Bisq 2 common module

### DIFF
--- a/build-logic/gradle-tasks/build.gradle.kts
+++ b/build-logic/gradle-tasks/build.gradle.kts
@@ -8,6 +8,5 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":commons"))
     implementation(libs.bouncycastle.pg)
 }

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/Architecture.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/Architecture.kt
@@ -1,0 +1,36 @@
+package bisq.gradle.common
+
+import java.util.*
+
+enum class Architecture(val architectureName: String) {
+    X86_64("x86_64"),
+    ARM_64("arm64"),
+}
+
+fun getArchitecture(): Architecture {
+    val architectureName = getArchitectureName()
+    if (isX86_64(architectureName)) {
+        return Architecture.X86_64
+    } else if (isArm64(architectureName)) {
+        return Architecture.ARM_64
+    }
+
+    throw IllegalStateException("Running on unsupported Architecture: $architectureName")
+}
+
+fun isX86_64(archName: String): Boolean {
+    return is64Bit(archName) && (archName.contains("x86") || archName.contains("amd"))
+}
+
+fun isArm64(archName: String): Boolean {
+    return is64Bit(archName) && (archName.contains("aarch") || archName.contains("arm"))
+}
+
+fun is64Bit(archName: String): Boolean {
+    return archName.contains("64")
+}
+
+fun getArchitectureName(): String {
+    return System.getProperty("os.arch").lowercase(Locale.US)
+}
+

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/OS.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/OS.kt
@@ -1,0 +1,38 @@
+package bisq.gradle.common
+
+import java.util.*
+
+enum class OS(val osName: String) {
+    LINUX("linux"),
+    MAC_OS("macos"),
+    WINDOWS("win")
+}
+
+fun getOS(): OS {
+    val osName = getOSName()
+    if (isLinux(osName)) {
+        return OS.LINUX
+    } else if (isMacOs(osName)) {
+        return OS.MAC_OS
+    } else if (isWindows(osName)) {
+        return OS.WINDOWS
+    }
+
+    throw IllegalStateException("Running on unsupported OS: $osName")
+}
+
+private fun isLinux(osName: String): Boolean {
+    return osName.contains("linux")
+}
+
+private fun isMacOs(osName: String): Boolean {
+    return osName.contains("mac") || osName.contains("darwin")
+}
+
+private fun isWindows(osName: String): Boolean {
+    return osName.contains("win")
+}
+
+fun getOSName(): String {
+    return System.getProperty("os.name").lowercase(Locale.US)
+}

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/Platform.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/Platform.kt
@@ -1,0 +1,44 @@
+package bisq.gradle.common
+
+import bisq.gradle.common.Architecture.ARM_64
+import bisq.gradle.common.Architecture.X86_64
+import bisq.gradle.common.OS.*
+import bisq.gradle.common.Platform.*
+
+enum class Platform(val platformName: String) {
+    LINUX_X86_64("linux_x86_64"),
+    LINUX_ARM_64("linux_arm64"),
+
+    MACOS_X86_64("macos_x86_64"),
+    MACOS_ARM_64("macos_arm64"),
+
+    WIN_X86_64("win_x86_64"),
+    WIN_ARM_64("win_arm64")
+}
+
+fun getPlatform(): Platform {
+    val os = getOS()
+    val architecture = getArchitecture()
+    when (os) {
+        LINUX -> {
+            return when (architecture) {
+                X86_64 -> LINUX_X86_64
+                ARM_64 -> LINUX_ARM_64
+            }
+        }
+
+        MAC_OS -> {
+            return when (architecture) {
+                X86_64 -> MACOS_X86_64
+                ARM_64 -> MACOS_ARM_64
+            }
+        }
+
+        WINDOWS -> {
+            return when (architecture) {
+                X86_64 -> WIN_X86_64
+                ARM_64 -> WIN_ARM_64
+            }
+        }
+    }
+}


### PR DESCRIPTION
We can't depend on Bisq 2's common module to be able to reuse the wallets library in Bisq 1.