### PR TITLE
Set PREFERRED_VERSION to 1 instead deriving it from the user profiles…

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/node/Node.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Node.java
@@ -42,7 +42,6 @@ import bisq.security.keys.KeyBundleService;
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -78,8 +77,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @Slf4j
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Node implements Connection.Handler {
-    @Setter
-    public static int preferredVersion = 0;
+    public static final int PREFERRED_VERSION = 1;
 
     public enum State {
         NEW,
@@ -408,11 +406,8 @@ public class Node implements Connection.Handler {
     }
 
     private Connection createOutboundConnection(Address address, Capability myCapability) {
-        // To get better chances to use the right version at the first attempt we use the preferredVersion which will
-        // be set from another higher level service and is based on the distribution of versions.
-        // If v2.1.0 reaches 50% distribution rate we use version 1 as preferredVersion.
         // This code can be removed once no old versions are expected anymore.
-        Capability candidate = Capability.withVersion(myCapability, preferredVersion);
+        Capability candidate = Capability.withVersion(myCapability, PREFERRED_VERSION);
         log.info("Create outbound connection to {} with capability version 1", address);
         try {
             return doCreateOutboundConnection(address, candidate);
@@ -420,7 +415,7 @@ public class Node implements Connection.Handler {
             if (e.getCause() != null && e.getReason() != null && e.getReason() == HANDSHAKE_FAILED) {
                 log.warn("Handshake at creating outbound connection to {} failed. We try again with capability version 0. Error: {}",
                         address, ExceptionUtil.getRootCauseMessage(e));
-                int version = preferredVersion == 0 ? 1 : 0;
+                int version = PREFERRED_VERSION == 0 ? 1 : 0;
                 candidate = Capability.withVersion(myCapability, version);
                 return doCreateOutboundConnection(address, candidate);
             } else {

--- a/user/src/main/java/bisq/user/profile/UserProfileService.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileService.java
@@ -22,7 +22,6 @@ import bisq.common.observable.Observable;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.network.NetworkService;
-import bisq.network.p2p.node.Node;
 import bisq.network.p2p.services.data.DataService;
 import bisq.network.p2p.services.data.storage.auth.AuthenticatedData;
 import bisq.persistence.DbSubDirectory;
@@ -166,14 +165,6 @@ public class UserProfileService implements PersistenceClient<UserProfileStore>, 
                 }
                 numUserProfiles.set(userProfileById.values().size());
                 persist();
-
-                double updated = getUserProfiles().stream()
-                        .mapToLong(UserProfile::getVersion)
-                        .average()
-                        .orElse(0);
-                if (updated >= 0.5) {
-                    Node.setPreferredVersion(1);
-                }
             }
         } else {
             if (userProfile.getPublishDate() > existingUserProfile.get().getPublishDate()) {


### PR DESCRIPTION
Set PREFERRED_VERSION to 1 instead deriving it from the user profiles version. Now we can be sure that the majority have updated. The data from the user profiles is not correct as there have been a bug in that area and only new installations got the version set. Also at first start those data is not available.