### PR TITLE
Correct description when creating account

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/create/CreatePaymentAccountView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/create/CreatePaymentAccountView.java
@@ -58,7 +58,7 @@ public class CreatePaymentAccountView extends View<VBox, CreatePaymentAccountMod
         accountName = new MaterialTextField(Res.get("user.paymentAccounts.createAccount.accountName"),
                 Res.get("user.paymentAccounts.createAccount.accountName.prompt"));
         accountName.setPrefWidth(width);
-        accountData = new MaterialTextArea(Res.get("user.paymentAccounts.createAccount.accountName"),
+        accountData = new MaterialTextArea(Res.get("user.paymentAccounts.accountData"),
                 Res.get("user.paymentAccounts.createAccount.accountData.prompt"));
         accountData.setPrefWidth(width);
         accountData.setFixedHeight(200);


### PR DESCRIPTION
Corrects the desciption text in CreatePaymentAccountView, that previously displayed the account name as description for the account data field. This can be seen in the images below, where the text "Payment account name" was duplicated previously:
**Before:**
![before](https://github.com/user-attachments/assets/75cbbf7a-f310-4926-b861-c4345ae0967f)
**After:**
![after](https://github.com/user-attachments/assets/58dfe2aa-d983-4bc5-8648-2dc4a57085b7)
