### PR TITLE
Add seed nodes after if there are no candidates at extending peer group.

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeService.java
@@ -50,6 +50,8 @@ import static bisq.network.NetworkService.NETWORK_IO_POOL;
 @Slf4j
 @Getter
 public class PeerExchangeService implements Node.Listener {
+    private static final int MAX_RETRY_ATTEMPTS = 10;
+
     private final Node node;
     private final PeerExchangeStrategy peerExchangeStrategy;
 
@@ -218,8 +220,8 @@ public class PeerExchangeService implements Node.Listener {
             log.info("We have a pending retryPeerExchangeAttempt. We ignore the retryPeerExchange call.");
             return;
         }
-        if (numRetryAttempts.get() > 10) {
-            log.warn("We have retried the peer exchange 10 times without success and give up.");
+        if (numRetryAttempts.get() > MAX_RETRY_ATTEMPTS) {
+            log.warn("We have retried the peer exchange {} times without success and give up.", MAX_RETRY_ATTEMPTS);
             return;
         }
         long delay = 1000L * numRetryAttempts.get() * numRetryAttempts.get();

--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeStrategy.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeStrategy.java
@@ -114,15 +114,17 @@ public class PeerExchangeStrategy {
 
     // After bootstrap, we might want to add more connections and use the peer exchange protocol for that.
     // We do not want to use seed nodes or already existing connections in that case.
+    // Only if we do not have any candidates we add seed nodes.
     List<Address> getAddressesForExtendingPeerGroup() {
         List<Address> candidates = getCandidates(getPriorityListForExtendingPeerGroup());
         if (candidates.isEmpty()) {
             // It can be that we don't have peers anymore which we have not already connected in the past.
             // We reset the usedAddresses and try again. It is likely that some peers have different peers to 
-            // send now.
+            // send now. We also add the seed nodes to get better chances for fresh nodes.
             log.debug("We reset the usedAddresses and try again to connect to peers we tried in the past.");
             usedAddresses.clear();
             candidates = getCandidates(getPriorityListForExtendingPeerGroup());
+            candidates.addAll(getSeedAddresses());
         }
         usedAddresses.addAll(candidates);
         return candidates;


### PR DESCRIPTION
For first start in case all seed nodes are no available, we give up connection to seed nodes after 10 attempts. We try though to extend our peer group but as there are no persisted and reported peers that list is empty. We add now the seednodes in that case to increase changes for recovering. We could increase the retry attempts as well, but it seems that change also improves resilience in case the persisted and reported peers are outdated, so we get fresh nodes from seed nodes.