### PR TITLE
Create cross-platform seednode dev setup

### DIFF
--- a/apps/build-logic/build.gradle.kts
+++ b/apps/build-logic/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    `kotlin-dsl` apply false
+    java
+}

--- a/apps/build-logic/dev-setup/build.gradle.kts
+++ b/apps/build-logic/dev-setup/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `java-gradle-plugin`
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        create("BisqDevSetupPlugin") {
+            id = "bisq.gradle.dev.setup.BisqDevSetupPlugin"
+            implementationClass = "bisq.gradle.dev.setup.BisqDevSetupPlugin"
+        }
+    }
+}

--- a/apps/build-logic/dev-setup/src/main/kotlin/bisq/gradle/dev/setup/BisqDevSetupPlugin.kt
+++ b/apps/build-logic/dev-setup/src/main/kotlin/bisq/gradle/dev/setup/BisqDevSetupPlugin.kt
@@ -1,0 +1,46 @@
+package bisq.gradle.dev.setup
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.SourceSet
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.jvm.toolchain.JvmImplementation
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.register
+import javax.inject.Inject
+
+class BisqDevSetupPlugin @Inject constructor(private val javaToolchainService: JavaToolchainService) : Plugin<Project> {
+    override fun apply(project: Project) {
+        val launcherProvider = javaToolchainService.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+            vendor.set(JvmVendorSpec.AZUL)
+            implementation.set(JvmImplementation.VENDOR_SPECIFIC)
+        }
+        val launcherExecutable = launcherProvider.map { it.executablePath }
+
+        val javaPluginExtension = project.extensions.findByType<JavaPluginExtension>()
+        checkNotNull(javaPluginExtension) { "Can't find JavaPluginExtension extension." }
+
+        val mainSourceSet = javaPluginExtension.sourceSets.named("main", SourceSet::class.java)
+        val runtimeClassPath: Provider<FileCollection> = mainSourceSet.map { it.runtimeClasspath }
+
+        project.tasks.register<BisqSeedNodeTask>("seed1") {
+            javaExecutable.set(launcherExecutable)
+            classPath.setFrom(runtimeClassPath)
+            nameSuffix.set("1")
+            port.set(8000)
+        }
+
+        project.tasks.register<BisqSeedNodeTask>("seed2") {
+            javaExecutable.set(launcherExecutable)
+            classPath.setFrom(runtimeClassPath)
+            nameSuffix.set("2")
+            port.set(8001)
+        }
+    }
+}

--- a/apps/build-logic/dev-setup/src/main/kotlin/bisq/gradle/dev/setup/BisqSeedNodeTask.kt
+++ b/apps/build-logic/dev-setup/src/main/kotlin/bisq/gradle/dev/setup/BisqSeedNodeTask.kt
@@ -1,0 +1,45 @@
+package bisq.gradle.dev.setup
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.TaskAction
+
+abstract class BisqSeedNodeTask : DefaultTask() {
+    @get:InputFile
+    abstract val javaExecutable: RegularFileProperty
+
+    @get:InputFiles
+    abstract val classPath: ConfigurableFileCollection
+
+    @get:Input
+    abstract val nameSuffix: Property<String>
+
+    @get:Input
+    abstract val port: Property<Int>
+
+    @TaskAction
+    fun start() {
+        val javaExecPath = javaExecutable.get().asFile.absolutePath
+        val fullClassPath = classPath.files.joinToString(":") { it.absolutePath }
+
+        val processBuilder = ProcessBuilder(javaExecPath,
+            "--class-path", fullClassPath,
+            "-Dapplication.appName=bisq2_seed${nameSuffix.get()}",
+            "-Dapplication.network.configByTransportType.clear.defaultNodePort=${port.get()}",
+            "-Dapplication.network.supportedTransportTypes.0=CLEAR",
+            "-Dapplication.network.seedAddressByTransportType.clear.0=127.0.0.1:8000",
+            "-Dapplication.network.seedAddressByTransportType.clear.1=127.0.0.1:8001",
+            "bisq.seed_node.SeedNodeApp")
+
+        processBuilder.redirectErrorStream(true)
+        processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD)
+
+        val process = processBuilder.start()
+        process.waitFor()
+    }
+}

--- a/apps/build-logic/gradle.properties
+++ b/apps/build-logic/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/apps/build-logic/settings.gradle.kts
+++ b/apps/build-logic/settings.gradle.kts
@@ -1,0 +1,1 @@
+include("dev-setup")

--- a/apps/seed-node-app/build.gradle.kts
+++ b/apps/seed-node-app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("bisq.java-library")
+    id("bisq.gradle.dev.setup.BisqDevSetupPlugin")
     application
 }
 

--- a/apps/settings.gradle.kts
+++ b/apps/settings.gradle.kts
@@ -3,6 +3,9 @@ pluginManagement {
         gradlePluginPortal()
     }
     includeBuild("../build-logic")
+    includeBuild("build-logic") {
+        name = "apps-build-logic"
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Several users reported Tor issues on Windows and running Bisq 2 on Windows is difficult. Most of our documentation is wrong (dev setup enables module encapsulation but release builds disable the module system) and the existing cross-platform regtest setup was commented out and is broken. This PR adds support to run seednodes on all operating systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom Gradle plugin to streamline development setup, including automated tasks for running seed node processes.
  - Added new build logic modules and configuration files to support the custom plugin.
- **Chores**
  - Enabled Gradle build caching to improve build performance.
  - Updated project settings to include new build logic modules and ensure proper plugin integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->