### PR TITLE
Save and display reporter and banReason for banned users

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
@@ -1,0 +1,217 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.overlay;
+
+import bisq.i18n.Res;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+@Slf4j
+public class TextInputDialog extends Popup {
+    private static final int DEFAULT_MAX_LENGTH = 1000;
+    private static final int PREFERRED_WIDTH = 520;
+
+    private final TextArea inputTextArea;
+    private final Label counterLabel;
+    private final Label descriptionLabel;
+    private final Button confirmButton;
+    private final Button cancelButton;
+
+    private Consumer<String> inputConsumer;
+    private Predicate<String> validator;
+    private int maxLength = DEFAULT_MAX_LENGTH;
+    private String confirmButtonText = Res.get("action.save");
+    private String cancelButtonText = Res.get("action.cancel");
+    private boolean showCounter = true;
+
+    public TextInputDialog(String headline) {
+        this(headline, null);
+    }
+
+    public TextInputDialog(String headline, String fieldLabel) {
+        if (headline != null) {
+            headline(headline);
+        }
+
+        hideCloseButton();
+
+        GridPane gridPane = new GridPane();
+        gridPane.setHgap(10);
+        gridPane.setVgap(10);
+        gridPane.setPadding(new Insets(15, 20, 10, 14));
+        gridPane.setPrefWidth(PREFERRED_WIDTH);
+
+        ColumnConstraints columnConstraints = new ColumnConstraints();
+        columnConstraints.setHgrow(Priority.ALWAYS);
+        columnConstraints.setFillWidth(true);
+        columnConstraints.setPercentWidth(100);
+        gridPane.getColumnConstraints().add(columnConstraints);
+
+        descriptionLabel = new Label();
+        descriptionLabel.setWrapText(true);
+        descriptionLabel.setManaged(false);
+        descriptionLabel.setVisible(false);
+        descriptionLabel.setMaxWidth(Double.MAX_VALUE);
+
+        inputTextArea = new TextArea(fieldLabel);
+        inputTextArea.setMaxWidth(Double.MAX_VALUE);
+
+        counterLabel = new Label(Res.get("component.TextInputDialog.text.characters.remaining", maxLength));
+        counterLabel.setManaged(showCounter);
+        counterLabel.setVisible(showCounter);
+
+        inputTextArea.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null && newValue.length() > maxLength) {
+                int caretPosition = inputTextArea.getCaretPosition();
+                double scrollLeft = inputTextArea.getScrollLeft();
+                double scrollTop = inputTextArea.getScrollTop();
+
+                inputTextArea.setText(oldValue);
+
+                // Try to restore the caret and scrollbars position
+                int newCaretPos = Math.min(caretPosition, oldValue.length());
+                inputTextArea.positionCaret(newCaretPos);
+
+                inputTextArea.setScrollLeft(scrollLeft);
+                inputTextArea.setScrollTop(scrollTop);
+
+                return;
+            }
+            updateRemainingCharsCount();
+        });
+
+        confirmButton = new Button(confirmButtonText);
+        cancelButton = new Button(cancelButtonText);
+
+        confirmButton.getStyleClass().add("action-button");
+        confirmButton.setDefaultButton(true);
+
+        HBox buttonBox = new HBox(10, confirmButton, cancelButton);
+        buttonBox.setPadding(new Insets(10, 0, 0, 0));
+        buttonBox.setAlignment(Pos.CENTER_RIGHT);
+
+        int rowIndex = 0;
+        gridPane.add(descriptionLabel, 0, rowIndex++);
+        gridPane.add(inputTextArea, 0, rowIndex++);
+        gridPane.add(counterLabel, 0, rowIndex++);
+        gridPane.add(buttonBox, 0, rowIndex);
+
+        confirmButton.setOnAction(e -> {
+            String input = inputTextArea.getText();
+            if (validator != null && !validator.test(input)) {
+                return;
+            }
+
+            if (inputConsumer != null) {
+                inputConsumer.accept(input);
+            }
+            hide();
+        });
+
+        cancelButton.setOnAction(e -> hide());
+
+        GridPane.setHgrow(inputTextArea, Priority.ALWAYS);
+        GridPane.setHgrow(buttonBox, Priority.ALWAYS);
+        GridPane.setHgrow(descriptionLabel, Priority.ALWAYS);
+        GridPane.setHgrow(counterLabel, Priority.ALWAYS);
+
+        content(gridPane);
+    }
+
+    public TextInputDialog setPromptText(String prompt) {
+        inputTextArea.setPromptText(prompt);
+        return this;
+    }
+
+    public TextInputDialog setInputFieldDescription(String instructions) {
+        if (instructions != null && !instructions.isEmpty()) {
+            descriptionLabel.setText(instructions);
+            descriptionLabel.setManaged(true);
+            descriptionLabel.setVisible(true);
+        }
+        return this;
+    }
+
+    public TextInputDialog setMaxLength(int maxLength) {
+        this.maxLength = maxLength;
+        updateRemainingCharsCount();
+        return this;
+    }
+
+    public TextInputDialog setConfirmButtonText(String text) {
+        confirmButtonText = text;
+        if (confirmButton != null) {
+            confirmButton.setText(text);
+        }
+        return this;
+    }
+
+    public TextInputDialog setCancelButtonText(String text) {
+        cancelButtonText = text;
+        if (cancelButton != null) {
+            cancelButton.setText(text);
+        }
+        return this;
+    }
+
+    public TextInputDialog showCounter(boolean show) {
+        showCounter = show;
+        if (counterLabel != null) {
+            counterLabel.setManaged(show);
+            counterLabel.setVisible(show);
+        }
+        return this;
+    }
+
+    public TextInputDialog validator(Predicate<String> validator) {
+        this.validator = validator;
+        return this;
+    }
+
+    public TextInputDialog onResult(Consumer<String> inputConsumer) {
+        this.inputConsumer = inputConsumer;
+        return this;
+    }
+
+    public static Optional<String> show(String headline, String fieldLabel) {
+        TextInputDialog dialog = new TextInputDialog(headline, fieldLabel);
+        String[] result = {null};
+
+        dialog.onResult(text -> result[0] = text);
+        dialog.show();
+
+        return Optional.ofNullable(result[0]);
+    }
+
+    private void updateRemainingCharsCount() {
+        int remaining = maxLength - (inputTextArea.getText() != null ? inputTextArea.getText().length() : 0);
+        counterLabel.setText(Res.get("component.TextInputDialog.text.characters.remaining", remaining));
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
@@ -21,22 +21,30 @@ import bisq.bisq_easy.NavigationTarget;
 import bisq.bonded_roles.bonded_role.BondedRole;
 import bisq.chat.ChatChannelDomain;
 import bisq.common.observable.Pin;
+import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIThread;
+import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.view.Navigation;
+import bisq.desktop.components.controls.BisqIconButton;
+import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.RichTableView;
 import bisq.desktop.main.content.components.UserProfileIcon;
 import bisq.i18n.Res;
 import bisq.network.SendMessageResult;
+import bisq.support.moderator.BannedUserModeratorData;
 import bisq.support.moderator.ModeratorService;
 import bisq.user.banned.BannedUserProfileData;
 import bisq.user.banned.BannedUserService;
 import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -44,6 +52,7 @@ import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 import lombok.EqualsAndHashCode;
@@ -53,6 +62,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class BannedUserProfileTable {
     @Getter
@@ -73,11 +83,13 @@ public class BannedUserProfileTable {
         private final Model model;
         private final BannedUserService bannedUserService;
         private final ModeratorService moderatorService;
+        private final UserProfileService userProfileService;
         private Pin bannedUserListItemsPin;
 
         private Controller(ServiceProvider serviceProvider) {
             bannedUserService = serviceProvider.getUserService().getBannedUserService();
             moderatorService = serviceProvider.getSupportService().getModeratorService();
+            userProfileService = serviceProvider.getUserService().getUserProfileService();
 
             model = new Model();
             view = new View(model, this);
@@ -86,7 +98,7 @@ public class BannedUserProfileTable {
         @Override
         public void onActivate() {
             bannedUserListItemsPin = FxBindings.<BannedUserProfileData, View.ListItem>bind(model.getListItems())
-                    .map(View.ListItem::new)
+                    .map(data -> View.ListItem.from(data, userProfileService, moderatorService))
                     .to(bannedUserService.getBannedUserProfileDataSet());
         }
 
@@ -171,7 +183,31 @@ public class BannedUserProfileTable {
                     .left()
                     .comparator(Comparator.comparing(ListItem::getUserName))
                     .valueSupplier(ListItem::getUserName)
-                    .setCellFactory(getUserProfileCellFactory())
+                    .setCellFactory(createUserProfileCellFactory(
+                            ListItem::getUserName,
+                            item -> Optional.of(item.getUserProfile())
+                    ))
+                    .build());
+
+            richTableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
+                    .title(Res.get("authorizedRole.moderator.bannedUserProfile.table.reporter"))
+                    .minWidth(150)
+                    .left()
+                    .comparator(Comparator.comparing(ListItem::getReporterUserName))
+                    .valueSupplier(ListItem::getReporterUserName)
+                    .setCellFactory(createUserProfileCellFactory(
+                            ListItem::getReporterUserName,
+                            ListItem::getReporterUserProfile
+                    ))
+                    .build());
+
+            richTableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
+                    .title(Res.get("authorizedRole.moderator.bannedUserProfile.table.banReason"))
+                    .minWidth(200)
+                    .left()
+                    .comparator(Comparator.comparing(ListItem::getBanReason))
+                    .valueSupplier(ListItem::getBanReason)
+                    .setCellFactory(getBanReasonCellFactory())
                     .build());
             richTableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
                     .isSortable(false)
@@ -187,7 +223,9 @@ public class BannedUserProfileTable {
                     .build());
         }
 
-        private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getUserProfileCellFactory() {
+        private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> createUserProfileCellFactory(
+                Function<ListItem, String> userNameExtractor,
+                Function<ListItem, Optional<UserProfile>> userProfileExtractor) {
             return column -> new TableCell<>() {
                 private final Label userName = new Label();
                 private final UserProfileIcon userProfileIcon = new UserProfileIcon();
@@ -203,11 +241,59 @@ public class BannedUserProfileTable {
                     super.updateItem(item, empty);
 
                     if (item != null && !empty) {
-                        userName.setText(item.getUserName());
-                        userProfileIcon.setUserProfile(item.getUserProfile());
-                        setGraphic(hBox);
+                        userName.setText(userNameExtractor.apply(item));
+
+                        Optional<UserProfile> profileOpt = userProfileExtractor.apply(item);
+                        if (profileOpt.isPresent()) {
+                            userProfileIcon.setUserProfile(profileOpt.get());
+                            setGraphic(hBox);
+                        } else {
+                            userProfileIcon.dispose();
+                            setGraphic(userName);
+                        }
                     } else {
                         userProfileIcon.dispose();
+                        setGraphic(null);
+                    }
+                }
+            };
+        }
+
+        private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getBanReasonCellFactory() {
+            return column -> new TableCell<>() {
+                private final Label banReason = new Label();
+                private final Button icon = BisqIconButton.createIconButton(AwesomeIcon.EXTERNAL_LINK);
+                private final HBox hBox = new HBox(banReason, icon);
+                private final BisqTooltip tooltip = new BisqTooltip(BisqTooltip.Style.DARK);
+
+                {
+                    icon.setMinWidth(30);
+                    HBox.setHgrow(icon, Priority.ALWAYS);
+                    HBox.setMargin(icon, new Insets(0, 10, 0, 10));
+                    hBox.setAlignment(Pos.CENTER_LEFT);
+                }
+
+                @Override
+                protected void updateItem(ListItem item, boolean empty) {
+                    super.updateItem(item, empty);
+
+                    if (item != null && !empty) {
+                        String banReasonText = StringUtils.toOptional(item.getBanReason()).orElse(Res.get("data.na"));
+                        banReason.setText(StringUtils.truncate(banReasonText, 30));
+                        banReason.setMaxHeight(30);
+                        tooltip.setText(banReasonText);
+                        banReason.setTooltip(tooltip);
+
+                        icon.setOnAction(e -> new Popup()
+                                .headline(Res.get("authorizedRole.moderator.bannedUserProfile.table.banReason.popup.headline"))
+                                .information(banReasonText)
+                                .actionButtonText(Res.get("action.copyToClipboard"))
+                                .onAction(() -> ClipboardUtil.copyToClipboard(banReasonText))
+                                .show());
+                        setGraphic(hBox);
+                    } else {
+                        icon.setOnAction(null);
+                        banReason.setTooltip(null);
                         setGraphic(null);
                     }
                 }
@@ -260,12 +346,44 @@ public class BannedUserProfileTable {
 
             private final UserProfile userProfile;
             private final String userName;
+            private final String reporterUserProfileId;
+            private final String reporterUserName;
+            private final Optional<UserProfile> reporterUserProfile;
+            private final String banReason;
 
-            private ListItem(BannedUserProfileData bannedUserProfileData) {
+            public static ListItem from(BannedUserProfileData data,
+                                        UserProfileService userProfileService,
+                                        ModeratorService moderatorService) {
+                return new ListItem(data, userProfileService, moderatorService);
+            }
+
+            private ListItem(BannedUserProfileData bannedUserProfileData,
+                             UserProfileService userProfileService,
+                             ModeratorService moderatorService) {
                 this.bannedUserProfileData = bannedUserProfileData;
 
                 userProfile = bannedUserProfileData.getUserProfile();
                 userName = userProfile.getUserName();
+                String accusedUserProfileId = userProfile.getId();
+
+                Optional<BannedUserModeratorData> moderatorDataOpt = moderatorService.findBannedUserModeratorData(accusedUserProfileId);
+
+                banReason = moderatorDataOpt
+                        .map(BannedUserModeratorData::getBanReason)
+                        .flatMap(StringUtils::toOptional)
+                        .orElse(Res.get("data.na"));
+
+                reporterUserProfileId = moderatorDataOpt
+                        .map(BannedUserModeratorData::getReporterUserProfileId)
+                        .orElse(null);
+
+                reporterUserProfile = Optional.ofNullable(reporterUserProfileId)
+                        .filter(id -> !id.isEmpty())
+                        .flatMap(userProfileService::findUserProfile);
+
+                reporterUserName = reporterUserProfile
+                        .map(UserProfile::getUserName)
+                        .orElse(Res.get("data.na"));
             }
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
@@ -31,6 +31,7 @@ import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqIconButton;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.overlay.Popup;
+import bisq.desktop.components.overlay.TextInputDialog;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.DateColumnUtil;
 import bisq.desktop.components.table.DateTableItem;
@@ -122,7 +123,13 @@ public class ReportToModeratorTable {
         }
 
         void onBan(ReportToModeratorMessage message) {
-            moderatorService.banReportedUser(message);
+            new TextInputDialog(Res.get("authorizedRole.moderator.banDialog.headline"))
+                    .setPromptText(Res.get("authorizedRole.moderator.banDialog.reason.prompt"))
+                    .setInputFieldDescription(Res.get("authorizedRole.moderator.banDialog.details"))
+                    .setConfirmButtonText(Res.get("authorizedRole.moderator.banDialog.action.ban"))
+                    .setMaxLength(500)
+                    .onResult(banReason -> moderatorService.banReportedUser(message, banReason))
+                    .show();
         }
 
         void onDeleteMessage(ReportToModeratorMessage message) {

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -96,8 +96,17 @@ authorizedRole.moderator.table.delete=Delete
 
 authorizedRole.moderator.table.message.popup.headline=Reporters message
 
+authorizedRole.moderator.banDialog.headline=Enter a ban reason
+authorizedRole.moderator.banDialog.details=This information will be stored locally and won't be visible to other moderators or the banned user
+authorizedRole.moderator.banDialog.reason.prompt=Enter ban reason...
+authorizedRole.moderator.banDialog.action.ban=Ban
+
 authorizedRole.moderator.bannedUserProfile.table.headline=Banned user profiles
 authorizedRole.moderator.bannedUserProfile.table.userProfile=User profile
+authorizedRole.moderator.bannedUserProfile.table.reporter=Reporter
+authorizedRole.moderator.bannedUserProfile.table.banReason=Ban Reason
+authorizedRole.moderator.bannedUserProfile.table.banReason.popup.headline=Ban Reason
+
 authorizedRole.moderator.bannedUserProfile.table.contact=Contact
 
 authorizedRole.moderator.table.removeBan=Remove ban

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -143,3 +143,7 @@ component.standardTable.filter.tooltip=Filter by {0}
 component.standardTable.numEntries=Number of entries: {0}
 component.standardTable.csv.plainValue={0} (plain value)
 
+####################################################################
+# TextInputDialog
+####################################################################
+component.TextInputDialog.text.characters.remaining={0} characters remaining

--- a/support/src/main/java/bisq/support/moderator/BannedUserModeratorData.java
+++ b/support/src/main/java/bisq/support/moderator/BannedUserModeratorData.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.moderator;
+
+import bisq.common.proto.PersistableProto;
+import bisq.common.proto.ProtoResolver;
+import bisq.common.proto.UnresolvableProtobufMessageException;
+import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@ToString
+@EqualsAndHashCode
+public final class BannedUserModeratorData implements PersistableProto {
+    private final String reporterUserProfileId;
+    private final String accusedUserProfileId;
+    private final String reportersMessage;
+    private final String banReason;
+
+    public BannedUserModeratorData(String reporterUserProfileId,
+                                   String accusedUserProfileId,
+                                   String reportersMessage,
+                                   String banReason) {
+        this.reporterUserProfileId = reporterUserProfileId;
+        this.accusedUserProfileId = accusedUserProfileId;
+        this.reportersMessage = reportersMessage;
+        this.banReason = banReason;
+    }
+
+    @Override
+    public bisq.support.protobuf.BannedUserModeratorData.Builder getBuilder(boolean serializeForHash) {
+        return bisq.support.protobuf.BannedUserModeratorData.newBuilder()
+                .setReporterUserProfileId(reporterUserProfileId)
+                .setAccusedUserProfileId(accusedUserProfileId)
+                .setReportMessage(reportersMessage)
+                .setBanReason(banReason);
+    }
+
+    @Override
+    public bisq.support.protobuf.BannedUserModeratorData toProto(boolean serializeForHash) {
+        return getBuilder(serializeForHash).build();
+    }
+
+    public static BannedUserModeratorData fromProto(bisq.support.protobuf.BannedUserModeratorData proto) {
+        return new BannedUserModeratorData(
+                proto.getReporterUserProfileId(),
+                proto.getAccusedUserProfileId(),
+                proto.getReportMessage(),
+                proto.getBanReason());
+    }
+
+    public static ProtoResolver<PersistableProto> getResolver() {
+        return any -> {
+            try {
+                return fromProto(any.unpack(bisq.support.protobuf.BannedUserModeratorData.class));
+            } catch (InvalidProtocolBufferException e) {
+                throw new UnresolvableProtobufMessageException(e);
+            }
+        };
+    }
+}

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -39,6 +39,15 @@ message ReportToModeratorMessage {
   string message = 4;
   chat.ChatChannelDomain chatChannelDomain = 5;
 }
+
+message BannedUserModeratorData {
+  string reporterUserProfileId = 1;
+  string accusedUserProfileId = 2;
+  string reportMessage = 3;
+  string banReason = 4;
+}
+
 message ModeratorStore {
   repeated ReportToModeratorMessage reportToModeratorMessages = 1;
+  repeated BannedUserModeratorData bannedUserModeratorData = 2;
 }

--- a/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
+++ b/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
@@ -33,8 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Set;
 
-import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
-import static bisq.network.p2p.services.data.storage.MetaData.TTL_100_DAYS;
+import static bisq.network.p2p.services.data.storage.MetaData.*;
 
 @Slf4j
 @EqualsAndHashCode


### PR DESCRIPTION
Displaying reporter and banReason for moderator in BannedUserProfileTable

Fixed #3181



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Moderators can now provide and store a ban reason when banning a user, improving record-keeping and transparency.
  - The banned users table displays new columns for "Reporter" and "Ban Reason," with the ability to view and copy the full ban reason via a popup.
  - A new text input dialog is available for entering ban reasons, featuring character counting and validation.

- **Improvements**
  - Enhanced localization support for new moderator actions and dialogs.
  - Updated data persistence to store and retrieve moderator ban details, including reporter and reason information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->