### PR TITLE
Fix BitcoinAmountDisplay issues

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
@@ -57,6 +57,7 @@ public class BitcoinAmountDisplay extends HBox {
     public BitcoinAmountDisplay(String amount, boolean showBtcCode) {
         this(amount);
         btcCode.setVisible(showBtcCode);
+        btcCode.setManaged(showBtcCode);
     }
 
     public BitcoinAmountDisplay(String amount) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/BaseAmountBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/BaseAmountBox.java
@@ -31,6 +31,7 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.text.TextAlignment;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
@@ -239,8 +240,9 @@ public class BaseAmountBox {
         }
 
         private void configureBitcoinAmountDisplay(BitcoinAmountDisplay btcText) {
-            btcText.setBaselineAlignment();
-            btcText.applyCompactConfig(16, 13, 28);
+            btcText.setTextAlignment(model.showCurrencyCode ? TextAlignment.LEFT : TextAlignment.RIGHT);
+            btcText.setTranslateY(2);
+            btcText.applyCompactConfig(15, 12, 28);
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/BisqEasyOpenTradesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/BisqEasyOpenTradesView.java
@@ -385,7 +385,7 @@ public final class BisqEasyOpenTradesView extends ChatView<BisqEasyOpenTradesVie
                 bitcoinAmountDisplay.getSignificantDigits().getStyleClass().add("bisq-easy-open-trades-bitcoin-amount-display");
                 bitcoinAmountDisplay.getLeadingZeros().getStyleClass().add("bisq-easy-open-trades-bitcoin-amount-display");
                 bitcoinAmountDisplay.getIntegerPart().getStyleClass().add("bisq-easy-open-trades-bitcoin-amount-display");
-                bitcoinAmountDisplay.setTranslateY(8);
+                bitcoinAmountDisplay.setTranslateY(5);
             }
 
             @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/TradeCompletedTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/TradeCompletedTable.java
@@ -251,6 +251,7 @@ public class TradeCompletedTable extends VBox {
         btcText.getIntegerPart().getStyleClass().add("medium-text");
         btcText.getSignificantDigits().getStyleClass().add("medium-text");
         btcText.getBtcCode().getStyleClass().addAll("small-text", "text-fill-grey-dimmed");
+        btcText.getLeadingZeros().getStyleClass().addAll("medium-text", "text-fill-grey-dimmed");
         btcText.applyCompactConfig(13, 10, 24);
     }
 


### PR DESCRIPTION
Improved BaseAmountBox to show range correctly.
Added styles for leadingZeros in TradeCompletedTable. btcCode is not managed now if it invisible.
Some text alignment in BisqEasyOpenTradesView

![image](https://github.com/user-attachments/assets/885f3281-c439-4cc8-9a27-83b5c133ae73)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the Bitcoin amount display’s layout, ensuring that elements are properly excluded from space allocation when hidden.
  - Adjusted text alignment and vertical positioning for a more balanced look.
  - Refined numerical formatting—particularly the styling of leading zeros—for improved visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->