### PR TITLE
http-api-bisq-version API

### DIFF
--- a/http-api/src/main/java/bisq/dto/settings/SettingsApiVersionDto.java
+++ b/http-api/src/main/java/bisq/dto/settings/SettingsApiVersionDto.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.dto.settings;
+
+public record SettingsApiVersionDto(String version) {
+}

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/settings/SettingsRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/settings/SettingsRestApi.java
@@ -17,8 +17,10 @@
 
 package bisq.http_api.rest_api.domain.settings;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.dto.DtoMappings;
+import bisq.dto.settings.SettingsApiVersionDto;
 import bisq.dto.settings.SettingsDto;
 import bisq.http_api.rest_api.domain.RestApiBase;
 import bisq.settings.SettingsService;
@@ -62,6 +64,19 @@ public class SettingsRestApi extends RestApiBase {
             return buildOkResponse(settingsDto);
         } catch (Exception e) {
             log.error("Failed to retrieve user settings", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/version")
+    @Operation(description = "Get the current Bisq2 version")
+    public Response getVersion() {
+        try {
+            String version = ApplicationVersion.getVersion().toString();
+            return Response.ok(new SettingsApiVersionDto(version)).build();
+        } catch (Exception e) {
+            log.error("Error getting version", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
         }
     }


### PR DESCRIPTION
 - trusted node work for https://github.com/bisq-network/bisq-mobile/issues/136
 - expose api version in settings/version path