### PR TITLE
Feat: Shift+Enter Newline Insertion at Caret in MyMessage Edit Text Area

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -172,7 +172,11 @@ public final class MyTextMessageBox extends BubbleMessageBox {
             if (keyEvent.getCode() == KeyCode.ENTER) {
                 keyEvent.consume();
                 if (keyEvent.isShiftDown()) {
-                    editInputField.appendText(System.lineSeparator());
+                    int caretPos = editInputField.getCaretPosition();
+                    String currentText = editInputField.getText();
+                    String newText = currentText.substring(0, caretPos) + System.lineSeparator() + currentText.substring(caretPos);
+                    editInputField.setText(newText);
+                    editInputField.positionCaret(caretPos + 1); // Move caret after the newline
                 } else if (!editInputField.getText().isEmpty()) {
                     controller.onSaveEditedMessage(item.getChatMessage(), editInputField.getText().trim());
                     onCloseEditMessage();


### PR DESCRIPTION
**Problem:**

Pressing Shift+Enter while editing a chat message currently appends a newline at the end of the text, ignoring the cursor position. This results in unexpected behavior where the new line is added only at the end, and text after the cursor is not pushed down.

**Solution:**

Modify the edit text area's key event handling so that when Shift+Enter is pressed, a newline character is inserted exactly at the caret (cursor) position instead of appended to the end. This ensures the text after the cursor moves to the next line, matching common multiline editing expectations.
![image](https://github.com/user-attachments/assets/72e11a53-45ae-44d3-9302-097435a6802d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Shift+Enter in the message edit input so that newlines are inserted at the current cursor position, making multi-line message editing more intuitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->