### PR TITLE
Allow dismissing the chat rules warning

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -110,6 +110,7 @@ public class ChatMessagesListController implements Controller {
     private Pin selectedChannelPin, chatMessagesPin, bisqEasyOfferbookMessageTypeFilterPin, highlightedMessagePin;
     private Subscription selectedChannelSubscription, focusSubscription, scrollValuePin, scrollBarVisiblePin,
             layoutChildrenDonePin;
+    private static final String DONT_SHOW_CHAT_RULES_WARNING_KEY = "privateChatRulesWarning";
 
     public ChatMessagesListController(ServiceProvider serviceProvider,
                                       Consumer<UserProfile> mentionUserHandler,
@@ -562,6 +563,20 @@ public class ChatMessagesListController implements Controller {
         Navigation.navigateTo(NavigationTarget.CHAT_RULES);
     }
 
+    public void onDismissChatRulesWarning() {
+        dontShowAgainService.putDontShowAgain(DONT_SHOW_CHAT_RULES_WARNING_KEY, true);
+
+         model.getSortedChatMessages().stream()
+                .filter(item -> item.getChatMessage().getChatMessageType() == ChatMessageType.CHAT_RULES_WARNING)
+                .findFirst()
+                .ifPresent(itemToRemove -> {
+                    UIThread.run(() -> {
+                        itemToRemove.dispose();
+                        model.getChatMessages().remove(itemToRemove);
+                    });
+                });
+    }
+
     public void onClickQuoteMessage(Optional<String> chatMessageId) {
         chatMessageId.ifPresent(messageId -> {
             model.getChatMessages().forEach(item -> {
@@ -655,13 +670,11 @@ public class ChatMessagesListController implements Controller {
                 .map(e -> e.getChatMessage().getId())
                 .collect(Collectors.toSet()));
 
-        boolean isMediator = false;
-        if (channel instanceof BisqEasyOpenTradeChannel bisqEasyOpenTradeChannel) {
-            if (bisqEasyOpenTradeChannel.isMediator()) {
-                isMediator = true;
-            }
-        }
-        if (!isMediator) {
+        boolean shouldShowWarningMessageForNoneMediator = dontShowAgainService.showAgain(DONT_SHOW_CHAT_RULES_WARNING_KEY)
+                && !(channel instanceof BisqEasyOpenTradeChannel bisqEasyOpenTradeChannel
+                && bisqEasyOpenTradeChannel.isMediator());
+
+        if (shouldShowWarningMessageForNoneMediator) {
             addChatRulesWarningMessageListItemInPrivateChats(channel);
         }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/ChatRulesWarningMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/ChatRulesWarningMessageBox.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.chat.message_container.list.message_box;
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
 import bisq.desktop.common.utils.ImageUtil;
+import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
@@ -36,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class ChatRulesWarningMessageBox extends MessageBox {
     private final Hyperlink learnMoreLink;
-    private final Hyperlink closeIcon;
+    private final BisqMenuItem closeIcon;
     private final Tooltip closeTooltip = new BisqTooltip(Res.get("action.dontShowAgain"));
 
     public ChatRulesWarningMessageBox(
@@ -64,11 +65,11 @@ public final class ChatRulesWarningMessageBox extends MessageBox {
         messageContentVBox.setFillWidth(true);
         messageContentVBox.setAlignment(Pos.CENTER_LEFT);
 
-        closeIcon = new Hyperlink("X");
-        closeIcon.getStyleClass().add("close-icon-link");
+        closeIcon = new BisqMenuItem("close-mini-grey", "close-mini-white");
+        closeIcon.useIconOnly(20);
         closeIcon.setCursor(Cursor.HAND);
         Tooltip.install(closeIcon, closeTooltip);
-        closeIcon.setOnAction(e -> {
+        closeIcon.setOnMouseClicked(e -> {
             controller.onDismissChatRulesWarning();
             e.consume();
         });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/ChatRulesWarningMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/ChatRulesWarningMessageBox.java
@@ -20,22 +20,24 @@ package bisq.desktop.main.content.chat.message_container.list.message_box;
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
 import bisq.desktop.common.utils.ImageUtil;
+import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessageListItem;
 import bisq.desktop.main.content.chat.message_container.list.ChatMessagesListController;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.VBox;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.*;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class ChatRulesWarningMessageBox extends MessageBox {
     private final Hyperlink learnMoreLink;
+    private final Hyperlink closeIcon;
+    private final Tooltip closeTooltip = new BisqTooltip(Res.get("action.dontShowAgain"));
 
     public ChatRulesWarningMessageBox(
             ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
@@ -56,28 +58,47 @@ public final class ChatRulesWarningMessageBox extends MessageBox {
         learnMoreLink.getStyleClass().addAll("text-fill-green", "font-light", "medium-text");
         learnMoreLink.setOnAction(e -> controller.onLearnMoreAboutChatRules());
 
-        VBox messageBg = new VBox();
-        messageBg.setSpacing(5);
-        messageBg.getChildren().addAll(warningHeadline, message, learnMoreLink);
-        messageBg.setFillWidth(true);
-        messageBg.setAlignment(Pos.CENTER_LEFT);
-        messageBg.getStyleClass().add("system-message-background");
-        HBox.setHgrow(messageBg, Priority.ALWAYS);
+        VBox messageContentVBox = new VBox();
+        messageContentVBox.setSpacing(5);
+        messageContentVBox.getChildren().addAll(warningHeadline, message, learnMoreLink);
+        messageContentVBox.setFillWidth(true);
+        messageContentVBox.setAlignment(Pos.CENTER_LEFT);
+
+        closeIcon = new Hyperlink("X");
+        closeIcon.getStyleClass().add("close-icon-link");
+        closeIcon.setCursor(Cursor.HAND);
+        Tooltip.install(closeIcon, closeTooltip);
+        closeIcon.setOnAction(e -> {
+            controller.onDismissChatRulesWarning();
+            e.consume();
+        });
+
+        StackPane messageBgStackPane = new StackPane();
+        messageBgStackPane.getStyleClass().add("system-message-background");
+        HBox.setHgrow(messageBgStackPane, Priority.ALWAYS);
+
+        messageBgStackPane.getChildren().addAll(messageContentVBox, closeIcon);
+
+        StackPane.setAlignment(closeIcon, Pos.TOP_RIGHT);
+        StackPane.setMargin(closeIcon, new Insets(0, 0, 5, 0));
+        StackPane.setAlignment(messageContentVBox, Pos.CENTER_LEFT);
 
         setFillWidth(true);
         HBox.setHgrow(this, Priority.ALWAYS);
         setPadding(new Insets(0));
 
-        VBox contentVBox = new VBox(messageBg);
-        contentVBox.setPrefWidth(Region.USE_PREF_SIZE);
-        contentVBox.setMaxWidth(CHAT_BOX_MAX_WIDTH);
-        contentVBox.setPadding(new Insets(0, 70, 0, 70));
-        getChildren().setAll(contentVBox);
+        VBox contentWidthLimiterVBox = new VBox(messageBgStackPane);
+        contentWidthLimiterVBox.setPrefWidth(Region.USE_PREF_SIZE);
+        contentWidthLimiterVBox.setMaxWidth(CHAT_BOX_MAX_WIDTH);
+        contentWidthLimiterVBox.setPadding(new Insets(0, 70, 0, 70));
+        getChildren().setAll(contentWidthLimiterVBox);
         setAlignment(Pos.CENTER);
     }
 
     @Override
     public void dispose() {
         learnMoreLink.setOnAction(null);
+        closeIcon.setOnMouseClicked(null);
+        Tooltip.uninstall(closeIcon, closeTooltip);
     }
 }

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -492,32 +492,6 @@
     -fx-text-fill: -fx-mid-text-color !important;
 }
 
-.close-icon-link {
-    -fx-text-fill: grey;
-    -fx-font-family: "IBM Plex Sans";
-    -fx-font-size: 1em;
-
-    -fx-padding: 0 4px 0 4px;
-    -fx-underline: false;
-    -fx-border-color: transparent;
-    -fx-background-color: transparent;
-    -fx-opacity: 0.7;
-}
-
-.close-icon-link:hover {
-    -fx-text-fill: -bisq-white !important;
-    -fx-underline: false;
-    -fx-opacity: 1.0;
-    -fx-background-color: -bisq-mid-grey-10 !important;
-    -fx-background-radius: 2;
-}
-
-.close-icon-link:visited {
-    -fx-text-fill: grey;
-    -fx-underline: false;
-     -fx-opacity: 0.7;
-}
-
 
 /*******************************************************************************
  * Chat guide                                                                  *

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -492,6 +492,32 @@
     -fx-text-fill: -fx-mid-text-color !important;
 }
 
+.close-icon-link {
+    -fx-text-fill: grey;
+    -fx-font-family: "IBM Plex Sans";
+    -fx-font-size: 1em;
+
+    -fx-padding: 0 4px 0 4px;
+    -fx-underline: false;
+    -fx-border-color: transparent;
+    -fx-background-color: transparent;
+    -fx-opacity: 0.7;
+}
+
+.close-icon-link:hover {
+    -fx-text-fill: -bisq-white !important;
+    -fx-underline: false;
+    -fx-opacity: 1.0;
+    -fx-background-color: -bisq-mid-grey-10 !important;
+    -fx-background-radius: 2;
+}
+
+.close-icon-link:visited {
+    -fx-text-fill: grey;
+    -fx-underline: false;
+     -fx-opacity: 0.7;
+}
+
 
 /*******************************************************************************
  * Chat guide                                                                  *


### PR DESCRIPTION
Adds a way to permanently hide the chat rules warning.

**Why:**
The warning message shown at the start of private/trade chats was always there and took up space after being read once.

**What:**
- Adds a small 'X' link/icon to the top-right of the warning message box.
- Clicking it saves a preference (`DontShowAgainService`) so the warning won't be shown for that user again.
- Includes tooltip i18n for the dismiss button.

![image](https://github.com/user-attachments/assets/7ee5f420-23e0-478b-9421-30a41f307765)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Don't show again" close icon to the chat rules warning message, allowing users to dismiss the warning and prevent it from appearing in the future.

- **Improvements**
  - Enhanced the chat rules warning message layout with a more intuitive close button and improved alignment for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->