### PR TITLE
Make test agnostic of running OS

### DIFF
--- a/persistence/src/main/java/bisq/persistence/backup/BackupService.java
+++ b/persistence/src/main/java/bisq/persistence/backup/BackupService.java
@@ -246,7 +246,8 @@ public class BackupService {
 
     @VisibleForTesting
     static Path resolveDirPath(Path dataDir, Path storeFilePath) {
-        String relativeStoreFilePath = getRelativePath(dataDir, storeFilePath);
+        boolean isWindowsPath = dataDir.toString().contains("\\");
+        String relativeStoreFilePath = getRelativePath(dataDir, storeFilePath, isWindowsPath);
         String relativeBackupDir = relativeStoreFilePath
                 .replaceFirst("db", "backups")
                 .replace(Persistence.EXTENSION, "")
@@ -255,10 +256,11 @@ public class BackupService {
         return Paths.get(dataDir.toString() + relativeBackupDir);
     }
 
+
+
     @VisibleForTesting
-    static String getRelativePath(Path dataDir, Path filePath) {
+    static String getRelativePath(Path dataDir, Path filePath, boolean isWindowsPath) {
         // We don't use File.pathSeparator as we use it in unit test which need to be OS independent.
-        boolean isWindowsPath = dataDir.toString().contains("\\");
         String normalizedDataDir = dataDir.toString().replace("\\", "/");
         String normalizedFilePath = filePath.toString().replace("\\", "/");
 

--- a/persistence/src/test/java/bisq/persistence/backup/BackupServiceTest.java
+++ b/persistence/src/test/java/bisq/persistence/backup/BackupServiceTest.java
@@ -66,43 +66,43 @@ public class BackupServiceTest {
         // ✅ Windows Test
         dataDir = Paths.get("C:\\Users\\bisq_user\\alice");
         storeFilePath = Paths.get(dataDir + "\\db\\private\\key_bundle_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, true);
         assertEquals("\\db\\private\\key_bundle_store.protobuf", dirPath);
 
         // ✅ macOS Test
         dataDir = Paths.get("/Users/bisq_user/Library/Application Support/alice");
         storeFilePath = Paths.get(dataDir + "/db/private/key_bundle_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, false);
         assertEquals("/db/private/key_bundle_store.protobuf", dirPath);
 
         // ✅ Unix Test
         dataDir = Paths.get("/home/bisq_user/alice");
         storeFilePath = Paths.get(dataDir + "/db/private/key_bundle_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, false);
         assertEquals("/db/private/key_bundle_store.protobuf", dirPath);
 
         // ✅ Windows UNC Path Test (Server Shares)
         dataDir = Paths.get("\\\\Server\\Share\\bisq_user\\alice");
         storeFilePath = Paths.get("\\\\Server\\Share\\bisq_user\\alice\\db\\private\\key_bundle_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, true);
         assertEquals("\\db\\private\\key_bundle_store.protobuf", dirPath);
 
         // ✅ Nested Directory Test
         dataDir = Paths.get("/home/bisq_user/alice");
         storeFilePath = Paths.get("/home/bisq_user/alice/db/subdir/private/key_bundle_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, false);
         assertEquals("/db/subdir/private/key_bundle_store.protobuf", dirPath);
 
         // ✅ Path with Trailing Slash in dataDir
         dataDir = Paths.get("/home/bisq_user/alice/");
         storeFilePath = Paths.get("/home/bisq_user/alice/db/private/key_bundle_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, false);
         assertEquals("/db/private/key_bundle_store.protobuf", dirPath);
 
         // ✅ Special Characters in Path
         dataDir = Paths.get("C:\\Users\\bisq user\\data");
         storeFilePath = Paths.get("C:\\Users\\bisq user\\data\\db\\private\\my file_store.protobuf");
-        dirPath = BackupService.getRelativePath(dataDir, storeFilePath);
+        dirPath = BackupService.getRelativePath(dataDir, storeFilePath, true);
         assertEquals("\\db\\private\\my file_store.protobuf", dirPath);
 
         // ❌ File Outside `dataDir` (Should Throw Exception)
@@ -111,7 +111,7 @@ public class BackupServiceTest {
         Path finalDataDir = dataDir;
         Path finalStoreFilePath = storeFilePath;
         assertThrows(IllegalArgumentException.class, () -> {
-            BackupService.getRelativePath(finalDataDir, finalStoreFilePath);
+            BackupService.getRelativePath(finalDataDir, finalStoreFilePath, false);
         });
     }
 


### PR DESCRIPTION
Add `isWindowsPath` flag as input parameter. Otherwise, since `Path` is used, this test can fail depending on which OS it is run from.