### PR TITLE
Revert some changes from pr 3222

### DIFF
--- a/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
@@ -59,10 +59,15 @@ public final class AuthorizedBondedRole implements AuthorizedDistributedData {
     private final Optional<AddressByTransportTypeMap> addressByTransportTypeMap;
     private final NetworkId networkId;
     // The oracle node which did the validation and publishing
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final Optional<AuthorizedOracleNode> authorizingOracleNode;
-    @ExcludeForHash
+
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
@@ -56,7 +56,11 @@ public final class AuthorizedMarketPriceData implements AuthorizedDistributedDat
     // We need deterministic sorting or the map, so we use a treemap
     private final TreeMap<Market, MarketPrice> marketPriceByCurrencyMap;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
@@ -54,7 +54,11 @@ public final class AuthorizedOracleNode implements AuthorizedDistributedData {
     private final String bondUserName;                // username from DAO proposal
     private final String signatureBase64;             // signature created by bond with username as message
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
@@ -58,7 +58,11 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
     private final String versionString;
     private final String releaseManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
@@ -64,7 +64,11 @@ public final class AuthorizedAlertData implements AuthorizedDistributedData {
     private final Optional<AuthorizedBondedRole> bannedRole;
     private final String securityManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/difficulty_adjustment/AuthorizedDifficultyAdjustmentData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/difficulty_adjustment/AuthorizedDifficultyAdjustmentData.java
@@ -53,7 +53,11 @@ public final class AuthorizedDifficultyAdjustmentData implements AuthorizedDistr
     private final double difficultyAdjustmentFactor;
     private final String securityManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/min_reputation_score/AuthorizedMinRequiredReputationScoreData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/min_reputation_score/AuthorizedMinRequiredReputationScoreData.java
@@ -54,7 +54,11 @@ public final class AuthorizedMinRequiredReputationScoreData implements Authorize
     private final long minRequiredReputationScore;
     private final String securityManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,6 +62,14 @@ public final class Capability implements NetworkProto {
                                           List<TransportType> supportedTransportTypes,
                                           List<Feature> features) {
         return new Capability(VERSION, address, supportedTransportTypes, features, ApplicationVersion.getVersion().getVersionAsString());
+    }
+
+    public static Capability withVersion(Capability capability, int version) {
+        return new Capability(version,
+                capability.getAddress(),
+                new ArrayList<>(capability.getSupportedTransportTypes()),
+                new ArrayList<>(capability.getFeatures()),
+                capability.getApplicationVersion());
     }
 
     @VisibleForTesting

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -51,6 +51,7 @@ public final class Capability implements NetworkProto {
     @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final List<Feature> features;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String applicationVersion;
 
     public static Capability myCapability(Address address,

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -48,8 +48,11 @@ public final class Capability implements NetworkProto {
     private final int version;
     private final Address address;
     private final List<TransportType> supportedTransportTypes;
+    // ExcludeForHash from version 1 on to not break hash for pow check or version 0. We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final List<Feature> features;
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String applicationVersion;

--- a/network/network/src/main/java/bisq/network/p2p/node/Node.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Node.java
@@ -18,9 +18,6 @@
 package bisq.network.p2p.node;
 
 
-import bisq.common.network.Address;
-import bisq.common.network.TransportConfig;
-import bisq.common.network.TransportType;
 import bisq.common.observable.Observable;
 import bisq.common.threading.ThreadName;
 import bisq.common.timer.Scheduler;
@@ -28,6 +25,9 @@ import bisq.common.util.CompletableFutureUtils;
 import bisq.common.util.ExceptionUtil;
 import bisq.common.util.StringUtils;
 import bisq.network.NetworkService;
+import bisq.common.network.Address;
+import bisq.common.network.TransportConfig;
+import bisq.common.network.TransportType;
 import bisq.network.identity.NetworkId;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.node.authorization.AuthorizationService;
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static bisq.network.NetworkService.DISPATCHER;
-import static bisq.network.p2p.node.ConnectionException.Reason.ADDRESS_BANNED;
+import static bisq.network.p2p.node.ConnectionException.Reason.*;
 import static bisq.network.p2p.node.Node.State.*;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.CompletableFuture.runAsync;
@@ -77,6 +77,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @Slf4j
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Node implements Connection.Handler {
+    public static final int PREFERRED_VERSION = 1;
 
     public enum State {
         NEW,
@@ -405,8 +406,23 @@ public class Node implements Connection.Handler {
     }
 
     private Connection createOutboundConnection(Address address, Capability myCapability) {
-        log.info("Create outbound connection to {}", address);
-        return doCreateOutboundConnection(address, myCapability);
+        // This code can be removed once no old versions are expected anymore.
+        Capability candidate = Capability.withVersion(myCapability, PREFERRED_VERSION);
+        log.info("Create outbound connection to {} with capability version 1", address);
+        try {
+            return doCreateOutboundConnection(address, candidate);
+        } catch (ConnectionException e) {
+            if (e.getCause() != null && e.getReason() != null && e.getReason() == HANDSHAKE_FAILED) {
+                log.warn("Handshake at creating outbound connection to {} failed. We try again with capability version 0. Error: {}",
+                        address, ExceptionUtil.getRootCauseMessage(e));
+                int version = PREFERRED_VERSION == 0 ? 1 : 0;
+                candidate = Capability.withVersion(myCapability, version);
+                return doCreateOutboundConnection(address, candidate);
+            } else {
+                // In case of other ConnectExceptions we don't try again as peer is offline
+                throw e;
+            }
+        }
     }
 
     private Connection doCreateOutboundConnection(Address address, Capability myCapability) {

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
@@ -333,7 +333,8 @@ public final class ConnectionHandshake {
             connectionMetrics.onReceived(requestNetworkEnvelope, deserializeTime);
 
             // We reply with the same version as the peer has to avoid pow hash check failures
-            Response response = new Response(capability, myNetworkLoad);
+            Capability responseCapability = Capability.withVersion(capability, requestersCapability.getVersion());
+            Response response = new Response(responseCapability, myNetworkLoad);
             AuthorizationToken token = authorizationService.createToken(response,
                     request.getNetworkLoad(),
                     peerAddress.getFullAddress(),

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
@@ -35,8 +35,10 @@ public final class InventoryResponse implements BroadcastMessage, Response {
     @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;
+    // After v 2.1.0 version 0 should not be used anymore. Then we can remove the excludeOnlyInVersions param to
+    // not need to maintain future versions. We add though hypothetical versions 2 and 3 for safety
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final Inventory inventory;
     private final int requestNonce;
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
@@ -62,7 +62,7 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
     }
 
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
     @EqualsAndHashCode.Exclude

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
@@ -41,7 +41,7 @@ public final class MailboxData implements StorageData {
     public final static long MAX_TLL = TimeUnit.DAYS.toMillis(15);
 
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
     @EqualsAndHashCode.Exclude

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
@@ -61,7 +61,7 @@ public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataReq
     }
 
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
     @EqualsAndHashCode.Exclude

--- a/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
+++ b/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
@@ -49,7 +49,11 @@ public final class BannedUserProfileData implements AuthorizedDistributedData {
     private final int version;
     private final UserProfile userProfile;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -94,7 +94,7 @@ public final class UserProfile implements DistributedData, PublishDateAware {
     @EqualsAndHashCode.Include
     private final String statement;
 
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final int avatarVersion;
     @ExcludeForHash
     private final int version;

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -98,6 +98,7 @@ public final class UserProfile implements DistributedData, PublishDateAware {
     private final int avatarVersion;
     @ExcludeForHash
     private final int version;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String applicationVersion;
 
     private transient String nym;

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedAccountAgeData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedAccountAgeData.java
@@ -52,7 +52,11 @@ public final class AuthorizedAccountAgeData implements AuthorizedDistributedData
     private final String profileId;
     private final long date;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
@@ -60,7 +60,11 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
@@ -55,7 +55,9 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
     private final long amount;
     private final byte[] hash;
     private final long lockTime;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
     private final int blockHeight;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
 
     @ExcludeForHash

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -59,7 +59,11 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -54,7 +54,9 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     private final long blockTime;
     private final long amount;
     private final byte[] hash;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
     private final int blockHeight;
+    @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
 
     @ExcludeForHash

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedSignedWitnessData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedSignedWitnessData.java
@@ -52,7 +52,11 @@ public final class AuthorizedSignedWitnessData implements AuthorizedDistributedD
     private final String profileId;
     private final long witnessSignDate;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedTimestampData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedTimestampData.java
@@ -51,7 +51,11 @@ public final class AuthorizedTimestampData implements AuthorizedDistributedData 
     private final String profileId;
     private final long date;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 


### PR DESCRIPTION
There are still too many nodes out with old versions and authorized data with version 0.
We have to wait for a few months more to apply those changes.