### PR TITLE
Wrap observer update calls into try/catch 

### DIFF
--- a/common/src/main/java/bisq/common/observable/collection/ObservableArray.java
+++ b/common/src/main/java/bisq/common/observable/collection/ObservableArray.java
@@ -18,6 +18,7 @@
 package bisq.common.observable.collection;
 
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+@Slf4j
 @EqualsAndHashCode(callSuper = true)
 public class ObservableArray<S> extends ObservableCollection<S> implements List<S> {
     public ObservableArray() {
@@ -48,13 +50,20 @@ public class ObservableArray<S> extends ObservableCollection<S> implements List<
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////
     // List implementation
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public boolean addAll(int index, @NotNull Collection<? extends S> c) {
-        boolean result = getList().addAll(index, c);
+    public boolean addAll(int index, @NotNull Collection<? extends S> values) {
+        boolean result = getList().addAll(index, values);
         if (result) {
-            observers.forEach(observer -> observer.addAll(c));
+            observers.forEach(observer -> {
+                try {
+                    observer.addAll(values);
+                } catch (Exception e) {
+                    log.error("Observer {} caused an exception at handling update.", observer, e);
+                }
+            });
         }
         return result;
     }
@@ -62,20 +71,38 @@ public class ObservableArray<S> extends ObservableCollection<S> implements List<
     @Override
     public S set(int index, S element) {
         S previous = getList().set(index, element);
-        observers.forEach(observer -> observer.add(element));
+        observers.forEach(observer -> {
+            try {
+                observer.add(element);
+            } catch (Exception e) {
+                log.error("Observer {} caused an exception at handling update.", observer, e);
+            }
+        });
         return previous;
     }
 
     @Override
     public void add(int index, S element) {
         getList().add(index, element);
-        observers.forEach(observer -> observer.add(element));
+        observers.forEach(observer -> {
+            try {
+                observer.add(element);
+            } catch (Exception e) {
+                log.error("Observer {} caused an exception at handling update.", observer, e);
+            }
+        });
     }
 
     @Override
     public S remove(int index) {
         S removedElement = getList().remove(index);
-        observers.forEach(observer -> observer.remove(removedElement));
+        observers.forEach(observer -> {
+            try {
+                observer.remove(removedElement);
+            } catch (Exception e) {
+                log.error("Observer {} caused an exception at handling update.", observer, e);
+            }
+        });
         return removedElement;
     }
 

--- a/common/src/main/java/bisq/common/observable/collection/ObservableCollection.java
+++ b/common/src/main/java/bisq/common/observable/collection/ObservableCollection.java
@@ -19,6 +19,7 @@ package bisq.common.observable.collection;
 
 import bisq.common.observable.Pin;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -28,6 +29,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+@Slf4j
 @EqualsAndHashCode
 public abstract class ObservableCollection<S> implements Collection<S> {
     protected final Collection<S> collection = createCollection();
@@ -47,7 +49,11 @@ public abstract class ObservableCollection<S> implements Collection<S> {
 
     public Pin addObserver(CollectionObserver<S> observer) {
         observers.add(observer);
-        observer.addAll(collection);
+        try {
+            observer.addAll(collection);
+        } catch (Exception e) {
+            log.error("Observer {} caused an exception at handling update.", observer, e);
+        }
         return () -> observers.remove(observer);
     }
 
@@ -73,7 +79,13 @@ public abstract class ObservableCollection<S> implements Collection<S> {
     public boolean add(S element) {
         boolean changed = collection.add(element);
         if (changed) {
-            observers.forEach(observer -> observer.add(element));
+            observers.forEach(observer -> {
+                try {
+                    observer.add(element);
+                } catch (Exception e) {
+                    log.error("Observer {} caused an exception at handling update.", observer, e);
+                }
+            });
         }
         return changed;
     }
@@ -82,7 +94,13 @@ public abstract class ObservableCollection<S> implements Collection<S> {
     public boolean addAll(@NotNull Collection<? extends S> values) {
         boolean changed = collection.addAll(values);
         if (changed) {
-            observers.forEach(observer -> observer.addAll(values));
+            observers.forEach(observer -> {
+                try {
+                    observer.addAll(values);
+                } catch (Exception e) {
+                    log.error("Observer {} caused an exception at handling update.", observer, e);
+                }
+            });
         }
         return changed;
     }
@@ -90,14 +108,26 @@ public abstract class ObservableCollection<S> implements Collection<S> {
     public void setAll(@NotNull Collection<? extends S> values) {
         collection.clear();
         collection.addAll(values);
-        observers.forEach(observer -> observer.setAll(values));
+        observers.forEach(observer -> {
+            try {
+                observer.setAll(values);
+            } catch (Exception e) {
+                log.error("Observer {} caused an exception at handling update.", observer, e);
+            }
+        });
     }
 
     @Override
     public boolean remove(Object element) {
         boolean changed = collection.remove(element);
         if (changed) {
-            observers.forEach(observer -> observer.remove(element));
+            observers.forEach(observer -> {
+                try {
+                    observer.remove(element);
+                } catch (Exception e) {
+                    log.error("Observer {} caused an exception at handling update.", observer, e);
+                }
+            });
         }
         return changed;
     }
@@ -106,7 +136,13 @@ public abstract class ObservableCollection<S> implements Collection<S> {
     public boolean removeAll(@NotNull Collection<?> values) {
         boolean changed = collection.removeAll(values);
         if (changed) {
-            observers.forEach(observer -> observer.removeAll(values));
+            observers.forEach(observer -> {
+                try {
+                    observer.removeAll(values);
+                } catch (Exception e) {
+                    log.error("Observer {} caused an exception at handling update.", observer, e);
+                }
+            });
         }
         return changed;
     }
@@ -114,7 +150,13 @@ public abstract class ObservableCollection<S> implements Collection<S> {
     @Override
     public void clear() {
         collection.clear();
-        observers.forEach(CollectionObserver::clear);
+        observers.forEach(observer -> {
+            try {
+                observer.clear();
+            } catch (Exception e) {
+                log.error("Observer {} caused an exception at handling update.", observer, e);
+            }
+        });
     }
 
     @Override

--- a/common/src/main/java/bisq/common/observable/collection/SimpleCollectionObserver.java
+++ b/common/src/main/java/bisq/common/observable/collection/SimpleCollectionObserver.java
@@ -19,6 +19,7 @@ package bisq.common.observable.collection;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collection;
 
@@ -27,6 +28,7 @@ import java.util.Collection;
  *
  * @param <S> The type of the source collection element.
  */
+@Slf4j
 @EqualsAndHashCode
 @ToString
 final class SimpleCollectionObserver<S> implements CollectionObserver<S> {
@@ -37,7 +39,12 @@ final class SimpleCollectionObserver<S> implements CollectionObserver<S> {
     }
 
     void onChange() {
-        observer.run();
+        try {
+            observer.run();
+        } catch (Exception e) {
+            log.error("Observer {} caused an exception at handling update.", observer, e);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Wrap observer update calls into try/catch to avoid that an exception at the handler would trigger an exception at the `addObserver`, the `set` or collection change methods. One failing handler would also break the loop for updating the other remaining observers.