### PR TITLE
rest-api websocket default setup for LAN

### DIFF
--- a/apps/http-api-app/src/main/resources/http_api_app.conf
+++ b/apps/http-api-app/src/main/resources/http_api_app.conf
@@ -28,10 +28,10 @@ application {
         includeRestApi = true
         server = {
             protocol = "http://"
-            host = "localhost"
+            host = "0.0.0.0"
             port = 8090
         }
-        localhostOnly = true    // Accessible only via localhost
+        localhostOnly = false    // Accessible only via localhost, default allow LAN
         whiteListEndPoints = []
         blackListEndPoints = []
         supportedAuth = []   // supported auth schemes. If empty no authentication is required


### PR DESCRIPTION
 - default websocket http rest api setup to allow LAN connectivity (to be used as trusted node for bisq-mobile with real devices)