### PR TITLE
remove first before add to ranking list

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/ranking/ReputationRankingController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/ranking/ReputationRankingController.java
@@ -88,6 +88,7 @@ public class ReputationRankingController implements Controller {
                             ReputationRankingController.this,
                             model.getFilterMenuItemToggleGroup(),
                             userProfileService);
+                    remove(key);
                     model.getListItems().add(listItem);
                 });
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/ranking/ReputationRankingController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/ranking/ReputationRankingController.java
@@ -88,7 +88,6 @@ public class ReputationRankingController implements Controller {
                             ReputationRankingController.this,
                             model.getFilterMenuItemToggleGroup(),
                             userProfileService);
-                    remove(key);
                     model.getListItems().add(listItem);
                 });
             }

--- a/user/src/main/java/bisq/user/profile/UserProfileService.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileService.java
@@ -170,6 +170,7 @@ public class UserProfileService implements PersistenceClient<UserProfileStore>, 
                 ObservableHashMap<String, UserProfile> userProfileById = getUserProfileById();
                 synchronized (persistableStore) {
                     addNymToNickNameHashMap(userProfile.getNym(), userProfile.getNickName());
+                    existingUserProfile.ifPresent(e -> userProfileById.remove(e.getId()));
                     userProfileById.put(userProfile.getId(), userProfile);
                 }
                 numUserProfiles.set(userProfileById.size());


### PR DESCRIPTION
user profile updated will add it to reputation ranking list, remove it first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user profile management by automatically removing outdated profiles before adding a refreshed or new one, ensuring that only the most current information is maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->