### PR TITLE
migration: Pass migrations to Migrator in constructor

### DIFF
--- a/evolution/src/main/java/bisq/evolution/migration/MigrationService.java
+++ b/evolution/src/main/java/bisq/evolution/migration/MigrationService.java
@@ -3,11 +3,14 @@ package bisq.evolution.migration;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.platform.Version;
+import bisq.evolution.migration.migrations.Migration;
+import bisq.evolution.migration.migrations.MigrationsForV2_1_2;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public class MigrationService implements Service {
@@ -26,7 +29,8 @@ public class MigrationService implements Service {
         Version appVersion = ApplicationVersion.getVersion();
 
         if (dataDirVersion.below(appVersion)) {
-            Migrator migrator = new Migrator(appVersion, dataDir);
+            List<Migration> allMigrations = List.of(new MigrationsForV2_1_2());
+            Migrator migrator = new Migrator(appVersion, dataDir, allMigrations);
             migrator.migrate();
         }
 

--- a/evolution/src/main/java/bisq/evolution/migration/Migrator.java
+++ b/evolution/src/main/java/bisq/evolution/migration/Migrator.java
@@ -4,7 +4,6 @@ import bisq.common.application.ApplicationVersion;
 import bisq.common.platform.Version;
 import bisq.evolution.migration.migrations.Migration;
 import bisq.evolution.migration.migrations.MigrationFailedException;
-import bisq.evolution.migration.migrations.MigrationsForV2_1_2;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -18,10 +17,10 @@ public class Migrator {
     private final Path dataDir;
     private final List<Migration> allMigrations;
 
-    public Migrator(Version appVersion, Path dataDir) {
+    public Migrator(Version appVersion, Path dataDir, List<Migration> allMigrations) {
         this.appVersion = appVersion;
         this.dataDir = dataDir;
-        this.allMigrations = List.of(new MigrationsForV2_1_2());
+        this.allMigrations = allMigrations;
     }
 
     public void migrate() {

--- a/evolution/src/test/java/bisq/evolution/migration/MigratorTest.java
+++ b/evolution/src/test/java/bisq/evolution/migration/MigratorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,7 +20,7 @@ public class MigratorTest {
         Files.writeString(versionFilePath, dataDirVersion.toString());
 
         Version appVersion = ApplicationVersion.getVersion();
-        Migrator migrator = new Migrator(appVersion, dataDir);
+        Migrator migrator = new Migrator(appVersion, dataDir, Collections.emptyList());
 
         migrator.migrate();
 


### PR DESCRIPTION
The migrations are hard-coded in the Migrator making it impossible to add test where some migrations fail.