### PR TITLE
Add devModeReputationScore to config.

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -84,6 +84,7 @@ public abstract class ApplicationService implements Service {
             return new Config(appDataDir,
                     appName,
                     config.getBoolean("devMode"),
+                    config.getLong("devModeReputationScore"),
                     config.getString("keyIds"),
                     config.getBoolean("ignoreSigningKeyInResourcesCheck"),
                     config.getBoolean("ignoreSignatureVerification"),
@@ -94,6 +95,7 @@ public abstract class ApplicationService implements Service {
         private final Path baseDir;
         private final String appName;
         private final boolean devMode;
+        private final long devModeReputationScore;
         private final List<String> keyIds;
         private final boolean ignoreSigningKeyInResourcesCheck;
         private final boolean ignoreSignatureVerification;
@@ -103,6 +105,7 @@ public abstract class ApplicationService implements Service {
         public Config(Path baseDir,
                       String appName,
                       boolean devMode,
+                      long devModeReputationScore,
                       String keyIds,
                       boolean ignoreSigningKeyInResourcesCheck,
                       boolean ignoreSignatureVerification,
@@ -111,6 +114,7 @@ public abstract class ApplicationService implements Service {
             this.baseDir = baseDir;
             this.appName = appName;
             this.devMode = devMode;
+            this.devModeReputationScore = devModeReputationScore;
             // We want to use the keyIds at the DesktopApplicationLauncher as a simple format. 
             // Using the typesafe format with indexes would require a more complicate parsing as we do not use 
             // typesafe at the DesktopApplicationLauncher class. Thus, we use a simple comma separated list instead and treat it as sting in typesafe.
@@ -177,6 +181,9 @@ public abstract class ApplicationService implements Service {
         }
 
         DevMode.setDevMode(config.isDevMode());
+        if (config.isDevMode()) {
+            DevMode.setDevModeReputationScore(config.getDevModeReputationScore());
+        }
 
         Locale locale = LocaleRepository.getDefaultLocale();
         CountryRepository.applyDefaultLocale(locale);

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -1,6 +1,7 @@
 application {
     appName = "Bisq2"
     devMode = false
+    devModeReputationScore = 0
     keyIds = "E222AA02,387C8307"
     ignoreSigningKeyInResourcesCheck = false
     ignoreSignatureVerification = false

--- a/apps/http-api-app/src/main/resources/http_api_app.conf
+++ b/apps/http-api-app/src/main/resources/http_api_app.conf
@@ -1,6 +1,7 @@
 application {
     appName = "Bisq2"
     devMode = false
+    devModeReputationScore = 0
     keyIds = "E222AA02,387C8307"
     ignoreSigningKeyInResourcesCheck = false
     ignoreSignatureVerification = false

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -1,6 +1,7 @@
 application {
     appName = "Bisq2"
     devMode = false
+    devModeReputationScore = 0
     keyIds = "E222AA02,387C8307"
     ignoreSigningKeyInResourcesCheck = false
     ignoreSignatureVerification = false

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -1,6 +1,7 @@
 application {
     appName = "OracleNode"
     devMode = false
+    devModeReputationScore = 0
     keyIds = "E222AA02,387C8307"
     ignoreSigningKeyInResourcesCheck = false
     ignoreSignatureVerification = false

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -1,6 +1,7 @@
 application {
     appName = "Bisq2_seed_node"
     devMode = false
+    devModeReputationScore = 0
     keyIds = "E222AA02,387C8307"
     ignoreSigningKeyInResourcesCheck = false
     ignoreSignatureVerification = false

--- a/common/src/main/java/bisq/common/application/DevMode.java
+++ b/common/src/main/java/bisq/common/application/DevMode.java
@@ -25,4 +25,14 @@ public class DevMode {
     public static boolean isDevMode() {
         return isDevMode;
     }
+
+    // Can be set as jvm argument if isDevMode is true. Value has to be > 0.
+    // All trade apps need to have that value set as it is used in a static manner independent of the user profile.
+    // This makes dev testing easier as sellers need to have reputation to be able to trade.
+    @Setter
+    private static long devModeReputationScore;
+
+    public static long devModeReputationScore() {
+        return devModeReputationScore;
+    }
 }

--- a/user/src/main/java/bisq/user/reputation/ReputationService.java
+++ b/user/src/main/java/bisq/user/reputation/ReputationService.java
@@ -18,6 +18,7 @@
 package bisq.user.reputation;
 
 import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
+import bisq.common.application.DevMode;
 import bisq.common.application.Service;
 import bisq.common.data.Pair;
 import bisq.common.observable.Observable;
@@ -133,10 +134,16 @@ public class ReputationService implements Service {
     }
 
     public Optional<ReputationScore> findReputationScore(String userProfileId) {
-        if (!scoreByUserProfileId.containsKey(userProfileId)) {
-            return Optional.empty();
+        long score;
+        if (DevMode.isDevMode() && DevMode.devModeReputationScore() > 0) {
+            score = DevMode.devModeReputationScore();
+        } else {
+            if (!scoreByUserProfileId.containsKey(userProfileId)) {
+                return Optional.empty();
+            }
+            score = scoreByUserProfileId.get(userProfileId);
         }
-        long score = scoreByUserProfileId.get(userProfileId);
+
         double fiveSystemScore = getFiveSystemScore(score);
         int index = getIndex(score, scoreByUserProfileId.values());
         int rank = scoreByUserProfileId.size() - index;


### PR DESCRIPTION
Can be set as jvm argument if isDevMode is true. Value has to be > 0. All trade apps need to have that value set as it is used in a static manner independent of the user profile. This makes dev testing easier as sellers need to have reputation to be able to trade.