### PR TITLE
Downgrade to java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,21 @@ in [the Bisq wiki](https://bisq.wiki/Bisq_Easy).
 3. **Setup bitcoind git submodule:**
    At project setup run first:
    ```bash
-   git submodule init
-   git submodule update
+   git submodule update --init --remote
    ```
 
    In case the submodule has changed after a project update, run:
    ```bash
-   git submodule update
+   cd wallets/bitcoind
+   git checkout main
+   git pull
+   cd ../..
+   ```
+
+   Commit the updated submodule
+   ```bash
+   git add wallets/bitcoind
+   git commit -m "Update submodule to latest commit on main"
    ```
 
 4. **Run desktop client:**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ in [the Bisq wiki](https://bisq.wiki/Bisq_Easy).
    ```
 
 2. **Install Dependencies:**
-   Bisq requires JDK 22. See our [Installation Guide](./docs/dev/build.md) for detailed instructions.
+   Bisq requires JDK 21. See our [Installation Guide](./docs/dev/build.md) for detailed instructions.
 
 3. **Setup bitcoind git submodule:**
    At project setup run first:

--- a/apps/desktop/desktop-app-launcher/build.gradle.kts
+++ b/apps/desktop/desktop-app-launcher/build.gradle.kts
@@ -17,10 +17,10 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
-    sourceCompatibility = JavaVersion.VERSION_22
-    targetCompatibility = JavaVersion.VERSION_22
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 
@@ -38,7 +38,7 @@ packaging {
 }
 
 javafx {
-    version = "22.0.1"
+    version = "21.0.6"
     modules = listOf("javafx.controls", "javafx.media")
 }
 

--- a/apps/desktop/desktop-app/build.gradle.kts
+++ b/apps/desktop/desktop-app/build.gradle.kts
@@ -20,10 +20,10 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
-    sourceCompatibility = JavaVersion.VERSION_22
-    targetCompatibility = JavaVersion.VERSION_22
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 application {
@@ -36,7 +36,7 @@ version = rootVersion
 // println("version is ${version}")
 
 javafx {
-    version = "22.0.1"
+    version = "21.0.6"
     modules = listOf("javafx.controls", "javafx.media")
 }
 

--- a/apps/desktop/desktop/build.gradle.kts
+++ b/apps/desktop/desktop/build.gradle.kts
@@ -5,14 +5,14 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
-    sourceCompatibility = JavaVersion.VERSION_22
-    targetCompatibility = JavaVersion.VERSION_22
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 javafx {
-    version = "22.0.1"
+    version = "21.0.6"
     modules = listOf("javafx.controls", "javafx.media")
 }
 

--- a/apps/desktop/webcam-app/build.gradle.kts
+++ b/apps/desktop/webcam-app/build.gradle.kts
@@ -15,7 +15,7 @@ application {
 }
 
 javafx {
-    version = "22.0.1"
+    version = "21.0.6"
     modules = listOf("javafx.controls", "javafx.media")
 }
 

--- a/apps/http-api-app/build.gradle.kts
+++ b/apps/http-api-app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/apps/node-monitor-web-app/build.gradle.kts
+++ b/apps/node-monitor-web-app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/bisq-easy/build.gradle.kts
+++ b/bisq-easy/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -119,7 +119,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
                 }
             } else {
                 // Bisq2
-                22
+                21
             }
         }
         return javaVersion.map { JavaLanguageVersion.of(it) }

--- a/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
+++ b/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
@@ -30,7 +30,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             when (javaVersion) {
                 11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-linux_x64.zip"
                 17 -> "https://cdn.azul.com/zulu/bin/zulu17.44.15-ca-jdk17.0.8-linux_x64.zip"
-                22 -> "https://cdn.azul.com/zulu/bin/zulu22.30.13-ca-jdk22.0.1-linux_x64.zip"
+                21 -> "https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-linux_x64.zip"
                 else -> null
             }
 
@@ -42,7 +42,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15_1-ca-jdk11.0.20-macosx_" + macOsArchName + ".tar.gz"
             15 -> "https://cdn.azul.com/zulu/bin/zulu15.46.17-ca-jdk15.0.10-macosx_" + macOsArchName + ".tar.gz"
             17 -> "https://cdn.azul.com/zulu/bin/zulu17.44.15_1-ca-jdk17.0.8-macosx_" + macOsArchName + ".tar.gz"
-            22 -> "https://cdn.azul.com/zulu/bin/zulu22.30.13-ca-jdk22.0.1-macosx_" + macOsArchName + ".tar.gz"
+            21 -> "https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-macosx_" + macOsArchName + ".tar.gz"
             else -> null
         }
     }
@@ -51,7 +51,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             when (javaVersion) {
                 11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_x64.zip"
                 17 -> "https://cdn.azul.com/zulu/bin/zulu17.44.15-ca-jdk17.0.8-win_x64.zip"
-                22 -> "https://cdn.azul.com/zulu/bin/zulu22.30.13-ca-jdk22.0.1-win_x64.zip"
+                21 -> "https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-win_x64.zip"
                 else -> null
             }
 }

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -12,14 +12,22 @@
 
 3. **Setup bitcoind git submodule:**
    At project setup run first:
-   ```sh
-   git submodule init
-   git submodule update
+   ```bash
+   git submodule update --init --remote
    ```
 
    In case the submodule has changed after a project update, run:
-   ```sh
-   git submodule update
+   ```bash
+   cd wallets/bitcoind
+   git checkout main
+   git pull
+   cd ../..
+   ```
+
+   Commit the updated submodule
+   ```bash
+   git add wallets/bitcoind
+   git commit -m "Update submodule to latest commit on main"
    ```
 
 4. **Build Bisq**

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -8,7 +8,7 @@
    ```
 
 2. **Install Dependencies:**
-   Bisq requires JDK 22. See our [Installation Guide](./docs/dev/build.md) for detailed instructions.
+   Bisq requires JDK 21. See our [Installation Guide](./docs/dev/build.md) for detailed instructions.
 
 3. **Setup bitcoind git submodule:**
    At project setup run first:
@@ -70,7 +70,7 @@ For a quick full cleanup/rebuild you can use
 
 1. You do _not_ need to install Gradle to build Bisq. The `gradlew` shell script will install it for you, if necessary.
 
-2. Bisq requires JDK 22. You can find out which
+2. Bisq requires JDK 21. You can find out which
    version you have with:
 
    ```sh

--- a/http-api/build.gradle.kts
+++ b/http-api/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/wallets/build.gradle.kts
+++ b/wallets/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -12,7 +12,7 @@ allprojects {
     plugins.apply("java")
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(22))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 }

--- a/wallets/electrum/build.gradle.kts
+++ b/wallets/electrum/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/wallets/elementsd/build.gradle.kts
+++ b/wallets/elementsd/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/wallets/process/build.gradle.kts
+++ b/wallets/process/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/wallets/wallet/build.gradle.kts
+++ b/wallets/wallet/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 // this one needs specific setup otherwise gives "invalid source release" error
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 


### PR DESCRIPTION
As Java 21 is a LTS version we prefer to stick with that. Java 22 is not provided on official download pages anymore and for Arch Linux there seems to be no provider.

The reason for java 22 update was discussed here:
https://github.com/bisq-network/bisq2/pull/2225