### PR TITLE
feat: Allow selecting and copying text from chat message bubbles

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/SelectableLabel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/SelectableLabel.java
@@ -75,13 +75,10 @@ public class SelectableLabel extends StackPane {
         label.setCursor(Cursor.TEXT);
         textArea.setContextMenu(new ContextMenu());
         textArea.setText(text);
+        textArea.setEditable(false);
         textArea.getStyleClass().addAll("selectable-label", "hide-vertical-scrollbar");
         label.boundsInParentProperty().addListener(labelBoundsListener);
         getStyleClass().addListener(new WeakListChangeListener<>(styleClassListener));
-    }
-
-    public void setEditable(boolean editable){
-        this.textArea.setEditable(editable);
     }
 
     public String getText() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
@@ -29,6 +29,7 @@ import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.DropdownMenu;
+import bisq.desktop.components.controls.SelectableLabel;
 import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
@@ -80,7 +81,7 @@ public abstract class BubbleMessageBox extends MessageBox {
     protected ReactMenuBox reactMenuBox;
     protected Label userName;
     protected Label dateTime;
-    protected final Label message;
+    protected final SelectableLabel message;
     protected HBox userNameAndDateHBox;
     protected final HBox messageBgHBox;
     protected final HBox messageHBox;
@@ -316,13 +317,13 @@ public abstract class BubbleMessageBox extends MessageBox {
         }
     }
 
-    private Label createAndGetMessage() {
-        Label label = new Label();
+    private SelectableLabel createAndGetMessage() {
+        SelectableLabel label = new SelectableLabel(item.getMessage());
         label.maxWidthProperty().unbind();
         label.setWrapText(true);
         label.setPadding(new Insets(10));
         label.getStyleClass().addAll("text-fill-white", "medium-text", "font-default");
-        label.setText(item.getMessage());
+        label.setEditable(false);
         return label;
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
@@ -323,7 +323,6 @@ public abstract class BubbleMessageBox extends MessageBox {
         label.setWrapText(true);
         label.setPadding(new Insets(10));
         label.getStyleClass().addAll("text-fill-white", "medium-text", "font-default");
-        label.setEditable(false);
         return label;
     }
 


### PR DESCRIPTION
## Description:
**Problem**: Users could not select text inside chat message bubbles, making it difficult to copy parts of a message.

**Solution**
Modified the chat message view components (e.g., replacing Labels with read-only TextAreas or similar) to enable standard text selection via mouse drag

**Impact**
Users can now easily select and copy text content (using Ctrl+C/Cmd+C) from individual chat messages.
![image](https://github.com/user-attachments/assets/f11aee9b-2b8c-4090-bd76-3698824b55e3)


**Performance Testing**
A performance test was conducted by rendering a large number of fake message bubbles (using the code on branch: [performance-test-allow-direct-text-selection-inside-chat-bubbles](https://github.com/54corbin/bisq2/commit/77241c7fc7d1e48eac97cb6ff76c29b2cdcc3480) to compare SelectableLabel against the standard Label. No noticeable difference in UI responsiveness or scroll performance was observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chat message boxes to support selectable text, allowing users to copy message content.
  - Added the ability to control whether chat messages are editable or read-only.

- **Improvements**
  - Improved consistency between displayed and internal text values in chat message components.
  - Refined label dimension handling for better text display and interaction in chat messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->