### PR TITLE
Improve shutdown handling

### DIFF
--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -352,7 +352,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
                             log.info("ApplicationService shutdown completed");
                             return true;
                         } else {
-                            startupErrorMessage.set("Shutdown applicationService failed with result=false");
+                            shutDownErrorMessage.set("Shutdown applicationService failed with result=false");
                             log.error(shutDownErrorMessage.get());
                         }
                     } else {

--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopExecutable.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopExecutable.java
@@ -120,19 +120,28 @@ public class DesktopExecutable extends Executable<DesktopApplicationService> {
 
     @Override
     protected void exitJvm() {
-        if (applicationService != null && applicationService.getShutDownErrorMessage().get() == null) {
-            exitJavaFXPlatform();
+        if (applicationService == null) {
+            log.warn("Shutdown before applicationService have been created");
+            super.exitJvm();
+        } else if (applicationService.getShutDownErrorMessage().get() == null) {
+            // If shutDownErrorMessage is set we display an error popup we leave it to the user to close it and
+            // shutdown the app by clicking the shutdown button
+            try {
+                // We might get called from a non UI thread
+                UIThread.run(this::exitJavaFXPlatform);
+            } catch (Exception e) {
+                log.error("Could not map shutdown handler to UI thread", e);
+                super.exitJvm();
+            }
         }
-        // If we have an error popup we leave it to the user to close it and shutdown the app by clicking the shutdown button
     }
 
     private void exitJavaFXPlatform() {
-        if (Platform.isFxApplicationThread()) {
-            // See https://openjfx.io/javadoc/19/javafx.graphics/javafx/application/Application.html
-            // Calling System.exit after Platform.exit causes exception
-            log.info("Exiting JavaFX Platform");
+        log.info("Exiting JavaFX Platform");
+        try {
             Platform.exit();
-        } else {
+        } catch (Exception e) {
+            log.error("Platform.exit failed", e);
             super.exitJvm();
         }
     }


### PR DESCRIPTION
We had a `Platform.isFxApplicationThread()` check, but usually we got called from the application service, thus a non UI thread and the `Platform.exit` case was never reached but instead the `exitJvm()` which was a non-graceful shutdown of the JavaFx runtime.

This should fix the error logs like below, which can be caused if there are pending `Platform.runLater` calls or new ones get fired after the rendering subsystem is already torn down (by threads, schedulers,...). With mapping our own `exitJavaFXPlatform` call in a `runLater`, it should give time to process the pending tasks (the runLater calls are executed in the order as they got called).
There might be still some edge cases left. We ignore the exception in the `uncaughtExceptionHandler` in case its caused from the `GraphicsPipeline`.

```
Feb-14 16:23:30.876 [ForkJoinPool.commonPool-worker-21] INFO b.a.Executable: Exiting JVM
Feb-14 16:23:31.075 [JavaFX Application Thread] ERROR b.d.DesktopExecutable: Uncaught exception: java.lang.NullPointerException: Cannot invoke "com.sun.prism.GraphicsPipeline.is3DSupported()" because the return value of "com.sun.prism.GraphicsPipeline.getPipeline()" is null
at [com.sun.javafx.tk](http://com.sun.javafx.tk/).quantum.QuantumToolkit.isSupported([QuantumToolkit.java:1230](http://quantumtoolkit.java:1230/))
at com.sun.javafx.application.PlatformImpl.isSupportedImpl([PlatformImpl.java:995](http://platformimpl.java:995/))
at com.sun.javafx.application.PlatformImpl.isSupported([PlatformImpl.java:655](http://platformimpl.java:655/))
at javafx.application.Platform.isSupported([Platform.java:271](http://platform.java:271/))
```

Credit to @mvp1983 who provided the logs and pushed for a fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced shutdown error reporting to ensure accurate messaging during failure scenarios.
  - Improved exception handling during application exit, leading to a smoother and more robust shutdown process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->