### PR TITLE
Fix Bitcoin Payment Confirmation Handling

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
@@ -33,7 +33,6 @@ import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
 import bisq.desktop.main.content.bisq_easy.components.WaitingState;
 import bisq.i18n.Res;
 import bisq.trade.bisq_easy.BisqEasyTrade;
-import bisq.user.profile.UserProfileService;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
@@ -103,12 +102,17 @@ public class SellerStateLightning3b extends BaseState {
                                 String expectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", peersUserName);
                                 boolean shouldUpdateUI = encodedLogMessage.equals(expectedEncoded);
                                 if (!shouldUpdateUI) {
-                                    String clearedPeersUserName = UserProfileService.getClearedUserName(peersUserName);
-                                    if (!clearedPeersUserName.equals(peersUserName)) {
-                                        String simplifiedExpectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln",
-                                                clearedPeersUserName);
-                                        shouldUpdateUI = encodedLogMessage.equals(simplifiedExpectedEncoded);
-                                    }
+                                    /*
+                                     * userName formats may differ between sender and receiver. A userName appears as
+                                     * simple "nickname" if unique in user's storage, or as "nickname [nym-id]" if
+                                     * multiple users share that nickname. Due to persistence state differences, one
+                                     * peer might use the simple format while the other uses the extended format.
+                                     * We therefore compare the encoded message against both the userName and the
+                                     * nickname alone to ensure reliable message matching.
+                                     */
+                                    String simplifiedExpectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln",
+                                            bisqEasyOpenTradeChannel.getPeer().getNickName());
+                                    shouldUpdateUI = encodedLogMessage.equals(simplifiedExpectedEncoded);
                                 }
 
                                 if (shouldUpdateUI) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
@@ -99,23 +99,21 @@ public class SellerStateLightning3b extends BaseState {
                         public void add(BisqEasyOpenTradeMessage message) {
                             if (message.getChatMessageType() == ChatMessageType.PROTOCOL_LOG_MESSAGE && message.getText().isPresent()) {
                                 String encodedLogMessage = message.getText().get();
-                                String expectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", peersUserName);
-                                boolean shouldUpdateUI = encodedLogMessage.equals(expectedEncoded);
-                                if (!shouldUpdateUI) {
-                                    /*
-                                     * userName formats may differ between sender and receiver. A userName appears as
-                                     * simple "nickname" if unique in user's storage, or as "nickname [nym-id]" if
-                                     * multiple users share that nickname. Due to persistence state differences, one
-                                     * peer might use the simple format while the other uses the extended format.
-                                     * We therefore compare the encoded message against both the userName and the
-                                     * nickname alone to ensure reliable message matching.
-                                     */
-                                    String simplifiedExpectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln",
-                                            bisqEasyOpenTradeChannel.getPeer().getNickName());
-                                    shouldUpdateUI = encodedLogMessage.equals(simplifiedExpectedEncoded);
-                                }
 
-                                if (shouldUpdateUI) {
+                                /*
+                                 * Username formats differ between peers due to how nicknames are displayed. When a
+                                 * peer's nickname is unique in a node's network view, it appears as just "nickname".
+                                 * When multiple users have chosen the same nickname independently, it displays as
+                                 * "nickname [nym-id]" to prevent confusion. Since peers' network views aren't
+                                 * guaranteed to be identical, we need to check against both the full username and
+                                 * simple nickname formats.
+                                 */
+
+                                String expectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", peersUserName);
+                                String nickNameEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln",
+                                        bisqEasyOpenTradeChannel.getPeer().getNickName());
+
+                                if (encodedLogMessage.equals(expectedEncoded) || encodedLogMessage.equals(nickNameEncoded)) {
                                     UIThread.run(() -> model.getBuyerHasConfirmedBitcoinReceipt().set(
                                             Res.get("bisqEasy.tradeState.info.seller.phase3b.receiptConfirmed.ln")));
                                 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
@@ -33,6 +33,7 @@ import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
 import bisq.desktop.main.content.bisq_easy.components.WaitingState;
 import bisq.i18n.Res;
 import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.user.profile.UserProfileService;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
@@ -100,8 +101,19 @@ public class SellerStateLightning3b extends BaseState {
                             if (message.getChatMessageType() == ChatMessageType.PROTOCOL_LOG_MESSAGE && message.getText().isPresent()) {
                                 String encodedLogMessage = message.getText().get();
                                 String expectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", peersUserName);
-                                if (encodedLogMessage.equals(expectedEncoded)) {
-                                    UIThread.run(() -> model.getBuyerHasConfirmedBitcoinReceipt().set(Res.get("bisqEasy.tradeState.info.seller.phase3b.receiptConfirmed.ln")));
+                                boolean shouldUpdateUI = encodedLogMessage.equals(expectedEncoded);
+                                if (!shouldUpdateUI) {
+                                    String clearedPeersUserName = UserProfileService.getClearedUserName(peersUserName);
+                                    if (!clearedPeersUserName.equals(peersUserName)) {
+                                        String simplifiedExpectedEncoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln",
+                                                clearedPeersUserName);
+                                        shouldUpdateUI = encodedLogMessage.equals(simplifiedExpectedEncoded);
+                                    }
+                                }
+
+                                if (shouldUpdateUI) {
+                                    UIThread.run(() -> model.getBuyerHasConfirmedBitcoinReceipt().set(
+                                            Res.get("bisqEasy.tradeState.info.seller.phase3b.receiptConfirmed.ln")));
                                 }
                             }
                         }

--- a/user/src/main/java/bisq/user/profile/UserProfileService.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileService.java
@@ -21,6 +21,7 @@ import bisq.common.application.Service;
 import bisq.common.observable.Observable;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.observable.map.ObservableHashMap;
+import bisq.common.util.StringUtils;
 import bisq.network.NetworkService;
 import bisq.network.p2p.services.data.DataService;
 import bisq.network.p2p.services.data.storage.auth.AuthenticatedData;
@@ -154,6 +155,17 @@ public class UserProfileService implements PersistenceClient<UserProfileStore>, 
         } else {
             return nickName + SEPARATOR_START + nym + SEPARATOR_END;
         }
+    }
+
+    public static String getClearedUserName(String userName) {
+        if (StringUtils.isEmpty(userName)) {
+            return userName;
+        }
+        int lastSeparatorIndex = userName.lastIndexOf(SEPARATOR_START);
+        if (lastSeparatorIndex > 0) {
+            return userName.substring(0, lastSeparatorIndex);
+        }
+        return userName;
     }
 
     private void processUserProfileAddedOrRefreshed(UserProfile userProfile) {

--- a/user/src/main/java/bisq/user/profile/UserProfileService.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileService.java
@@ -21,7 +21,6 @@ import bisq.common.application.Service;
 import bisq.common.observable.Observable;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.observable.map.ObservableHashMap;
-import bisq.common.util.StringUtils;
 import bisq.network.NetworkService;
 import bisq.network.p2p.services.data.DataService;
 import bisq.network.p2p.services.data.storage.auth.AuthenticatedData;
@@ -155,17 +154,6 @@ public class UserProfileService implements PersistenceClient<UserProfileStore>, 
         } else {
             return nickName + SEPARATOR_START + nym + SEPARATOR_END;
         }
-    }
-
-    public static String getClearedUserName(String userName) {
-        if (StringUtils.isEmpty(userName)) {
-            return userName;
-        }
-        int lastSeparatorIndex = userName.lastIndexOf(SEPARATOR_START);
-        if (lastSeparatorIndex > 0) {
-            return userName.substring(0, lastSeparatorIndex);
-        }
-        return userName;
     }
 
     private void processUserProfileAddedOrRefreshed(UserProfile userProfile) {


### PR DESCRIPTION
The issue can be in UserProfileService.getUserName() which can return different getUserName for the same inputs for different users  (UserProfileStore contains different information)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of transaction confirmations: the interface now more accurately displays Bitcoin receipt updates by accommodating variations in username formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->