### PR TITLE
migration: Write new data directory version if all migrations succeed

### DIFF
--- a/application/src/main/java/bisq/application/migration/migrations/MigrationsForV2_1_2.java
+++ b/application/src/main/java/bisq/application/migration/migrations/MigrationsForV2_1_2.java
@@ -1,12 +1,10 @@
 package bisq.application.migration.migrations;
 
-import bisq.common.application.ApplicationVersion;
 import bisq.common.file.FileUtils;
 import bisq.common.platform.OS;
 import bisq.common.platform.Version;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class MigrationsForV2_1_2 implements Migration {
@@ -18,9 +16,6 @@ public class MigrationsForV2_1_2 implements Migration {
                 Path torDataDir = dataDir.resolve("tor");
                 FileUtils.deleteFileOrDirectory(torDataDir);
             }
-
-            Path versionFilePath = dataDir.resolve("version");
-            Files.writeString(versionFilePath, ApplicationVersion.getVersion().toString());
         } catch (IOException e) {
             throw new MigrationFailedException(e);
         }

--- a/application/src/test/java/bisq/application/migration/MigratorTest.java
+++ b/application/src/test/java/bisq/application/migration/MigratorTest.java
@@ -1,0 +1,29 @@
+package bisq.application.migration;
+
+import bisq.common.application.ApplicationVersion;
+import bisq.common.platform.Version;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MigratorTest {
+    @Test
+    void migrationSuccess(@TempDir Path dataDir) throws IOException {
+        Path versionFilePath = dataDir.resolve("version");
+        Version dataDirVersion = new Version("2.1.0");
+        Files.writeString(versionFilePath, dataDirVersion.toString());
+
+        Version appVersion = ApplicationVersion.getVersion();
+        Migrator migrator = new Migrator(appVersion, dataDir);
+
+        migrator.migrate();
+
+        String readVersion = Files.readString(dataDir.resolve("version"));
+        assertThat(readVersion).isEqualTo(appVersion.toString());
+    }
+}

--- a/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
+++ b/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
@@ -1,6 +1,5 @@
 package bisq.application.migration.migrations;
 
-import bisq.common.application.ApplicationVersion;
 import bisq.common.platform.Version;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -18,20 +17,17 @@ public class MigrationsForV2_1_2Tests {
     private final MigrationsForV2_1_2 migrationsForV212 = new MigrationsForV2_1_2();
 
     @Test
-    void migrationTest(@TempDir Path dataDir) throws IOException {
+    void migrateEmptyDataDir(@TempDir Path dataDir) {
         Version version = migrationsForV212.getVersion();
         Version expectedVersion = new Version("2.1.2");
         assertThat(version).isEqualTo(expectedVersion);
 
         migrationsForV212.run(dataDir);
-        String readVersion = Files.readString(dataDir.resolve("version"));
-        assertThat(readVersion)
-                .isEqualTo(ApplicationVersion.getVersion().toString());
     }
 
     @Test
     @EnabledOnOs({OS.MAC, OS.WINDOWS})
-    void torFilesRemovalTestOnMacAndWindows(@TempDir Path dataDir) throws IOException {
+    void torFilesRemovalTestOnMacAndWindows(@TempDir Path dataDir) {
         Path torDataDir = dataDir.resolve("tor");
         createFakeTorDataDir(torDataDir);
 
@@ -46,15 +42,11 @@ public class MigrationsForV2_1_2Tests {
 
         fileExists = pluggableTransportDir.resolve("README.SNOWFLAKE.md").toFile().exists();
         assertThat(fileExists).isTrue();
-
-        Path versionFilePath = dataDir.resolve("version");
-        String version = Files.readString(versionFilePath);
-        assertThat(version).isEqualTo(ApplicationVersion.getVersion().toString());
     }
 
     @Test
     @EnabledOnOs(OS.LINUX)
-    void torFilesRemovalTestOnLinux(@TempDir Path dataDir) throws IOException {
+    void torFilesRemovalTestOnLinux(@TempDir Path dataDir) {
         Path torDataDir = dataDir.resolve("tor");
         createFakeTorDataDir(torDataDir);
 
@@ -69,10 +61,6 @@ public class MigrationsForV2_1_2Tests {
 
         fileExists = pluggableTransportDir.resolve("README.SNOWFLAKE.md").toFile().exists();
         assertThat(fileExists).isFalse();
-
-        Path versionFilePath = dataDir.resolve("version");
-        String version = Files.readString(versionFilePath);
-        assertThat(version).isEqualTo(ApplicationVersion.getVersion().toString());
     }
 
     private void createFakeTorDataDir(Path torDataDir) {


### PR DESCRIPTION
Migrations are applied if the app version number is higher than the data directory version number. Currently, the only existing migration writes the new version number to the data directory after applying its migration. Moving the data directory version write to the Migrator makes the code future-proof when we have multiple migrations.