### PR TITLE
Add support for message delivery state with multiple peers

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/message_box/MyProtocolLogMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/message_box/MyProtocolLogMessageBox.java
@@ -19,86 +19,24 @@ package bisq.desktop.main.content.bisq_easy.open_trades.message_box;
 
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
-import bisq.desktop.common.utils.ImageUtil;
-import bisq.desktop.components.controls.BisqMenuItem;
-import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
-import bisq.i18n.Res;
-import javafx.geometry.Pos;
-import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
-import org.fxmisc.easybind.EasyBind;
-import org.fxmisc.easybind.Subscription;
+import bisq.desktop.main.content.chat.message_container.list.message_box.MessageDeliveryStatusBox;
 
 public class MyProtocolLogMessageBox extends PeerProtocolLogMessageBox {
-    private final Subscription shouldShowTryAgainPin, messageDeliveryStatusNodePin;
-    private final BisqMenuItem tryAgainMenuItem;
+    private final MessageDeliveryStatusBox messageDeliveryStatusBox;
 
     public MyProtocolLogMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                                    ChatMessagesListController controller) {
         super(item);
 
-        Label deliveryStateIcon = new Label();
-        BisqTooltip deliveryStateIconToolTip = new BisqTooltip();
-        deliveryStateIcon.setTooltip(deliveryStateIconToolTip);
+        messageDeliveryStatusBox = new MessageDeliveryStatusBox(item, controller);
 
-        HBox deliveryStateHBox = new HBox(deliveryStateIcon);
-        deliveryStateHBox.setAlignment(Pos.CENTER);
-
-        tryAgainMenuItem = new BisqMenuItem("try-again-grey", "try-again-white");
-        tryAgainMenuItem.useIconOnly(22);
-        tryAgainMenuItem.setTooltip(new BisqTooltip(Res.get("chat.message.resendMessage")));
-
-        HBox messageStatusHbox = new HBox(5, tryAgainMenuItem, deliveryStateHBox);
-        messageStatusHbox.setAlignment(Pos.CENTER);
-
-        messageDeliveryStatusNodePin = EasyBind.subscribe(item.getMessageDeliveryStatus(), status -> {
-            messageStatusHbox.setManaged(status != null);
-            messageStatusHbox.setVisible(status != null);
-            deliveryStateIconToolTip.setText(item.getMessageDeliveryStatusTooltip());
-            if (status != null) {
-                switch (status) {
-                    // Successful delivery
-                    case ACK_RECEIVED:
-                    case MAILBOX_MSG_RECEIVED:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("received-check-grey"));
-                        break;
-                    // Pending delivery
-                    case CONNECTING:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("connecting-grey"));
-                        break;
-                    case SENT:
-                    case TRY_ADD_TO_MAILBOX:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("sent-message-grey"));
-                        break;
-                    case ADDED_TO_MAILBOX:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("mailbox-grey"));
-                        break;
-                    case FAILED:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("undelivered-message-yellow"));
-                        break;
-                }
-            }
-        });
-
-        shouldShowTryAgainPin = EasyBind.subscribe(item.getCanManuallyResendMessage(), showTryAgain -> {
-            tryAgainMenuItem.setVisible(showTryAgain);
-            tryAgainMenuItem.setManaged(showTryAgain);
-            if (showTryAgain) {
-                tryAgainMenuItem.setOnAction(e -> controller.onResendMessage(item.getMessageId()));
-            } else {
-                tryAgainMenuItem.setOnAction(null);
-            }
-        });
-
-        dateTimeHBox.getChildren().add(0, messageStatusHbox);
+        dateTimeHBox.getChildren().add(0, messageDeliveryStatusBox);
     }
 
     @Override
     public void dispose() {
-        shouldShowTryAgainPin.unsubscribe();
-        messageDeliveryStatusNodePin.unsubscribe();
-        tryAgainMenuItem.setOnAction(null);
+        messageDeliveryStatusBox.dispose();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/message_box/MyProtocolLogMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/message_box/MyProtocolLogMessageBox.java
@@ -82,7 +82,7 @@ public class MyProtocolLogMessageBox extends PeerProtocolLogMessageBox {
             }
         });
 
-        shouldShowTryAgainPin = EasyBind.subscribe(item.getShouldShowTryAgain(), showTryAgain -> {
+        shouldShowTryAgainPin = EasyBind.subscribe(item.getCanManuallyResendMessage(), showTryAgain -> {
             tryAgainMenuItem.setVisible(showTryAgain);
             tryAgainMenuItem.setManaged(showTryAgain);
             if (showTryAgain) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/message_box/MyProtocolLogMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/message_box/MyProtocolLogMessageBox.java
@@ -19,32 +19,66 @@ package bisq.desktop.main.content.bisq_easy.open_trades.message_box;
 
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
+import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.controls.BisqMenuItem;
+import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
+import bisq.i18n.Res;
 import javafx.geometry.Pos;
+import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 public class MyProtocolLogMessageBox extends PeerProtocolLogMessageBox {
     private final Subscription shouldShowTryAgainPin, messageDeliveryStatusNodePin;
+    private final BisqMenuItem tryAgainMenuItem;
 
     public MyProtocolLogMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                                    ChatMessagesListController controller) {
         super(item);
 
-        BisqMenuItem tryAgainMenuItem = item.getTryAgainMenuItem();
-        HBox deliveryStateHBox = new HBox();
+        Label deliveryStateIcon = new Label();
+        BisqTooltip deliveryStateIconToolTip = new BisqTooltip();
+        deliveryStateIcon.setTooltip(deliveryStateIconToolTip);
+
+        HBox deliveryStateHBox = new HBox(deliveryStateIcon);
         deliveryStateHBox.setAlignment(Pos.CENTER);
+
+        tryAgainMenuItem = new BisqMenuItem("try-again-grey", "try-again-white");
+        tryAgainMenuItem.useIconOnly(22);
+        tryAgainMenuItem.setTooltip(new BisqTooltip(Res.get("chat.message.resendMessage")));
+
         HBox messageStatusHbox = new HBox(5, tryAgainMenuItem, deliveryStateHBox);
         messageStatusHbox.setAlignment(Pos.CENTER);
 
-        messageDeliveryStatusNodePin = EasyBind.subscribe(item.getMessageDeliveryStatusNode(), node -> {
-            deliveryStateHBox.setManaged(node != null);
-            deliveryStateHBox.setVisible(node != null);
-            if (node != null) {
-                deliveryStateHBox.getChildren().setAll(node);
+        messageDeliveryStatusNodePin = EasyBind.subscribe(item.getMessageDeliveryStatus(), status -> {
+            messageStatusHbox.setManaged(status != null);
+            messageStatusHbox.setVisible(status != null);
+            deliveryStateIconToolTip.setText(item.getMessageDeliveryStatusTooltip());
+            if (status != null) {
+                switch (status) {
+                    // Successful delivery
+                    case ACK_RECEIVED:
+                    case MAILBOX_MSG_RECEIVED:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("received-check-grey"));
+                        break;
+                    // Pending delivery
+                    case CONNECTING:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("connecting-grey"));
+                        break;
+                    case SENT:
+                    case TRY_ADD_TO_MAILBOX:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("sent-message-grey"));
+                        break;
+                    case ADDED_TO_MAILBOX:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("mailbox-grey"));
+                        break;
+                    case FAILED:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("undelivered-message-yellow"));
+                        break;
+                }
             }
         });
 
@@ -65,5 +99,6 @@ public class MyProtocolLogMessageBox extends PeerProtocolLogMessageBox {
     public void dispose() {
         shouldShowTryAgainPin.unsubscribe();
         messageDeliveryStatusNodePin.unsubscribe();
+        tryAgainMenuItem.setOnAction(null);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -117,7 +117,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
     // Delivery status
     private final Set<Pin> mapPins = new HashSet<>();
     private final Set<Pin> statusPins = new HashSet<>();
-    private final BooleanProperty shouldShowTryAgain = new SimpleBooleanProperty();
+    private final BooleanProperty canManuallyResendMessage = new SimpleBooleanProperty();
     private final SimpleObjectProperty<MessageDeliveryStatus> messageDeliveryStatus = new SimpleObjectProperty<>();
     private String messageDeliveryStatusTooltip;
     private final Optional<ResendMessageService> resendMessageService;
@@ -403,9 +403,9 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                 log.info("updateMessageStatus status={}, messageId={}, peersProfileId={}", status, messageId, peersProfileId);
             }
             if (status == MessageDeliveryStatus.FAILED) {
-                this.shouldShowTryAgain.set(resendMessageService.map(service -> service.canManuallyResendMessage(messageId)).orElse(false));
+                canManuallyResendMessage.set(resendMessageService.map(service -> service.canManuallyResendMessage(messageId)).orElse(false));
             } else {
-                this.shouldShowTryAgain.set(false);
+                canManuallyResendMessage.set(false);
             }
         }))));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -402,6 +402,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
                 messageDeliveryStatusTooltip = Res.get("chat.message.deliveryState." + status.name());
                 log.info("updateMessageStatus status={}, messageId={}, peersProfileId={}", status, messageId, peersProfileId);
             }
+            messageDeliveryStatus.set(status);
             if (status == MessageDeliveryStatus.FAILED) {
                 canManuallyResendMessage.set(resendMessageService.map(service -> service.canManuallyResendMessage(messageId)).orElse(false));
             } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MessageDeliveryStatusBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MessageDeliveryStatusBox.java
@@ -19,83 +19,112 @@ package bisq.desktop.main.content.chat.message_container.list.message_box;
 
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
+import bisq.common.data.Triple;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
 import bisq.i18n.Res;
+import bisq.network.p2p.services.confidential.ack.MessageDeliveryStatus;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class MessageDeliveryStatusBox extends HBox {
-    private final Subscription shouldShowTryAgainPin, messageDeliveryStatusNodePin;
-    private final BisqMenuItem tryAgainMenuItem;
+    private final Subscription messageDeliveryStatusNodePin;
+    private final Map<String, Triple<BisqMenuItem, Label, BisqTooltip>> deliveryStateTripleByProfileId = new HashMap<>();
 
     public MessageDeliveryStatusBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                                     ChatMessagesListController controller) {
-        super(5);
+        super(7.5);
         setAlignment(Pos.CENTER);
 
-        Label deliveryStateIcon = new Label();
-        BisqTooltip deliveryStateIconToolTip = new BisqTooltip();
-        deliveryStateIcon.setTooltip(deliveryStateIconToolTip);
+        messageDeliveryStatusNodePin = EasyBind.subscribe(item.getMessageDeliveryStatusByPeerProfileId(), map -> {
+            setManaged(map != null);
+            setVisible(map != null);
+            if (map == null) {
+                return;
+            }
+            map.forEach((peersProfileId, triple) -> {
+                MessageDeliveryStatus status = triple.getFirst();
+                String ackRequestingMessageId = triple.getSecond();
+                boolean canManuallyResendMessage = triple.getThird();
 
-        HBox deliveryStateHBox = new HBox(deliveryStateIcon);
-        deliveryStateHBox.setAlignment(Pos.CENTER);
+                Triple<BisqMenuItem, Label, BisqTooltip> deliveryStateTriple = deliveryStateTripleByProfileId.get(peersProfileId);
+                BisqMenuItem tryAgainMenuItem;
+                Label icon;
+                BisqTooltip tooltip;
+                if (deliveryStateTriple == null) {
+                    tryAgainMenuItem = new BisqMenuItem("try-again-grey", "try-again-white");
+                    tryAgainMenuItem.useIconOnly(22);
+                    tryAgainMenuItem.setTooltip(new BisqTooltip(Res.get("chat.message.resendMessage")));
 
-        tryAgainMenuItem = new BisqMenuItem("try-again-grey", "try-again-white");
-        tryAgainMenuItem.useIconOnly(22);
-        tryAgainMenuItem.setTooltip(new BisqTooltip(Res.get("chat.message.resendMessage")));
+                    icon = new Label();
+                    tooltip = new BisqTooltip();
+                    icon.setTooltip(tooltip);
 
-        getChildren().addAll(tryAgainMenuItem, deliveryStateHBox);
+                    HBox hBox = new HBox(1, tryAgainMenuItem, icon);
+                    hBox.setAlignment(Pos.CENTER);
+                    getChildren().add(hBox);
 
-        messageDeliveryStatusNodePin = EasyBind.subscribe(item.getMessageDeliveryStatus(), status -> {
-            setManaged(status != null);
-            setVisible(status != null);
-            deliveryStateIconToolTip.setText(item.getMessageDeliveryStatusTooltip());
-            if (status != null) {
+                    deliveryStateTripleByProfileId.put(peersProfileId, new Triple<>(tryAgainMenuItem, icon, tooltip));
+                } else {
+                    tryAgainMenuItem = deliveryStateTriple.getFirst();
+                    icon = deliveryStateTriple.getSecond();
+                    tooltip = deliveryStateTriple.getThird();
+                }
+
+                tryAgainMenuItem.setVisible(canManuallyResendMessage);
+                tryAgainMenuItem.setManaged(canManuallyResendMessage);
+                if (canManuallyResendMessage) {
+                    tryAgainMenuItem.setOnAction(e -> controller.onResendMessage(ackRequestingMessageId));
+                } else {
+                    tryAgainMenuItem.setOnAction(null);
+                }
+
+
+                String deliveryState = Res.get("chat.message.deliveryState." + status.name());
+                if (map.size() > 1) {
+                    String userName = controller.getUserName(peersProfileId);
+                    tooltip.setText(Res.get("chat.message.deliveryState.multiplePeers", userName, deliveryState));
+                } else {
+                    tooltip.setText(deliveryState);
+                }
+
                 switch (status) {
                     // Successful delivery
                     case ACK_RECEIVED:
                     case MAILBOX_MSG_RECEIVED:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("received-check-grey"));
+                        icon.setGraphic(ImageUtil.getImageViewById("received-check-grey"));
                         break;
                     // Pending delivery
                     case CONNECTING:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("connecting-grey"));
+                        icon.setGraphic(ImageUtil.getImageViewById("connecting-grey"));
                         break;
                     case SENT:
                     case TRY_ADD_TO_MAILBOX:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("sent-message-grey"));
+                        icon.setGraphic(ImageUtil.getImageViewById("sent-message-grey"));
                         break;
                     case ADDED_TO_MAILBOX:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("mailbox-grey"));
+                        icon.setGraphic(ImageUtil.getImageViewById("mailbox-grey"));
                         break;
                     case FAILED:
-                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("undelivered-message-yellow"));
+                        icon.setGraphic(ImageUtil.getImageViewById("undelivered-message-yellow"));
                         break;
                 }
-            }
-        });
-
-        shouldShowTryAgainPin = EasyBind.subscribe(item.getCanManuallyResendMessage(), showTryAgain -> {
-            tryAgainMenuItem.setVisible(showTryAgain);
-            tryAgainMenuItem.setManaged(showTryAgain);
-            if (showTryAgain) {
-                tryAgainMenuItem.setOnAction(e -> controller.onResendMessage(item.getMessageId()));
-            } else {
-                tryAgainMenuItem.setOnAction(null);
-            }
+            });
         });
     }
 
     public void dispose() {
-        shouldShowTryAgainPin.unsubscribe();
         messageDeliveryStatusNodePin.unsubscribe();
-        tryAgainMenuItem.setOnAction(null);
+        deliveryStateTripleByProfileId.values().forEach(triple ->
+                triple.getFirst().setOnAction(null));
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MessageDeliveryStatusBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MessageDeliveryStatusBox.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list.message_box;
+
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatMessage;
+import bisq.desktop.common.utils.ImageUtil;
+import bisq.desktop.components.controls.BisqMenuItem;
+import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
+import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
+import bisq.i18n.Res;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.Subscription;
+
+public class MessageDeliveryStatusBox extends HBox {
+    private final Subscription shouldShowTryAgainPin, messageDeliveryStatusNodePin;
+    private final BisqMenuItem tryAgainMenuItem;
+
+    public MessageDeliveryStatusBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
+                                    ChatMessagesListController controller) {
+        super(5);
+        setAlignment(Pos.CENTER);
+
+        Label deliveryStateIcon = new Label();
+        BisqTooltip deliveryStateIconToolTip = new BisqTooltip();
+        deliveryStateIcon.setTooltip(deliveryStateIconToolTip);
+
+        HBox deliveryStateHBox = new HBox(deliveryStateIcon);
+        deliveryStateHBox.setAlignment(Pos.CENTER);
+
+        tryAgainMenuItem = new BisqMenuItem("try-again-grey", "try-again-white");
+        tryAgainMenuItem.useIconOnly(22);
+        tryAgainMenuItem.setTooltip(new BisqTooltip(Res.get("chat.message.resendMessage")));
+
+        getChildren().addAll(tryAgainMenuItem, deliveryStateHBox);
+
+        messageDeliveryStatusNodePin = EasyBind.subscribe(item.getMessageDeliveryStatus(), status -> {
+            setManaged(status != null);
+            setVisible(status != null);
+            deliveryStateIconToolTip.setText(item.getMessageDeliveryStatusTooltip());
+            if (status != null) {
+                switch (status) {
+                    // Successful delivery
+                    case ACK_RECEIVED:
+                    case MAILBOX_MSG_RECEIVED:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("received-check-grey"));
+                        break;
+                    // Pending delivery
+                    case CONNECTING:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("connecting-grey"));
+                        break;
+                    case SENT:
+                    case TRY_ADD_TO_MAILBOX:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("sent-message-grey"));
+                        break;
+                    case ADDED_TO_MAILBOX:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("mailbox-grey"));
+                        break;
+                    case FAILED:
+                        deliveryStateIcon.setGraphic(ImageUtil.getImageViewById("undelivered-message-yellow"));
+                        break;
+                }
+            }
+        });
+
+        shouldShowTryAgainPin = EasyBind.subscribe(item.getCanManuallyResendMessage(), showTryAgain -> {
+            tryAgainMenuItem.setVisible(showTryAgain);
+            tryAgainMenuItem.setManaged(showTryAgain);
+            if (showTryAgain) {
+                tryAgainMenuItem.setOnAction(e -> controller.onResendMessage(item.getMessageId()));
+            } else {
+                tryAgainMenuItem.setOnAction(null);
+            }
+        });
+    }
+
+    public void dispose() {
+        shouldShowTryAgainPin.unsubscribe();
+        messageDeliveryStatusNodePin.unsubscribe();
+        tryAgainMenuItem.setOnAction(null);
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -114,7 +114,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         HBox.setMargin(editInputField, new Insets(6, -10, -25, 0));
         messageBgHBox.getChildren().setAll(messageVBox, userProfileIconVbox);
 
-        shouldShowTryAgainPin = EasyBind.subscribe(item.getShouldShowTryAgain(), showTryAgain -> {
+        shouldShowTryAgainPin = EasyBind.subscribe(item.getCanManuallyResendMessage(), showTryAgain -> {
             tryAgainMenuItem.setVisible(showTryAgain);
             tryAgainMenuItem.setManaged(showTryAgain);
             if (showTryAgain) {

--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
@@ -176,10 +176,13 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
         String shortUid = StringUtils.createUid();
         long date = new Date().getTime();
         if (channel.isInMediation() && channel.getMediator().isPresent()) {
+            String senderId = channel.getMyUserIdentity().getId();
             List<CompletableFuture<SendMessageResult>> futures = channel.getTraders().stream()
+                    .filter(peer -> !peer.getId().equals(senderId))
                     .map(peer -> sendMessage(shortUid, text, citation, channel, peer, chatMessageType, date))
                     .collect(Collectors.toList());
             channel.getMediator()
+                    .filter(mediator -> !mediator.getId().equals(senderId))
                     .map(mediator -> sendMessage(shortUid, text, citation, channel, mediator, chatMessageType, date))
                     .ifPresent(futures::add);
             return CompletableFutureUtils.allOf(futures)

--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessage.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessage.java
@@ -48,6 +48,8 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public final class BisqEasyOpenTradeMessage extends PrivateChatMessage<BisqEasyOpenTradeMessageReaction> implements BisqEasyOfferMessage {
+    public static final String ACK_REQUESTING_MESSAGE_ID_SEPARATOR = "_";
+
     public static BisqEasyOpenTradeMessage createTakeOfferMessage(String tradeId,
                                                                   String channelId,
                                                                   UserProfile senderUserProfile,
@@ -224,5 +226,10 @@ public final class BisqEasyOpenTradeMessage extends PrivateChatMessage<BisqEasyO
     @Override
     public boolean addChatMessageReaction(ChatMessageReaction chatMessageReaction) {
         return addPrivateChatMessageReaction((BisqEasyOpenTradeMessageReaction) chatMessageReaction);
+    }
+
+    @Override
+    public String getAckRequestingMessageId() {
+        return id + ACK_REQUESTING_MESSAGE_ID_SEPARATOR + receiverUserProfileId;
     }
 }

--- a/chat/src/main/java/bisq/chat/priv/PrivateChatMessage.java
+++ b/chat/src/main/java/bisq/chat/priv/PrivateChatMessage.java
@@ -130,6 +130,11 @@ public abstract class PrivateChatMessage<R extends ChatMessageReaction> extends 
         return receiverNetworkId;
     }
 
+    @Override
+    public String getAckRequestingMessageId() {
+        return id;
+    }
+
     public boolean addPrivateChatMessageReaction(R newReaction) {
         Optional<R> existingReaction = getChatMessageReactions().stream()
                 .filter(privateChatReaction -> privateChatReaction.matches(newReaction))

--- a/chat/src/main/java/bisq/chat/reactions/ChatMessageReaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/ChatMessageReaction.java
@@ -35,7 +35,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Getter
 @EqualsAndHashCode
 public abstract class ChatMessageReaction implements NetworkProto {
-    private final String id;
+    protected final String id;
     protected final String userProfileId;
     private final String chatChannelId;
     private final ChatChannelDomain chatChannelDomain;

--- a/chat/src/main/java/bisq/chat/reactions/PrivateChatMessageReaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/PrivateChatMessageReaction.java
@@ -76,4 +76,9 @@ public abstract class PrivateChatMessageReaction extends ChatMessageReaction imp
     public NetworkId getReceiver() {
         return receiverNetworkId;
     }
+
+    @Override
+    public String getAckRequestingMessageId() {
+        return id;
+    }
 }

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -213,6 +213,7 @@ chat.message.deliveryState.MAILBOX_MSG_RECEIVED=Peer has downloaded mailbox mess
 # suppress inspection "UnusedProperty"
 chat.message.deliveryState.FAILED=Sending message failed.
 chat.message.resendMessage=Click to resend the message.
+chat.message.deliveryState.multiplePeers=Message delivery status for {0}:\n{1}
 
 chat.message.contextMenu.ignoreUser=Ignore user
 chat.message.contextMenu.reportUser=Report user to moderator

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessageService.java
@@ -311,7 +311,7 @@ public class ConfidentialMessageService implements Node.Listener, DataService.Li
     private void handleResult(EnvelopePayloadMessage envelopePayloadMessage, SendConfidentialMessageResult result) {
         if (envelopePayloadMessage instanceof AckRequestingMessage) {
             messageDeliveryStatusService.ifPresent(service -> {
-                String messageId = ((AckRequestingMessage) envelopePayloadMessage).getId();
+                String messageId = ((AckRequestingMessage) envelopePayloadMessage).getAckRequestingMessageId();
                 service.applyMessageDeliveryStatus(messageId, result.getMessageDeliveryStatus());
 
                 // If we tried to store in mailbox we check if at least one successful broadcast happened

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ConfidentialMessageService.java
@@ -311,8 +311,8 @@ public class ConfidentialMessageService implements Node.Listener, DataService.Li
     private void handleResult(EnvelopePayloadMessage envelopePayloadMessage, SendConfidentialMessageResult result) {
         if (envelopePayloadMessage instanceof AckRequestingMessage) {
             messageDeliveryStatusService.ifPresent(service -> {
-                String messageId = ((AckRequestingMessage) envelopePayloadMessage).getAckRequestingMessageId();
-                service.applyMessageDeliveryStatus(messageId, result.getMessageDeliveryStatus());
+                String ackRequestingMessageId = ((AckRequestingMessage) envelopePayloadMessage).getAckRequestingMessageId();
+                service.applyMessageDeliveryStatus(ackRequestingMessageId, result.getMessageDeliveryStatus());
 
                 // If we tried to store in mailbox we check if at least one successful broadcast happened
                 if (result.getMessageDeliveryStatus() == MessageDeliveryStatus.TRY_ADD_TO_MAILBOX) {
@@ -320,10 +320,10 @@ public class ConfidentialMessageService implements Node.Listener, DataService.Li
                             .whenComplete((broadcastResult, throwable) -> {
                                 if (throwable != null || broadcastResult.getNumSuccess() == 0) {
                                     log.warn("mailboxFuture completed and resulted in MessageDeliveryStatus.FAILED");
-                                    service.applyMessageDeliveryStatus(messageId, MessageDeliveryStatus.FAILED);
+                                    service.applyMessageDeliveryStatus(ackRequestingMessageId, MessageDeliveryStatus.FAILED);
                                 } else {
                                     log.info("mailboxFuture completed and resulted in MessageDeliveryStatus.ADDED_TO_MAILBOX");
-                                    service.applyMessageDeliveryStatus(messageId, MessageDeliveryStatus.ADDED_TO_MAILBOX);
+                                    service.applyMessageDeliveryStatus(ackRequestingMessageId, MessageDeliveryStatus.ADDED_TO_MAILBOX);
                                 }
                             });
                 }

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/AckRequestingMessage.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/AckRequestingMessage.java
@@ -11,7 +11,7 @@ public interface AckRequestingMessage extends Request {
     /**
      * @return The message ID
      */
-    String getId();
+    String getAckRequestingMessageId();
 
     /**
      * @return The NetworkId of the sender of that message.
@@ -30,6 +30,6 @@ public interface AckRequestingMessage extends Request {
     }
 
     default String getRequestId() {
-        return getId();
+        return getAckRequestingMessageId();
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusService.java
@@ -117,11 +117,11 @@ public class MessageDeliveryStatusService implements PersistenceClient<MessageDe
     // API
     /* --------------------------------------------------------------------- */
 
-    public void applyMessageDeliveryStatus(String messageId, MessageDeliveryStatus status) {
+    public void applyMessageDeliveryStatus(String ackRequestingMessageId, MessageDeliveryStatus status) {
         Map<String, Observable<MessageDeliveryStatus>> messageDeliveryStatusByMessageId = getMessageDeliveryStatusByMessageId();
         synchronized (messageDeliveryStatusByMessageId) {
-            if (messageDeliveryStatusByMessageId.containsKey(messageId)) {
-                Observable<MessageDeliveryStatus> observableStatus = messageDeliveryStatusByMessageId.get(messageId);
+            if (messageDeliveryStatusByMessageId.containsKey(ackRequestingMessageId)) {
+                Observable<MessageDeliveryStatus> observableStatus = messageDeliveryStatusByMessageId.get(ackRequestingMessageId);
                 // If we have already a received state we return.
                 // This ensures that a later received failed state from one transport does not overwrite the received state from
                 // another transport.
@@ -130,11 +130,11 @@ public class MessageDeliveryStatusService implements PersistenceClient<MessageDe
                 }
                 observableStatus.set(status);
             } else {
-                persistableStore.getCreationDateByMessageId().putIfAbsent(messageId, System.currentTimeMillis());
-                messageDeliveryStatusByMessageId.put(messageId, new Observable<>(status));
+                persistableStore.getCreationDateByMessageId().putIfAbsent(ackRequestingMessageId, System.currentTimeMillis());
+                messageDeliveryStatusByMessageId.put(ackRequestingMessageId, new Observable<>(status));
             }
-            log.info("Persist MessageDeliveryStatus {} with message ID {}",
-                    messageDeliveryStatusByMessageId.get(messageId).get(), messageId);
+            log.info("Persist MessageDeliveryStatus {} with ackRequestingMessageId {}",
+                    messageDeliveryStatusByMessageId.get(ackRequestingMessageId).get(), ackRequestingMessageId);
             persist();
         }
     }

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusService.java
@@ -183,19 +183,19 @@ public class MessageDeliveryStatusService implements PersistenceClient<MessageDe
             return;
         }
 
-        if (ackedMessageIds.contains(message.getId())) {
+        if (ackedMessageIds.contains(message.getAckRequestingMessageId())) {
             log.warn("We received already that AckRequestingMessage and sent the AckMessage");
             return;
         }
 
-        AckMessage ackMessage = new AckMessage(message.getId());
+        AckMessage ackMessage = new AckMessage(message.getAckRequestingMessageId());
         NetworkId networkId = message.getReceiver();
         keyBundleService.findKeyPair(networkId.getPubKey().getKeyId())
                 .ifPresent(keyPair -> {
-                    log.info("Received a {} with message ID {}", message.getClass().getSimpleName(), message.getId());
+                    log.info("Received a {} with message ID {}", message.getClass().getSimpleName(), message.getAckRequestingMessageId());
                     NetworkIdWithKeyPair networkIdWithKeyPair = new NetworkIdWithKeyPair(networkId, keyPair);
                     networkService.confidentialSend(ackMessage, message.getSender(), networkIdWithKeyPair);
-                    ackedMessageIds.add(message.getId());
+                    ackedMessageIds.add(message.getAckRequestingMessageId());
                 });
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/resend/ResendMessageData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/resend/ResendMessageData.java
@@ -121,7 +121,7 @@ public class ResendMessageData implements NetworkProto {
     }
 
     public String getId() {
-        return getAckRequestingMessage().getId();
+        return getAckRequestingMessage().getAckRequestingMessageId();
     }
 
     public AckRequestingMessage getAckRequestingMessage() {

--- a/support/src/main/java/bisq/support/mediation/MediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/MediationRequest.java
@@ -129,7 +129,7 @@ public final class MediationRequest implements MailboxMessage, ExternalNetworkMe
     /* --------------------------------------------------------------------- */
 
     @Override
-    public String getId() {
+    public String getAckRequestingMessageId() {
         return createMessageId(tradeId);
     }
 

--- a/trade/src/main/java/bisq/trade/protocol/messages/TradeMessage.java
+++ b/trade/src/main/java/bisq/trade/protocol/messages/TradeMessage.java
@@ -67,6 +67,11 @@ public abstract class TradeMessage implements MailboxMessage, ExternalNetworkMes
                 .setReceiver(receiver.toProto(serializeForHash));
     }
 
+    @Override
+    public String getAckRequestingMessageId() {
+        return id;
+    }
+
     abstract public bisq.trade.protobuf.TradeMessage.Builder getValueBuilder(boolean serializeForHash);
 
     public static TradeMessage fromProto(bisq.trade.protobuf.TradeMessage proto) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/3268

In mediation: messages  to both peers failed
![Screenshot 2025-03-07 at 17 48 25](https://github.com/user-attachments/assets/d7533ebd-6c31-4a1c-9b25-4481fa4a2d55)

Resent one:
![Screenshot 2025-03-07 at 17 48 12](https://github.com/user-attachments/assets/7e501f70-c981-4dc5-a584-a29376f98f66)

Tooltip gives info which peer:
![Screenshot 2025-03-07 at 17 24 50](https://github.com/user-attachments/assets/6909201c-03df-4932-9af6-ef25929c08c6)
