### PR TITLE
Allow reporting a user profile everywhere in the app

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/ProfileCardController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/ProfileCardController.java
@@ -116,7 +116,6 @@ public class ProfileCardController extends TabController<ProfileCardModel>
             profileCardReputationController.updateUserProfileData(userProfile);
             profileCardOffersController.updateUserProfileData(userProfile);
             boolean isMyProfile = userIdentityService.isUserIdentityPresent(userProfile.getId());
-            model.getShouldShowReportButton().set(!isMyProfile && selectedChannel.isPresent());
             model.getShouldShowUserActionsMenu().set(!isMyProfile);
             model.getOffersTabButtonText().set(Res.get("user.profileCard.tab.offers",
                     profileCardOffersController.getNumberOffers()).toUpperCase());
@@ -168,13 +167,19 @@ public class ProfileCardController extends TabController<ProfileCardModel>
     }
 
     void onReportUser() {
+        // Chat channel domain is a required field in the protobuf ReportToModeratorMessage.
+        ChatChannelDomain chatChannelDomain;
         if (selectedChannel.isPresent()) {
-            ChatChannelDomain chatChannelDomain = selectedChannel.get().getChatChannelDomain();
-            OverlayController.hide(() -> {
-                Navigation.navigateTo(NavigationTarget.REPORT_TO_MODERATOR,
-                        new ReportToModeratorWindow.InitData(model.getUserProfile().get(), chatChannelDomain));
-            });
+            // If the user profile is reported from a chat, then we use the domain of that chat.
+            chatChannelDomain = selectedChannel.get().getChatChannelDomain();
+        } else {
+            // Otherwise we use Support as the default domain to ensure backwards compatibility.
+            chatChannelDomain = ChatChannelDomain.SUPPORT;
         }
+
+        OverlayController.hide(() ->
+            Navigation.navigateTo(NavigationTarget.REPORT_TO_MODERATOR,
+                    new ReportToModeratorWindow.InitData(model.getUserProfile().get(), chatChannelDomain)));
     }
 
     void onClose() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/ProfileCardModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/ProfileCardModel.java
@@ -34,7 +34,6 @@ public class ProfileCardModel extends TabModel {
     private final ObjectProperty<UserProfile> userProfile = new SimpleObjectProperty<>();
     private final ObjectProperty<ReputationScore> reputationScore = new SimpleObjectProperty<>();
     private final BooleanProperty ignoreUserSelected = new SimpleBooleanProperty();
-    private final BooleanProperty shouldShowReportButton = new SimpleBooleanProperty();
     private final BooleanProperty shouldShowUserActionsMenu = new SimpleBooleanProperty();
     private final StringProperty offersTabButtonText = new SimpleStringProperty();
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/ProfileCardView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/ProfileCardView.java
@@ -72,8 +72,6 @@ public class ProfileCardView extends TabView<ProfileCardModel, ProfileCardContro
         ignore.managedProperty().bind(model.getIgnoreUserSelected().not().and(model.getShouldShowUserActionsMenu()));
         undoIgnore.visibleProperty().bind(model.getIgnoreUserSelected().and(model.getShouldShowUserActionsMenu()));
         undoIgnore.managedProperty().bind(model.getIgnoreUserSelected().and(model.getShouldShowUserActionsMenu()));
-        report.visibleProperty().bind(model.getShouldShowReportButton());
-        report.managedProperty().bind(model.getShouldShowReportButton());
         userActionsBox.visibleProperty().bind(model.getShouldShowUserActionsMenu());
         userActionsBox.managedProperty().bind(model.getShouldShowUserActionsMenu());
         offersTabButton.getLabel().textProperty().bind(model.getOffersTabButtonText());
@@ -102,8 +100,6 @@ public class ProfileCardView extends TabView<ProfileCardModel, ProfileCardContro
         ignore.managedProperty().unbind();
         undoIgnore.visibleProperty().unbind();
         undoIgnore.managedProperty().unbind();
-        report.visibleProperty().unbind();
-        report.managedProperty().unbind();
         userActionsBox.visibleProperty().unbind();
         userActionsBox.managedProperty().unbind();
         offersTabButton.getLabel().textProperty().unbind();


### PR DESCRIPTION
Chat channel domain is a required field in to report to moderator protobuf message.
To have the flexibility to report a user profile anywhere in the app while ensuring backwards compatibility, `Support` is used as the default domain for these cases.

Resolves #3073