### PR TITLE
Prevent buyers from taking offers of sellers with insufficient reputation

### DIFF
--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyTradeAmountLimits.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyTradeAmountLimits.java
@@ -107,6 +107,8 @@ public class BisqEasyTradeAmountLimits {
                 });
     }
 
+
+
     public static Optional<Result> checkOfferAmountLimitForMaxOrFixedAmount(ReputationService reputationService,
                                                                             UserIdentityService userIdentityService,
                                                                             UserProfileService userProfileService,
@@ -157,7 +159,7 @@ public class BisqEasyTradeAmountLimits {
                 .flatMap(fiatAmount -> findRequiredReputationScoreByFiatAmount(marketPriceService, offer.getMarket(), fiatAmount));
     }
 
-    private static Optional<Long> findRequiredReputationScoreForMinAmount(MarketPriceService marketPriceService,
+    public static Optional<Long> findRequiredReputationScoreForMinAmount(MarketPriceService marketPriceService,
                                                                           BisqEasyOffer offer) {
         return OfferAmountUtil.findQuoteSideMinAmount(marketPriceService, offer)
                 .flatMap(fiatAmount -> findRequiredReputationScoreByFiatAmount(marketPriceService, offer.getMarket(), fiatAmount));
@@ -232,6 +234,7 @@ public class BisqEasyTradeAmountLimits {
         MATCH_MIN_SCORE,
         SCORE_TOO_LOW;
 
+        // TODO: Remove this. We cannot have mutable properties inside an enum
         @Setter
         private Long requiredReputationScore;
 

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -223,26 +223,13 @@ chat.message.takeOffer.seller.myReputationScoreTooLow.warning=Your reputation sc
   To learn more about the reputation system, visit: [HYPERLINK:https://bisq.wiki/Reputation].\n\n\
   You can read more about how to build up your reputation at ''Reputation/Build Reputation''.
 
-chat.message.takeOffer.buyer.makersReputationScoreTooLow.headline=Security warning
-chat.message.takeOffer.buyer.makersReputationScoreTooLow.warning=The seller''s reputation score of {0} is below the required score of {1} for a trade amount of {2}.\n\n\
-  Bisq Easy''s security model relies on the seller''s reputation as the buyer need to send the fiat currency first. \
-  If you choose to proceed with taking the offer despite the lack of reputation, ensure you fully understand the risks involved.\n\n\
-  To learn more about the reputation system, visit: [HYPERLINK:https://bisq.wiki/Reputation].\n\n\
-  Do you want to continue and take that offer?
-
-chat.message.takeOffer.buyer.makersReputationScoreTooLow.yes=Yes, I understand the risk and want to continue
-chat.message.takeOffer.buyer.makersReputationScoreTooLow.no=No, I look for another offer
-
-chat.message.takeOffer.buyer.makersReputationTooLowButInLowAmountTolerance.headline=Please review the risks when taking that offer
-chat.message.takeOffer.buyer.makersReputationTooLowButInLowAmountTolerance.warning=The seller''s reputation score is {0}, \
-  which is below the required score of {1} for a trade amount of {2}.\n\n\
-  Since the trade amount is relatively low, the reputation requirements have been relaxed. \
-  However, if you choose to proceed despite the seller''s insufficient reputation, make sure you fully understand the associated risks. \
-  Bisq Easy''s security model depends on the seller''s reputation, as the buyer is required to send fiat currency first.\n\n\
-  To learn more about the reputation system, visit: [HYPERLINK:https://bisq.wiki/Reputation].\n\n\
-  Do you still want to take the offer?
-chat.message.takeOffer.buyer.makersReputationTooLowButInLowAmountTolerance.yes=Yes, I understand the risk and want to continue
-chat.message.takeOffer.buyer.makersReputationTooLowButInLowAmountTolerance.no=No, I look for another offer
+chat.message.takeOffer.buyer.invalidOffer.headline=This offer can't be taken
+chat.message.takeOffer.buyer.invalidOffer.fixedAmount.text=The seller''s reputation score of {0} is below the required score of {1} for the trade amount of {2}.\n\n\
+  Bisq Easy''s security model relies on the seller''s reputation as the buyer need to send the fiat currency first.\n\n\
+  To learn more about the reputation system, visit: [HYPERLINK:https://bisq.wiki/Reputation].
+chat.message.takeOffer.buyer.invalidOffer.rangeAmount.text=The seller''s reputation score of {0} is below the required score of {1} for the minimum of the trade amount range of {2}.\n\n\
+  Bisq Easy''s security model relies on the seller''s reputation as the buyer need to send the fiat currency first.\n\n\
+  To learn more about the reputation system, visit: [HYPERLINK:https://bisq.wiki/Reputation].
 
 chat.message.offer.offerAlreadyTaken.warn=You have already taken that offer.
 chat.message.delete.differentUserProfile.warn=This chat message was created with another user profile.\n\n\


### PR DESCRIPTION
Towards #3074

This is necessary for backwards compatibility, since in older versions sellers can create offers without the required reputation.