### PR TITLE
Restrict amount and price text fields to accept only numbers

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyViewUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyViewUtils.java
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 public class BisqEasyViewUtils {
+    public static final String NUMERIC_WITH_DECIMAL_REGEX = "\\d*([.,]\\d*)?";
     private static final String[] customPaymentIconIds = {
             "CUSTOM_PAYMENT_1", "CUSTOM_PAYMENT_2", "CUSTOM_PAYMENT_3",
             "CUSTOM_PAYMENT_4", "CUSTOM_PAYMENT_5", "CUSTOM_PAYMENT_6"};

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyViewUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/BisqEasyViewUtils.java
@@ -38,7 +38,8 @@ import java.math.BigInteger;
 import java.util.List;
 
 public class BisqEasyViewUtils {
-    public static final String NUMERIC_WITH_DECIMAL_REGEX = "\\d*([.,]\\d*)?";
+    public static final String POSITIVE_NUMERIC_WITH_DECIMAL_REGEX = "\\d*([.,]\\d*)?";
+    public static final String NUMERIC_WITH_DECIMAL_REGEX = "-?\\d*([.,]\\d*)?";
     private static final String[] customPaymentIconIds = {
             "CUSTOM_PAYMENT_1", "CUSTOM_PAYMENT_2", "CUSTOM_PAYMENT_3",
             "CUSTOM_PAYMENT_4", "CUSTOM_PAYMENT_5", "CUSTOM_PAYMENT_6"};

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/PriceInput.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/PriceInput.java
@@ -24,6 +24,7 @@ import bisq.common.observable.Pin;
 import bisq.common.util.MathUtils;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.controls.validator.NumberValidator;
+import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import bisq.i18n.Res;
 import bisq.presentation.formatters.PriceFormatter;
 import bisq.presentation.parser.PriceParser;
@@ -266,7 +267,8 @@ public class PriceInput {
         private View(Model model, Controller controller, NumberValidator validator) {
             super(new VBox(), model, controller);
 
-            textInput = new PriceInputBox(model.description.get(), Res.get("component.priceInput.prompt"));
+            textInput = new PriceInputBox(model.description.get(), Res.get("component.priceInput.prompt"),
+                    BisqEasyViewUtils.POSITIVE_NUMERIC_WITH_DECIMAL_REGEX);
             textInput.setPrefWidth(WIDTH);
             textInput.setValidator(validator);
             textInput.conversionPriceSymbolTextProperty().set("%");

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/PriceInputBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/PriceInputBox.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.content.bisq_easy.components;
 
 import bisq.desktop.components.controls.MaterialTextField;
+import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
@@ -66,7 +67,8 @@ public class PriceInputBox extends MaterialTextField {
         getStyleClass().add("price-input-box");
 
         textInputTextListener = (observable, oldValue, newValue) -> {
-            if (newValue.length() > INPUT_TEXT_MAX_LENGTH) {
+            if (newValue.length() > INPUT_TEXT_MAX_LENGTH
+                    || !newValue.matches(BisqEasyViewUtils.NUMERIC_WITH_DECIMAL_REGEX)) {
                 textInputControl.setText(oldValue);
             }
             applyFontStyle(textInputControl.getLength());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/PriceInputBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/PriceInputBox.java
@@ -18,7 +18,6 @@
 package bisq.desktop.main.content.bisq_easy.components;
 
 import bisq.desktop.components.controls.MaterialTextField;
-import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
@@ -43,7 +42,7 @@ public class PriceInputBox extends MaterialTextField {
     private final HBox textInputAndSymbolHBox;
     private final ChangeListener<String> textInputTextListener;
 
-    public PriceInputBox(String description, String prompt) {
+    public PriceInputBox(String description, String prompt, String numericRegex) {
         super(description, prompt);
 
         bg.getStyleClass().setAll("bisq-dual-amount-bg");
@@ -67,8 +66,7 @@ public class PriceInputBox extends MaterialTextField {
         getStyleClass().add("price-input-box");
 
         textInputTextListener = (observable, oldValue, newValue) -> {
-            if (newValue.length() > INPUT_TEXT_MAX_LENGTH
-                    || !newValue.matches(BisqEasyViewUtils.NUMERIC_WITH_DECIMAL_REGEX)) {
+            if (newValue.length() > INPUT_TEXT_MAX_LENGTH || !newValue.matches(numericRegex)) {
                 textInputControl.setText(oldValue);
             }
             applyFontStyle(textInputControl.getLength());
@@ -76,8 +74,8 @@ public class PriceInputBox extends MaterialTextField {
         initialize();
     }
 
-    public PriceInputBox(String description) {
-        this(description, null);
+    public PriceInputBox(String description, String numericRegex) {
+        this(description, null, numericRegex);
     }
 
     public void initialize() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/QuoteAmountInputBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/QuoteAmountInputBox.java
@@ -211,6 +211,8 @@ public class QuoteAmountInputBox {
     }
 
     private static class View extends bisq.desktop.common.view.View<HBox, Model, Controller> {
+        private static final String NUMERIC_WITH_DECIMAL_REGEX = "\\d*([.,]\\d*)?";
+
         private final ChangeListener<String> textListener;
         private final ChangeListener<Boolean> focusListener;
         private final ChangeListener<Monetary> amountListener;
@@ -258,7 +260,7 @@ public class QuoteAmountInputBox {
 
         private void onTextChanged(ObservableValue<? extends String> observable, String oldValue, String newValue) {
             if (model.textInputMaxCharCount.isPresent()) {
-                if (newValue.length() > model.textInputMaxCharCount.get()) {
+                if (newValue.length() > model.textInputMaxCharCount.get() || !newValue.matches(NUMERIC_WITH_DECIMAL_REGEX)) {
                     textInput.setText(oldValue);
                 }
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/QuoteAmountInputBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/QuoteAmountInputBox.java
@@ -21,6 +21,7 @@ import bisq.common.currency.Market;
 import bisq.common.monetary.Monetary;
 import bisq.common.util.MathUtils;
 import bisq.common.util.StringUtils;
+import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import bisq.presentation.formatters.AmountFormatter;
 import bisq.presentation.parser.AmountParser;
 import javafx.beans.property.BooleanProperty;
@@ -211,8 +212,6 @@ public class QuoteAmountInputBox {
     }
 
     private static class View extends bisq.desktop.common.view.View<HBox, Model, Controller> {
-        private static final String NUMERIC_WITH_DECIMAL_REGEX = "\\d*([.,]\\d*)?";
-
         private final ChangeListener<String> textListener;
         private final ChangeListener<Boolean> focusListener;
         private final ChangeListener<Monetary> amountListener;
@@ -260,7 +259,8 @@ public class QuoteAmountInputBox {
 
         private void onTextChanged(ObservableValue<? extends String> observable, String oldValue, String newValue) {
             if (model.textInputMaxCharCount.isPresent()) {
-                if (newValue.length() > model.textInputMaxCharCount.get() || !newValue.matches(NUMERIC_WITH_DECIMAL_REGEX)) {
+                if (newValue.length() > model.textInputMaxCharCount.get()
+                        || !newValue.matches(BisqEasyViewUtils.NUMERIC_WITH_DECIMAL_REGEX)) {
                     textInput.setText(oldValue);
                 }
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/QuoteAmountInputBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/QuoteAmountInputBox.java
@@ -260,7 +260,7 @@ public class QuoteAmountInputBox {
         private void onTextChanged(ObservableValue<? extends String> observable, String oldValue, String newValue) {
             if (model.textInputMaxCharCount.isPresent()) {
                 if (newValue.length() > model.textInputMaxCharCount.get()
-                        || !newValue.matches(BisqEasyViewUtils.NUMERIC_WITH_DECIMAL_REGEX)) {
+                        || !newValue.matches(BisqEasyViewUtils.POSITIVE_NUMERIC_WITH_DECIMAL_REGEX)) {
                     textInput.setText(oldValue);
                 }
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/price/TradeWizardPriceView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/price/TradeWizardPriceView.java
@@ -23,6 +23,7 @@ import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.UnorderedList;
 import bisq.desktop.components.controls.validator.PercentageValidator;
+import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import bisq.desktop.main.content.bisq_easy.components.PriceInput;
 import bisq.desktop.main.content.bisq_easy.components.PriceInputBox;
 import bisq.i18n.Res;
@@ -80,7 +81,8 @@ public class TradeWizardPriceView extends View<VBox, TradeWizardPriceModel, Trad
         pricingModels.getStyleClass().addAll("selection-models", "bisq-text-3");
 
         // Input box
-        percentageInput = new PriceInputBox(Res.get("bisqEasy.price.percentage.inputBoxText"));
+        percentageInput = new PriceInputBox(Res.get("bisqEasy.price.percentage.inputBoxText"),
+                BisqEasyViewUtils.NUMERIC_WITH_DECIMAL_REGEX);
         percentageInput.setValidator(new PercentageValidator());
         percentageInput.textInputSymbolTextProperty().set("%");
         VBox fieldsBox = new VBox(20, priceInput.getRoot(), percentageInput);


### PR DESCRIPTION
Prevent input of anything other than numbers with optional floating point in both amount and price text input fields.