### PR TITLE
Use the 30k min required reputation score for backward compatibility.

### DIFF
--- a/offer/src/main/java/bisq/offer/bisq_easy/BisqEasyOffer.java
+++ b/offer/src/main/java/bisq/offer/bisq_easy/BisqEasyOffer.java
@@ -60,6 +60,9 @@ public final class BisqEasyOffer extends Offer<BitcoinPaymentMethodSpec, FiatPay
                          List<FiatPaymentMethod> fiatPaymentMethods,
                          String makersTradeTerms,
                          List<String> supportedLanguageCodes) {
+        // We use the default SettingsService.DEFAULT_MIN_REQUIRED_REPUTATION_SCORE (as we don't have the dependency
+        // to settings we use the plain value) so that offers from makers on 2.1.1 can only be taken by v2.1.0 takers with
+        // 30k reputation score. This can be removed once there are no pre-2.1.1 users anymore.
         this(StringUtils.createUid(),
                 System.currentTimeMillis(),
                 makerNetworkId,
@@ -70,7 +73,7 @@ public final class BisqEasyOffer extends Offer<BitcoinPaymentMethodSpec, FiatPay
                 List.of(TradeProtocolType.BISQ_EASY),
                 PaymentMethodSpecUtil.createBitcoinPaymentMethodSpecs(bitcoinPaymentMethods),
                 PaymentMethodSpecUtil.createFiatPaymentMethodSpecs(fiatPaymentMethods),
-                OfferOptionUtil.fromTradeTerms(makersTradeTerms),
+                OfferOptionUtil.fromTradeTermsAndReputationScore(makersTradeTerms, 30_000),
                 supportedLanguageCodes
         );
     }

--- a/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
+++ b/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
@@ -25,6 +25,17 @@ import java.util.List;
 import java.util.Optional;
 
 public class OfferOptionUtil {
+    public static List<OfferOption> fromTradeTermsAndReputationScore(String makersTradeTerms, long requiredTotalReputationScore) {
+        List<OfferOption> offerOptions = new ArrayList<>();
+        if (makersTradeTerms != null && !makersTradeTerms.isEmpty()) {
+            offerOptions.add(new TradeTermsOption(makersTradeTerms));
+        }
+        if (requiredTotalReputationScore > 0) {
+            offerOptions.add(new ReputationOption(requiredTotalReputationScore));
+        }
+        return offerOptions;
+    }
+
     public static List<OfferOption> fromTradeTerms(String makersTradeTerms) {
         List<OfferOption> offerOptions = new ArrayList<>();
         if (makersTradeTerms != null && !makersTradeTerms.isEmpty()) {
@@ -37,6 +48,13 @@ public class OfferOptionUtil {
         return offerOptions.stream()
                 .filter(option -> option instanceof TradeTermsOption)
                 .map(option -> (TradeTermsOption) option)
+                .findAny();
+    }
+
+    public static Optional<ReputationOption> findReputationOption(Collection<OfferOption> offerOptions) {
+        return offerOptions.stream()
+                .filter(option -> option instanceof ReputationOption)
+                .map(option -> (ReputationOption) option)
                 .findAny();
     }
 


### PR DESCRIPTION
In case a 2.1.1 user makes a buy offer, the min req. score is 30k, protecting the maker from pre 2.1.1 user with lower score. For 2.1.1 takers its ignored.