### PR TITLE
Implement MigrationService

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -17,6 +17,7 @@
 
 package bisq.application;
 
+import bisq.application.migration.MigrationService;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.DevMode;
 import bisq.common.application.OptionUtils;
@@ -124,6 +125,7 @@ public abstract class ApplicationService implements Service {
     protected final Config config;
     @Getter
     protected final PersistenceService persistenceService;
+    private final MigrationService migrationService;
     @SuppressWarnings("FieldCanBeLocal") // Pin it so that it does not get GC'ed
     private final MemoryReport memoryReport;
     private FileLock instanceLock;
@@ -185,6 +187,7 @@ public abstract class ApplicationService implements Service {
 
         String absoluteDataDirPath = dataDir.toAbsolutePath().toString();
         persistenceService = new PersistenceService(absoluteDataDirPath);
+        migrationService = new MigrationService(dataDir);
     }
 
     private void checkInstanceLock() {
@@ -207,7 +210,9 @@ public abstract class ApplicationService implements Service {
         return persistenceService.readAllPersisted();
     }
 
-    public abstract CompletableFuture<Boolean> initialize();
+    public CompletableFuture<Boolean> initialize() {
+        return migrationService.runMigrations();
+    }
 
     public abstract CompletableFuture<Boolean> shutdown();
 

--- a/application/src/main/java/bisq/application/migration/MigrationService.java
+++ b/application/src/main/java/bisq/application/migration/MigrationService.java
@@ -1,0 +1,46 @@
+package bisq.application.migration;
+
+import bisq.common.application.ApplicationVersion;
+import bisq.common.platform.Version;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+public class MigrationService {
+    static final Version VERSION_BEFORE_MIGRATION_SERVICE_INTRODUCED = new Version("2.1.1");
+    private final Path dataDir;
+    private final File dataDirVersionFile;
+
+    public MigrationService(Path dataDir) {
+        this.dataDir = dataDir;
+        this.dataDirVersionFile = dataDir.resolve("version").toFile();
+    }
+
+    public CompletableFuture<Boolean> runMigrations() {
+        Version dataDirVersion = getDataDirVersion();
+        Version appVersion = ApplicationVersion.getVersion();
+
+        if (dataDirVersion.below(appVersion)) {
+            Migrator migrator = new Migrator(appVersion, dataDir);
+            migrator.migrate();
+        }
+
+        return CompletableFuture.completedFuture(true);
+    }
+
+    Version getDataDirVersion() {
+        if (!dataDirVersionFile.exists()) {
+            return VERSION_BEFORE_MIGRATION_SERVICE_INTRODUCED;
+        }
+
+        try {
+            String version = Files.readString(dataDirVersionFile.toPath());
+            return new Version(version);
+        } catch (IOException e) {
+            throw new RuntimeException("Can't identify data dir version. This shouldn't happen.", e);
+        }
+    }
+}

--- a/application/src/main/java/bisq/application/migration/Migrator.java
+++ b/application/src/main/java/bisq/application/migration/Migrator.java
@@ -1,11 +1,11 @@
 package bisq.application.migration;
 
 import bisq.application.migration.migrations.Migration;
+import bisq.application.migration.migrations.MigrationsForV2_1_2;
 import bisq.common.platform.Version;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -17,7 +17,7 @@ public class Migrator {
     public Migrator(Version appVersion, Path dataDir) {
         this.appVersion = appVersion;
         this.dataDir = dataDir;
-        this.allMigrations = Collections.emptyList();
+        this.allMigrations = List.of(new MigrationsForV2_1_2());
     }
 
     public void migrate() {

--- a/application/src/main/java/bisq/application/migration/Migrator.java
+++ b/application/src/main/java/bisq/application/migration/Migrator.java
@@ -1,0 +1,32 @@
+package bisq.application.migration;
+
+import bisq.application.migration.migrations.Migration;
+import bisq.common.platform.Version;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+public class Migrator {
+    private final Version appVersion;
+    private final Path dataDir;
+    private final List<Migration> allMigrations;
+
+    public Migrator(Version appVersion, Path dataDir) {
+        this.appVersion = appVersion;
+        this.dataDir = dataDir;
+        this.allMigrations = Collections.emptyList();
+    }
+
+    public void migrate() {
+        for (Migration migration : allMigrations) {
+            Version migrationVersion = migration.getVersion();
+            if (migrationVersion.belowOrEqual(appVersion)) {
+                log.info("Running {} migrations.", migrationVersion);
+                migration.run(dataDir);
+            }
+        }
+    }
+}

--- a/application/src/main/java/bisq/application/migration/migrations/Migration.java
+++ b/application/src/main/java/bisq/application/migration/migrations/Migration.java
@@ -1,0 +1,11 @@
+package bisq.application.migration.migrations;
+
+import bisq.common.platform.Version;
+
+import java.nio.file.Path;
+
+public interface Migration {
+    void run(Path dataDir);
+
+    Version getVersion();
+}

--- a/application/src/main/java/bisq/application/migration/migrations/MigrationFailedException.java
+++ b/application/src/main/java/bisq/application/migration/migrations/MigrationFailedException.java
@@ -1,0 +1,7 @@
+package bisq.application.migration.migrations;
+
+public class MigrationFailedException extends RuntimeException {
+    public MigrationFailedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/application/src/main/java/bisq/application/migration/migrations/MigrationsForV2_1_2.java
+++ b/application/src/main/java/bisq/application/migration/migrations/MigrationsForV2_1_2.java
@@ -1,0 +1,26 @@
+package bisq.application.migration.migrations;
+
+import bisq.common.application.ApplicationVersion;
+import bisq.common.platform.Version;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MigrationsForV2_1_2 implements Migration {
+
+    @Override
+    public void run(Path dataDir) {
+        try {
+            Path versionFilePath = dataDir.resolve("version");
+            Files.writeString(versionFilePath, ApplicationVersion.getVersion().toString());
+        } catch (IOException e) {
+            throw new MigrationFailedException(e);
+        }
+    }
+
+    @Override
+    public Version getVersion() {
+        return new Version("2.1.2");
+    }
+}

--- a/application/src/test/java/bisq/application/migration/MigrationServiceTests.java
+++ b/application/src/test/java/bisq/application/migration/MigrationServiceTests.java
@@ -1,0 +1,43 @@
+package bisq.application.migration;
+
+import bisq.common.platform.InvalidVersionException;
+import bisq.common.platform.Version;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MigrationServiceTests {
+    @Test
+    void getDataDirVersionBeforeMigrationServiceIntroduced(@TempDir Path dataDir) {
+        MigrationService migrationService = new MigrationService(dataDir);
+        Version dataDirVersion = migrationService.getDataDirVersion();
+        assertThat(dataDirVersion)
+                .isEqualTo(MigrationService.VERSION_BEFORE_MIGRATION_SERVICE_INTRODUCED);
+    }
+
+    @Test
+    void getDataDirInvalidVersion(@TempDir Path dataDir) throws IOException {
+        Path versionFilePath = dataDir.resolve("version");
+        Files.writeString(versionFilePath, "2.1-alpha");
+
+        MigrationService migrationService = new MigrationService(dataDir);
+        assertThrows(InvalidVersionException.class, migrationService::getDataDirVersion);
+    }
+
+    @Test
+    void getDataDirVersion(@TempDir Path dataDir) throws IOException {
+        Path versionFilePath = dataDir.resolve("version");
+        Files.writeString(versionFilePath, "2.1.34");
+
+        MigrationService migrationService = new MigrationService(dataDir);
+        Version dataDirVersion = migrationService.getDataDirVersion();
+        assertThat(dataDirVersion)
+                .isEqualTo(new Version("2.1.34"));
+    }
+}

--- a/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
+++ b/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
@@ -1,0 +1,28 @@
+package bisq.application.migration.migrations;
+
+import bisq.common.application.ApplicationVersion;
+import bisq.common.platform.Version;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MigrationsForV2_1_2Tests {
+    private final MigrationsForV2_1_2 migrationsForV212 = new MigrationsForV2_1_2();
+
+    @Test
+    void migrationTest(@TempDir Path dataDir) throws IOException {
+        Version version = migrationsForV212.getVersion();
+        Version expectedVersion = new Version("2.1.2");
+        assertThat(version).isEqualTo(expectedVersion);
+
+        migrationsForV212.run(dataDir);
+        String readVersion = Files.readString(dataDir.resolve("version"));
+        assertThat(readVersion)
+                .isEqualTo(ApplicationVersion.getVersion().toString());
+    }
+}

--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -219,7 +219,8 @@ public class DesktopApplicationService extends ApplicationService {
 
     @Override
     public CompletableFuture<Boolean> initialize() {
-        return securityService.initialize()
+        return super.initialize()
+                .thenCompose(result -> securityService.initialize())
                 .thenCompose(result -> {
                     setState(State.INITIALIZE_NETWORK);
 

--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/OracleNodeApplicationService.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/OracleNodeApplicationService.java
@@ -80,7 +80,8 @@ public class OracleNodeApplicationService extends ApplicationService {
 
     @Override
     public CompletableFuture<Boolean> initialize() {
-        return securityService.initialize()
+        return super.initialize()
+                .thenCompose(result -> securityService.initialize())
                 .thenCompose(result -> networkService.initialize())
                 .thenCompose(result -> identityService.initialize())
                 .thenCompose(result -> bondedRolesService.initialize())

--- a/apps/rest-api-app/src/main/java/bisq/rest_api/RestApiApplicationService.java
+++ b/apps/rest-api-app/src/main/java/bisq/rest_api/RestApiApplicationService.java
@@ -167,7 +167,8 @@ public class RestApiApplicationService extends ApplicationService {
 
     @Override
     public CompletableFuture<Boolean> initialize() {
-        return securityService.initialize()
+        return super.initialize()
+                .thenCompose(result -> securityService.initialize())
                 .thenCompose(result -> {
                     setState(State.INITIALIZE_NETWORK);
 

--- a/apps/seed-node-app/src/main/java/bisq/seed_node/SeedNodeApplicationService.java
+++ b/apps/seed-node-app/src/main/java/bisq/seed_node/SeedNodeApplicationService.java
@@ -75,7 +75,8 @@ public class SeedNodeApplicationService extends ApplicationService {
 
     @Override
     public CompletableFuture<Boolean> initialize() {
-        return securityService.initialize()
+        return super.initialize()
+                .thenCompose(result -> securityService.initialize())
                 .thenCompose(result -> networkService.initialize())
                 .thenCompose(result -> identityService.initialize())
                 .thenCompose(result -> bondedRolesService.initialize())

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
@@ -14,6 +14,8 @@ class LinuxPackages(private val resourcesPath: Path, private val appName: String
                 "--linux-package-name", appName.lowercase().replace(" ", ""),
                 "--linux-app-release", "1",
 
+                "--linux-package-deps", "tor",
+
                 "--linux-menu-group", "Network",
                 "--linux-shortcut",
 

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
@@ -1,5 +1,7 @@
 package bisq.gradle.tor_binary
 
+import bisq.gradle.common.OS
+import bisq.gradle.common.getOS
 import bisq.gradle.tasks.download.SignedBinaryDownloader
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
@@ -47,6 +49,11 @@ class TorBinaryPackager(private val project: Project, private val torBinaryDownl
                 destinationDirectory.set(project.layout.buildDirectory.dir("generated/src/main/resources"))
                 from(project.layout.buildDirectory.dir(PROCESSED_DIR))
             }
+
+        if (getOS() == OS.LINUX) {
+            // The Bisq package depends on Tor and the OS's package manager installs Tor and its dependencies for us.
+            return
+        }
 
         val processResourcesTask = project.tasks.named("processResources")
         processResourcesTask.configure {

--- a/common/src/main/java/bisq/common/platform/InvalidVersionException.java
+++ b/common/src/main/java/bisq/common/platform/InvalidVersionException.java
@@ -1,0 +1,7 @@
+package bisq.common.platform;
+
+public class InvalidVersionException extends RuntimeException {
+    public InvalidVersionException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/bisq/common/platform/Version.java
+++ b/common/src/main/java/bisq/common/platform/Version.java
@@ -23,10 +23,10 @@ import lombok.Getter;
 public class Version implements Comparable<Version> {
     public static void validate(String versionAsString) {
         if (versionAsString == null || versionAsString.isEmpty()) {
-            throw new IllegalArgumentException("Version must not be null or empty");
+            throw new InvalidVersionException("Version must not be null or empty");
         }
         if (!versionAsString.matches("[0-9]+(\\.[0-9]+)*")) {
-            throw new IllegalArgumentException("Invalid version format. version=" + versionAsString);
+            throw new InvalidVersionException("Invalid version format. version=" + versionAsString);
         }
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorNotInstalledException.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorNotInstalledException.java
@@ -1,0 +1,4 @@
+package bisq.tor;
+
+public class TorNotInstalledException extends RuntimeException {
+}

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -182,7 +182,6 @@ public class TorService implements Service {
             }
         }
 
-        installTorIfNotUpToDate();
         return torDataDirPath.resolve("tor");
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/tor/TorService.java
@@ -18,6 +18,7 @@
 package bisq.tor;
 
 import bisq.common.application.Service;
+import bisq.common.file.FileUtils;
 import bisq.common.observable.Observable;
 import bisq.common.platform.LinuxDistribution;
 import bisq.common.platform.OS;
@@ -74,7 +75,16 @@ public class TorService implements Service {
         }
 
         if (!LinuxDistribution.isWhonix()) {
-            installTorIfNotUpToDate();
+            try {
+                Path torDataDirPath = transportConfig.getDataDir();
+                FileUtils.makeDirs(torDataDirPath.toFile());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (!OS.isLinux()) {
+                installTorIfNotUpToDate();
+            }
 
             PasswordDigest hashedControlPassword = PasswordDigest.generateDigest();
             createTorrcConfigFile(torDataDirPath, hashedControlPassword);
@@ -177,11 +187,8 @@ public class TorService implements Service {
     private Path getTorBinaryPath() {
         if (OS.isLinux()) {
             Optional<Path> systemTorBinaryPath = NativeTorProcess.getSystemTorPath();
-            if (systemTorBinaryPath.isPresent()) {
-                return systemTorBinaryPath.get();
-            }
+            return systemTorBinaryPath.orElseThrow(TorNotInstalledException::new);
         }
-
         return torDataDirPath.resolve("tor");
     }
 

--- a/network/tor/tor/src/main/java/bisq/tor/installer/TorInstaller.java
+++ b/network/tor/tor/src/main/java/bisq/tor/installer/TorInstaller.java
@@ -58,9 +58,6 @@ public class TorInstaller {
 
     private void install() throws IOException {
         try {
-            File torDir = torInstallationFiles.getTorDir();
-            FileUtils.makeDirs(torDir);
-
             File destDir = torInstallationFiles.getTorDir();
             new TorBinaryZipExtractor(destDir).extractBinary();
             log.info("Tor files installed to {}", destDir.getAbsolutePath());


### PR DESCRIPTION
The MigrationService allows us to perform necessary migrations when upgrading to a new Bisq version. So far, the only option is to try to perform the migrations on each run. The MigrationService runs the necessary migrations if the data directory version is below the app version.

I tested this PR on:
- an instance with a fresh data directory
- an instance with a data directory of v2.1.1 (applies migration)
- an instance with an already migrated data directory (v2.1.2)

This feature is needed to remove redundant Tor files after merging PR #2938. A follow-up PR will contain the required changes.

Changes:
- [Implement MigrationService](https://github.com/bisq-network/bisq2/commit/31167e00930479788145dec50c372c2c10881683)
- [Version: Throw InvalidVersionException for invalid versions](https://github.com/bisq-network/bisq2/commit/27f1a6ad1d9627c92a25ce7488254b41a414b11d)
- [Test MigrationService data directory version detection](https://github.com/bisq-network/bisq2/commit/9d8187dffd875bcc6a9a2129ca7d20f20cbcda6a)
  - Test with data directory before MigrationService was introduced
  - Test with invalid data directory version
  - Test with valid data directory version
- [Implement migration for v2.1.2](https://github.com/bisq-network/bisq2/commit/c216ccab54f93fe74b46435d4e44488564abf234)
  - This migration writes the current version number to the data directory. The remaining migrations depend on another open PR and will follow soon.
- [ApplicationService: Apply migrations before starting services](https://github.com/bisq-network/bisq2/commit/ff2dca8a70cd6335d2ffd95b24b4fab46e7e38d3)