### PR TITLE
Add HashCashV2TokenService

### DIFF
--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -102,7 +102,7 @@ application {
         version = 1
 
         supportedTransportTypes = ["TOR"]
-        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH"]
+        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH","AUTHORIZATION_HASH_CASH_V2"]
 
         serviceNode {
             p2pServiceNode=["PEER_GROUP","DATA","CONFIDENTIAL","ACK","MONITOR"]
@@ -119,7 +119,7 @@ application {
         }
 
         authorization {
-            myPreferredAuthorizationTokenTypes=["HASH_CASH"]
+            myPreferredAuthorizationTokenTypes=["HASH_CASH_V2"]
         }
 
         clearNetPeerGroup {

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -105,7 +105,7 @@ application {
         version = 1
 
         supportedTransportTypes = ["TOR"]
-        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH"]
+        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH","AUTHORIZATION_HASH_CASH_V2"]
 
         serviceNode {
             p2pServiceNode=["PEER_GROUP","DATA","CONFIDENTIAL","ACK","MONITOR","REPORT_RESPONSE"]
@@ -122,7 +122,7 @@ application {
         }
 
         authorization {
-            myPreferredAuthorizationTokenTypes=["HASH_CASH"]
+            myPreferredAuthorizationTokenTypes=["HASH_CASH_V2"]
         }
 
         clearNetPeerGroup {

--- a/apps/rest-api-app/src/main/resources/rest_api.conf
+++ b/apps/rest-api-app/src/main/resources/rest_api.conf
@@ -101,7 +101,7 @@ application {
         version = 1
 
         supportedTransportTypes = ["TOR"]
-        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH"]
+        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH","AUTHORIZATION_HASH_CASH_V2"]
 
         serviceNode {
             p2pServiceNode=["PEER_GROUP","DATA","CONFIDENTIAL","ACK","MONITOR","REPORT_REQUEST"]
@@ -118,7 +118,7 @@ application {
         }
 
         authorization {
-            myPreferredAuthorizationTokenTypes=["HASH_CASH"]
+            myPreferredAuthorizationTokenTypes=["HASH_CASH_V2"]
         }
 
         clearNetPeerGroup {

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -89,7 +89,7 @@ application {
         version = 1
 
         supportedTransportTypes = ["TOR"]
-        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH"]
+        features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH","AUTHORIZATION_HASH_CASH_V2"]
 
         serviceNode {
             p2pServiceNode=["PEER_GROUP","DATA","MONITOR","REPORT_RESPONSE"]
@@ -106,7 +106,7 @@ application {
         }
 
         authorization {
-            myPreferredAuthorizationTokenTypes=["HASH_CASH"]
+            myPreferredAuthorizationTokenTypes=["HASH_CASH_V2"]
         }
 
         clearNetPeerGroup {

--- a/common/src/main/java/bisq/common/proto/ProtobufUtils.java
+++ b/common/src/main/java/bisq/common/proto/ProtobufUtils.java
@@ -83,7 +83,7 @@ public class ProtobufUtils {
                     try {
                         return enumFromProto(enumType, ((Enum<?>) enumProto).name());
                     } catch (Exception e) {
-                        log.warn("Could not resolve enum for proto {}.", enumProto, e);
+                        log.warn("Could not resolve enum for proto {}. We skip that collection entry.", enumProto, e);
                         return null;
                     }
                 })

--- a/network/network/src/main/java/bisq/network/p2p/node/Feature.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Feature.java
@@ -3,6 +3,8 @@ package bisq.network.p2p.node;
 import bisq.common.proto.ProtoEnum;
 import bisq.common.proto.ProtobufUtils;
 
+import java.util.Set;
+
 /**
  * Features are used to signal which features the node supports. Those might be variations of different implementations
  * like HashCash or EquiHash algorithms for proof of work, or different implementations for requesting inventory data.
@@ -11,7 +13,10 @@ public enum Feature implements ProtoEnum {
     INVENTORY_HASH_SET,
     INVENTORY_MINI_SKETCH,
     AUTHORIZATION_HASH_CASH,
-    AUTHORIZATION_EQUI_HASH;
+    AUTHORIZATION_EQUI_HASH,
+    AUTHORIZATION_HASH_CASH_V2;
+
+    public static final Set<Feature> DEFAULT_FEATURES = Set.of(INVENTORY_HASH_SET, AUTHORIZATION_HASH_CASH);
 
     @Override
     public bisq.network.protobuf.Feature toProtoEnum() {

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationToken.java
@@ -21,6 +21,7 @@ import bisq.common.proto.NetworkProto;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.network.p2p.node.authorization.token.equi_hash.EquiHashToken;
 import bisq.network.p2p.node.authorization.token.hash_cash.HashCashToken;
+import bisq.network.p2p.node.authorization.token.hash_cash_v2.HashCashV2Token;
 import lombok.Getter;
 
 public abstract class AuthorizationToken implements NetworkProto {
@@ -40,10 +41,17 @@ public abstract class AuthorizationToken implements NetworkProto {
     }
 
     public static AuthorizationToken fromProto(bisq.network.protobuf.AuthorizationToken proto) {
-        return switch (proto.getMessageCase()) {
-            case HASHCASHTOKEN -> HashCashToken.fromProto(proto);
-            case EQUIHASHTOKEN -> EquiHashToken.fromProto(proto);
-            default -> throw new UnresolvableProtobufMessageException(proto);
-        };
+        switch (proto.getMessageCase()) {
+            case HASHCASHTOKEN: {
+                return HashCashToken.fromProto(proto);
+            }
+            case EQUIHASHTOKEN: {
+                return EquiHashToken.fromProto(proto);
+            }
+            case HASHCASHV2TOKEN: {
+                return HashCashV2Token.fromProto(proto);
+            }
+        }
+        throw new UnresolvableProtobufMessageException(proto);
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationTokenType.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationTokenType.java
@@ -8,14 +8,20 @@ import java.util.Optional;
 
 public enum AuthorizationTokenType implements ProtoEnum {
     HASH_CASH,
-    EQUI_HASH;
+    EQUI_HASH,
+    HASH_CASH_V2;
 
     public static Optional<AuthorizationTokenType> fromFeature(Feature feature) {
-        return switch (feature) {
-            case AUTHORIZATION_HASH_CASH -> Optional.of(AuthorizationTokenType.HASH_CASH);
-            case AUTHORIZATION_EQUI_HASH -> Optional.of(AuthorizationTokenType.EQUI_HASH);
-            default -> Optional.empty();
-        };
+        switch (feature) {
+            case AUTHORIZATION_HASH_CASH:
+                return Optional.of(AuthorizationTokenType.HASH_CASH);
+            case AUTHORIZATION_EQUI_HASH:
+                return Optional.of(AuthorizationTokenType.EQUI_HASH);
+            case AUTHORIZATION_HASH_CASH_V2:
+                return Optional.of(AuthorizationTokenType.HASH_CASH_V2);
+            default:
+                return Optional.empty();
+        }
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash_v2/HashCashV2Token.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash_v2/HashCashV2Token.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.node.authorization.token.hash_cash_v2;
+
+import bisq.network.p2p.node.authorization.AuthorizationToken;
+import bisq.network.p2p.node.authorization.AuthorizationTokenType;
+import bisq.security.pow.ProofOfWork;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public final class HashCashV2Token extends AuthorizationToken {
+    private final ProofOfWork proofOfWork;
+    private final int messageCounter;
+
+    public HashCashV2Token(ProofOfWork proofOfWork, int messageCounter) {
+        this(AuthorizationTokenType.HASH_CASH_V2, proofOfWork, messageCounter);
+    }
+
+    private HashCashV2Token(AuthorizationTokenType authorizationTokenType, ProofOfWork proofOfWork, int messageCounter) {
+        super(authorizationTokenType);
+
+        this.proofOfWork = proofOfWork;
+        this.messageCounter = messageCounter;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(authorizationTokenType == AuthorizationTokenType.HASH_CASH_V2);
+    }
+
+    @Override
+    public bisq.network.protobuf.AuthorizationToken toProto(boolean serializeForHash) {
+        return resolveProto(serializeForHash);
+    }
+
+    @Override
+    public bisq.network.protobuf.AuthorizationToken.Builder getBuilder(boolean serializeForHash) {
+        return getAuthorizationTokenBuilder().setHashCashV2Token(
+                bisq.network.protobuf.HashCashV2Token.newBuilder()
+                        .setProofOfWork(proofOfWork.toProto(serializeForHash))
+                        .setMessageCounter(messageCounter));
+    }
+
+    public static HashCashV2Token fromProto(bisq.network.protobuf.AuthorizationToken proto) {
+        bisq.network.protobuf.HashCashV2Token hashCashV2TokenProto = proto.getHashCashV2Token();
+        return new HashCashV2Token(AuthorizationTokenType.fromProto(proto.getAuthorizationTokenType()),
+                ProofOfWork.fromProto(hashCashV2TokenProto.getProofOfWork()),
+                hashCashV2TokenProto.getMessageCounter());
+    }
+}

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash_v2/HashCashV2TokenService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash_v2/HashCashV2TokenService.java
@@ -1,0 +1,277 @@
+package bisq.network.p2p.node.authorization.token.hash_cash_v2;
+
+import bisq.common.application.DevMode;
+import bisq.common.encoding.Hex;
+import bisq.common.util.ByteArrayUtils;
+import bisq.common.util.MathUtils;
+import bisq.common.util.StringUtils;
+import bisq.network.p2p.message.EnvelopePayloadMessage;
+import bisq.network.p2p.node.authorization.AuthorizationToken;
+import bisq.network.p2p.node.authorization.AuthorizationTokenService;
+import bisq.network.p2p.node.network_load.NetworkLoad;
+import bisq.security.DigestUtil;
+import bisq.security.pow.ProofOfWork;
+import bisq.security.pow.hashcash.HashCashProofOfWorkService;
+import com.google.common.base.Charsets;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigInteger;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Slf4j
+public class HashCashV2TokenService extends AuthorizationTokenService<HashCashV2Token> {
+    public final static double MIN_MESSAGE_COST = 0.01;
+    public final static double MIN_LOAD = 0.01;
+    public final static int MIN_DIFFICULTY = 128;  // 2^7 = 128; 3 ms on old CPU, 1 ms on high-end CPU. Would result in an average time of 1-5 ms on high-end CPU
+    public final static int TARGET_DIFFICULTY = 65536;  // 2^16 = 262144; 1000 ms on old CPU, 60-140 ms on high-end CPU. Would result in an average time of 100-150 ms on high-end CPU
+    public final static int MAX_DIFFICULTY = 1048576;  // 2^20 = 1048576; Would result in an average time 0.5-2 sec on high-end CPU
+    public final static int DIFFICULTY_TOLERANCE = 50_000;
+
+    private final HashCashProofOfWorkService proofOfWorkService;
+    // Keep track of message counter per connection to avoid reuse of pow
+    private final Map<String, Set<Integer>> receivedMessageCountersByConnectionId = new ConcurrentHashMap<>();
+    @Getter
+    private final Metrics metrics = new Metrics();
+
+    public HashCashV2TokenService(HashCashProofOfWorkService proofOfWorkService) {
+        this.proofOfWorkService = proofOfWorkService;
+    }
+
+    @Override
+    public HashCashV2Token createToken(EnvelopePayloadMessage message,
+                                       NetworkLoad networkLoad,
+                                       String peerAddress,
+                                       int messageCounter) {
+        long ts = System.currentTimeMillis();
+        double difficulty = calculateDifficulty(message, networkLoad);
+        byte[] challenge = getChallenge(peerAddress, messageCounter);
+        byte[] payload = getPayload(message);
+        ProofOfWork proofOfWork = proofOfWorkService.mint(payload, challenge, difficulty);
+        long duration = System.currentTimeMillis() - ts;
+        metrics.update(duration, networkLoad.getLoad());
+
+        HashCashV2Token token = new HashCashV2Token(proofOfWork, messageCounter);
+        log.debug("Create HashCashV2Token for {} took {} ms" +
+                        "\ncostFactor={}" +
+                        "\ngetPayload(message)={}" +
+                        "\nnetworkLoad={}" +
+                        "\nhashCashV2Token={}",
+                message.getClass().getSimpleName(), duration,
+                message.getCostFactor(),
+                Hex.encode(payload),
+                networkLoad,
+                token);
+        return token;
+    }
+
+    @Override
+    public boolean isAuthorized(EnvelopePayloadMessage message,
+                                AuthorizationToken authorizationToken,
+                                NetworkLoad currentNetworkLoad,
+                                Optional<NetworkLoad> previousNetworkLoad,
+                                String connectionId,
+                                String myAddress) {
+        HashCashV2Token hashCashV2Token = (HashCashV2Token) authorizationToken;
+        ProofOfWork proofOfWork = hashCashV2Token.getProofOfWork();
+        int messageCounter = hashCashV2Token.getMessageCounter();
+
+        // Verify that pow is not reused
+        Set<Integer> receivedMessageCounters;
+        if (receivedMessageCountersByConnectionId.containsKey(connectionId)) {
+            receivedMessageCounters = receivedMessageCountersByConnectionId.get(connectionId);
+            if (receivedMessageCounters.contains(messageCounter)) {
+                log.warn("Invalid receivedMessageCounters. We received the proofOfWork for that message already.");
+                return false;
+            }
+        } else {
+            receivedMessageCounters = new HashSet<>();
+            receivedMessageCountersByConnectionId.put(connectionId, receivedMessageCounters);
+        }
+        receivedMessageCounters.add(messageCounter);
+
+        // Verify payload
+        byte[] payload = getPayload(message);
+        byte[] proofOfWorkPayload = proofOfWork.getPayload();
+        if (!Arrays.equals(payload, proofOfWorkPayload)) {
+            // We try again with ignoring ExcludeForHash annotations by using the serialize() method.
+            byte[] payloadWithoutUsingExcludeForHash = message.serialize();
+            if (Arrays.equals(payloadWithoutUsingExcludeForHash, proofOfWorkPayload)) {
+                log.info("Proof of work payload not matching message.serializeForHash() but " +
+                        "matching message.serialize(). This is expected for certain messages from " +
+                        "nodes which do not run the latest version.");
+            } else {
+                log.warn("Message payload not matching proof of work payload. " +
+                                "getPayload(message)={};\n" +
+                                "proofOfWork.getPayload()={};\n" +
+                                "getPayload(message).length={};\n" +
+                                "proofOfWork.getPayload().length={}\n" +
+                                "message={}",
+                        StringUtils.truncate(Hex.encode(payload), 200),
+                        StringUtils.truncate(Hex.encode(proofOfWorkPayload), 200),
+                        payload.length,
+                        proofOfWorkPayload.length,
+                        StringUtils.truncate(message.toString(), 5000));
+                return false;
+            }
+        }
+
+        // Verify challenge
+        if (!Arrays.equals(getChallenge(myAddress, messageCounter), proofOfWork.getChallenge())) {
+            log.warn("Invalid challenge");
+            return false;
+        }
+
+        // Verify difficulty
+        if (isDifficultyInvalid(message, proofOfWork.getDifficulty(), currentNetworkLoad, previousNetworkLoad)) {
+            return false;
+        }
+        return proofOfWorkService.verify(proofOfWork);
+    }
+
+    // We check the difficulty used for the proof of work if it matches the current network load or if available the
+    // previous network load. If the difference is inside a tolerance range we consider it still valid, but it should
+    // be investigated why that happens, thus we log those cases.
+    // It is likely caused when there is a flood of messages as it is the case when the oracle node republishes its data.
+    // During that time the local network load rises, but we might not have exchanges with our peers our network load 
+    // (3-5 min interval) and thus peers use a too low network load to calculate the difficulty for messages sent to us.
+    // We could trigger a network load exchange if detect a certain level of deviation but as long we don't observe 
+    // those deviations in normal network mode, we ignore it.
+    private boolean isDifficultyInvalid(EnvelopePayloadMessage message,
+                                        double proofOfWorkDifficulty,
+                                        NetworkLoad currentNetworkLoad,
+                                        Optional<NetworkLoad> previousNetworkLoad) {
+        log.debug("isDifficultyInvalid/currentNetworkLoad: message.getCostFactor()={}, networkLoad.getValue()={}",
+                message.getCostFactor(), currentNetworkLoad.getLoad());
+        double expectedDifficulty = calculateDifficulty(message, currentNetworkLoad);
+        if (proofOfWorkDifficulty >= expectedDifficulty) {
+            // We don't want to call calculateDifficulty with the previousNetworkLoad if we are not in dev mode.
+            if (DevMode.isDevMode() && proofOfWorkDifficulty > expectedDifficulty && previousNetworkLoad.isPresent()) {
+                // Might be that the difficulty was using the previous network load
+                double expectedPreviousDifficulty = calculateDifficulty(message, previousNetworkLoad.get());
+                if (proofOfWorkDifficulty != expectedPreviousDifficulty) {
+                    log.warn("Unexpected high difficulty provided. This might be a bug (but valid as provided difficulty is larger as expected): " +
+                                    "expectedDifficulty={}; expectedPreviousDifficulty={}; proofOfWorkDifficulty={}",
+                            expectedDifficulty, expectedPreviousDifficulty, proofOfWorkDifficulty);
+                }
+            }
+            return false;
+        }
+
+        double missing = expectedDifficulty - proofOfWorkDifficulty;
+        double deviationToTolerance = MathUtils.roundDouble(missing / DIFFICULTY_TOLERANCE * 100, 2);
+        double deviationToExpectedDifficulty = MathUtils.roundDouble(missing / expectedDifficulty * 100, 2);
+        if (previousNetworkLoad.isEmpty()) {
+            log.debug("No previous network load available");
+            if (missing <= DIFFICULTY_TOLERANCE) {
+                log.info("Difficulty of current network load deviates from the proofOfWork difficulty but is inside the tolerated range.\n" +
+                                "deviationToTolerance={}%; deviationToExpectedDifficulty={}%; expectedDifficulty={}; proofOfWorkDifficulty={}",
+                        deviationToTolerance, deviationToExpectedDifficulty, expectedDifficulty, proofOfWorkDifficulty);
+                return false;
+            }
+
+            log.warn("Difficulty of current network load deviates from the proofOfWork difficulty and is outside the tolerated range.\n" +
+                            "deviationToTolerance={}%; deviationToExpectedDifficulty={}%; expectedDifficulty={}; proofOfWorkDifficulty={}",
+                    deviationToTolerance, deviationToExpectedDifficulty, expectedDifficulty, proofOfWorkDifficulty);
+            return true;
+        }
+
+        log.debug("isDifficultyInvalid/previousNetworkLoad: message.getCostFactor()={}, networkLoad.getValue()={}",
+                message.getCostFactor(), previousNetworkLoad.get().getLoad());
+        double expectedPreviousDifficulty = calculateDifficulty(message, previousNetworkLoad.get());
+        if (proofOfWorkDifficulty >= expectedPreviousDifficulty) {
+            log.debug("Difficulty of previous network load is correct");
+            if (proofOfWorkDifficulty > expectedPreviousDifficulty) {
+                log.warn("Unexpected high difficulty provided. This might be a bug (but valid as provided difficulty is larger as expected): " +
+                                "expectedPreviousDifficulty={}; proofOfWorkDifficulty={}",
+                        expectedPreviousDifficulty, proofOfWorkDifficulty);
+            }
+            return false;
+        }
+
+        if (missing <= DIFFICULTY_TOLERANCE) {
+            log.info("Difficulty of current network load deviates from the proofOfWork difficulty but is inside the tolerated range.\n" +
+                            "deviationToTolerance={}%; deviationToExpectedDifficulty={}%; expectedDifficulty={}; proofOfWorkDifficulty={}",
+                    deviationToTolerance, deviationToExpectedDifficulty, expectedDifficulty, proofOfWorkDifficulty);
+            return false;
+        }
+
+        double missingUsingPrevious = expectedPreviousDifficulty - proofOfWorkDifficulty;
+        if (missingUsingPrevious <= DIFFICULTY_TOLERANCE) {
+            deviationToTolerance = MathUtils.roundDouble(missingUsingPrevious / DIFFICULTY_TOLERANCE * 100, 2);
+            deviationToExpectedDifficulty = MathUtils.roundDouble(missingUsingPrevious / expectedPreviousDifficulty * 100, 2);
+            log.info("Difficulty of previous network load deviates from the proofOfWork difficulty but is inside the tolerated range.\n" +
+                            "deviationToTolerance={}%; deviationToExpectedDifficulty={}%; expectedDifficulty={}; proofOfWorkDifficulty={}",
+                    deviationToTolerance, deviationToExpectedDifficulty, expectedPreviousDifficulty, proofOfWorkDifficulty);
+            return false;
+        }
+
+        log.warn("Difficulties of current and previous network load deviate from the proofOfWork difficulty and are outside the tolerated range.\n" +
+                        "deviationToTolerance={}%; deviationToExpectedDifficulty={}%; expectedDifficulty={}; proofOfWorkDifficulty={}",
+                deviationToTolerance, deviationToExpectedDifficulty, expectedDifficulty, proofOfWorkDifficulty);
+        return true;
+    }
+
+    private byte[] getPayload(EnvelopePayloadMessage message) {
+        // In contrast to HashCashTokenService we use the hash of the message to reduce size of the pow object.
+        return DigestUtil.hash(message.serializeForHash());
+    }
+
+    private byte[] getChallenge(String peerAddress, int messageCounter) {
+        return DigestUtil.sha256(ByteArrayUtils.concat(peerAddress.getBytes(Charsets.UTF_8),
+                BigInteger.valueOf(messageCounter).toByteArray()));
+    }
+
+    private double calculateDifficulty(EnvelopePayloadMessage message, NetworkLoad networkLoad) {
+        double messageCostFactor = MathUtils.bounded(MIN_MESSAGE_COST, 1, message.getCostFactor());
+        double load = MathUtils.bounded(MIN_LOAD, 1, networkLoad.getLoad());
+        double difficulty = TARGET_DIFFICULTY * messageCostFactor * load * networkLoad.getDifficultyAdjustmentFactor();
+        return MathUtils.bounded(MIN_DIFFICULTY, MAX_DIFFICULTY, difficulty);
+    }
+
+    @Slf4j
+
+    public static class Metrics {
+        private final List<Long> aggregatedPoWDuration = new CopyOnWriteArrayList<>();
+        private final List<Double> aggregatedNetworkLoadValues = new CopyOnWriteArrayList<>();
+        @Getter
+        private long accumulatedPoWDuration;
+        @Getter
+        private int numPowTokensCreated;
+        @Getter
+        private long averagePowTimePerMessage;
+        @Getter
+        private double averageNetworkLoad;
+
+        void update(long duration, double networkLoad) {
+            accumulatedPoWDuration += duration;
+            aggregatedPoWDuration.add(duration);
+            aggregatedNetworkLoadValues.add(networkLoad);
+            numPowTokensCreated = aggregatedPoWDuration.size();
+            if (numPowTokensCreated % 10 == 0) {
+                averagePowTimePerMessage = MathUtils.roundDoubleToLong(aggregatedPoWDuration.stream().mapToLong(e -> e).average().orElse(0D));
+                averageNetworkLoad = MathUtils.roundDouble(aggregatedNetworkLoadValues.stream().mapToDouble(e -> e).average().orElse(0D), 4);
+
+                if (numPowTokensCreated % 100 == 0) {
+                    if (averagePowTimePerMessage > 1000) {
+                        log.warn("Average time/message used for PoW is very high");
+                    } else if (averagePowTimePerMessage > 300) {
+                        log.warn("Average time/message used for PoW is higher as expected");
+                    }
+                    log.info("Total time used for PoW: {} sec; Average time/message used for PoW: {} ms; Average network load value: {}; Number of messages: {}",
+                            MathUtils.roundDoubleToLong(accumulatedPoWDuration / 1000d),
+                            averagePowTimePerMessage,
+                            averageNetworkLoad,
+                            numPowTokensCreated);
+                    if (aggregatedPoWDuration.size() > 100_000) {
+                        log.warn("aggregatedPoWDuration is getting too large. We clear the list.");
+                        aggregatedPoWDuration.clear();
+                        aggregatedNetworkLoadValues.clear();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshakeInitiator.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshakeInitiator.java
@@ -17,13 +17,14 @@
 
 package bisq.network.p2p.node.handshake;
 
-import bisq.common.util.StringUtils;
 import bisq.common.network.Address;
 import bisq.common.network.AddressOwnershipProof;
 import bisq.common.network.AddressOwnershipProofGenerator;
+import bisq.common.util.StringUtils;
 import bisq.network.p2p.message.NetworkEnvelope;
 import bisq.network.p2p.node.Capability;
 import bisq.network.p2p.node.ConnectionException;
+import bisq.network.p2p.node.Feature;
 import bisq.network.p2p.node.OutboundConnection;
 import bisq.network.p2p.node.authorization.AuthorizationService;
 import bisq.network.p2p.node.authorization.AuthorizationToken;
@@ -33,7 +34,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -76,7 +76,7 @@ public class ConnectionHandshakeInitiator {
                 NetworkLoad.INITIAL_NETWORK_LOAD,
                 peerAddress.getFullAddress(),
                 0,
-                new ArrayList<>());
+                Feature.DEFAULT_FEATURES);
         return new NetworkEnvelope(token, request);
     }
 

--- a/network/network/src/main/proto/network.proto
+++ b/network/network/src/main/proto/network.proto
@@ -22,6 +22,7 @@ enum Feature {
   FEATURE_INVENTORY_MINI_SKETCH = 2;
   FEATURE_AUTHORIZATION_HASH_CASH = 3;
   FEATURE_AUTHORIZATION_EQUI_HASH = 4;
+  FEATURE_AUTHORIZATION_HASH_CASH_V2 = 5;
 }
 
 message Capability {
@@ -74,12 +75,19 @@ enum AuthorizationTokenType{
   AUTHORIZATIONTOKENTYPE_UNSPECIFIED = 0;
   AUTHORIZATIONTOKENTYPE_HASH_CASH = 1;
   AUTHORIZATIONTOKENTYPE_EQUI_HASH = 2;
+  AUTHORIZATIONTOKENTYPE_HASH_CASH_V2 = 3;
 }
 
 message HashCashToken {
   security.ProofOfWork proofOfWork = 1;
   sint32 messageCounter = 2;
 }
+
+message HashCashV2Token {
+  security.ProofOfWork proofOfWork = 1;
+  sint32 messageCounter = 2;
+}
+
 message EquiHashToken {
   security.ProofOfWork proofOfWork = 1;
   sint32 messageCounter = 2;
@@ -90,6 +98,7 @@ message AuthorizationToken {
   oneof message {
     HashCashToken hashCashToken = 10;
     EquiHashToken equiHashToken = 11;
+    HashCashV2Token hashCashV2Token = 12;
   };
 }
 

--- a/network/network/src/test/java/bisq/network/p2p/node/authorization/AuthorizationServiceTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/node/authorization/AuthorizationServiceTest.java
@@ -90,6 +90,20 @@ public class AuthorizationServiceTest {
         result = AuthorizationService.selectAuthorizationTokenType(myPreferredAuthorizationTokenTypes, peersFeatures);
         assertEquals(AuthorizationTokenType.EQUI_HASH, result);
 
+        peersFeatures = List.of(Feature.AUTHORIZATION_EQUI_HASH, Feature.AUTHORIZATION_HASH_CASH);
+        myPreferredAuthorizationTokenTypes = List.of(AuthorizationTokenType.HASH_CASH_V2);
+        result = AuthorizationService.selectAuthorizationTokenType(myPreferredAuthorizationTokenTypes, peersFeatures);
+        assertEquals(AuthorizationTokenType.EQUI_HASH, result);
+
+        peersFeatures = List.of(Feature.AUTHORIZATION_EQUI_HASH, Feature.AUTHORIZATION_HASH_CASH, Feature.AUTHORIZATION_HASH_CASH_V2);
+        myPreferredAuthorizationTokenTypes = List.of(AuthorizationTokenType.HASH_CASH_V2);
+        result = AuthorizationService.selectAuthorizationTokenType(myPreferredAuthorizationTokenTypes, peersFeatures);
+        assertEquals(AuthorizationTokenType.HASH_CASH_V2, result);
+
+        peersFeatures = List.of(Feature.AUTHORIZATION_HASH_CASH_V2);
+        myPreferredAuthorizationTokenTypes = List.of(AuthorizationTokenType.HASH_CASH);
+        result = AuthorizationService.selectAuthorizationTokenType(myPreferredAuthorizationTokenTypes, peersFeatures);
+        assertEquals(AuthorizationTokenType.HASH_CASH_V2, result);
 
         // Multiple myPreferredAuthorizationTokenTypes and peersFeatures
         peersFeatures = List.of(Feature.AUTHORIZATION_HASH_CASH, Feature.AUTHORIZATION_EQUI_HASH);

--- a/security/src/main/java/bisq/security/pow/ProofOfWork.java
+++ b/security/src/main/java/bisq/security/pow/ProofOfWork.java
@@ -35,8 +35,9 @@ import java.util.Optional;
 @Getter
 @EqualsAndHashCode
 public final class ProofOfWork implements NetworkProto {
-    // payload is usually the pubKeyHash
-    private final byte[] payload;       // message of 1000 chars has about 1300 bytes
+    // With HashCashV2 we use the 20 byte hash of the serialized message for the payload
+    // instead the serialized message as in HashCash(V1)
+    private final byte[] payload;
     private final long counter;
     // If challenge does not make sense we set it null
     // Challenge need to be hashed to 256 bits


### PR DESCRIPTION
We used the serialized message for the payload in the ProofOfWork data, which can be quite large in case of inventory requests or other large messages.

To avoid that we introduce the new HashCashV2TokenService which use the hash of the serialized message instead, thus reducing the size of the payload field to 20 bytes.

To support backward compatability we add a new Feature for that and use the new version only if the peer support that feature.