### PR TITLE
FileCreationWatcher: Fix timeout deadlock

### DIFF
--- a/java-se/src/main/java/bisq/java_se/utils/FileCreationWatcher.java
+++ b/java-se/src/main/java/bisq/java_se/utils/FileCreationWatcher.java
@@ -50,9 +50,10 @@ public class FileCreationWatcher {
                     StandardWatchEventKinds.ENTRY_CREATE);
             while (true) {
                 WatchKey watchKey = watchService.poll(1, TimeUnit.MINUTES);
-                if(watchKey==null){
+                if (watchKey == null) {
                     continue;
                 }
+
                 for (WatchEvent<?> event : watchKey.pollEvents()) {
                     WatchEvent.Kind<?> kind = event.kind();
 
@@ -71,7 +72,8 @@ public class FileCreationWatcher {
                         return newFilePath;
                     }
                 }
-                if(!watchKey.reset()){
+
+                if (!watchKey.reset()) {
                     log.warn("File watcher is no longer valid.");
                 }
             }

--- a/java-se/src/main/java/bisq/java_se/utils/FileCreationWatcher.java
+++ b/java-se/src/main/java/bisq/java_se/utils/FileCreationWatcher.java
@@ -48,10 +48,11 @@ public class FileCreationWatcher {
         try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
             directoryToWatch.register(watchService,
                     StandardWatchEventKinds.ENTRY_CREATE);
+
             while (true) {
                 WatchKey watchKey = watchService.poll(1, TimeUnit.MINUTES);
                 if (watchKey == null) {
-                    continue;
+                    throw new FileCreationWatcherTimeoutException("No changes detected for 1 minute (timeout).");
                 }
 
                 for (WatchEvent<?> event : watchKey.pollEvents()) {

--- a/java-se/src/main/java/bisq/java_se/utils/FileCreationWatcherTimeoutException.java
+++ b/java-se/src/main/java/bisq/java_se/utils/FileCreationWatcherTimeoutException.java
@@ -1,0 +1,7 @@
+package bisq.java_se.utils;
+
+public class FileCreationWatcherTimeoutException extends RuntimeException {
+    public FileCreationWatcherTimeoutException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
PR https://github.com/bisq-network/bisq2/pull/3327 introduced a deadlock. We handle the timeout explicitly now.

Other changes:
- [FileCreationWatcher: Format code](https://github.com/bisq-network/bisq2/commit/acad7aed4f8955117ad981df9a1bb7650946cc9c)