### PR TITLE
REST_API/payment accounts

### DIFF
--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -242,7 +242,8 @@ public class DesktopApplicationService extends JavaSeApplicationService {
                 supportService,
                 tradeService,
                 settingsService,
-                openTradeItemsService);
+                openTradeItemsService,
+                accountService);
     }
 
     @Override

--- a/apps/http-api-app/src/main/java/bisq/http_api_node/HttpApiApplicationService.java
+++ b/apps/http-api-app/src/main/java/bisq/http_api_node/HttpApiApplicationService.java
@@ -178,7 +178,8 @@ public class HttpApiApplicationService extends JavaSeApplicationService {
                 supportService,
                 tradeService,
                 settingsService,
-                openTradeItemsService);
+                openTradeItemsService,
+                accountService);
     }
 
     @Override

--- a/http-api/src/main/java/bisq/dto/DtoMappings.java
+++ b/http-api/src/main/java/bisq/dto/DtoMappings.java
@@ -17,6 +17,7 @@
 
 package bisq.dto;
 
+import bisq.account.AccountService;
 import bisq.account.payment_method.BitcoinPaymentMethod;
 import bisq.account.payment_method.FiatPaymentMethod;
 import bisq.account.protocol_type.TradeProtocolType;
@@ -38,6 +39,7 @@ import bisq.contract.ContractSignatureData;
 import bisq.contract.Party;
 import bisq.contract.Role;
 import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.dto.account.UserDefinedFiatAccountDto;
 import bisq.dto.account.protocol_type.TradeProtocolTypeDto;
 import bisq.dto.chat.ChatMessageTypeDto;
 import bisq.dto.chat.CitationDto;
@@ -982,7 +984,6 @@ public class DtoMappings {
             );
         }
     }
-
 
     // trade
 

--- a/http-api/src/main/java/bisq/dto/DtoMappings.java
+++ b/http-api/src/main/java/bisq/dto/DtoMappings.java
@@ -18,6 +18,7 @@
 package bisq.dto;
 
 import bisq.account.AccountService;
+import bisq.account.accounts.UserDefinedFiatAccount;
 import bisq.account.payment_method.BitcoinPaymentMethod;
 import bisq.account.payment_method.FiatPaymentMethod;
 import bisq.account.protocol_type.TradeProtocolType;
@@ -40,6 +41,7 @@ import bisq.contract.Party;
 import bisq.contract.Role;
 import bisq.contract.bisq_easy.BisqEasyContract;
 import bisq.dto.account.UserDefinedFiatAccountDto;
+import bisq.dto.account.UserDefinedFiatAccountPayloadDto;
 import bisq.dto.account.protocol_type.TradeProtocolTypeDto;
 import bisq.dto.chat.ChatMessageTypeDto;
 import bisq.dto.chat.CitationDto;
@@ -981,6 +983,20 @@ public class DtoMappings {
                     MarketMapping.fromBisq2Model(settingsService.getSelectedMarket().get()),
                     settingsService.getNumDaysAfterRedactingTradeData().get(),
                     settingsService.getUseAnimations().get()
+            );
+        }
+    }
+
+    // paymentaccount
+    public static class UserDefinedFiatAccountMapping {
+        // toBisq2Model method not implemented, as we get accountName, accountData props for account creation calls
+
+        public static UserDefinedFiatAccountDto fromBisq2Model(UserDefinedFiatAccount account) {
+            return new UserDefinedFiatAccountDto(
+                    account.getAccountName(),
+                    new UserDefinedFiatAccountPayloadDto(
+                            account.getAccountPayload().getAccountData()
+                    )
             );
         }
     }

--- a/http-api/src/main/java/bisq/dto/account/UserDefinedFiatAccountDto.java
+++ b/http-api/src/main/java/bisq/dto/account/UserDefinedFiatAccountDto.java
@@ -1,0 +1,7 @@
+package bisq.dto.account;
+
+public record UserDefinedFiatAccountDto(
+    String accountName,
+    UserDefinedFiatAccountPayloadDto accountPayload
+) { }
+

--- a/http-api/src/main/java/bisq/dto/account/UserDefinedFiatAccountPayloadDto.java
+++ b/http-api/src/main/java/bisq/dto/account/UserDefinedFiatAccountPayloadDto.java
@@ -1,0 +1,5 @@
+package bisq.dto.account;
+
+public record UserDefinedFiatAccountPayloadDto(
+        String accountData
+) { }

--- a/http-api/src/main/java/bisq/http_api/HttpApiService.java
+++ b/http-api/src/main/java/bisq/http_api/HttpApiService.java
@@ -17,6 +17,7 @@
 
 package bisq.http_api;
 
+import bisq.account.AccountService;
 import bisq.bonded_roles.BondedRolesService;
 import bisq.chat.ChatService;
 import bisq.common.application.Service;
@@ -26,6 +27,7 @@ import bisq.http_api.rest_api.RestApiService;
 import bisq.http_api.rest_api.domain.explorer.ExplorerRestApi;
 import bisq.http_api.rest_api.domain.market_price.MarketPriceRestApi;
 import bisq.http_api.rest_api.domain.offers.OfferbookRestApi;
+import bisq.http_api.rest_api.domain.payment_accounts.PaymentAccountsRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
@@ -62,7 +64,8 @@ public class HttpApiService implements Service {
                           SupportService supportedService,
                           TradeService tradeService,
                           SettingsService settingsService,
-                          OpenTradeItemsService openTradeItemsService) {
+                          OpenTradeItemsService openTradeItemsService,
+                          AccountService accountService) {
         boolean restApiConfigEnabled = restApiConfig.isEnabled();
         boolean webSocketConfigEnabled = webSocketConfig.isEnabled();
         if (restApiConfigEnabled || webSocketConfigEnabled) {
@@ -77,6 +80,7 @@ public class HttpApiService implements Service {
             UserIdentityRestApi userIdentityRestApi = new UserIdentityRestApi(securityService, userService.getUserIdentityService());
             MarketPriceRestApi marketPriceRestApi = new MarketPriceRestApi(bondedRolesService.getMarketPriceService());
             SettingsRestApi settingsRestApi = new SettingsRestApi(settingsService);
+            PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
             ExplorerRestApi explorerRestApi = new ExplorerRestApi(bondedRolesService.getExplorerService());
             if (restApiConfigEnabled) {
                 var restApiResourceConfig = new RestApiResourceConfig(restApiConfig.getRestApiBaseUrl(),
@@ -85,7 +89,8 @@ public class HttpApiService implements Service {
                         userIdentityRestApi,
                         marketPriceRestApi,
                         settingsRestApi,
-                        explorerRestApi);
+                        explorerRestApi,
+                        paymentAccountsRestApi);
                 this.restApiService = Optional.of(new RestApiService(restApiConfig, restApiResourceConfig));
             } else {
                 this.restApiService = Optional.empty();
@@ -98,7 +103,8 @@ public class HttpApiService implements Service {
                         userIdentityRestApi,
                         marketPriceRestApi,
                         settingsRestApi,
-                        explorerRestApi);
+                        explorerRestApi,
+                        paymentAccountsRestApi);
                 this.webSocketService = Optional.of(new WebSocketService(webSocketConfig,
                         webSocketConfig.getRestApiBaseAddress(),
                         webSocketResourceConfig,

--- a/http-api/src/main/java/bisq/http_api/rest_api/RestApiResourceConfig.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/RestApiResourceConfig.java
@@ -3,6 +3,7 @@ package bisq.http_api.rest_api;
 import bisq.http_api.rest_api.domain.explorer.ExplorerRestApi;
 import bisq.http_api.rest_api.domain.market_price.MarketPriceRestApi;
 import bisq.http_api.rest_api.domain.offers.OfferbookRestApi;
+import bisq.http_api.rest_api.domain.payment_accounts.PaymentAccountsRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
@@ -19,7 +20,8 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
                                  UserIdentityRestApi userIdentityRestApi ,
                                  MarketPriceRestApi marketPriceRestApi,
                                  SettingsRestApi settingsRestApi,
-                                 ExplorerRestApi explorerRestApi) {
+                                 ExplorerRestApi explorerRestApi,
+                                 PaymentAccountsRestApi paymentAccountsRestApi) {
         super(swaggerBaseUrl);
 
         //todo apply filtering with whiteListEndPoints/whiteListEndPoints
@@ -33,6 +35,7 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
         register(MarketPriceRestApi.class);
         register(SettingsRestApi.class);
         register(ExplorerRestApi.class);
+        register(PaymentAccountsRestApi.class);
 
         register(new AbstractBinder() {
             @Override
@@ -43,6 +46,7 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
                 bind(marketPriceRestApi).to(MarketPriceRestApi.class);
                 bind(settingsRestApi).to(SettingsRestApi.class);
                 bind(explorerRestApi).to(ExplorerRestApi.class);
+                bind(paymentAccountsRestApi).to(PaymentAccountsRestApi.class);
             }
         });
     }

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/AddAccountRequest.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/AddAccountRequest.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.http_api.rest_api.domain.payment_accounts;
+
+import bisq.dto.common.currency.MarketDto;
+import bisq.dto.offer.DirectionDto;
+import bisq.dto.offer.amount.spec.AmountSpecDto;
+import bisq.dto.offer.price.spec.PriceSpecDto;
+
+import java.util.Set;
+
+public record AddAccountRequest(String accountName,
+                                String accountData) {
+}

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/AddAccountRequest.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/AddAccountRequest.java
@@ -17,13 +17,8 @@
 
 package bisq.http_api.rest_api.domain.payment_accounts;
 
-import bisq.dto.common.currency.MarketDto;
-import bisq.dto.offer.DirectionDto;
-import bisq.dto.offer.amount.spec.AmountSpecDto;
-import bisq.dto.offer.price.spec.PriceSpecDto;
-
 import java.util.Set;
 
-public record AddAccountRequest(String accountName,
-                                String accountData) {
-}
+public record AddAccountRequest(
+        String accountName,
+        String accountData) { }

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/AddAccountResponse.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/AddAccountResponse.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.http_api.rest_api.domain.payment_accounts;
+
+public record AddAccountResponse(String accountName) {
+}

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/PaymentAccountChangeRequest.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/PaymentAccountChangeRequest.java
@@ -17,4 +17,11 @@
 
 package bisq.http_api.rest_api.domain.payment_accounts;
 
-public record AddAccountResponse(String accountName) { }
+import bisq.dto.account.UserDefinedFiatAccountDto;
+
+import javax.annotation.Nullable;
+
+public record PaymentAccountChangeRequest(
+        @Nullable UserDefinedFiatAccountDto selectedAccount
+) {
+}

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/PaymentAccountsRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/payment_accounts/PaymentAccountsRestApi.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.http_api.rest_api.domain.payment_accounts;
+
+import bisq.account.AccountService;
+import bisq.account.accounts.Account;
+import bisq.account.accounts.UserDefinedFiatAccount;
+import bisq.account.payment_method.*;
+import bisq.bisq_easy.BisqEasyServiceUtil;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.currency.Market;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.dto.DtoMappings;
+import bisq.dto.account.UserDefinedFiatAccountDto;
+import bisq.dto.account.UserDefinedFiatAccountPayloadDto;
+import bisq.dto.settings.SettingsDto;
+import bisq.http_api.rest_api.domain.RestApiBase;
+import bisq.http_api.rest_api.domain.offers.CreateOfferRequest;
+import bisq.http_api.rest_api.domain.offers.CreateOfferResponse;
+import bisq.http_api.rest_api.domain.settings.SettingsChangeRequest;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.AmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.PriceSpec;
+import bisq.user.identity.UserIdentity;
+import bisq.user.profile.UserProfile;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Path("/payment_accounts")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Payment Accounts API", description = "API for managing user payment accounts")
+public class PaymentAccountsRestApi extends RestApiBase {
+    private final AccountService accountService;
+
+    public PaymentAccountsRestApi(AccountService accountService) {
+        this.accountService = accountService;
+    }
+
+    @GET
+    @Operation(
+            summary = "Get user payment accounts",
+            description = "Retrieve the payment accounts",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Payment accounts retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = SettingsDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getPaymentAccounts() {
+        try {
+            Map<String, Account<?, ? extends PaymentMethod<?>>> accountByNameMap = accountService.getAccountByNameMap();
+
+            List<Account<?, ? extends PaymentMethod<?>>> accountsList = new ArrayList<>(accountByNameMap.values());
+
+            List<UserDefinedFiatAccountDto> userAccounts = new ArrayList<>();
+            for (Account<?, ? extends PaymentMethod<?>> account : accountsList) {
+                if (account instanceof UserDefinedFiatAccount) {
+                    UserDefinedFiatAccount castedAccount = (UserDefinedFiatAccount) account;
+                    userAccounts.add(
+                            new UserDefinedFiatAccountDto(
+                                    castedAccount.getAccountName(),
+                                    new UserDefinedFiatAccountPayloadDto(
+                                            castedAccount.getAccountPayload().getAccountData()
+                                    )
+                            )
+                    );
+                }
+            }
+
+            return buildOkResponse(userAccounts);
+        } catch (Exception e) {
+            log.error("Failed to retrieve payment accounts", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @POST
+    @Operation(
+            summary = "Add new user payment account",
+            description = "Add new user payment account",
+            requestBody = @RequestBody(
+                    description = "",
+                    content = @Content(schema = @Schema(implementation = AddAccountRequest.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "",
+                            content = @Content(schema = @Schema(example = ""))),
+                    @ApiResponse(responseCode = "400", description = "Invalid input"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public void addAccount(AddAccountRequest request, @Suspended AsyncResponse asyncResponse) {
+        asyncResponse.setTimeout(10, TimeUnit.SECONDS);
+        asyncResponse.setTimeoutHandler(response -> {
+            response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out"));
+        });
+        try {
+            accountService.addPaymentAccount(new UserDefinedFiatAccount(request.accountName(), request.accountData()));
+            asyncResponse.resume(buildResponse(Response.Status.CREATED, new AddAccountResponse(request.accountName())));
+        } catch (Exception e) {
+            asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
+        }
+    }
+}

--- a/http-api/src/main/java/bisq/http_api/web_socket/WebSocketRestApiResourceConfig.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/WebSocketRestApiResourceConfig.java
@@ -4,6 +4,7 @@ import bisq.http_api.rest_api.RestApiResourceConfig;
 import bisq.http_api.rest_api.domain.explorer.ExplorerRestApi;
 import bisq.http_api.rest_api.domain.market_price.MarketPriceRestApi;
 import bisq.http_api.rest_api.domain.offers.OfferbookRestApi;
+import bisq.http_api.rest_api.domain.payment_accounts.PaymentAccountsRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
@@ -19,7 +20,8 @@ public class WebSocketRestApiResourceConfig extends RestApiResourceConfig {
                                           UserIdentityRestApi userIdentityRestApi,
                                           MarketPriceRestApi marketPriceRestApi,
                                           SettingsRestApi settingsRestApi,
-                                          ExplorerRestApi explorerRestApi) {
-        super(swaggerBaseUrl, offerbookRestApi, tradeRestApi, userIdentityRestApi, marketPriceRestApi, settingsRestApi, explorerRestApi);
+                                          ExplorerRestApi explorerRestApi,
+                                          PaymentAccountsRestApi paymentAccountsRestApi) {
+        super(swaggerBaseUrl, offerbookRestApi, tradeRestApi, userIdentityRestApi, marketPriceRestApi, settingsRestApi, explorerRestApi, paymentAccountsRestApi);
     }
 }


### PR DESCRIPTION
Part PR for https://github.com/bisq-network/bisq-mobile/issues/238

Rest APIs for Payment account endpoints for bisq-mobile::xClients:
 - GET /payment_accounts - To fetch all accounts
 - POST /payment_accounts - To create a new account
 - DELETE /payment_accounts/{:accountName} - To delete an existing account
 - GET /payment_accounts/selected - To get selected account
 - PATCH /payment_accounts/selected - To update selected account


Only UserDefinedFiatAccount and UserDefinedFiatAccountPayload are handled. Account hierarchy of classes is ignored  for bisq-mobile