### PR TITLE
Reviewed ES translations for trade apps properties

### DIFF
--- a/i18n/src/main/resources/trade_apps_es.properties
+++ b/i18n/src/main/resources/trade_apps_es.properties
@@ -3,7 +3,7 @@
 ######################################################
 tradeApps.compare=Comparar protocolos
 tradeApps.bisqMuSig=Bisq MuSig
-tradeApps.subMarine=Intercambios Submarinos
+tradeApps.subMarine=Submarine Swaps
 tradeApps.bisqLightning=Bisq Lightning
 tradeApps.more=Más
 
@@ -17,10 +17,10 @@ tradeApps.convenience=Comodidad
 tradeApps.overview=Visión general
 tradeApps.tradeOffs=Pros/Contras
 
-tradeApps.overview.headline=Descubre la mejor manera de comerciar Bitcoin
-tradeApps.overview.subHeadline=Un protocolo de comercio sirve como marco fundamental para el comercio de Bitcoin de manera segura. Cada protocolo de comercio presenta su propio conjunto de ventajas y desventajas en términos de seguridad, privacidad y comodidad.\nBisq te ofrece la flexibilidad de seleccionar el protocolo óptimo que se alinee con tus preferencias.\n\nExplora los próximos protocolos de comercio programados para integrarse en Bisq. Por ahora, Bisq Easy es el único protocolo implementado, diseñado para usuarios novatos de Bitcoin y adecuado para cantidades de comercio menores. Mantente atento a las actualizaciones si alguno de los próximos protocolos te interesa.
+tradeApps.overview.headline=Descubre la mejor manera de comprar y vender Bitcoin
+tradeApps.overview.subHeadline=Un protocolo de compra-venta sirve como marco fundamental para el comprar y vender Bitcoin de manera segura. Cada protocolo de compra-venta presenta su propio conjunto de ventajas y desventajas en términos de seguridad, privacidad y comodidad.\nBisq te ofrece la flexibilidad de seleccionar el protocolo óptimo que se alinee con tus preferencias.\n\nExplora los próximos protocolos de comercio programados para integrarse en Bisq. Por ahora, Bisq Easy es el único protocolo implementado, diseñado para usuarios novatos de Bitcoin y adecuado para cantidades pequeñas. Mantente atento a las actualizaciones si alguno de los próximos protocolos te interesa.
 
-tradeApps.overview.more=Además, hay más protocolos en el horizonte, programados para implementaciones futuras.
+tradeApps.overview.more=Además, hay más protocolos en el horizonte, planeados para implementaciones futuras.
 
 
 ######################################################
@@ -32,11 +32,11 @@ tradeApps.BISQ_EASY=Bisq Easy
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.BISQ_EASY=BTC/Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.overview.BISQ_EASY=Protocolo de comercio basado en chat fácil de usar. La seguridad se basa en la reputación del vendedor.
+tradeApps.overview.BISQ_EASY=Protocolo de compra-venta basado en chat fácil de usar. La seguridad se basa en la reputación del vendedor.
 # suppress inspection "UnusedProperty"
 tradeApps.overview.security.BISQ_EASY=La seguridad se basa en la reputación del vendedor. Solo adecuado para cantidades pequeñas.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.BISQ_EASY=Depende del método de transferencia fiat utilizado. La transferencia fiat en línea normalmente revela la identidad al compañero de comercio. En el lado de Bitcoin, está limitado por las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar la fusión de monedas de múltiples comercios aumenta la privacidad). Consulta la wiki de Bisq para más información.
+tradeApps.overview.privacy.BISQ_EASY=Depende del método de transferencia fiat utilizado. La transferencia fiat en línea normalmente revela la identidad a la contraparte. En el lado de Bitcoin, está sujeto a las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar mezclar bitcoin de diferentes compra-ventas aumenta la privacidad). Consulta la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
 tradeApps.overview.convenience.BISQ_EASY=Interfaz de chat muy fácil de usar. El comprador de Bitcoin no necesita tener Bitcoin.
 
@@ -51,22 +51,22 @@ tradeApps.overview.BISQ_MU_SIG=El protocolo MuSig de Bisq requiere solo una tran
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.BISQ_MU_SIG=BTC/Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.BISQ_MU_SIG=La seguridad se basa en depósitos de seguridad así como en características adicionales en relación a los límites de comercio. Consulte la wiki de Bisq para más información.
+tradeApps.overview.security.BISQ_MU_SIG=La seguridad se basa en depósitos de seguridad así como en características adicionales en relación a limitar las cantidades de la compra-venta. Consulta la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.BISQ_MU_SIG=Depende del método de transferencia Fiat utilizado. La transferencia Fiat en línea normalmente revela la identidad al compañero de comercio. En el lado de Bitcoin, está limitado por las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar la fusión de monedas de múltiples intercambios aumenta la privacidad). Consulte la wiki de Bisq para más información.
+tradeApps.overview.privacy.BISQ_MU_SIG=Depende del método de transferencia fiat utilizado. La transferencia fiat en línea normalmente revela la identidad a la contraparte. En el lado de Bitcoin, está sujeto a las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar mezclar bitcoin de diferentes compra-ventas aumenta la privacidad). Consulta la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.convenience.BISQ_MU_SIG=El usuario necesita tener una pequeña cantidad de Bitcoins para bloquear el depósito de seguridad. Puede ser tan rápido como el tiempo de confirmación de la blockchain o hasta unos días dependiendo del método de pago fiat.
+tradeApps.overview.convenience.BISQ_MU_SIG=El usuario necesita tener una pequeña cantidad de Bitcoins para bloquear en una fianza. Puede llevar desde simplemente el tiempo de confirmación de la blockchain hasta unos días dependiendo del método de pago fiat escogido.
 
 # suppress inspection "UnusedProperty"
 tradeApps.BISQ_MU_SIG.subHeadline=Basado en MuSig, intercambios atómicos y Taproot, requiere solo una transacción
 # suppress inspection "UnusedProperty"
-tradeApps.BISQ_MU_SIG.overview=Conceptualmente sigue el protocolo de comercio utilizado en Bisq 1, basado en un depósito de seguridad y un proceso de resolución de disputas.\n- Reduce el número de transacciones de 4 a 1.\n- Mejora la privacidad al hacer que la transacción de depósito parezca una transacción estándar de 'pago a clave pública-hash'.\n- Evita el problema de que un vendedor necesite abrir una arbitraje en caso de que el comprador no libere el depósito de seguridad después del comercio. Los intercambios atómicos garantizarán que el vendedor pueda recuperar su depósito incluso sin la cooperación del comprador.\n- En caso de un socio comercial no receptivo, una estructura de transacción de pago en múltiples etapas asegura que no se requiera arbitraje ni reembolso por parte de la DAO.\n- Taproot proporciona más flexibilidad y privacidad.\n- Obtén más detalles en: https://github.com/bisq-network/proposals/issues/456
+tradeApps.BISQ_MU_SIG.overview=Conceptualmente sigue el protocolo de comercio utilizado en Bisq 1, basado en una fianza y un proceso de resolución de disputas.\n- Reduce el número de transacciones de 4 a 1.\n- Mejora la privacidad al hacer que la transacción de depósito parezca una transacción estándar de 'pago a clave pública-hash'.\n- Evita el problema de que un vendedor necesite abrir una arbitraje en caso de que el comprador no libere la fianza después de la compra-venta. Los intercambios atómicos garantizarán que el vendedor pueda recuperar su fianza incluso sin la cooperación del comprador.\n- En caso de que la contraparte se ausente, una estructura de transacción de pago en múltiples etapas asegura que no se requiera arbitraje ni reembolso por parte de la DAO.\n- Taproot proporciona más flexibilidad y privacidad.\n- Puedes obtener más detalles en: https://github.com/bisq-network/proposals/issues/456
 # suppress inspection "UnusedProperty"
 tradeApps.BISQ_MU_SIG.release=Se espera que Bisq MuSig esté listo para su lanzamiento en el cuarto trimestre de 2024.
 # suppress inspection "UnusedProperty"
-tradeApps.BISQ_MU_SIG.pro=+ Seguridad razonablemente buena para cantidades de comercio de valor medio\n+ Comparado con Bisq Easy, las propiedades de seguridad son mejores y se pueden comerciar mayores cantidades. Las cantidades mayores acercan los precios de comercio a las tarifas de mercado.\n+ Logra lidiar con el sistema heredado del mundo fiat
+tradeApps.BISQ_MU_SIG.pro=+ Seguridad razonablemente buena para cantidades de valor medio\n+ Comparado con Bisq Easy, las propiedades de seguridad son mejores y se pueden comerciar mayores cantidades. Las cantidades mayores hacen que los precios sean más cercanos al precio de mercado.\n+ Logra lidiar adecuadamente con el sistema tradicional del mundo fiat
 # suppress inspection "UnusedProperty"
-tradeApps.BISQ_MU_SIG.con=- Ambos comerciantes necesitan tener BTC para el depósito de seguridad\n- El nodo Bisq del creador necesita estar en línea ya que el proceso de aceptación de la oferta es interactivo\n- Como la transferencia fiat se realiza en sistemas heredados como transferencias bancarias, hereda todos esos inconvenientes, como riesgo de contracargo, transferencia lenta, exposición de privacidad al compañero cuando los detalles de la transferencia bancaria contienen el nombre real. Aunque estos diversos inconvenientes pueden mitigarse utilizando métodos de pago que conllevan bajo riesgo de contracargo, son rápidos o instantáneos y usan ID de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o el comercio cara a cara.
+tradeApps.BISQ_MU_SIG.con=- Ambas partes necesitan tener BTC para la fianza\n- El nodo Bisq del ofertante necesita estar en línea ya que el proceso de toma de la oferta es interactivo\n- Como la transferencia fiat se realiza en sistemas tradicionales como las transferencias bancarias, hereda todos sus inconvenientes, como riesgo de reversión del pago, lentitud, o las exposiciones de detalles personales a la contraparte al compartir los datos de pago. Aunque estos inconvenientes pueden mitigarse utilizando métodos de pago que tengan bajo riesgo de reversión, sean rápidos o instantáneos y usen IDs de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o la compra-venta en persona.
 
 
 ######################################################
@@ -76,25 +76,25 @@ tradeApps.BISQ_MU_SIG.con=- Ambos comerciantes necesitan tener BTC para el depó
 # suppress inspection "UnusedProperty"
 tradeApps.SUBMARINE=Submarine Swaps
 # suppress inspection "UnusedProperty"
-tradeApps.overview.SUBMARINE=Intercambio entre Bitcoin en la red Lightning y Bitcoin en la cadena principal
+tradeApps.overview.SUBMARINE=Swap entre Bitcoin en la red Lightning y Bitcoin en la cadena principal
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.SUBMARINE=LN-BTC/BTC
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.SUBMARINE=El intercambio atómico proporciona un nivel de seguridad muy alto.
+tradeApps.overview.security.SUBMARINE=Los swaps atómicos proporcionan un nivel de seguridad muy alto.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.SUBMARINE=Los intercambios pueden mejorar potencialmente la privacidad al romper rastros para el análisis de cadena.
+tradeApps.overview.privacy.SUBMARINE=Los swaps pueden mejorar potencialmente la privacidad al romper rastros usadas por el chain analysis.
 # suppress inspection "UnusedProperty"
 tradeApps.overview.convenience.SUBMARINE=El usuario necesita instalar y configurar una cartera Lightning. Una vez instalada, es muy cómoda de usar.
 # suppress inspection "UnusedProperty"
-tradeApps.SUBMARINE.subHeadline=Los intercambios Submarine permiten intercambiar Bitcoin fuera de cadena y en cadena de forma segura sin riesgo de contraparte
+tradeApps.SUBMARINE.subHeadline=Los Submarine Swaps permiten intercambiar Bitcoin fuera de la cadena y en la cadena de forma segura sin riesgo de contraparte
 # suppress inspection "UnusedProperty"
-tradeApps.SUBMARINE.overview=El intercambio se realiza utilizando el secreto de un contrato con bloqueo de tiempo hash (HTLC) en la red Lightning para un contrato en una transacción de Bitcoin. Al reclamar el pago de Lightning, se revela al remitente del pago de Lightning el secreto para reclamar el Bitcoin en la cadena. Esto asegura que un pago desbloquee el otro, lo que permite un intercambio sin riesgo de contraparte.
+tradeApps.SUBMARINE.overview=El swap se realiza utilizando el secreto de un hash time-locked contract (HTLC) en la red Lightning para un contrato en una transacción de Bitcoin. Al reclamar el pago de Lightning, se revela al remitente del pago de Lightning el secreto para reclamar el Bitcoin en la cadena. Esto asegura que un pago desbloquee el otro, lo que permite un intercambio sin riesgo de contraparte.
 # suppress inspection "UnusedProperty"
-tradeApps.SUBMARINE.release=Se espera que los intercambios submarinos estén listos para su lanzamiento en el segundo trimestre de 2025.
+tradeApps.SUBMARINE.release=Se espera que los Submarine Swaps estén listos para su lanzamiento en el segundo trimestre de 2025.
 # suppress inspection "UnusedProperty"
-tradeApps.SUBMARINE.pro=+ Muy alta seguridad para grandes cantidades de comercio\n+ Intercambiar Bitcoin en cadena por Lightning puede mejorar potencialmente la privacidad.\n+ El intercambio puede ser realizado por bots de comercio, lo que permite operaciones rápidas y automatizadas.
+tradeApps.SUBMARINE.pro=+ Gran seguridad para grandes cantidades de comercio\n+ Hacer swap de Bitcoin en cadena por Lightning puede mejorar potencialmente la privacidad.\n+ El intercambio puede ser realizado a través de bots, lo que permite operaciones rápidas y automatizadas.
 # suppress inspection "UnusedProperty"
-tradeApps.SUBMARINE.con=- Las tarifas de minería para la transacción de Bitcoin pueden hacer que los pequeños intercambios no sean económicos\n- Los comerciantes deben cuidar los tiempos de espera de las transacciones. En caso de congestión de la cadena de bloques y confirmación retrasada, eso puede representar un riesgo de seguridad.
+tradeApps.SUBMARINE.con=- Las tarifas de minería para la transacción de Bitcoin pueden hacer que las cantidades pequeñas no sean económicas\n- Los usuarios deben cuidar los tiempos de espera de las transacciones. La congestión de la cadena de bloques y los retrasos en la confirmación, pueden representar un riesgo de seguridad.
 
 
 ######################################################
@@ -104,25 +104,25 @@ tradeApps.SUBMARINE.con=- Las tarifas de minería para la transacción de Bitcoi
 # suppress inspection "UnusedProperty"
 tradeApps.LIQUID_MU_SIG=Liquid MuSig
 # suppress inspection "UnusedProperty"
-tradeApps.overview.LIQUID_MU_SIG=El protocolo MuSig de Bisq adaptado a la cadena lateral Liquid
+tradeApps.overview.LIQUID_MU_SIG=El protocolo MuSig de Bisq adaptado a la sidechain Liquid
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.LIQUID_MU_SIG=L-BTC/Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.LIQUID_MU_SIG=La seguridad se basa en depósitos de seguridad así como en características adicionales en relación a los límites de comercio. Consulte la wiki de Bisq para más información.
+tradeApps.overview.security.LIQUID_MU_SIG=La seguridad se basa en fianzas así como en características adicionales en relación a limitar las cantidades de la compra-venta. Consulte la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.LIQUID_MU_SIG=Depende del método de transferencia fiat utilizado. La transferencia fiat en línea normalmente revela la identidad al compañero de comercio. En el lado Liquid, tiene mejor privacidad que el Bitcoin principal debido a transacciones confidenciales.
+tradeApps.overview.privacy.LIQUID_MU_SIG=Depende del método de transferencia fiat utilizado. La transferencia fiat por internet normalmente revela la identidad a la contraparte. En el lado Liquid, tiene mejor privacidad que el Bitcoin normal gracias a transacciones confidenciales.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.convenience.LIQUID_MU_SIG=El usuario necesita tener una pequeña cantidad de L-BTC para bloquear el depósito de seguridad. La confirmación en la blockchain de Liquid es muy rápida (aproximadamente 1 minuto). El tiempo para el comercio depende del método de pago utilizado y del tiempo de respuesta del comerciante.
+tradeApps.overview.convenience.LIQUID_MU_SIG=El usuario necesita tener una pequeña cantidad de L-BTC para bloquear la fianza. La confirmación en la blockchain de Liquid es muy rápida (aproximadamente 1 minuto). La duración de la transacción depende del método de pago utilizado y del tiempo de respuesta de la contraparte.
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_MU_SIG.subHeadline=Basado en un depósito de seguridad, una transacción MuSig y un proceso de resolución de disputas en múltiples capas
+tradeApps.LIQUID_MU_SIG.subHeadline=Basado en una fianza, una transacción MuSig y un proceso de resolución de disputas en múltiples capas
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_MU_SIG.overview=Conceptualmente sigue el protocolo MuSig de Bisq (en Bitcoin mainnet). Liquid no tiene las mismas propiedades de censura que Bitcoin, aunque ofrece algunos beneficios sobre Bitcoin mainnet:\n- Liquid tiene un tiempo de confirmación de bloques muy corto, de aproximadamente 1 minuto.\n- Las tarifas de transacción son muy bajas.\n- La privacidad es mejor debido a las transacciones confidenciales que ocultan el monto enviado.
+tradeApps.LIQUID_MU_SIG.overview=Conceptualmente sigue el protocolo MuSig de Bisq (en Bitcoin mainnet). Liquid no tiene las mismas propiedades de incensurabilidad que Bitcoin, aunque ofrece algunos beneficios sobre Bitcoin en mainnet:\n- Liquid tiene un tiempo de confirmación de bloques muy corto, de aproximadamente 1 minuto.\n- Las comisiones de transacción son muy bajas.\n- La privacidad es mejor debido a las transacciones confidenciales que ocultan la cantidad enviado.
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_MU_SIG.release=Liquid MuSig se espera que esté listo para su lanzamiento en el segundo trimestre de 2025.
+tradeApps.LIQUID_MU_SIG.release=Se espera que Liquid MuSig esté listo para su lanzamiento en el segundo trimestre de 2025.
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_MU_SIG.pro=+ Seguridad razonablemente buena para montos de comercio de valor medio\n+ Comparado con Bisq MuSig, tiene tarifas de transacción más bajas, confirmación más rápida y mejor privacidad.\n+ Logra lidiar con el sistema legado del mundo Fiat
+tradeApps.LIQUID_MU_SIG.pro=+ Seguridad razonable para cantidades de valor medio\n+ Comparado con Bisq MuSig, tiene comisiones de transacción más bajas, confirmación más rápida y mejor privacidad.\n+ Logra lidiar adecuadamente con el sistema tradicional del mundo Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_MU_SIG.con=- Ambos comerciantes necesitan tener L-BTC para el depósito de seguridad\n- Liquid es una cadena lateral federada y no tiene el mismo nivel de resistencia a la censura que Bitcoin en la red principal.\n- El peg-in de Bitcoin principal a Liquid Bitcoin es sin confianza, aunque para el peg-out de L-BTC a BTC se requiere autorización de la federación.\n- El nodo Bisq del creador necesita estar en línea ya que el proceso de aceptación de la oferta es interactivo\n- Como la transferencia Fiat se realiza en sistemas heredados como transferencias bancarias, hereda todos esos inconvenientes, como riesgo de contracargo, transferencia lenta, exposición de privacidad al compañero cuando los detalles de la transferencia bancaria contienen el nombre real. Aunque estos diversos inconvenientes pueden mitigarse utilizando métodos de pago que conllevan bajo riesgo de contracargo, son rápidos o instantáneos y usan ID de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o el comercio cara a cara.
+tradeApps.LIQUID_MU_SIG.con=- Ambos usuarios necesitan tener L-BTC para la fianza\n- Liquid es una sidechain federada y no tiene el mismo nivel de resistencia a la censura que Bitcoin en la red principal.\n- El peg-in de Bitcoin a Liquid Bitcoin no require confiar en la federación, pero el peg-out de L-BTC a BTC requiere autorización de la federación.\n- El nodo Bisq del ofertante necesita estar en línea ya que el proceso de toma de la oferta es interactivo\n- Como la transferencia fiat se realiza en sistemas tradicionales como las transferencias bancarias, hereda todos sus inconvenientes, como riesgo de reversión del pago, lentitud, o las exposiciones de detalles personales a la contraparte al compartir los datos de pago. Aunque estos inconvenientes pueden mitigarse utilizando métodos de pago que tengan bajo riesgo de reversión, sean rápidos o instantáneos y usen IDs de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o la compra-venta en persona.
 
 
 ######################################################
@@ -132,25 +132,25 @@ tradeApps.LIQUID_MU_SIG.con=- Ambos comerciantes necesitan tener L-BTC para el d
 # suppress inspection "UnusedProperty"
 tradeApps.BISQ_LIGHTNING=Bisq Lightning
 # suppress inspection "UnusedProperty"
-tradeApps.overview.BISQ_LIGHTNING=Permite el intercambio de Bitcoin en Lightning Network por Fiat combinando swaps submarinos y el protocolo Liquid MuSig
+tradeApps.overview.BISQ_LIGHTNING=Permite la compra-venta de Bitcoin en Lightning Network por Fiat combinando swaps submarinos y el protocolo Liquid MuSig
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.BISQ_LIGHTNING=LN-BTC/Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.BISQ_LIGHTNING=La seguridad se basa en depósitos de seguridad así como en características adicionales en relación con los límites de comercio. Consulta la wiki de Bisq para más información.
+tradeApps.overview.security.BISQ_LIGHTNING=La seguridad se basa en fianzas así como en características adicionales en relación a limitar las cantidades de la compra-venta. Consulta la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.BISQ_LIGHTNING=Depende del método de transferencia Fiat utilizado. La transferencia Fiat en línea suele revelar la identidad al socio comercial. En el lado de Lightning, ofrece mejor privacidad que el Bitcoin en cadena ya que no deja rastros en la Blockchain. En el lado de Liquid, ofrece mejor privacidad que el Bitcoin en la red principal debido a las transacciones confidenciales.
+tradeApps.overview.privacy.BISQ_LIGHTNING=Depende del método de transferencia Fiat utilizado. La transferencia fiat por internet normalmente revela la identidad a la contraparte. En el lado de Lightning, ofrece mejor privacidad que el Bitcoin en cadena ya que no deja rastros en la cadena. En el lado de Liquid, ofrece mejor privacidad que el Bitcoin en la red principal debido a las transacciones confidenciales.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.convenience.BISQ_LIGHTNING=El usuario necesita tener una pequeña cantidad de Bitcoin en Lightning para bloquear el depósito de seguridad. Los swaps submarinos y las transacciones comerciales se benefician del rápido tiempo de confirmación de la cadena de bloques de aproximadamente 1 minuto. El tiempo para completar el comercio depende del método de pago utilizado y del tiempo de respuesta del comerciante.
+tradeApps.overview.convenience.BISQ_LIGHTNING=El usuario necesita tener una pequeña cantidad de Bitcoin en Lightning para bloquear la fianza. Los swaps submarinos y las transacciones de la compra-venta se benefician del rápido tiempo de confirmación de la cadena de bloques de aproximadamente 1 minuto. El tiempo para completar el comercio depende del método de pago utilizado y del tiempo de respuesta de la contraparte.
 # suppress inspection "UnusedProperty"
 tradeApps.BISQ_LIGHTNING.subHeadline=Combina los swaps submarinos de Lightning a Liquid y el protocolo Liquid MuSig
 # suppress inspection "UnusedProperty"
-tradeApps.BISQ_LIGHTNING.overview=Permite que los comerciantes utilicen su Bitcoin fuera de la cadena en Lightning para comerciar con Fiat basado en el protocolo Liquid MuSig. El protocolo es una cadena de 3 intercambios y 2 protocolos diferentes:\n- Primero, los comerciantes intercambian su Bitcoin en Lightning a través de un swap submarino inverso a L-BTC (swap submarino entre Lightning y Liquid). Este intercambio se realiza con cualquier proveedor de liquidez, no con el socio comercial.\n- Luego, el comercio se realiza en Liquid utilizando el protocolo MuSig.\n- Una vez completada la operación, el L-BTC se intercambia de vuelta a Lightning mediante un swap submarino (nuevamente con otro comerciante/proveedor de liquidez).
+tradeApps.BISQ_LIGHTNING.overview=Permite que los usuarios utilicen su Bitcoin fuera de la cadena en Lightning para intercambiar con Fiat basado en el protocolo Liquid MuSig. El protocolo es una secuencia de 3 intercambios y 2 protocolos diferentes:\n- Primero, los usuarios intercambian su Bitcoin en Lightning a través de un swap submarino inverso a L-BTC (swap submarino entre Lightning y Liquid). Este intercambio se realiza con cualquier proveedor de liquidez, no con la contraparte.\n- Luego, la compra-venta en sí se realiza en Liquid utilizando el protocolo MuSig.\n- Una vez completada la operación, el L-BTC se intercambia de vuelta a Lightning mediante un swap submarino (nuevamente con otro proveedor de liquidez).
 # suppress inspection "UnusedProperty"
 tradeApps.BISQ_LIGHTNING.release=Se espera que Bisq Lightning esté listo para su lanzamiento en Q2/2025.
 # suppress inspection "UnusedProperty"
-tradeApps.BISQ_LIGHTNING.pro=+ Seguridad razonablemente buena para montos de comercio de valor medio\n+ Comparado con Bisq MuSig, hay tarifas de transacción más bajas, confirmación más rápida y mejor privacidad.\n+ Maneja el sistema heredado del mundo Fiat
+tradeApps.BISQ_LIGHTNING.pro=+ Seguridad razonablemente buena para cantidades de valor medio\n+ Comparado con Bisq MuSig, las comisiones de transacción son más bajas, la confirmación es más rápida y la privacidad es superior.\n+ Lidia adecuadamente con el sistema tradicional del mundo Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.BISQ_LIGHTNING.con=- Ambos comerciantes necesitan tener BTC en Lightning para el depósito de seguridad\n- La participación de 2 comerciantes adicionales para los intercambios Submarino añade complejidad y posibles riesgos (más bien pequeños).\n- Liquid es una cadena lateral federada y no tiene el mismo nivel de resistencia a la censura que Bitcoin en la red principal.\n- El peg-in de Bitcoin principal a Liquid Bitcoin es sin confianza, aunque para el peg-out de L-BTC a BTC se requiere autorización de la federación.\n- El nodo Bisq del creador necesita estar en línea ya que el proceso de aceptación de la oferta es interactivo\n- Como la transferencia Fiat se realiza en sistemas heredados como transferencias bancarias, hereda todos esos inconvenientes, como riesgo de contracargo, transferencia lenta, exposición de privacidad al compañero cuando los detalles de la transferencia bancaria contienen el nombre real. Aunque estos diversos inconvenientes pueden mitigarse utilizando métodos de pago que conllevan bajo riesgo de contracargo, son rápidos o instantáneos y usan ID de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o el comercio cara a cara.
+tradeApps.BISQ_LIGHTNING.con=- Ambos usuarios necesitan tener BTC en Lightning para la fianza\n- La participación de 2 contrapartes adicionales para los Submarine Swaps añade complejidad y riesgos (más bien pequeños).\n- Liquid es una sidechain federada y no tiene el mismo nivel de resistencia a la censura que Bitcoin en la red principal.\n- El peg-in de Bitcoin a Liquid Bitcoin no require confiar en la federación, pero el peg-out de L-BTC a BTC requiere autorización de la federación.\n- El nodo Bisq del ofertabte necesita estar en línea ya que el proceso de toma de la oferta es interactivo\n- Como la transferencia fiat se realiza en sistemas tradicionales como las transferencias bancarias, hereda todos sus inconvenientes, como riesgo de reversión del pago, lentitud, o las exposiciones de detalles personales a la contraparte al compartir los datos de pago. Aunque estos inconvenientes pueden mitigarse utilizando métodos de pago que tengan bajo riesgo de reversión, sean rápidos o instantáneos y usen IDs de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o la compra-venta en persona.
 
 
 ######################################################
@@ -158,27 +158,27 @@ tradeApps.BISQ_LIGHTNING.con=- Ambos comerciantes necesitan tener BTC en Lightni
 ######################################################
 
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_SWAP=Intercambios Liquid
+tradeApps.LIQUID_SWAP=Liquid Swaps
 # suppress inspection "UnusedProperty"
-tradeApps.overview.LIQUID_SWAP=Comercio de cualquier activo basado en Liquid como USDT y BTC-L con un intercambio atómico en la red Liquid
+tradeApps.overview.LIQUID_SWAP=Realiza compra-ventas de cualquier activo basado en Liquid como USDT o BTC-L con un swap atómico en la red Liquid
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.LIQUID_SWAP=Activos Liquid
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.LIQUID_SWAP=Seguridad máxima utilizando contratos inteligentes en la misma cadena de bloques.
+tradeApps.overview.security.LIQUID_SWAP=Seguridad máxima utilizando contratos inteligentes en una sola cadena de bloques
 # suppress inspection "UnusedProperty"
 tradeApps.overview.privacy.LIQUID_SWAP=Liquid soporta transacciones confidenciales, por lo tanto, no revela la cantidad en la cadena de bloques.
 # suppress inspection "UnusedProperty"
 tradeApps.overview.convenience.LIQUID_SWAP=El usuario necesita instalar y configurar la cartera Elements para Liquid. Una vez instalada, es muy cómoda de usar.
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_SWAP.subHeadline=Protocolo de intercambio atómico basado en la cadena lateral Liquid para comerciar cualquier activo Liquid
+tradeApps.LIQUID_SWAP.subHeadline=Protocolo de swaps atómico basado en la sidechain Liquid para realizar compra-ventas de cualquier activo Liquid
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_SWAP.overview=Para utilizar los intercambios Liquid el usuario necesita instalar y ejecutar la cartera Elements y configurarla, para que pueda ser accesible desde la aplicación Bisq.\n\nEl activo más utilizado en Liquid es USDT (Tether), una moneda estable vinculada al USD. Aunque esto no es comparable con algo como Bitcoin, tiene muchas ventajas sobre el USD Fiat que involucra normalmente transferencias bancarias con todos los problemas e inconvenientes del sistema Fiat heredado.\n\nL-BTC podría ser utilizado en el otro extremo del intercambio, que es un sustituto de Bitcoin en la cadena Liquid. Para convertir Bitcoin a L-BTC uno necesita enviar Bitcoin a una dirección de peg-in y recibirá después de 102 confirmaciones L-BTC por ello. Volver de L-BTC a Bitcoin (peg-out) funciona de manera similar pero requiere autorización de la federación Liquid, que es un grupo de empresas e individuos en el espacio de Bitcoin. Por lo tanto, no es un proceso completamente sin confianza.\n\nUno debería evitar comparar los activos Liquid con las propiedades de Bitcoin. Apunta a otros casos de uso y no puede alcanzar el alto nivel de descentralización y resistencia a la censura de Bitcoin. Más bien puede verse como una alternativa a los productos financieros tradicionales. Al usar la tecnología blockchain evita intermediarios clásicos, mejora la seguridad y la privacidad y proporciona una mejor experiencia al usuario.
+tradeApps.LIQUID_SWAP.overview=Para utilizar los Liquid Swaps el usuario necesita instalar y ejecutar la cartera Elements y configurarla, para que pueda ser accesible desde la aplicación Bisq.\n\nEl activo más utilizado en Liquid es USDT (Tether), una moneda estable vinculada al USD. Aunque esto no es comparable con algo como Bitcoin, tiene muchas ventajas sobre el USD Fiat que suele implicar transferencias bancarias y todos los problemas e incomodidades derivados de su uso.\n\nL-BTC puede ser utilizado en el otro extremo del intercambio, que es un sustituto de Bitcoin en la cadena Liquid. Para convertir Bitcoin a L-BTC uno necesita enviar Bitcoin a una dirección de peg-in y recibirá después de 102 confirmaciones L-BTC por ello. Volver de L-BTC a Bitcoin (peg-out) funciona de manera similar, pero requiere autorización de la federación Liquid, que es un grupo de empresas e individuos en el espacio de Bitcoin. Por lo tanto, el proceso implica confiar en la federación.\n\nUno debería evitar comparar los activos Liquid con las propiedades de Bitcoin. Liquid está dirigido a otro casos de uso y no puede alcanzar el alto nivel de descentralización y resistencia a la censura de Bitcoin. Más bien puede verse como una alternativa a los productos financieros tradicionales. Al usar la tecnología blockchain evita intermediarios clásicos, mejora la seguridad y la privacidad y proporciona una mejor experiencia al usuario.
 # suppress inspection "UnusedProperty"
 tradeApps.LIQUID_SWAP.release=Los intercambios Liquid todavía están en desarrollo. Se espera que sean lanzados en el Q2/2025.
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_SWAP.pro=+ Las transacciones confidenciales proporcionan buena privacidad\n+ Tiempo de confirmación rápido de aproximadamente 1 minuto\n+ Tarifas de transacción bajas\n+ Adecuado para transacciones de alto valor
+tradeApps.LIQUID_SWAP.pro=+ Las transacciones confidenciales proporcionan buena privacidad\n+ Tiempo de confirmación rápido de aproximadamente 1 minuto\n+ Comisiones de transacción bajas\n+ Adecuado para transacciones de alto valor
 # suppress inspection "UnusedProperty"
-tradeApps.LIQUID_SWAP.con=- Requiere ejecutar la cartera y la cadena de bloques Elements\n- Ambos comerciantes deben estar en línea\n- El peg-out de L-BTC no es sin confianza
+tradeApps.LIQUID_SWAP.con=- Requiere ejecutar la cartera y la cadena de bloques Elements\n- Ambos usuarios deben estar en línea\n- El peg-out de L-BTC implica confianza en la federación
 
 
 ######################################################
@@ -186,25 +186,25 @@ tradeApps.LIQUID_SWAP.con=- Requiere ejecutar la cartera y la cadena de bloques 
 ######################################################
 
 # suppress inspection "UnusedProperty"
-tradeApps.BSQ_SWAP=Intercambios BSQ
+tradeApps.BSQ_SWAP=BSQ Swaps
 # suppress inspection "UnusedProperty"
-tradeApps.overview.BSQ_SWAP=Comercio de Bitcoin y el token BSQ a través de intercambios atómicos, de manera instantánea y segura
+tradeApps.overview.BSQ_SWAP=Compra-venta de Bitcoin y el token BSQ a través de swaps atómicos, de manera instantánea y segura
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.BSQ_SWAP=BSQ/BTC
 # suppress inspection "UnusedProperty"
 tradeApps.overview.security.BSQ_SWAP=Seguridad máxima utilizando un contrato inteligente en la misma cadena de bloques.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.BSQ_SWAP=Limitado por las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar la fusión de monedas de múltiples intercambios aumenta la privacidad). BSQ tiene potencialmente menos privacidad debido al menor conjunto de anonimato. Consulte la wiki de Bisq para más información.
+tradeApps.overview.privacy.BSQ_SWAP=Sujeto a las limitaciones de privacidad de Bitcoin y al comportamiento del usuario (evitar mezclar bitcoin de múltiples compra-ventas aumenta la privacidad). BSQ tiene potencialmente menos privacidad debido al menor conjunto de anonimato. Consulte la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
 tradeApps.overview.convenience.BSQ_SWAP=El usuario necesita instalar y configurar la cartera BSQ. Una vez instalada, es muy cómoda de usar.
 # suppress inspection "UnusedProperty"
-tradeApps.BSQ_SWAP.subHeadline=Intercambio atómico entre BSQ (moneda coloreada en Bitcoin) y Bitcoin
+tradeApps.BSQ_SWAP.subHeadline=Swap atómico entre BSQ (moneda coloreada en Bitcoin) y Bitcoin
 # suppress inspection "UnusedProperty"
-tradeApps.BSQ_SWAP.overview=Mismo modelo que se utiliza en Bisq 1. Como se basa en una única transacción atómica, es muy seguro.\nSerá necesario ejecutar el nodo Bisq 1 con la API DAO habilitada.
+tradeApps.BSQ_SWAP.overview=Mismo modelo que se utiliza en Bisq 1. Como se basa en una única transacción atómica, es muy seguro.\nSerá necesario ejecutar el nodo Bisq 1 con la API de la DAO habilitada.
 # suppress inspection "UnusedProperty"
-tradeApps.BSQ_SWAP.release=Se espera que los intercambios BSQ estén listos para su lanzamiento en el Q3/2025.
+tradeApps.BSQ_SWAP.release=Se espera que los BSQ Swaps estén listos para su lanzamiento en el Q3/2025.
 # suppress inspection "UnusedProperty"
-tradeApps.BSQ_SWAP.pro=+ Muy seguro\n+ Relativamente rápido, aunque solo después de la confirmación de la cadena de bloques se considera completo el intercambio\n+ No se requiere transacción de tarifa de creador ni depósito de seguridad
+tradeApps.BSQ_SWAP.pro=+ Muy seguro\n+ Relativamente rápido, aunque solo la compra-venta solo se considera como completada después de la confirmación de la cadena de bloques\n+ No requiere transacción de comisión para crear la oferta ni fianza
 # suppress inspection "UnusedProperty"
 tradeApps.BSQ_SWAP.con=- Necesidad de ejecutar Bisq 1 para los datos BSQ/DAO\n- Limitado al mercado BSQ/BTC
 
@@ -214,27 +214,27 @@ tradeApps.BSQ_SWAP.con=- Necesidad de ejecutar Bisq 1 para los datos BSQ/DAO\n- 
 ######################################################
 
 # suppress inspection "UnusedProperty"
-tradeApps.LIGHTNING_ESCROW=Fideicomiso Lightning
+tradeApps.LIGHTNING_ESCROW=Lightning Escrow
 # suppress inspection "UnusedProperty"
-tradeApps.overview.LIGHTNING_ESCROW=Protocolo de comercio basado en fideicomiso en la red Lightning utilizando criptografía de cálculo multiparte
+tradeApps.overview.LIGHTNING_ESCROW=Protocolo de compra-venta basado en un escrow en la red Lightning utilizando criptografía de cálculo multiparte
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.LIGHTNING_ESCROW=LN-BTC/Fiat
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.LIGHTNING_ESCROW=La seguridad se basa en depósitos de seguridad así como en características adicionales en relación a los límites de comercio. El protocolo utiliza algunas técnicas criptográficas novedosas que no están probadas en batalla y auditadas. Consulte la wiki de Bisq para más información.
+tradeApps.overview.security.LIGHTNING_ESCROW=La seguridad se basa en depósitos de seguridad así como en características adicionales en relación a limitar las cantidades de la compra-venta. El protocolo utiliza algunas técnicas criptográficas novedosas con poco uso en el entornos reales y pendientes de auditar. Consulte la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.LIGHTNING_ESCROW=Depende del método de transferencia Fiat utilizado. La transferencia Fiat en línea normalmente revela la identidad al compañero de comercio. En el lado de Bitcoin, está limitado por las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar la fusión de monedas de múltiples intercambios aumenta la privacidad). Consulte la wiki de Bisq para más información.
+tradeApps.overview.privacy.LIGHTNING_ESCROW=Depende del método de transferencia Fiat utilizado. La transferencia fiat por internet normalmente revela la identidad a la contraparte. En el lado de Bitcoin, está sujeto a las limitaciones de privacidad de Bitcoin y depende del comportamiento del usuario (evitar mezclar bitcoin de diferentes compra-ventas aumenta la privacidad). Consulta la wiki de Bisq para más información.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.convenience.LIGHTNING_ESCROW=El usuario necesita tener una pequeña cantidad de Bitcoin para bloquear el depósito de seguridad.
+tradeApps.overview.convenience.LIGHTNING_ESCROW=El usuario necesita tener una pequeña cantidad de Bitcoin para bloquear la fianza.
 # suppress inspection "UnusedProperty"
-tradeApps.LIGHTNING_ESCROW.subHeadline=Protocolo de tres partes para comerciar Fiat con Bitcoin en la Red Lightning.
+tradeApps.LIGHTNING_ESCROW.subHeadline=Protocolo de tres partes para intercambiar Fiat por Bitcoin en la Red Lightning.
 # suppress inspection "UnusedProperty"
-tradeApps.LIGHTNING_ESCROW.overview=Se basa en múltiples pagos de Lightning y divide los secretos para los HTLCs para construir una configuración segura en la que el tercer partido garantiza que los comerciantes se comporten de manera justa. Utiliza circuitos enmascarados para lograr una computación segura entre múltiples partes.\n\nEl usuario necesita ejecutar un nodo de Lightning que esté configurado con la aplicación Bisq.\n\nConceptualmente es similar al protocolo Bisq MuSig, pero en lugar de la transacción MuSig utiliza esta configuración de 3 partes y en lugar de Bitcoin en cadena utiliza Bitcoin en la Red Lightning.
+tradeApps.LIGHTNING_ESCROW.overview=Se basa en múltiples pagos de Lightning y divide los secretos para los HTLCs para construir una configuración segura en la la tercera parte garantiza que los usuarios se comporten de manera justa. Utiliza circuitos enmascarados para lograr una computación segura entre múltiples partes.\n\nEl usuario necesita ejecutar un nodo de Lightning que esté configurado con la aplicación Bisq.\n\nConceptualmente es similar al protocolo Bisq MuSig, pero en lugar de la transacción MuSig utiliza esta configuración de 3 partes y en lugar de Bitcoin en cadena utiliza Bitcoin en la Red Lightning.
 # suppress inspection "UnusedProperty"
-tradeApps.LIGHTNING_ESCROW.release=Se espera que el Fideicomiso Lightning esté listo para su lanzamiento en el Q4/2025.
+tradeApps.LIGHTNING_ESCROW.release=Se espera que el Escrow Lightning esté listo para su lanzamiento en el Q4/2025.
 # suppress inspection "UnusedProperty"
-tradeApps.LIGHTNING_ESCROW.pro=+ En comparación con Bisq Easy, las propiedades de seguridad son mejores y se pueden comerciar mayores cantidades. Las cantidades mayores acercan los precios de comercio a las tarifas de mercado.\n+ Los pagos de Bitcoin son casi instantáneos\n+ Tarifas de transacción (de enrutamiento) muy bajas
+tradeApps.LIGHTNING_ESCROW.pro=+ En comparación con Bisq Easy, las propiedades de seguridad son mejores y se pueden manejar cantidades mayores. Las cantidades mayores acercan los precios de las compra-ventas al precio de mercado.\n+ Los pagos de Bitcoin son casi instantáneos\n+ Comisiones de transacción (de enrutamiento) muy bajas
 # suppress inspection "UnusedProperty"
-tradeApps.LIGHTNING_ESCROW.con=- Necesidad de ejecutar un nodo Lightning\n- Ambos comerciantes necesitan tener BTC (en Lightning) para el depósito de seguridad.\n- El nodo Bisq del creador necesita estar en línea ya que el proceso de aceptación de la oferta es interactivo.\n- Como la transferencia Fiat se realiza en sistemas heredados como transferencias bancarias, hereda todos esos inconvenientes, como riesgo de contracargo, transferencia lenta, exposición de privacidad al compañero cuando los detalles de la transferencia bancaria contienen el nombre real. Aunque estos diversos inconvenientes pueden mitigarse utilizando métodos de pago que conllevan bajo riesgo de contracargo, son rápidos o instantáneos y usan ID de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o el comercio cara a cara.
+tradeApps.LIGHTNING_ESCROW.con=- Necesidad de ejecutar un nodo Lightning\n- Ambos usuarios necesitan tener BTC (en Lightning) para la fianza.\n- El nodo Bisq del creador necesita estar en línea ya que el proceso de aceptación de la oferta es interactivo.\n- Como la transferencia fiat se realiza en sistemas tradicionales como las transferencias bancarias, hereda todos sus inconvenientes, como riesgo de reversión del pago, lentitud, o las exposiciones de detalles personales a la contraparte al compartir los datos de pago. Aunque estos inconvenientes pueden mitigarse utilizando métodos de pago que tengan bajo riesgo de reversión, sean rápidos o instantáneos y usen IDs de cuenta o correo electrónico en lugar de nombres reales. Ciertos métodos de pago evitan completamente el sistema bancario, como el efectivo por correo o la compra-venta en persona.
 
 
 ######################################################
@@ -242,24 +242,24 @@ tradeApps.LIGHTNING_ESCROW.con=- Necesidad de ejecutar un nodo Lightning\n- Ambo
 ######################################################
 
 # suppress inspection "UnusedProperty"
-tradeApps.MONERO_SWAP=Intercambios Monero
+tradeApps.MONERO_SWAP=Monero Swaps
 # suppress inspection "UnusedProperty"
-tradeApps.overview.MONERO_SWAP=Comercio de Bitcoin y Monero mediante un intercambio atómico entre cadenas
+tradeApps.overview.MONERO_SWAP=Compra-venta de Bitcoin y Monero mediante un swap atómico entre cadenas
 # suppress inspection "UnusedProperty"
 tradeApps.overview.markets.MONERO_SWAP=XMR/BTC
 # suppress inspection "UnusedProperty"
-tradeApps.overview.security.MONERO_SWAP=Muy alta seguridad utilizando firmas adaptativas para intercambiar de manera atómica entre las cadenas de bloques de Monero y Bitcoin.
+tradeApps.overview.security.MONERO_SWAP=Gran seguridad utilizando firmas adaptativas para hacer swaps atómicos entre las cadenas de bloques de Monero y Bitcoin.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.privacy.MONERO_SWAP=Muy alta en el lado de Monero debido a su fuerte privacidad inherente. En el lado de Bitcoin, está limitado por las limitaciones de privacidad de Bitcoin.
+tradeApps.overview.privacy.MONERO_SWAP=Muy alta en el lado de Monero debido a su fuerte privacidad inherente. En el lado de Bitcoin, está sujeta a las limitaciones de privacidad de Bitcoin.
 # suppress inspection "UnusedProperty"
-tradeApps.overview.convenience.MONERO_SWAP=El usuario necesita instalar el demonio de intercambio Farcaster y un nodo completo de Monero y Bitcoin. Una vez instalado, es muy conveniente.
+tradeApps.overview.convenience.MONERO_SWAP=El usuario necesita instalar el daemon de swaps Farcaster y un nodo completo de Monero y Bitcoin. Una vez instalado, es muy cómodo.
 # suppress inspection "UnusedProperty"
-tradeApps.MONERO_SWAP.subHeadline=Protocolo de intercambio atómico entre cadenas para comerciar Bitcoin con Monero
+tradeApps.MONERO_SWAP.subHeadline=Protocolo de swaps atómicos entre cadenas para comerciar Bitcoin con Monero
 # suppress inspection "UnusedProperty"
-tradeApps.MONERO_SWAP.overview=Basado en el proyecto Farcaster (financiado por la comunidad de Monero) utilizando contratos de tiempo bloqueado hash (HTLC), firmas adaptativas y prueba de conocimiento cero para intercambiar de manera atómica Bitcoin y Monero.\n\nEl usuario necesita instalar y ejecutar un nodo de Bitcoin, un nodo de Monero y el demonio de Farcaster. Durante el intercambio, los nodos de ambos comerciantes necesitan estar en línea. El esfuerzo adicional al usar ese protocolo se compensa con un nivel muy alto de seguridad. Aunque los usuarios deben familiarizarse con los detalles de ese concepto y ser conscientes de que hay casos límite que conllevan algunos pequeños riesgos.
+tradeApps.MONERO_SWAP.overview=Basado en el proyecto Farcaster (financiado por la comunidad de Monero) utilizando hash time lock contracts (HTLC), firmas adaptativas y pruebas de conocimiento cero para hacer swaps atómicos entre Bitcoin y Monero.\n\nEl usuario necesita instalar y ejecutar un nodo de Bitcoin, un nodo de Monero y el daemon de Farcaster. Durante el intercambio, los nodos de ambos usuarios necesitan estar en línea. El esfuerzo adicional al usar este protocolo se compensa con un nivel muy alto de seguridad. Aunque los usuarios deben familiarizarse con los detalles de ese concepto y ser conscientes de que hay situaciones excepcionales que conllevan algunos pequeños riesgos.
 # suppress inspection "UnusedProperty"
-tradeApps.MONERO_SWAP.release=Se espera que los intercambios Monero estén listos para su lanzamiento en el Q3/2025.
+tradeApps.MONERO_SWAP.release=Se espera que los Monero Swaps estén listos para su lanzamiento en el Q3/2025.
 # suppress inspection "UnusedProperty"
-tradeApps.MONERO_SWAP.pro=+ Muy seguro\n+ Privacidad decente. En el lado de Bitcoin, hereda las propiedades de privacidad de Bitcoin. En el lado de Monero, se beneficia de la alta privacidad de Monero.\n+ Adecuado para transacciones de alto valor
+tradeApps.MONERO_SWAP.pro=+ Muy seguro\n+ Privacidad decente. En el lado de Bitcoin, está sujeto a las propiedades de privacidad de Bitcoin. En el lado de Monero, se beneficia de la alta privacidad de Monero.\n+ Adecuado para transacciones de alto valor
 # suppress inspection "UnusedProperty"
-tradeApps.MONERO_SWAP.con=- Requiere algunas habilidades técnicas y experiencia para ejecutar la infraestructura requerida\n- El tiempo de confirmación se basa en las confirmaciones en ambas cadenas de bloques, que normalmente serán de unos 20-30 minutos.\n- Las tarifas de transacción en el lado de Bitcoin podrían ser no triviales en caso de alta congestión de la cadena de bloques (aunque esto es bastante raro)\n- Ambos comerciantes necesitan estar en línea\n- Requiere mucho almacenamiento de disco rápido para los nodos
+tradeApps.MONERO_SWAP.con=- Requiere algunas habilidades técnicas y experiencia para ejecutar la infraestructura requerida\n- El tiempo de confirmación se basa en las confirmaciones en ambas cadenas de bloques, que normalmente serán de unos 20-30 minutos.\n- Las comisiones de transacción en el lado de Bitcoin podrían ser significativas en caso de alta congestión de la cadena de bloques (aunque esto es poco frecuente)\n- Ambos usuarios necesitan estar en línea\n- Requiere mucho almacenamiento con discos rápidos para los nodos


### PR DESCRIPTION
This PR makes improvements on the Spanish translations for the trade apps properties file.

There were a few mistakes in place, such as dangling English strings, awkward machine translations and inconsistencies around language usage