### PR TITLE
docs: Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ in [the Bisq wiki](https://bisq.wiki/Bisq_Easy).
 
 4. **Run desktop client:**
    ```bash
-   ./gradlew apps:desktop:desktop-app:run
+   apps/desktop/desktop-app/build/install/desktop-app/bin/desktop-app
    ```
 
 5. **Run desktop client with custom data directory:**

--- a/README.md
+++ b/README.md
@@ -26,31 +26,18 @@ in [the Bisq wiki](https://bisq.wiki/Bisq_Easy).
 
 1. **Clone Bisq 2:**
    ```bash
-   git clone https://github.com/bisq-network/bisq2.git
+   git clone --recurse-submodules https://github.com/bisq-network/bisq2.git
+   ```
+   ```bash
    cd bisq2
    ```
 
 2. **Install Dependencies:**
    Bisq requires JDK 21. See our [Installation Guide](./docs/dev/build.md) for detailed instructions.
 
-3. **Setup bitcoind git submodule:**
-   At project setup run first:
+3. **Update to latest GitHub version:**
    ```bash
-   git submodule update --init --remote
-   ```
-
-   In case the submodule has changed after a project update, run:
-   ```bash
-   cd wallets/bitcoind
-   git checkout main
-   git pull
-   cd ../..
-   ```
-
-   Commit the updated submodule
-   ```bash
-   git add wallets/bitcoind
-   git commit -m "Update submodule to latest commit on main"
+   git pull --recurse-submodules
    ```
 
 4. **Run desktop client:**

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -82,7 +82,7 @@ For a quick full cleanup/rebuild you can use
 To run the Bisq 2 desktop app with Gradle and the default settings (using the Tor network) use:
 
 ```sh
-./gradlew apps:desktop:desktop-app:run
+apps/desktop/desktop-app/build/install/desktop-app/bin/desktop-app
 ```
 
 In that configuration the desktop app connects to the public seed nodes via the Tor network.

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -1,33 +1,19 @@
 ## Building Bisq 2
 
 1. **Clone Bisq 2**
-
-   ```sh
-   git clone https://github.com/bisq-network/bisq2
+   ```bash
+   git clone --recurse-submodules https://github.com/bisq-network/bisq2.git
+   ```
+   ```bash
    cd bisq2
    ```
 
 2. **Install Dependencies:**
    Bisq requires JDK 21.
 
-3. **Setup bitcoind git submodule:**
-   At project setup run first:
+3. **Update to latest GitHub version:**
    ```bash
-   git submodule update --init --remote
-   ```
-
-   In case the submodule has changed after a project update, run:
-   ```bash
-   cd wallets/bitcoind
-   git checkout main
-   git pull
-   cd ../..
-   ```
-
-   Commit the updated submodule
-   ```bash
-   git add wallets/bitcoind
-   git commit -m "Update submodule to latest commit on main"
+   git pull --recurse-submodules
    ```
 
 4. **Build Bisq**


### PR DESCRIPTION
- [docs: Fix git clone and pull instructions](https://github.com/bisq-network/bisq2/commit/c40e12a44092c5c2fad885c1569a190ee6c04040)
  - The README.md and build.md build instructions were incorrect.
- [docs: Fix run instructions](https://github.com/bisq-network/bisq2/commit/11743f8d433802246fb2016f7d1cb06bc4e6e4c6)
  - Gradle's default run task loads JavaFX on the module path (only supported option) [1] but we never followed the convention. The JVM enforces since version 16 module boundaries globally [2]. The packaging system loads all JARs on the classpath (including JavaFX). Therefore, developers and users have a different setup.<br><br>[1] https://github.com/openjfx/javafx-gradle-plugin/blob/bdf717a65ab0caac9cfa677efc9d3943e6f8483e/src/main/java/org/openjfx/gradle/JavaFXPlugin.java#L99 <br>[2] https://www.oracle.com/java/technologies/javase/16-relnote-issues.html#JDK-8256299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup and build instructions to simplify Git submodule management and streamline the process for running the desktop app.
  - Improved clarity and consistency in code examples and formatting in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->