### PR TITLE
Create bisq easy trade details view

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/CopyOnClickLabel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/CopyOnClickLabel.java
@@ -27,6 +27,6 @@ public class CopyOnClickLabel extends Label {
         super(text);
         setTooltip(new BisqTooltip(Res.get("action.copyToClipboard")));
         setCursor(Cursor.HAND);
-        setOnMouseClicked(e -> ClipboardUtil.copyToClipboard(text));
+        setOnMouseClicked(e -> ClipboardUtil.copyToClipboard(this.getText()));
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsController.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy.open_trades.trade_details;
+
+import bisq.bisq_easy.NavigationTarget;
+import bisq.chat.bisqeasy.open_trades.BisqEasyOpenTradeChannel;
+import bisq.common.monetary.Coin;
+import bisq.common.monetary.Fiat;
+import bisq.common.monetary.Monetary;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.util.StringUtils;
+import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.view.Controller;
+import bisq.desktop.common.view.InitWithDataController;
+import bisq.desktop.common.view.NavigationController;
+import bisq.desktop.overlay.OverlayController;
+import bisq.i18n.Res;
+import bisq.network.identity.NetworkId;
+import bisq.offer.Direction;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.offer.price.spec.FloatPriceSpec;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.offer.price.spec.PriceSpec;
+import bisq.presentation.formatters.AmountFormatter;
+import bisq.presentation.formatters.DateFormatter;
+import bisq.presentation.formatters.PercentageFormatter;
+import bisq.presentation.formatters.PriceFormatter;
+import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.bisq_easy.BisqEasyTradeFormatter;
+import bisq.trade.bisq_easy.BisqEasyTradeUtils;
+import bisq.user.identity.UserIdentityService;
+import bisq.user.profile.UserProfile;
+import com.google.common.base.Joiner;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class TradeDetailsController extends NavigationController
+        implements InitWithDataController<TradeDetailsController.InitData> {
+    protected final UserIdentityService userIdentityService;
+    @Getter
+    private final TradeDetailsView view;
+
+    @Getter
+    private final TradeDetailsModel model;
+
+    public TradeDetailsController(ServiceProvider serviceProvider) {
+        super(NavigationTarget.BISQ_EASY_TRADE_DETAILS);
+
+        userIdentityService = serviceProvider.getUserService().getUserIdentityService();
+        model = new TradeDetailsModel();
+        view = new TradeDetailsView(model, this);
+    }
+
+    private static String getPriceSpec(BisqEasyContract contract) {
+        PriceSpec priceSpec = contract.getAgreedPriceSpec();
+        String priceSpecStr = "";
+        switch (priceSpec) {
+            case MarketPriceSpec marketPriceSpec ->
+                    priceSpecStr = Res.get("bisqEasy.openTrades.tradeDetails.marketPrice");
+            case FloatPriceSpec floatPriceSpec -> {
+                String absPercent = PercentageFormatter.formatToPercentWithSymbol(Math.abs(floatPriceSpec.getPercentage()));
+                priceSpecStr = Res.get(floatPriceSpec.getPercentage() >= 0
+                        ? "bisqEasy.openTrades.tradeDetails.aboveMarketPrice"
+                        : "bisqEasy.openTrades.tradeDetails.belowMarketPrice", absPercent);
+            }
+            case FixPriceSpec fixPriceSpec -> priceSpecStr = Res.get("bisqEasy.openTrades.tradeDetails.fixedPrice");
+            case null, default -> {
+                // this should not happen unless a new PriceSpec is added
+            }
+        }
+        return priceSpecStr;
+    }
+
+    private static String formatNetworkAddresses(AddressByTransportTypeMap addressMap) {
+        return Joiner.on(", ").join(addressMap.entrySet().stream()
+                .map(e -> e.getValue().getFullAddress())
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void initWithData(InitData initData) {
+        BisqEasyTrade trade = initData.bisqEasyTrade;
+        BisqEasyOpenTradeChannel channel = initData.channel;
+        model.getTradeId().set(trade.getId());
+        model.getPeerUsername().set(channel.getPeer().getUserName());
+
+        String bitcoinPaymentAddress = trade.getBitcoinPaymentData().get();
+        if (StringUtils.isNotEmpty(bitcoinPaymentAddress)) {
+            model.getBitcoinPaymentAddress().set(bitcoinPaymentAddress);
+        } else {
+            model.getBitcoinPaymentAddress().set("");
+        }
+
+        BisqEasyContract contract = trade.getContract();
+        long date = contract.getTakeOfferDate();
+        model.getOfferTakenDateTime().set(DateFormatter.formatDateTime(date));
+
+        long quoteSideAmount = contract.getQuoteSideAmount();
+        Monetary quoteAmount = Fiat.from(quoteSideAmount, trade.getOffer().getMarket().getQuoteCurrencyCode());
+
+        NetworkId peerNetworkId = trade.getPeer().getNetworkId();
+        String peerAddress = formatNetworkAddresses(peerNetworkId.getAddressByTransportTypeMap());
+        model.getPeerNetworkAddress().set(peerAddress);
+
+        String amountInFiat = AmountFormatter.formatAmount(quoteAmount);
+        model.getAmountInFiat().set(amountInFiat);
+        String currencyAbbreviation = quoteAmount.getCode();
+        model.getCurrency().set(currencyAbbreviation);
+
+        long baseSideAmount = contract.getBaseSideAmount();
+        Coin amountInBTC = Coin.asBtcFromValue(baseSideAmount);
+        String baseAmountString = AmountFormatter.formatAmount(amountInBTC, false);
+        model.getAmountInBTC().set(baseAmountString);
+
+        String btcPaymentMethod = contract.getBaseSidePaymentMethodSpec().getDisplayString();
+        model.getBitcoinPaymentMethod().set(btcPaymentMethod);
+        String fiatPaymentMethod = contract.getQuoteSidePaymentMethodSpec().getDisplayString();
+        model.getFiatPaymentMethod().set(fiatPaymentMethod);
+
+        String paymentAccountData = trade.getPaymentAccountData().get();
+        if (StringUtils.isNotEmpty(paymentAccountData)) {
+            model.getPaymentAccountData().set(paymentAccountData);
+        } else {
+            model.getPaymentAccountData().set("");
+        }
+
+        String myMakerTakerRole = BisqEasyTradeFormatter.getMakerTakerRole(trade);
+        model.getMyMakerTakerRole().set(myMakerTakerRole);
+        Direction direction = BisqEasyTradeFormatter.getDirectionObject(trade);
+        String buyerSellerRole = (direction == Direction.BUY) ? Res.get("bisqEasy.openTrades.tradeDetails.buyBtc") : Res.get("bisqEasy.openTrades.tradeDetails.sellBtc");
+        model.getMySellBuyRole().set(buyerSellerRole);
+
+        Optional<UserProfile> mediator = channel.getMediator();
+        if (mediator.isPresent()) {
+            model.getMediator().set(mediator.get().getUserName());
+        } else {
+            model.getMediator().set("");
+        }
+
+        PriceQuote priceQuote = BisqEasyTradeUtils.getPriceQuote(trade);
+        String codes = priceQuote.getMarket().getMarketCodes();
+        model.getPriceSpec().set(codes + " @ " + getPriceSpec(contract));
+        String price = PriceFormatter.format(BisqEasyTradeUtils.getPriceQuote(trade));
+        model.getTradePrice().set(price);
+    }
+
+    @Override
+    public void onActivate() {
+    }
+
+    @Override
+    public void onDeactivate() {
+    }
+
+    @Override
+    protected Optional<? extends Controller> createController(NavigationTarget navigationTarget) {
+        return Optional.empty();
+    }
+
+    void onClose() {
+        OverlayController.hide();
+    }
+
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    public static class InitData {
+        private final BisqEasyTrade bisqEasyTrade;
+        private final BisqEasyOpenTradeChannel channel;
+
+        public InitData(BisqEasyTrade bisqEasyTrade, BisqEasyOpenTradeChannel channel) {
+            this.bisqEasyTrade = bisqEasyTrade;
+            this.channel = channel;
+        }
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsModel.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy.open_trades.trade_details;
+
+import bisq.bisq_easy.NavigationTarget;
+import bisq.desktop.common.view.NavigationModel;
+import javafx.beans.property.SimpleStringProperty;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class TradeDetailsModel extends NavigationModel {
+    private final SimpleStringProperty peerUsername = new SimpleStringProperty();
+    private final SimpleStringProperty tradeId = new SimpleStringProperty();
+    private final SimpleStringProperty amountInFiat = new SimpleStringProperty();
+    private final SimpleStringProperty currency = new SimpleStringProperty();
+    private final SimpleStringProperty bitcoinPaymentAddress = new SimpleStringProperty();
+    private final SimpleStringProperty amountInBTC = new SimpleStringProperty();
+    private final SimpleStringProperty tradePrice = new SimpleStringProperty();
+    private final SimpleStringProperty priceSpec = new SimpleStringProperty();
+    private final SimpleStringProperty mySellBuyRole = new SimpleStringProperty();
+    private final SimpleStringProperty myMakerTakerRole = new SimpleStringProperty();
+    private final SimpleStringProperty offerTakenDateTime = new SimpleStringProperty();
+    private final SimpleStringProperty fiatPaymentMethod = new SimpleStringProperty();
+    private final SimpleStringProperty bitcoinPaymentMethod = new SimpleStringProperty();
+    private final SimpleStringProperty peerNetworkAddress = new SimpleStringProperty();
+    private final SimpleStringProperty paymentAccountData = new SimpleStringProperty();
+    private final SimpleStringProperty mediator = new SimpleStringProperty();
+
+    @Override
+    public NavigationTarget getDefaultNavigationTarget() {
+        return NavigationTarget.BISQ_EASY_TRADE_DETAILS;
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsView.java
@@ -1,0 +1,289 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy.open_trades.trade_details;
+
+import bisq.desktop.common.utils.GridPaneUtil;
+import bisq.desktop.common.view.NavigationView;
+import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.BisqIconButton;
+import bisq.desktop.components.controls.CopyOnClickLabel;
+import bisq.desktop.components.controls.MaterialTextField;
+import bisq.desktop.overlay.OverlayModel;
+import bisq.i18n.Res;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TradeDetailsView extends NavigationView<VBox, TradeDetailsModel, TradeDetailsController> {
+
+    private final Label headline, processHeadline, processDescription, myRoleLabel, amountLabel, paymentMethodLabel;
+    private final Label tradePriceLabel, tradeIdLabel, peerUsernameLabel, dateLabel, mediatorLabel, peerNetworkAddressLabel;
+    private final CopyOnClickLabel tradeAmountFiat, tradeAmountBtc, tradeId;
+    private final Text makerTakerRole, buySellRole, btcPaymentMethod, currency, fiatPaymentMethod, btcLabel;
+    private final Text tradePriceAmount, priceSpec, peerUsername, tradeDate, mediator, peerNetworkAddress;
+    private final Button closeButton;
+    MaterialTextField btcPaymentAddress, paymentAccountData;
+
+    public TradeDetailsView(TradeDetailsModel model, TradeDetailsController controller) {
+        super(new VBox(), model, controller);
+
+        root.setPrefWidth(OverlayModel.WIDTH);
+        root.setPrefHeight(OverlayModel.HEIGHT);
+        closeButton = BisqIconButton.createIconButton("close");
+        HBox closeButtonRow = new HBox(Spacer.fillHBox(), closeButton);
+        closeButtonRow.setPadding(new Insets(0, 10, 0, 10));
+        closeButtonRow.getStyleClass().add("trade-details-close-button-row");
+        closeButtonRow.setAlignment(Pos.CENTER_RIGHT);
+        root.getChildren().add(closeButtonRow);
+
+        Region emptySpace = new Region();
+        emptySpace.setMinHeight(30);
+        emptySpace.setMaxHeight(30);
+        headline = createLabel("trade-details-headline");
+        VBox headlineBox = new VBox(5, emptySpace, headline);
+        headlineBox.setAlignment(Pos.CENTER);
+        Region line1 = getLine();
+        headlineBox.getChildren().add(line1);
+        root.getChildren().add(headlineBox);
+
+        int numColumns = 3;
+        GridPane gridPane = new GridPane();
+        gridPane.setHgap(10);
+        gridPane.setVgap(10);
+        gridPane.setAlignment(Pos.BOTTOM_LEFT);
+        GridPaneUtil.setGridPaneMultiColumnsConstraints(gridPane, numColumns);
+
+        int rowIndex = 0;
+        Insets topInset = new Insets(0, 0, -14, 0);
+        myRoleLabel = createLabel("trade-details-small-grey");
+        GridPane.setMargin(myRoleLabel, topInset);
+        gridPane.add(myRoleLabel, 0, rowIndex);
+        amountLabel = createLabel("trade-details-small-grey");
+        GridPane.setMargin(amountLabel, topInset);
+        gridPane.add(amountLabel, 1, rowIndex);
+        paymentMethodLabel = createLabel("trade-details-small-grey");
+        GridPane.setMargin(paymentMethodLabel, topInset);
+        gridPane.add(paymentMethodLabel, 2, rowIndex);
+
+        rowIndex++;
+        makerTakerRole = createText("trade-details-large-light");
+        gridPane.add(makerTakerRole, 0, rowIndex);
+        tradeAmountFiat = createCopyOnClickLabel("trade-details-large-light");
+        currency = createText("trade-details-medium-grey");
+        HBox fiatText = new HBox(5, tradeAmountFiat, currency);
+        fiatText.setAlignment(Pos.BASELINE_LEFT);
+        gridPane.add(fiatText, 1, rowIndex);
+        fiatPaymentMethod = createText("trade-details-large-light");
+        gridPane.add(fiatPaymentMethod, 2, rowIndex);
+
+        rowIndex++;
+        buySellRole = createText("trade-details-large-light");
+        gridPane.add(buySellRole, 0, rowIndex);
+        tradeAmountBtc = createCopyOnClickLabel("trade-details-large-light");
+        btcLabel = createText("trade-details-medium-grey");
+        HBox btcText = new HBox(5, tradeAmountBtc, btcLabel);
+        btcText.setAlignment(Pos.BASELINE_LEFT);
+        gridPane.add(btcText, 1, rowIndex);
+        btcPaymentMethod = createText("trade-details-large-light");
+        gridPane.add(btcPaymentMethod, 2, rowIndex);
+
+        rowIndex++;
+        Region emptyRow1 = new Region();
+        GridPane.setColumnSpan(emptyRow1, numColumns);
+        emptyRow1.setPrefHeight(40);
+        gridPane.add(emptyRow1, 0, rowIndex);
+        rowIndex++;
+        Region line3 = getLine();
+        GridPane.setColumnSpan(line3, numColumns);
+        gridPane.add(line3, 0, rowIndex);
+
+        rowIndex++;
+        tradePriceLabel = createLabel("trade-details-medium-grey");
+        tradePriceLabel.setAlignment(Pos.BOTTOM_LEFT);
+        gridPane.add(tradePriceLabel, 0, rowIndex);
+        tradePriceAmount = createText("trade-details-medium-light");
+        priceSpec = createText("trade-details-medium-grey");
+        HBox tradePriceBox = new HBox(5, tradePriceAmount, priceSpec);
+        tradePriceBox.setAlignment(Pos.BOTTOM_LEFT);
+        GridPane.setColumnSpan(tradePriceBox, 2);
+        gridPane.add(tradePriceBox, 1, rowIndex);
+        rowIndex++;
+        tradeIdLabel = createLabel("trade-details-medium-grey");
+        gridPane.add(tradeIdLabel, 0, rowIndex);
+        tradeId = createCopyOnClickLabel("trade-details-medium-light");
+        GridPane.setColumnSpan(tradeId, 2);
+        gridPane.add(tradeId, 1, rowIndex);
+        rowIndex++;
+        dateLabel = createLabel("trade-details-medium-grey");
+        gridPane.add(dateLabel, 0, rowIndex);
+        tradeDate = createText("trade-details-medium-light");
+        GridPane.setColumnSpan(tradeDate, 2);
+        gridPane.add(tradeDate, 1, rowIndex);
+        rowIndex++;
+        peerUsernameLabel = createLabel("trade-details-medium-grey");
+        gridPane.add(peerUsernameLabel, 0, rowIndex);
+        peerUsername = createText("trade-details-medium-light");
+        GridPane.setColumnSpan(peerUsername, 2);
+        gridPane.add(peerUsername, 1, rowIndex);
+        rowIndex++;
+        peerNetworkAddressLabel = createLabel("trade-details-medium-grey");
+        gridPane.add(peerNetworkAddressLabel, 0, rowIndex);
+        peerNetworkAddress = createText("trade-details-medium-light");
+        GridPane.setColumnSpan(peerNetworkAddress, 2);
+        gridPane.add(peerNetworkAddress, 1, rowIndex);
+        rowIndex++;
+        mediatorLabel = createLabel("trade-details-medium-grey");
+        gridPane.add(mediatorLabel, 0, rowIndex);
+        mediator = createText("trade-details-medium-light");
+        GridPane.setColumnSpan(mediator, 2);
+        gridPane.add(mediator, 1, rowIndex);
+
+        // process information section
+        rowIndex++;
+        Region emptyRow2 = new Region();
+        GridPane.setColumnSpan(emptyRow2, numColumns);
+        emptyRow2.setPrefHeight(40);
+        gridPane.add(emptyRow2, 0, rowIndex);
+        rowIndex++;
+        processHeadline = createLabel("trade-details-medium-light");
+        GridPane.setColumnSpan(processHeadline, numColumns);
+        gridPane.add(processHeadline, 0, rowIndex);
+        rowIndex++;
+        processDescription = createLabel("trade-details-small-grey");
+        processDescription.setPadding(new Insets(-10, 0, 0, 0));
+        GridPane.setColumnSpan(processDescription, numColumns);
+        gridPane.add(processDescription, 0, rowIndex);
+        rowIndex++;
+        Region line2 = getLine();
+        GridPane.setColumnSpan(line2, numColumns);
+        gridPane.add(line2, 0, rowIndex);
+        rowIndex++;
+        btcPaymentAddress = new MaterialTextField(Res.get("bisqEasy.openTrades.tradeDetails.btcPaymentAddress"));
+        btcPaymentAddress.setEditable(false);
+        btcPaymentAddress.showCopyIcon();
+        GridPane.setColumnSpan(btcPaymentAddress, numColumns);
+        gridPane.add(btcPaymentAddress, 0, rowIndex);
+        rowIndex++;
+        paymentAccountData = new MaterialTextField(Res.get("bisqEasy.openTrades.tradeDetails.paymentAccountData"));
+        paymentAccountData.setEditable(false);
+        paymentAccountData.showCopyIcon();
+        GridPane.setColumnSpan(paymentAccountData, numColumns);
+        gridPane.add(paymentAccountData, 0, rowIndex);
+
+        gridPane.setPadding(new Insets(10, 40, 10, 20));
+        ScrollPane scrollPane = new ScrollPane(gridPane);
+        scrollPane.setFitToWidth(true);
+        VBox container = new VBox(scrollPane);
+        container.setPadding(new Insets(10, 22, 10, 20));
+        root.getChildren().addAll(container);
+    }
+
+    @Override
+    protected void onViewAttached() {
+        headline.setText(Res.get("bisqEasy.openTrades.tradeDetails.headline"));
+        processHeadline.setText(Res.get("bisqEasy.openTrades.tradeDetails.processSection"));
+        myRoleLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.myRole"));
+        amountLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.amount"));
+        paymentMethodLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.paymentMethod"));
+        processDescription.setText(Res.get("bisqEasy.openTrades.tradeDetails.processDescription"));
+        btcLabel.setText("BTC");
+        tradePriceLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.tradePrice"));
+        tradeIdLabel.setText(Res.get("bisqEasy.openTrades.table.tradeId"));
+        peerUsernameLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.peerUsername"));
+        peerNetworkAddressLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.peerNetworkAddress"));
+        dateLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.offerTakenDate"));
+        mediatorLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.selectedMediator"));
+
+        buySellRole.textProperty().bind(model.getMySellBuyRole());
+        makerTakerRole.textProperty().bind(model.getMyMakerTakerRole());
+        tradeAmountFiat.textProperty().bind(model.getAmountInFiat());
+        currency.textProperty().bind(model.getCurrency());
+        tradeAmountBtc.textProperty().bind(model.getAmountInBTC());
+        btcPaymentMethod.textProperty().bind(model.getBitcoinPaymentMethod());
+        fiatPaymentMethod.textProperty().bind(model.getFiatPaymentMethod());
+        btcPaymentAddress.textProperty().bind(model.getBitcoinPaymentAddress());
+        paymentAccountData.textProperty().bind(model.getPaymentAccountData());
+        tradePriceAmount.textProperty().bind(model.getTradePrice());
+        priceSpec.textProperty().bind(model.getPriceSpec());
+        tradeId.textProperty().bind(model.getTradeId());
+        peerUsername.textProperty().bind(model.getPeerUsername());
+        peerNetworkAddress.textProperty().bind(model.getPeerNetworkAddress());
+        tradeDate.textProperty().bind(model.getOfferTakenDateTime());
+        mediator.textProperty().bind(model.getMediator());
+
+        closeButton.setOnAction(e -> controller.onClose());
+    }
+
+    @Override
+    protected void onViewDetached() {
+        buySellRole.textProperty().unbind();
+        makerTakerRole.textProperty().unbind();
+        tradeAmountFiat.textProperty().unbind();
+        currency.textProperty().unbind();
+        tradeAmountBtc.textProperty().unbind();
+        btcPaymentMethod.textProperty().unbind();
+        fiatPaymentMethod.textProperty().unbind();
+        btcPaymentAddress.textProperty().unbind();
+        paymentAccountData.textProperty().unbind();
+        tradePriceAmount.textProperty().unbind();
+        priceSpec.textProperty().unbind();
+        tradeId.textProperty().unbind();
+        peerUsername.textProperty().unbind();
+        peerNetworkAddress.textProperty().unbind();
+        tradeDate.textProperty().unbind();
+        mediator.textProperty().unbind();
+
+        closeButton.setOnAction(null);
+    }
+
+    private Label createLabel(String style) {
+        Label label = new Label();
+        label.getStyleClass().add(style);
+        return label;
+    }
+
+    private Text createText(String style) {
+        Text text = new Text();
+        text.getStyleClass().add(style);
+        return text;
+    }
+
+    private CopyOnClickLabel createCopyOnClickLabel(String style) {
+        CopyOnClickLabel text = new CopyOnClickLabel("");
+        text.getStyleClass().add(style);
+        return text;
+    }
+
+    private Region getLine() {
+        Region line = new Region();
+        line.setMinHeight(1);
+        line.setMaxHeight(1);
+        line.setStyle("-fx-background-color: -bisq-border-color-grey");
+        line.setPadding(new Insets(9, 0, 8, 0));
+        return line;
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -32,7 +32,10 @@ import bisq.desktop.common.view.Controller;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.BisqEasyServiceUtil;
 import bisq.desktop.main.content.bisq_easy.components.TradeDataHeader;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.*;
+import bisq.desktop.common.view.Navigation;
+import bisq.bisq_easy.NavigationTarget;
 import bisq.i18n.Res;
 import bisq.offer.price.spec.PriceSpec;
 import bisq.settings.DontShowAgainService;
@@ -211,6 +214,20 @@ public class TradeStateController implements Controller {
                 .onAction(this::doInterruptTrade)
                 .closeButtonText(Res.get("confirmation.no"))
                 .show();
+    }
+
+    void onViewTradeDetails() {
+        BisqEasyOpenTradeChannel channel = model.getChannel().get();
+        Optional<BisqEasyTrade> optionalBisqEasyTrade = BisqEasyServiceUtil.findTradeFromChannel(serviceProvider,
+                channel);
+        if (optionalBisqEasyTrade.isEmpty()) {
+            model.resetAll();
+            return;
+        }
+
+        BisqEasyTrade bisqEasyTrade = optionalBisqEasyTrade.get();
+        Navigation.navigateTo(NavigationTarget.BISQ_EASY_TRADE_DETAILS,
+                new TradeDetailsController.InitData(bisqEasyTrade, channel));
     }
 
     void onRejectPrice() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateView.java
@@ -20,7 +20,9 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
 import bisq.desktop.common.Icons;
 import bisq.desktop.common.Layout;
 import bisq.desktop.common.Transitions;
+import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
+import bisq.desktop.components.controls.BisqIconButton;
 import bisq.desktop.components.containers.Spacer;
 import bisq.i18n.Res;
 import de.jensd.fx.fontawesome.AwesomeIcon;
@@ -31,6 +33,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
+import javafx.scene.image.ImageView;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +45,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
     private final HBox phaseAndInfoHBox, cancelledHBox, interruptedHBox, errorHBox, isInMediationHBox;
     private final Button cancelButton, closeTradeButton, exportButton, reportToMediatorButton, acceptSellersPriceButton,
             rejectPriceButton;
+    private final Button tradeDetailsButton;
     private final Label cancelledInfo, errorMessage, buyerPriceDescriptionApprovalOverlay, sellerPriceDescriptionApprovalOverlay;
     private final VBox tradePhaseBox, tradeDataHeaderBox, sellerPriceApprovalOverlay;
     private final Pane sellerPriceApprovalContent;
@@ -58,7 +62,10 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         cancelButton.setMinWidth(160);
         cancelButton.getStyleClass().add("outlined-button");
 
-        tradeDataHeader.getChildren().addAll(Spacer.fillHBox(), cancelButton);
+        ImageView greenInfoIcon = ImageUtil.getImageViewById("icon-info-green");
+        tradeDetailsButton = BisqIconButton.createIconButton(greenInfoIcon, Res.get("bisqEasy.openTrades.tradeDetails.open"));
+
+        tradeDataHeader.getChildren().addAll(tradeDetailsButton, Spacer.fillHBox(), cancelButton);
         tradeDataHeaderBox = new VBox(tradeDataHeader, Layout.hLine());
 
 
@@ -186,6 +193,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         });
 
         cancelButton.setOnAction(e -> controller.onInterruptTrade());
+        tradeDetailsButton.setOnAction(e -> controller.onViewTradeDetails());
         closeTradeButton.setOnAction(e -> controller.onCloseTrade());
         exportButton.setOnAction(e -> controller.onExportTrade());
         rejectPriceButton.setOnAction(e -> controller.onRejectPrice());
@@ -227,6 +235,7 @@ public class TradeStateView extends View<VBox, TradeStateModel, TradeStateContro
         showSellersPriceApprovalOverlayPin.unsubscribe();
 
         cancelButton.setOnAction(null);
+        tradeDetailsButton.setOnAction(null);
         closeTradeButton.setOnAction(null);
         exportButton.setOnAction(null);
         rejectPriceButton.setOnAction(null);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/OverlayController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/OverlayController.java
@@ -25,6 +25,7 @@ import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.NavigationController;
 import bisq.desktop.main.content.bisq_easy.offerbook.offer_details.BisqEasyOfferDetailsController;
 import bisq.desktop.main.content.bisq_easy.onboarding.video.BisqEasyVideoController;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
 import bisq.desktop.main.content.bisq_easy.take_offer.TakeOfferController;
 import bisq.desktop.main.content.bisq_easy.trade_guide.BisqEasyGuideController;
 import bisq.desktop.main.content.bisq_easy.trade_wizard.TradeWizardController;
@@ -135,6 +136,7 @@ public class OverlayController extends NavigationController {
             case BISQ_EASY_VIDEO -> Optional.of(new BisqEasyVideoController(serviceProvider));
             case BISQ_EASY_GUIDE -> Optional.of(new BisqEasyGuideController(serviceProvider));
             case WALLET_GUIDE -> Optional.of(new WalletGuideController(serviceProvider));
+            case BISQ_EASY_TRADE_DETAILS -> Optional.of(new TradeDetailsController(serviceProvider));
             case BISQ_EASY_OFFER_DETAILS -> Optional.of(new BisqEasyOfferDetailsController(serviceProvider));
             case CHAT_RULES -> Optional.of(new ChatRulesController(serviceProvider));
             case CREATE_PROFILE -> Optional.of(new CreateUserProfileController(serviceProvider));

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -1275,3 +1275,50 @@
     -fx-border-radius: 0;
     -fx-border-insets: 0 0 -7.5 0;
 }
+
+/*******************************************************************************
+ *                                                                             *
+ * Trade details                                                               *
+ *                                                                             *
+ ******************************************************************************/
+
+.trade-details-headline {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-font-size: 2.3em;
+    -fx-font-family: "IBM Plex Sans Light";
+}
+
+.trade-details-medium-light {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-font-size: 1.4em;
+    -fx-font-family: "IBM Plex Sans Light";
+}
+
+.trade-details-small-grey {
+    -fx-fill: -fx-mid-text-color;
+    -fx-text-fill: -fx-mid-text-color;
+    -fx-font-size: 0.9em;
+    -fx-font-family: "IBM Plex Sans Light";
+}
+
+.trade-details-large-light {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-font-family: "IBM Plex Sans Light";
+    -fx-font-size: 1.7em;
+}
+
+.trade-details-medium-grey {
+    -fx-fill: -fx-mid-text-color;
+    -fx-text-fill: -fx-mid-text-color;
+    -fx-font-family: "IBM Plex Sans Light";
+    -fx-font-size: 1.3em;
+}
+
+.trade-details-close-button-row {
+    -fx-background-color: -bisq-dark-grey-20;
+    -fx-min-height: 50;
+    -fx-max-height: 50;
+}

--- a/apps/desktop/desktop/src/main/resources/css/images.css
+++ b/apps/desktop/desktop/src/main/resources/css/images.css
@@ -784,6 +784,10 @@
     -fx-image: url("/images/icons/icon-info-grey.png");
 }
 
+#icon-info-green {
+    -fx-image: url("/images/icons/icon-info-green.png");
+}
+
 #icon-help-white {
     -fx-image: url("/images/icons/icon-help-white.png");
 }

--- a/bisq-easy/src/main/java/bisq/bisq_easy/NavigationTarget.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/NavigationTarget.java
@@ -82,6 +82,8 @@ public enum NavigationTarget {
     WALLET_GUIDE_CREATE_WALLET(WALLET_GUIDE, false),
     WALLET_GUIDE_RECEIVE(WALLET_GUIDE, false),
 
+    BISQ_EASY_TRADE_DETAILS(OVERLAY, false),
+
     BISQ_EASY_OFFER_DETAILS(OVERLAY, false),
 
     CHAT_RULES(OVERLAY, false),

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -647,6 +647,28 @@ bisqEasy.openTrades.chat.window.title={0} - Chat with {1} / Trade ID: {2}
 bisqEasy.openTrades.chat.peerLeft.headline={0} has left the trade
 bisqEasy.openTrades.chat.peerLeft.subHeadline=If the trade is not completed on your side and if you need assistance, contact the mediator or visit the support chat.
 
+bisqEasy.openTrades.tradeDetails.open=Open trade details
+bisqEasy.openTrades.tradeDetails.headline=Trade Details
+bisqEasy.openTrades.tradeDetails.processSection=Process Information
+bisqEasy.openTrades.tradeDetails.processDescription=This section contains information that will be filled out during the trade process.
+bisqEasy.openTrades.tradeDetails.myRole=MY ROLE
+bisqEasy.openTrades.tradeDetails.amount=AMOUNT
+bisqEasy.openTrades.tradeDetails.paymentMethod=PAYMENT METHOD
+bisqEasy.openTrades.tradeDetails.buyBtc=Buying BTC
+bisqEasy.openTrades.tradeDetails.sellBtc=Selling BTC
+bisqEasy.openTrades.tradeDetails.tradePrice=Trade price
+bisqEasy.openTrades.tradeDetails.marketPrice=market price
+bisqEasy.openTrades.tradeDetails.fixedPrice=fixed price
+bisqEasy.openTrades.tradeDetails.aboveMarketPrice={0} above market price
+bisqEasy.openTrades.tradeDetails.belowMarketPrice={0} below market price
+bisqEasy.openTrades.tradeDetails.btcPaymentAddress=BTC payment address
+bisqEasy.openTrades.tradeDetails.paymentAccountData=Payment account data
+bisqEasy.openTrades.tradeDetails.peerUsername=Peer username
+bisqEasy.openTrades.tradeDetails.offerTakenDate=Trade date
+bisqEasy.openTrades.tradeDetails.peerNetworkAddress=Peer network address
+bisqEasy.openTrades.tradeDetails.selectedMediator=Selected mediator
+
+
 ######################################################
 # Private chat
 ######################################################

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeFormatter.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeFormatter.java
@@ -53,9 +53,14 @@ public class BisqEasyTradeFormatter {
     }
 
     public static String getDirection(BisqEasyTrade trade) {
+        Direction direction = getDirectionObject(trade);
+        return getDirection(direction);
+    }
+
+    public static Direction getDirectionObject(BisqEasyTrade trade) {
         return switch (trade.getTradeRole()) {
-            case BUYER_AS_TAKER, BUYER_AS_MAKER -> getDirection(Direction.BUY);
-            case SELLER_AS_TAKER, SELLER_AS_MAKER -> getDirection(Direction.SELL);
+            case BUYER_AS_TAKER, BUYER_AS_MAKER -> Direction.BUY;
+            case SELLER_AS_TAKER, SELLER_AS_MAKER -> Direction.SELL;
         };
     }
 


### PR DESCRIPTION
Closes bisq-network/bisq2#2568
This commit creates a pop up screen that contains trade details of a bisq easy trade. The design is similar to that used in trade wizard review offer page.
The open button looks like this: 
![Screenshot from 2024-10-25 14-02-21](https://github.com/user-attachments/assets/db9da8de-339c-4879-9be1-e366b4959baa)
This opens the following popup:
<img src="https://github.com/user-attachments/assets/306bdd3f-f62b-44a5-b129-795d629a909c" alt="Trade details" width="600" />

**Benefits**
This view can act as a central point for displaying important trade data, which is currently displayed in several separate locations, meaning this might increase clarity for users. It currently does not display anything that is not already visible in some other way, but this can easily be extended if wanted. 

**Future work**
Several more fields can be added here that can be of use, for example:
-  time since last user activity from peer
-  transaction ID
-  blockchain confirmation
**I suggest that I write an issue where we all can input what more fields that would be nice to have when this is merged.**