### PR TITLE
Increase a bit visibility of version number next to bisq logo #3206

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavView.java
@@ -163,10 +163,10 @@ public class LeftNavView extends View<AnchorPane, LeftNavModel, LeftNavControlle
         mainMenuItems.setLayoutY(menuTop);
 
         version = new Label(model.getVersion());
-        version.setOpacity(0.5);
+        version.setOpacity(0.9);
         version.getStyleClass().add("bisq-smaller-dimmed-label");
         version.setLayoutX(91);
-        version.setLayoutY(26.5);
+        version.setLayoutY(24);
         Pane logoAndVersion = new Pane(logoExpanded, logoCollapsed, version);
 
         Layout.pinToAnchorPane(mainMenuItems, menuTop, 0, 0, MARKER_WIDTH);

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -513,12 +513,12 @@
 
 .bisq-smaller-label {
     -fx-text-fill: -fx-light-text-color;
-    -fx-font-size: 0.73em;
+    -fx-font-size: 1em;
 }
 
 .bisq-smaller-dimmed-label {
     -fx-text-fill: -fx-mid-text-color;
-    -fx-font-size: 0.73em;
+    -fx-font-size: 1em;
 }
 
 .bisq-grey-dimmed {


### PR DESCRIPTION
updated version font size and Y position, and since the connections on the bottom shared the same class, they also got slightly bigger. 

![image](https://github.com/user-attachments/assets/3ee713a5-ad35-466d-bd6b-5ef2ece74a9c)
