### PR TITLE
Tor: Ship all required shared libraries with Bisq

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
@@ -14,6 +14,8 @@ class LinuxPackages(private val resourcesPath: Path, private val appName: String
                 "--linux-package-name", appName.lowercase().replace(" ", ""),
                 "--linux-app-release", "1",
 
+                "--linux-package-deps", "tor",
+
                 "--linux-menu-group", "Network",
                 "--linux-shortcut",
 

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
@@ -1,5 +1,7 @@
 package bisq.gradle.tor_binary
 
+import bisq.gradle.common.OS
+import bisq.gradle.common.getOS
 import bisq.gradle.tasks.download.SignedBinaryDownloader
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
@@ -47,6 +49,11 @@ class TorBinaryPackager(private val project: Project, private val torBinaryDownl
                 destinationDirectory.set(project.layout.buildDirectory.dir("generated/src/main/resources"))
                 from(project.layout.buildDirectory.dir(PROCESSED_DIR))
             }
+
+        if (getOS() == OS.LINUX) {
+            // The Bisq package depends on Tor and the OS's package manager installs Tor and its dependencies for us.
+            return
+        }
 
         val processResourcesTask = project.tasks.named("processResources")
         processResourcesTask.configure {

--- a/network/tor/tor/src/main/java/bisq/tor/TorNotInstalledException.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorNotInstalledException.java
@@ -1,0 +1,4 @@
+package bisq.tor;
+
+public class TorNotInstalledException extends RuntimeException {
+}

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -182,7 +182,6 @@ public class TorService implements Service {
             }
         }
 
-        installTorIfNotUpToDate();
         return torDataDirPath.resolve("tor");
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -18,6 +18,7 @@
 package bisq.tor;
 
 import bisq.common.application.Service;
+import bisq.common.file.FileUtils;
 import bisq.common.observable.Observable;
 import bisq.common.platform.LinuxDistribution;
 import bisq.common.platform.OS;
@@ -74,7 +75,16 @@ public class TorService implements Service {
         }
 
         if (!LinuxDistribution.isWhonix()) {
-            installTorIfNotUpToDate();
+            try {
+                Path torDataDirPath = transportConfig.getDataDir();
+                FileUtils.makeDirs(torDataDirPath.toFile());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!OS.isLinux()) {
+                installTorIfNotUpToDate();
+            }
 
             PasswordDigest hashedControlPassword = PasswordDigest.generateDigest();
             createTorrcConfigFile(torDataDirPath, hashedControlPassword);
@@ -177,11 +187,8 @@ public class TorService implements Service {
     private Path getTorBinaryPath() {
         if (OS.isLinux()) {
             Optional<Path> systemTorBinaryPath = NativeTorProcess.getSystemTorPath();
-            if (systemTorBinaryPath.isPresent()) {
-                return systemTorBinaryPath.get();
-            }
+            return systemTorBinaryPath.orElseThrow(TorNotInstalledException::new);
         }
-
         return torDataDirPath.resolve("tor");
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/installer/TorInstaller.java
+++ b/network/tor/tor/src/main/java/bisq/tor/installer/TorInstaller.java
@@ -58,9 +58,6 @@ public class TorInstaller {
 
     private void install() throws IOException {
         try {
-            File torDir = torInstallationFiles.getTorDir();
-            FileUtils.makeDirs(torDir);
-
             File destDir = torInstallationFiles.getTorDir();
             new TorBinaryZipExtractor(destDir).extractBinary();
             log.info("Tor files installed to {}", destDir.getAbsolutePath());


### PR DESCRIPTION
Tor failed to start for some users because their operating system didn't ship Tor's dependencies. This change instructs the package manager to install tor and all its required during the Bisq installation. Furthermore, we don't need to ship the Tor binary and its libraries on Linux anymore leading to package size savings.

Changes:
- [packaging: Add tor package to required Linux dependencies](https://github.com/bisq-network/bisq2/commit/d378a423509a73b9fb8340f70360c23ed4cca421)
- [TorService: Remove duplicate call to installTorIfNotUpToDate()](https://github.com/bisq-network/bisq2/commit/181f970d5400a1e856b8a96e90b1841d75028daf)
- [tor: Use system tor (installed by package manager)](https://github.com/bisq-network/bisq2/commit/4c791be7ab95cdcacd474302cf8ee52297252684)
- [build-logic: Don't bundle Tor on Linux](https://github.com/bisq-network/bisq2/commit/246535de503a734b526ea573cf35cf9dd7c5ec02)

Fixes #2906