### PR TITLE
Add more improvements to the offerbook list splitpane

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -362,7 +362,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         header.setMinHeight(HEADER_HEIGHT);
         header.setMaxHeight(HEADER_HEIGHT);
         header.setAlignment(Pos.CENTER_LEFT);
-        header.setPadding(new Insets(4, 0, 0, 15));
+        header.setPadding(new Insets(4, 0, 0, 7));
         header.getStyleClass().add("chat-header-title");
 
         marketSelectorSearchBox = new SearchBox();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -306,6 +306,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         double finalPosition = calculateNormalizedPosition(showOfferListExpanded);
         Transitions.animateDividerPosition(divider, initialPosition, finalPosition, SPLITPANE_ANIMATION_DURATION);
         updateChatContainerStyleClass();
+        updateSplitPaneStyleClass(showOfferListExpanded);
     }
 
     private double calculateNormalizedPosition(boolean showOfferListExpanded) {
@@ -340,6 +341,14 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
             VBox.setMargin(chatVBox, offerListExpandedInsets);
         }
         chatVBox.getStyleClass().add(styleClass);
+    }
+
+    private void updateSplitPaneStyleClass(boolean showOfferListExpanded) {
+        String collapsedOfferlistStyle = "split-pane-w-offerlist-collapsed";
+        splitPane.getStyleClass().remove(collapsedOfferlistStyle);
+        if (!showOfferListExpanded) {
+            splitPane.getStyleClass().add(collapsedOfferlistStyle);
+        }
     }
 
     private BisqEasyOfferbookModel getModel() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -523,7 +523,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
         subheader.getStyleClass().add("offerbook-subheader");
         subheader.setAlignment(Pos.CENTER);
 
-        chatMessagesComponent.setMinWidth(700);
+        chatMessagesComponent.setMinWidth(505);
 
         VBox.setVgrow(chatMessagesComponent, Priority.ALWAYS);
         chatVBox = new VBox(titleHBox, Layout.hLine(), subheader, chatMessagesComponent);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
@@ -262,7 +262,7 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
 
     private void expandListView() {
         header.setAlignment(Pos.CENTER_LEFT);
-        header.setPadding(new Insets(4, 0, 0, 15));
+        header.setPadding(new Insets(4, 0, 0, 7));
         root.setMaxWidth(Double.MAX_VALUE);
         root.setMinWidth(COLLAPSED_LIST_WIDTH);
         content.getStyleClass().remove("collapsed-offer-list-container");

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -381,6 +381,10 @@
     -fx-background-color: -bisq-dark-grey-20;
 }
 
+.split-pane-w-offerlist-collapsed:horizontal > .split-pane-divider {
+    -fx-cursor: default;
+}
+
 .create-offer-button {
     -fx-background-color: -fx-default-button;
     -fx-text-fill: -fx-light-text-color;


### PR DESCRIPTION
- Fix margins for a smoother transition
- Reduce min width of offerbook chatbox
- Hide splitpane horizontal resize cursor when offerlist is collapsed