### PR TITLE
Revert relax tor control success reply commit 8004e691d

### DIFF
--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
@@ -346,6 +346,6 @@ public class TorControlProtocol implements AutoCloseable {
     }
 
     private boolean isSuccessReply(String reply) {
-        return reply.startsWith("250");
+        return reply.equals("250 OK");
     }
 }


### PR DESCRIPTION
The relaxed version was introduced as I observed a failure at `SETEVENTS HS_DESC` when I received a `250-ServiceID=jegykan32vgws363nx436ptrqhtbfcb6mibax7da7f62gpcxsy5hwlid` instead of a `250 OK` reply.

But in most cases the `250 OK` reply is the expected one. For multiline replies it would require parsing the reply until the end, and according to @alvasw we do not need to support that multi line reply in that case.