### PR TITLE
fix crash on generating swagger docs

### DIFF
--- a/apps/http-api-app/src/main/java/bisq/http_api_node/HttpApiApp.java
+++ b/apps/http-api-app/src/main/java/bisq/http_api_node/HttpApiApp.java
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * JAX-RS application for the Bisq REST API
- * Swagger docs at: http://localhost:8082/doc/v1/index.html
+ * Swagger docs at: http://localhost:8090/doc/v1/index.html
  */
 @Slf4j
 public class HttpApiApp extends Executable<HttpApiApplicationService> {

--- a/apps/http-api-app/src/main/java/bisq/http_api_node/HttpApiApp.java
+++ b/apps/http-api-app/src/main/java/bisq/http_api_node/HttpApiApp.java
@@ -23,7 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * JAX-RS application for the Bisq REST API
- * Swagger docs at: http://localhost:8090/doc/v1/index.html
+ * Swagger docs at: http://localhost:8090/doc/v1/index.html or http://localhost:8082/doc/v1/index.html in case RestAPI
+ * is used without websockets
  */
 @Slf4j
 public class HttpApiApp extends Executable<HttpApiApplicationService> {

--- a/http-api/src/main/java/bisq/http_api/HttpApiService.java
+++ b/http-api/src/main/java/bisq/http_api/HttpApiService.java
@@ -45,7 +45,8 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * JAX-RS application for the Bisq REST API
- * Swagger docs at: http://localhost:8090/doc/v1/index.html
+ * Swagger docs at: http://localhost:8090/doc/v1/index.html or http://localhost:8082/doc/v1/index.html in case RestAPI
+ * is used without websockets
  */
 @Slf4j
 public class HttpApiService implements Service {

--- a/http-api/src/main/java/bisq/http_api/HttpApiService.java
+++ b/http-api/src/main/java/bisq/http_api/HttpApiService.java
@@ -45,7 +45,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * JAX-RS application for the Bisq REST API
- * Swagger docs at: http://localhost:8082/doc/v1/index.html
+ * Swagger docs at: http://localhost:8090/doc/v1/index.html
  */
 @Slf4j
 public class HttpApiService implements Service {

--- a/http-api/src/main/java/bisq/http_api/rest_api/RestApiService.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/RestApiService.java
@@ -33,7 +33,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * JAX-RS application for the Bisq REST API
- * Swagger docs at: http://localhost:8090/doc/v1/index.html
+ * Swagger docs at: http://localhost:8090/doc/v1/index.html or http://localhost:8082/doc/v1/index.html in case RestAPI
+ * is used without websockets
  */
 @Slf4j
 public class RestApiService implements Service {

--- a/http-api/src/main/java/bisq/http_api/rest_api/RestApiService.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/RestApiService.java
@@ -33,7 +33,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * JAX-RS application for the Bisq REST API
- * Swagger docs at: http://localhost:8082/doc/v1/index.html
+ * Swagger docs at: http://localhost:8090/doc/v1/index.html
  */
 @Slf4j
 public class RestApiService implements Service {

--- a/http-api/src/main/java/bisq/http_api/web_socket/util/GrizzlySwaggerHttpHandler.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/util/GrizzlySwaggerHttpHandler.java
@@ -25,6 +25,7 @@ import org.glassfish.grizzly.http.server.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -54,7 +55,6 @@ public class GrizzlySwaggerHttpHandler extends HttpHandler {
             
             // Read all bytes to determine content length instead of using Paths which causes a crash in most cases
             byte[] data = inputStream.readAllBytes();
-            response.setContentLengthLong(data.length);
             setContentType(response, resourceName);
             response.getOutputStream().write(data);
         } catch (IOException e) {
@@ -70,23 +70,11 @@ public class GrizzlySwaggerHttpHandler extends HttpHandler {
      * @param resourceName to determine the content type of
      */
     private void setContentType(Response response, String resourceName) {
-        if (resourceName.endsWith(".html")) {
-            response.setContentType("text/html");
-        } else if (resourceName.endsWith(".css")) {
-            response.setContentType("text/css");
-        } else if (resourceName.endsWith(".js")) {
-            response.setContentType("application/javascript");
-        } else if (resourceName.endsWith(".json")) {
-            response.setContentType("application/json");
-        } else if (resourceName.endsWith(".png")) {
-            response.setContentType("image/png");
-        } else if (resourceName.endsWith(".jpg") || resourceName.endsWith(".jpeg")) {
-            response.setContentType("image/jpeg");
-        } else if (resourceName.endsWith(".svg")) {
-            response.setContentType("image/svg+xml");
-        } else {
-            response.setContentType("application/octet-stream");
+        String contentType = URLConnection.guessContentTypeFromName(resourceName);
+        if (contentType == null) {
+            contentType = "application/octet-stream"; // Default binary
         }
+        response.setContentType(contentType);
     }
 }
 


### PR DESCRIPTION
 - fix crash when generating swagger docs for http-api, and code docs default port
 
 
<img width="1492" alt="Screenshot 2025-03-20 at 15 32 11" src="https://github.com/user-attachments/assets/e8a451c3-1878-4679-848f-1c31d938f832" />
