### PR TITLE
Fix closing of QrCodeWindow

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState3a.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState3a.java
@@ -141,13 +141,14 @@ public class SellerState3a extends BaseState {
             super.onDeactivate();
 
             model.getBtcSentButtonDisabled().unbind();
-
+            //QrCodeWindow closes if model.getQrCodeWindow() is not null
+            //So, close QrCodeWindow first, before clearing model
+            doCloseQrCodeWindow();
             model.getQrCodeWindow().set(null);
             model.setLargeQrCodeImage(null);
             model.setSmallQrCodeImage(null);
             model.setPaymentProofValidator(null);
             model.setBitcoinPaymentValidator(null);
-            doCloseQrCodeWindow();
         }
 
         private void onConfirmedBtcSent() {

--- a/i18n/src/main/resources/bisq_easy_pcm.properties
+++ b/i18n/src/main/resources/bisq_easy_pcm.properties
@@ -747,7 +747,7 @@ bisqEasy.tradeState.info.seller.phase3a.fiatPaymentReceivedCheckBox=I don confir
 bisqEasy.tradeState.info.seller.phase3a.sendBtc=Send {0} go di buyer
 bisqEasy.tradeState.info.seller.phase3a.baseAmount=Amount wey you go Send
 bisqEasy.tradeState.info.seller.phase3a.qrCodeDisplay.openWindow=Open bigger display
-bisqEasy.tradeState.info.seller.phase3a.qrCodeDisplay.window.title=Scan QR Code for trad ''{0}''
+bisqEasy.tradeState.info.seller.phase3a.qrCodeDisplay.window.title=Scan QR Code for trade ''{0}''
 # suppress inspection "UnusedProperty"
 bisqEasy.tradeState.info.seller.phase3b.headline.MAIN_CHAIN=Dey wait for blockchain Confirmeshon
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
QrCodeWindow closing is depended from model state. 
Before fix: if we leave SellerState3a (click on other item of the table, for instance), QrCodeWindow leaves as is and from this moment - can't be closed (via 'x' or 'close' button).

After: if we leave SellerState3a QrCodeWindow closes  