### PR TITLE
fix(fiat-currency): fallback to USD

### DIFF
--- a/common/src/main/java/bisq/common/currency/FiatCurrencyRepository.java
+++ b/common/src/main/java/bisq/common/currency/FiatCurrencyRepository.java
@@ -84,8 +84,12 @@ public class FiatCurrencyRepository {
 
         // The language and variant components of the locale at Currency.getInstance are ignored.
         Locale countryLocale = new Locale(locale.getLanguage(), countryCode);
-        Currency currency = Currency.getInstance(countryLocale);
-        return new FiatCurrency(currency);
+        try {
+            Currency currency = Currency.getInstance(countryLocale);
+            return new FiatCurrency(currency);
+        } catch (Exception e) {
+             return new FiatCurrency("USD");
+        }
     }
 
     public static Map<String, FiatCurrency> getCurrencyByCodeMap() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving currency by country code by adding fallback handling. If the currency cannot be determined, the system now defaults to USD instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->