### PR TITLE
Move Transifex steps to separate workflow triggered by workflow_run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,23 +69,3 @@ jobs:
       os: ${{ matrix.os }}
       name: wallet module
       build-root-dir: wallets
-
-  if_merged:
-      if: github.event.pull_request.merged == true
-      name: Push translation source files to Transifex
-      runs-on: ubuntu-latest
-      steps:
-        - name: "Check if TX_TOKEN secret exists"
-          env:
-            transifex_secret: ${{secrets.TX_TOKEN}}
-          if: ${{env.transifex_secret == ''}}
-          run: |
-             echo "The secret \"TX_TOKEN\" has not been set; please go to \"settings \> secrets and variables\" to create it"
-             exit 1
-        - name: Checkout
-          uses: actions/checkout@v4.2.0
-        - name: Push source files using transifex client
-          uses: transifex/cli-action@v2
-          with:
-            token: ${{ secrets.TX_TOKEN }}
-            args: push -s

--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -1,0 +1,50 @@
+name: Transifex
+
+on:
+  workflow_run:
+    workflows: [ Build Bisq 2 ]
+    types: [ completed ]
+
+jobs:
+  if_merged:
+    name: Push translation source files to Transifex
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history so we can check commits properly
+          fetch-depth: 0
+
+      - name: Check if the commit is in the main branch
+        id: check_commit
+        run: |
+          git fetch origin main
+          if git merge-base --is-ancestor ${{ github.event.workflow_run.head_sha }} origin/main; then
+            echo "commit_in_main=true" >> $GITHUB_OUTPUT
+          else
+            echo "commit_in_main=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Check if TX_TOKEN secret exists"
+        if: "steps.check_commit.outputs.commit_in_main == 'true'"
+        env:
+          transifex_secret: ${{ secrets.TX_TOKEN }}
+        run: |
+          if [ -z "$transifex_secret" ]; then
+            echo "The secret \"TX_TOKEN\" has not been set; please go to \"settings > secrets and variables\" to create it"
+            exit 1
+          fi
+
+      - name: Checkout at the specific commit
+        if: "steps.check_commit.outputs.commit_in_main == 'true'"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Push source files using Transifex client
+        if: "steps.check_commit.outputs.commit_in_main == 'true'"
+        uses: transifex/cli-action@v2
+        with:
+          token: ${{ secrets.TX_TOKEN }}
+          args: push -s


### PR DESCRIPTION
# Secure Transifex Integration by Using `workflow_run` Trigger

This pull request moves the Transifex synchronization steps from the main build workflow (`build.yml`) to a separate workflow file, ensuring secure access to secrets and enhancing the security of our GitHub Actions workflows.

## Background

Previously, the Transifex steps were included in the main build workflow triggered by `pull_request` events. However, workflows triggered by `pull_request` do not have access to secrets when the pull request originates from a forked repository. This limitation prevented the Transifex action from running successfully, as it requires access to the `TX_TOKEN` secret.

Using `pull_request_target` could have granted access to secrets, but it poses significant security risks. According to GitHub's security guidance, workflows triggered by `pull_request_target` can be exploited if untrusted code is executed, potentially exposing secrets or compromising the repository.

## Solution

To address this issue securely, I have:

- **Moved the Transifex steps to a separate workflow** (`sync_transifex.yml`).
- **Configured the new workflow to trigger on `workflow_run`** events when the main build workflow (`Build Bisq 2`) completes successfully.
- **Added a check to ensure the commit is part of the `main` branch**, verifying that the pull request has been merged before running the Transifex steps.

By doing so, the Transifex workflow has access to the necessary secrets without exposing them to untrusted pull request code.

## Security Considerations

This approach aligns with best practices recommended by GitHub to prevent potential security vulnerabilities:

- **Avoids the use of `pull_request_target`** for executing untrusted code with access to secrets.
- **Ensures secrets are only accessible in workflows triggered by trusted events**, such as `workflow_run` after merging into `main`.
- **Prevents malicious actors from manipulating workflows** to exfiltrate secrets or compromise the repository.

For more details on the security implications, please refer to GitHub's article on [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).