### PR TITLE
Make public access methods/getters in *Store classes package scope

### DIFF
--- a/account/src/main/java/bisq/account/AccountStore.java
+++ b/account/src/main/java/bisq/account/AccountStore.java
@@ -24,6 +24,8 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -33,15 +35,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
-public final class AccountStore implements PersistableStore<AccountStore> {
+final class AccountStore implements PersistableStore<AccountStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, Account<?, ? extends PaymentMethod<?>>> accountByName = new ConcurrentHashMap<>();
+    @Getter(AccessLevel.PACKAGE)
     private final Observable<Account<?, ? extends PaymentMethod<?>>> selectedAccount = new Observable<>();
 
-    public AccountStore() {
+    AccountStore() {
         this(new HashMap<>(), Optional.empty());
     }
 
-    public AccountStore(Map<String, Account<?, ? extends PaymentMethod<?>>> accountByName,
+    AccountStore(Map<String, Account<?, ? extends PaymentMethod<?>>> accountByName,
                         Optional<Account<?, ? extends PaymentMethod<?>>> selectedAccount) {
         this.accountByName.putAll(accountByName);
         this.selectedAccount.set(selectedAccount.orElse(null));
@@ -92,13 +96,5 @@ public final class AccountStore implements PersistableStore<AccountStore> {
         accountByName.clear();
         accountByName.putAll(persisted.accountByName);
         selectedAccount.set(persisted.selectedAccount.get());
-    }
-
-    Map<String, Account<?, ? extends PaymentMethod<?>>> getAccountByName() {
-        return accountByName;
-    }
-
-    Observable<Account<?, ? extends PaymentMethod<?>>> getSelectedAccount() {
-        return selectedAccount;
     }
 }

--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeStore.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeStore.java
@@ -23,7 +23,9 @@ import bisq.persistence.PersistableStore;
 import bisq.user.reputation.requests.AuthorizeAccountAgeRequest;
 import bisq.user.reputation.requests.AuthorizeSignedWitnessRequest;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
@@ -37,15 +39,13 @@ import java.util.stream.Collectors;
  * persisted as encrypted entries and the decryption key is help by another bonded role. So it would require the
  * cooperation of the oracle node operator with the key holder.
  */
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class Bisq1BridgeStore implements PersistableStore<Bisq1BridgeStore> {
-    @Getter
+final class Bisq1BridgeStore implements PersistableStore<Bisq1BridgeStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Set<AuthorizeAccountAgeRequest> accountAgeRequests = new CopyOnWriteArraySet<>();
-    @Getter
+    @Getter(AccessLevel.PACKAGE)
     private final Set<AuthorizeSignedWitnessRequest> signedWitnessRequests = new CopyOnWriteArraySet<>();
-
-    public Bisq1BridgeStore() {
-    }
 
     private Bisq1BridgeStore(Set<AuthorizeAccountAgeRequest> accountAgeRequests, Set<AuthorizeSignedWitnessRequest> signedWitnessRequests) {
         this.accountAgeRequests.addAll(accountAgeRequests);

--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/timestamp/TimestampStore.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/timestamp/TimestampStore.java
@@ -22,7 +22,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -30,13 +32,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class TimestampStore implements PersistableStore<TimestampStore> {
-    @Getter
+final class TimestampStore implements PersistableStore<TimestampStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, Long> timestampsByProfileId = new ConcurrentHashMap<>();
-
-    public TimestampStore() {
-    }
 
     private TimestampStore(Map<String, Long> timestampsByProfileId) {
         this.timestampsByProfileId.putAll(timestampsByProfileId);

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceStore.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceStore.java
@@ -25,19 +25,21 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class MarketPriceStore implements PersistableStore<MarketPriceStore> {
+final class MarketPriceStore implements PersistableStore<MarketPriceStore> {
     private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
     private final Observable<Market> selectedMarket = new Observable<>(MarketRepository.getDefault());
-
-    public MarketPriceStore() {
-    }
 
     private MarketPriceStore(Map<Market, MarketPrice> marketPriceByCurrencyMap, Market selectedMarket) {
         this.marketPriceByCurrencyMap.putAll(marketPriceByCurrencyMap);
@@ -90,13 +92,5 @@ public final class MarketPriceStore implements PersistableStore<MarketPriceStore
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         marketPriceByCurrencyMap.putAll(map);
         selectedMarket.set(persisted.getSelectedMarket().get());
-    }
-
-    ObservableHashMap<Market, MarketPrice> getMarketPriceByCurrencyMap() {
-        return marketPriceByCurrencyMap;
-    }
-
-    Observable<Market> getSelectedMarket() {
-        return selectedMarket;
     }
 }

--- a/chat/src/main/java/bisq/chat/ChatChannelSelectionStore.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelSelectionStore.java
@@ -21,22 +21,22 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-@Getter
-public final class ChatChannelSelectionStore implements PersistableStore<ChatChannelSelectionStore> {
+final class ChatChannelSelectionStore implements PersistableStore<ChatChannelSelectionStore> {
     @Nullable
-    @Setter
+    @Setter(AccessLevel.PACKAGE)
     private String selectedChannelId;
-
-    public ChatChannelSelectionStore() {
-    }
 
     private ChatChannelSelectionStore(@Nullable String selectedChannelId) {
         this.selectedChannelId = selectedChannelId;

--- a/chat/src/main/java/bisq/chat/bisq_easy/offerbook/BisqEasyOfferbookChannelStore.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/offerbook/BisqEasyOfferbookChannelStore.java
@@ -22,18 +22,18 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Getter
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class BisqEasyOfferbookChannelStore implements PersistableStore<BisqEasyOfferbookChannelStore> {
     private final ObservableSet<BisqEasyOfferbookChannel> channels = new ObservableSet<>();
-
-    public BisqEasyOfferbookChannelStore() {
-    }
 
     private BisqEasyOfferbookChannelStore(List<BisqEasyOfferbookChannel> channels) {
         this.channels.setAll(channels);

--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelStore.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelStore.java
@@ -22,18 +22,17 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
-import lombok.Getter;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Getter
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class BisqEasyOpenTradeChannelStore implements PersistableStore<BisqEasyOpenTradeChannelStore> {
     private final ObservableSet<BisqEasyOpenTradeChannel> channels = new ObservableSet<>();
-
-    public BisqEasyOpenTradeChannelStore() {
-    }
 
     private BisqEasyOpenTradeChannelStore(Set<BisqEasyOpenTradeChannel> privateTradeChannels) {
         setAll(privateTradeChannels);
@@ -80,7 +79,7 @@ public class BisqEasyOpenTradeChannelStore implements PersistableStore<BisqEasyO
         return new BisqEasyOpenTradeChannelStore(new HashSet<>(channels));
     }
 
-    public void setAll(Set<BisqEasyOpenTradeChannel> privateTradeChannels) {
+    void setAll(Set<BisqEasyOpenTradeChannel> privateTradeChannels) {
         this.channels.setAll(privateTradeChannels);
     }
 }

--- a/chat/src/main/java/bisq/chat/common/CommonPublicChatChannelStore.java
+++ b/chat/src/main/java/bisq/chat/common/CommonPublicChatChannelStore.java
@@ -22,18 +22,18 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Getter
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class CommonPublicChatChannelStore implements PersistableStore<CommonPublicChatChannelStore> {
     private final ObservableSet<CommonPublicChatChannel> channels = new ObservableSet<>();
-
-    CommonPublicChatChannelStore() {
-    }
 
     private CommonPublicChatChannelStore(Set<CommonPublicChatChannel> privateDiscussionChannels) {
         setAll(privateDiscussionChannels);
@@ -80,7 +80,7 @@ public class CommonPublicChatChannelStore implements PersistableStore<CommonPubl
         return new CommonPublicChatChannelStore(new HashSet<>(channels));
     }
 
-    public void setAll(Set<CommonPublicChatChannel> privateDiscussionChannels) {
+    void setAll(Set<CommonPublicChatChannel> privateDiscussionChannels) {
         this.channels.setAll(privateDiscussionChannels);
     }
 }

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationsStore.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationsStore.java
@@ -22,6 +22,8 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -29,11 +31,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public final class ChatNotificationsStore implements PersistableStore<ChatNotificationsStore> {
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+final class ChatNotificationsStore implements PersistableStore<ChatNotificationsStore> {
     private final ObservableSet<ChatNotification> chatNotifications = new ObservableSet<>();
-
-    public ChatNotificationsStore() {
-    }
 
     ChatNotificationsStore(Collection<ChatNotification> chatNotifications) {
         this.chatNotifications.setAll(chatNotifications);

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelStore.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelStore.java
@@ -22,18 +22,18 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Getter
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class TwoPartyPrivateChatChannelStore implements PersistableStore<TwoPartyPrivateChatChannelStore> {
     private final ObservableSet<TwoPartyPrivateChatChannel> channels = new ObservableSet<>();
-
-    TwoPartyPrivateChatChannelStore() {
-    }
 
     TwoPartyPrivateChatChannelStore(Set<TwoPartyPrivateChatChannel> twoPartyPrivateChatChannels) {
         setAll(twoPartyPrivateChatChannels);
@@ -80,7 +80,7 @@ public class TwoPartyPrivateChatChannelStore implements PersistableStore<TwoPart
         return new TwoPartyPrivateChatChannelStore(new HashSet<>(channels));
     }
 
-    public void setAll(Set<TwoPartyPrivateChatChannel> twoPartyPrivateChatChannels) {
+    void setAll(Set<TwoPartyPrivateChatChannel> twoPartyPrivateChatChannels) {
         this.channels.setAll(twoPartyPrivateChatChannels);
     }
 }

--- a/identity/src/main/java/bisq/identity/IdentityStore.java
+++ b/identity/src/main/java/bisq/identity/IdentityStore.java
@@ -21,6 +21,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
@@ -28,15 +31,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class IdentityStore implements PersistableStore<IdentityStore> {
+final class IdentityStore implements PersistableStore<IdentityStore> {
     // Is only empty before we get initialize called the first time
     private Optional<Identity> defaultIdentity = Optional.empty();
     private final Map<String, Identity> activeIdentityByTag = new ConcurrentHashMap<>();
     private final Set<Identity> retired = new CopyOnWriteArraySet<>();
-
-    public IdentityStore() {
-    }
 
     private IdentityStore(Optional<Identity> defaultIdentity,
                           Map<String, Identity> activeIdentityByTag,
@@ -96,18 +98,6 @@ public final class IdentityStore implements PersistableStore<IdentityStore> {
 
         retired.clear();
         retired.addAll(persisted.getRetired());
-    }
-
-    Map<String, Identity> getActiveIdentityByTag() {
-        return activeIdentityByTag;
-    }
-
-    Set<Identity> getRetired() {
-        return retired;
-    }
-
-    Optional<Identity> getDefaultIdentity() {
-        return defaultIdentity;
     }
 
     void setDefaultIdentity(Identity defaultIdentity) {

--- a/network/network/src/main/java/bisq/network/NetworkIdStore.java
+++ b/network/network/src/main/java/bisq/network/NetworkIdStore.java
@@ -22,6 +22,9 @@ import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.network.identity.NetworkId;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -30,14 +33,13 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class NetworkIdStore implements PersistableStore<NetworkIdStore> {
+final class NetworkIdStore implements PersistableStore<NetworkIdStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, NetworkId> networkIdByTag = new ConcurrentHashMap<>();
 
-    public NetworkIdStore() {
-    }
-
-    public NetworkIdStore(Map<String, NetworkId> networkIdByTag) {
+    NetworkIdStore(Map<String, NetworkId> networkIdByTag) {
         this.networkIdByTag.putAll(networkIdByTag);
     }
 
@@ -81,10 +83,6 @@ public final class NetworkIdStore implements PersistableStore<NetworkIdStore> {
     @Override
     public NetworkIdStore getClone() {
         return new NetworkIdStore(new HashMap<>(networkIdByTag));
-    }
-
-    Map<String, NetworkId> getNetworkIdByTag() {
-        return networkIdByTag;
     }
 
     Optional<NetworkId> findNetworkId(String tag) {

--- a/network/network/src/main/java/bisq/network/NetworkServiceStore.java
+++ b/network/network/src/main/java/bisq/network/NetworkServiceStore.java
@@ -23,6 +23,9 @@ import bisq.common.network.AddressByTransportTypeMap;
 import bisq.network.identity.NetworkId;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -33,16 +36,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class NetworkServiceStore implements PersistableStore<NetworkServiceStore> {
+final class NetworkServiceStore implements PersistableStore<NetworkServiceStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Set<AddressByTransportTypeMap> seedNodes = new CopyOnWriteArraySet<>();
     @Deprecated(since = "2.1.0") // Moved to NetworkIdStore
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, NetworkId> networkIdByTag = new ConcurrentHashMap<>();
 
-    public NetworkServiceStore() {
-    }
-
-    public NetworkServiceStore(Set<AddressByTransportTypeMap> seedNodes, Map<String, NetworkId> networkIdByTag) {
+    NetworkServiceStore(Set<AddressByTransportTypeMap> seedNodes, Map<String, NetworkId> networkIdByTag) {
         this.seedNodes.addAll(seedNodes);
         this.networkIdByTag.putAll(networkIdByTag);
     }
@@ -96,14 +99,5 @@ public final class NetworkServiceStore implements PersistableStore<NetworkServic
     @Override
     public NetworkServiceStore getClone() {
         return new NetworkServiceStore(new HashSet<>(seedNodes), new HashMap<>(networkIdByTag));
-    }
-
-    Set<AddressByTransportTypeMap> getSeedNodes() {
-        return seedNodes;
-    }
-
-    @Deprecated(since = "2.1.0")
-    Map<String, NetworkId> getNetworkIdByTag() {
-        return networkIdByTag;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/ack/MessageDeliveryStatusStore.java
@@ -23,6 +23,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -30,13 +33,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class MessageDeliveryStatusStore implements PersistableStore<MessageDeliveryStatusStore> {
+final class MessageDeliveryStatusStore implements PersistableStore<MessageDeliveryStatusStore> {
     private final ObservableHashMap<String, Observable<MessageDeliveryStatus>> messageDeliveryStatusByMessageId = new ObservableHashMap<>();
     private final Map<String, Long> creationDateByMessageId = new ConcurrentHashMap<>();
-
-    MessageDeliveryStatusStore() {
-    }
 
     MessageDeliveryStatusStore(Map<String, Observable<MessageDeliveryStatus>> messageDeliveryStatusByMessageId,
                                Map<String, Long> creationDateByMessageId) {
@@ -90,13 +92,5 @@ public final class MessageDeliveryStatusStore implements PersistableStore<Messag
     @Override
     public MessageDeliveryStatusStore getClone() {
         return new MessageDeliveryStatusStore(new HashMap<>(messageDeliveryStatusByMessageId), new HashMap<>(creationDateByMessageId));
-    }
-
-    ObservableHashMap<String, Observable<MessageDeliveryStatus>> getMessageDeliveryStatusByMessageId() {
-        return messageDeliveryStatusByMessageId;
-    }
-
-    Map<String, Long> getCreationDateByMessageId() {
-        return creationDateByMessageId;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/confidential/resend/ResendMessageStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/confidential/resend/ResendMessageStore.java
@@ -21,21 +21,23 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class ResendMessageStore implements PersistableStore<ResendMessageStore> {
+final class ResendMessageStore implements PersistableStore<ResendMessageStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, ResendMessageData> resendMessageDataByMessageId = new ConcurrentHashMap<>();
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, AtomicInteger> numResendsByMessageId = new ConcurrentHashMap<>();
-
-    ResendMessageStore() {
-    }
 
     ResendMessageStore(Map<String, ResendMessageData> resendMessageDataByMessageId, Map<String, AtomicInteger> numResendsByMessageId) {
         this.resendMessageDataByMessageId.putAll(resendMessageDataByMessageId);
@@ -89,13 +91,5 @@ public final class ResendMessageStore implements PersistableStore<ResendMessageS
     @Override
     public ResendMessageStore getClone() {
         return new ResendMessageStore(new HashMap<>(resendMessageDataByMessageId), new HashMap<>(numResendsByMessageId));
-    }
-
-    Map<String, ResendMessageData> getResendMessageDataByMessageId() {
-        return resendMessageDataByMessageId;
-    }
-
-    Map<String, AtomicInteger> getNumResendsByMessageId() {
-        return numResendsByMessageId;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/DataStore.java
@@ -23,7 +23,9 @@ import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.network.p2p.services.data.DataRequest;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,16 +35,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
 @ToString
 public final class DataStore<T extends DataRequest> implements PersistableStore<DataStore<T>> {
-    @Getter
+    @Getter(AccessLevel.PUBLIC)
     private final Map<ByteArray, T> map = new ConcurrentHashMap<>();
 
-    public DataStore() {
-    }
-
-    public DataStore(Map<ByteArray, T> map) {
+    DataStore(Map<ByteArray, T> map) {
         this.map.putAll(map);
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/PeerGroupStore.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/PeerGroupStore.java
@@ -22,6 +22,9 @@ import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.network.Address;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -29,12 +32,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class PeerGroupStore implements PersistableStore<PeerGroupStore> {
+final class PeerGroupStore implements PersistableStore<PeerGroupStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<Address, Peer> persistedPeersByAddress = new ConcurrentHashMap<>();
-
-    public PeerGroupStore() {
-    }
 
     private PeerGroupStore(Map<Address, Peer> persistedPeersByAddress) {
         this.persistedPeersByAddress.putAll(persistedPeersByAddress);
@@ -79,9 +81,5 @@ public final class PeerGroupStore implements PersistableStore<PeerGroupStore> {
     public void applyPersisted(PeerGroupStore persisted) {
         persistedPeersByAddress.clear();
         persistedPeersByAddress.putAll(persisted.getPersistedPeersByAddress());
-    }
-
-    Map<Address, Peer> getPersistedPeersByAddress() {
-        return persistedPeersByAddress;
     }
 }

--- a/offer/src/main/java/bisq/offer/bisq_musig/MyBisqMuSigOffersStore.java
+++ b/offer/src/main/java/bisq/offer/bisq_musig/MyBisqMuSigOffersStore.java
@@ -22,20 +22,20 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class MyBisqMuSigOffersStore implements PersistableStore<MyBisqMuSigOffersStore> {
-    @Getter
+final class MyBisqMuSigOffersStore implements PersistableStore<MyBisqMuSigOffersStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final ObservableSet<BisqMuSigOffer> offers = new ObservableSet<>();
-
-    public MyBisqMuSigOffersStore() {
-    }
 
     private MyBisqMuSigOffersStore(Set<BisqMuSigOffer> offers) {
         this.offers.addAll(offers);
@@ -81,11 +81,11 @@ public final class MyBisqMuSigOffersStore implements PersistableStore<MyBisqMuSi
         };
     }
 
-    public void add(BisqMuSigOffer offer) {
+    void add(BisqMuSigOffer offer) {
         offers.add(offer);
     }
 
-    public void remove(BisqMuSigOffer offer) {
+    void remove(BisqMuSigOffer offer) {
         offers.remove(offer);
     }
 }

--- a/offer/src/main/java/bisq/offer/poc/PocOpenOfferStore.java
+++ b/offer/src/main/java/bisq/offer/poc/PocOpenOfferStore.java
@@ -21,19 +21,19 @@ import bisq.common.observable.collection.ObservableSet;
 import bisq.common.proto.ProtoResolver;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.Message;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
 import java.util.Set;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class PocOpenOfferStore implements PersistableStore<PocOpenOfferStore> {
-    @Getter
+final class PocOpenOfferStore implements PersistableStore<PocOpenOfferStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final ObservableSet<PocOpenOffer> openOffers = new ObservableSet<>();
-
-    public PocOpenOfferStore() {
-    }
 
     private PocOpenOfferStore(Set<PocOpenOffer> openOffers) {
         this.openOffers.addAll(openOffers);
@@ -56,11 +56,11 @@ public final class PocOpenOfferStore implements PersistableStore<PocOpenOfferSto
         return null;
     }
 
-    public void add(PocOpenOffer openOffer) {
+    void add(PocOpenOffer openOffer) {
         openOffers.add(openOffer);
     }
 
-    public void remove(PocOpenOffer openOffer) {
+    void remove(PocOpenOffer openOffer) {
         openOffers.remove(openOffer);
     }
 

--- a/persistence/src/test/java/bisq/persistence/TimestampStore.java
+++ b/persistence/src/test/java/bisq/persistence/TimestampStore.java
@@ -21,7 +21,9 @@ import bisq.common.data.StringLongPair;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -29,13 +31,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class TimestampStore implements PersistableStore<TimestampStore> {
-    @Getter
+final class TimestampStore implements PersistableStore<TimestampStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, Long> timestampsByProfileId = new ConcurrentHashMap<>();
-
-    public TimestampStore() {
-    }
 
     private TimestampStore(Map<String, Long> timestampsByProfileId) {
         this.timestampsByProfileId.putAll(timestampsByProfileId);

--- a/security/src/main/java/bisq/security/keys/KeyBundleStore.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundleStore.java
@@ -22,6 +22,9 @@ import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.util.StringUtils;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -30,17 +33,16 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class KeyBundleStore implements PersistableStore<KeyBundleStore> {
+final class KeyBundleStore implements PersistableStore<KeyBundleStore> {
     // Secret uid used for deriving keyIds
     // As the keyID is public in the mailbox message we do not want to leak any information of the user identity
     // to the network.
     // Once we have persisted the stores we use the secretUid from the persisted data
+    @Getter(AccessLevel.PACKAGE)
     private String secretUid = StringUtils.createUid();
     private final Map<String, KeyBundle> keyBundleById = new ConcurrentHashMap<>();
-
-    public KeyBundleStore() {
-    }
 
     private KeyBundleStore(String secretUid,
                            Map<String, KeyBundle> keyBundleById) {
@@ -92,21 +94,17 @@ public final class KeyBundleStore implements PersistableStore<KeyBundleStore> {
         keyBundleById.putAll(persisted.keyBundleById);
     }
 
-    public Optional<KeyBundle> findKeyBundle(String keyId) {
+    Optional<KeyBundle> findKeyBundle(String keyId) {
         synchronized (keyBundleById) {
             return Optional.ofNullable(keyBundleById.get(keyId));
         }
     }
 
-    public void putKeyBundle(String keyId, KeyBundle keyBundle) {
+    void putKeyBundle(String keyId, KeyBundle keyBundle) {
         synchronized (keyBundleById) {
             if (keyBundleById.put(keyId, keyBundle) != null) {
                 log.warn("We had already an entry for key ID {}", keyId);
             }
         }
-    }
-
-    String getSecretUid() {
-        return secretUid;
     }
 }

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 import static bisq.settings.SettingsService.*;
 
 @Slf4j
-public final class SettingsStore implements PersistableStore<SettingsStore> {
+final class SettingsStore implements PersistableStore<SettingsStore> {
     final Cookie cookie;
     final Map<String, Boolean> dontShowAgainMap = new ConcurrentHashMap<>();
     final Observable<Boolean> useAnimations = new Observable<>();
@@ -69,7 +69,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
     final Observable<ChatMessageType> bisqEasyOfferbookMessageTypeFilter = new Observable<>();
     final Observable<Integer> numDaysAfterRedactingTradeData = new Observable<>();
 
-    public SettingsStore() {
+    SettingsStore() {
         this(new Cookie(),
                 new HashMap<>(),
                 true,
@@ -99,7 +99,7 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 DEFAULT_NUM_DAYS_AFTER_REDACTING_TRADE_DATA);
     }
 
-    public SettingsStore(Cookie cookie,
+    SettingsStore(Cookie cookie,
                          Map<String, Boolean> dontShowAgainMap,
                          boolean useAnimations,
                          Market selectedMarket,

--- a/support/src/main/java/bisq/support/mediation/MediatorStore.java
+++ b/support/src/main/java/bisq/support/mediation/MediatorStore.java
@@ -22,20 +22,20 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-@Getter
 final class MediatorStore implements PersistableStore<MediatorStore> {
     private final ObservableSet<MediationCase> mediationCases = new ObservableSet<>();
-
-    MediatorStore() {
-    }
 
     private MediatorStore(Set<MediationCase> mediationCases) {
         this.mediationCases.setAll(mediationCases);

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeStore.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeStore.java
@@ -22,7 +22,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
@@ -31,17 +33,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
 final class BisqEasyTradeStore implements PersistableStore<BisqEasyTradeStore> {
-    @Getter
     private final ObservableSet<BisqEasyTrade> trades = new ObservableSet<>();
 
     // We keep track of all trades by storing the trade IDs to avoid that the same trade can be taken again.
-    @Getter
     private final ObservableSet<String> tradeIds = new ObservableSet<>();
-
-    BisqEasyTradeStore() {
-    }
 
     private BisqEasyTradeStore(Set<BisqEasyTrade> trades, Set<String> tradeIds) {
         this.trades.setAll(trades);

--- a/trade/src/main/java/bisq/trade/bisq_musig/BisqMuSigTradeStore.java
+++ b/trade/src/main/java/bisq/trade/bisq_musig/BisqMuSigTradeStore.java
@@ -21,7 +21,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -30,13 +32,11 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class BisqMuSigTradeStore implements PersistableStore<BisqMuSigTradeStore> {
-    @Getter
+final class BisqMuSigTradeStore implements PersistableStore<BisqMuSigTradeStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, BisqMuSigTrade> tradeById = new ConcurrentHashMap<>();
-
-    public BisqMuSigTradeStore() {
-    }
 
     private BisqMuSigTradeStore(Map<String, BisqMuSigTrade> tradeById) {
         this.tradeById.putAll(tradeById);
@@ -85,15 +85,14 @@ public final class BisqMuSigTradeStore implements PersistableStore<BisqMuSigTrad
         };
     }
 
-
-    public void add(BisqMuSigTrade trade) {
+    void add(BisqMuSigTrade trade) {
         String tradeId = trade.getId();
         if (!tradeById.containsKey(tradeId)) {
             tradeById.put(tradeId, trade);
         }
     }
 
-    public Optional<BisqMuSigTrade> findTrade(String tradeId) {
+    Optional<BisqMuSigTrade> findTrade(String tradeId) {
         return Optional.ofNullable(tradeById.get(tradeId));
     }
 }

--- a/trade/src/main/java/bisq/trade/submarine/SubmarineTradeStore.java
+++ b/trade/src/main/java/bisq/trade/submarine/SubmarineTradeStore.java
@@ -21,7 +21,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -30,13 +32,11 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class SubmarineTradeStore implements PersistableStore<SubmarineTradeStore> {
-    @Getter
+final class SubmarineTradeStore implements PersistableStore<SubmarineTradeStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final Map<String, SubmarineTrade> tradeById = new ConcurrentHashMap<>();
-
-    public SubmarineTradeStore() {
-    }
 
     private SubmarineTradeStore(Map<String, SubmarineTrade> tradeById) {
         this.tradeById.putAll(tradeById);
@@ -85,15 +85,14 @@ public final class SubmarineTradeStore implements PersistableStore<SubmarineTrad
         };
     }
 
-
-    public void add(SubmarineTrade trade) {
+    void add(SubmarineTrade trade) {
         String tradeId = trade.getId();
         if (!tradeById.containsKey(tradeId)) {
             tradeById.put(tradeId, trade);
         }
     }
 
-    public Optional<SubmarineTrade> findTrade(String tradeId) {
+    Optional<SubmarineTrade> findTrade(String tradeId) {
         return Optional.ofNullable(tradeById.get(tradeId));
     }
 }

--- a/user/src/main/java/bisq/user/banned/BannedUserStore.java
+++ b/user/src/main/java/bisq/user/banned/BannedUserStore.java
@@ -22,6 +22,8 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
@@ -29,10 +31,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
-public final class BannedUserStore implements PersistableStore<BannedUserStore> {
+final class BannedUserStore implements PersistableStore<BannedUserStore> {
+    @Getter(AccessLevel.PACKAGE)
     private final ObservableSet<BannedUserProfileData> bannedUserProfileDataSet = new ObservableSet<>();
 
-    public BannedUserStore() {
+    BannedUserStore() {
         this(new HashSet<>());
     }
 
@@ -79,9 +82,5 @@ public final class BannedUserStore implements PersistableStore<BannedUserStore> 
     public void applyPersisted(BannedUserStore persisted) {
         bannedUserProfileDataSet.clear();
         bannedUserProfileDataSet.addAll(persisted.getBannedUserProfileDataSet());
-    }
-
-    ObservableSet<BannedUserProfileData> getBannedUserProfileDataSet() {
-        return bannedUserProfileDataSet;
     }
 }

--- a/user/src/main/java/bisq/user/identity/UserIdentityStore.java
+++ b/user/src/main/java/bisq/user/identity/UserIdentityStore.java
@@ -43,7 +43,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * Persists my user profiles and the selected user profile.
  */
 @Slf4j
-public final class UserIdentityStore implements PersistableStore<UserIdentityStore> {
+final class UserIdentityStore implements PersistableStore<UserIdentityStore> {
     // For plain text those data are set. If encryption is used the protobuf lists are not filled.
     private final Observable<UserIdentity> selectedUserIdentityObservable = new Observable<>();
     private final ObservableSet<UserIdentity> userIdentities = new ObservableSet<>();

--- a/user/src/main/java/bisq/user/profile/UserProfileStore.java
+++ b/user/src/main/java/bisq/user/profile/UserProfileStore.java
@@ -23,7 +23,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -36,16 +38,14 @@ import java.util.stream.Collectors;
 /**
  * Persists my user profiles and the selected user profile.
  */
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-@Getter
-public final class UserProfileStore implements PersistableStore<UserProfileStore> {
+final class UserProfileStore implements PersistableStore<UserProfileStore> {
     private final Map<String, Set<String>> nymsByNickName = new ConcurrentHashMap<>();
     private final ObservableSet<String> ignoredUserProfileIds = new ObservableSet<>();
     private final ObservableHashMap<String, UserProfile> userProfileById = new ObservableHashMap<>();
     private final Object lock = new Object();
-
-    public UserProfileStore() {
-    }
 
     private UserProfileStore(Map<String, Set<String>> nymsByNickName,
                              Set<String> ignoredUserProfileIds,

--- a/user/src/main/java/bisq/user/reputation/AccountAgeStore.java
+++ b/user/src/main/java/bisq/user/reputation/AccountAgeStore.java
@@ -21,7 +21,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,14 +32,12 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 @Slf4j
-@Getter
-public final class AccountAgeStore implements PersistableStore<AccountAgeStore> {
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter(AccessLevel.PACKAGE)
+final class AccountAgeStore implements PersistableStore<AccountAgeStore> {
     private final Set<String> jsonRequests = new CopyOnWriteArraySet<>();
-    @Setter
+    @Setter(AccessLevel.PACKAGE)
     private long lastRequested = 0;
-
-    public AccountAgeStore() {
-    }
 
     private AccountAgeStore(Set<String> jsonRequests, long lastRequested) {
         this.lastRequested = lastRequested;

--- a/user/src/main/java/bisq/user/reputation/ProfileAgeStore.java
+++ b/user/src/main/java/bisq/user/reputation/ProfileAgeStore.java
@@ -21,7 +21,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,15 +31,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-@Getter
-public final class ProfileAgeStore implements PersistableStore<ProfileAgeStore> {
+final class ProfileAgeStore implements PersistableStore<ProfileAgeStore> {
     private final Set<String> profileIds = new CopyOnWriteArraySet<>();
-    @Setter
+    @Setter(AccessLevel.PACKAGE)
     private long lastRequested = 0;
-
-    public ProfileAgeStore() {
-    }
 
     private ProfileAgeStore(Set<String> jsonRequests, long lastRequested) {
         this.lastRequested = lastRequested;

--- a/user/src/main/java/bisq/user/reputation/SignedWitnessStore.java
+++ b/user/src/main/java/bisq/user/reputation/SignedWitnessStore.java
@@ -21,7 +21,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,15 +31,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-@Getter
-public final class SignedWitnessStore implements PersistableStore<SignedWitnessStore> {
+final class SignedWitnessStore implements PersistableStore<SignedWitnessStore> {
     private final Set<String> jsonRequests = new CopyOnWriteArraySet<>();
-    @Setter
+    @Setter(AccessLevel.PACKAGE)
     private long lastRequested = 0;
-
-    public SignedWitnessStore() {
-    }
 
     private SignedWitnessStore(Set<String> jsonRequests, long lastRequested) {
         this.lastRequested = lastRequested;

--- a/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWalletStore.java
+++ b/wallets/elementsd/src/main/java/bisq/wallets/elementsd/LiquidWalletStore.java
@@ -23,22 +23,21 @@ import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import bisq.wallets.json_rpc.RpcConfig;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public final class LiquidWalletStore implements PersistableStore<LiquidWalletStore> {
-    @Getter
-    @Setter
+@Getter(AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+final class LiquidWalletStore implements PersistableStore<LiquidWalletStore> {
+    @Setter(AccessLevel.PACKAGE)
     private Optional<RpcConfig> rpcConfig = Optional.empty();
-    @Getter
     private final ObservableArray<String> walletAddresses = new ObservableArray<>();
-
-    public LiquidWalletStore() {
-    }
 
     private LiquidWalletStore(Optional<RpcConfig> rpcConfig, List<String> walletAddresses) {
         this.rpcConfig = rpcConfig;

--- a/wallets/wallet/src/main/java/bisq/wallets/bitcoind/BitcoinWalletStore.java
+++ b/wallets/wallet/src/main/java/bisq/wallets/bitcoind/BitcoinWalletStore.java
@@ -22,7 +22,9 @@ import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,16 +32,14 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-public final class BitcoinWalletStore implements PersistableStore<BitcoinWalletStore> {
-    @Getter
-    @Setter
+final class BitcoinWalletStore implements PersistableStore<BitcoinWalletStore> {
+    @Getter(AccessLevel.PACKAGE)
+    @Setter(AccessLevel.PACKAGE)
     private Optional<RpcConfig> rpcConfig = Optional.empty();
-    @Getter
+    @Getter(AccessLevel.PACKAGE)
     private final ObservableSet<String> receiveAddresses = new ObservableSet<>();
-
-    public BitcoinWalletStore() {
-    }
 
     private BitcoinWalletStore(Optional<RpcConfig> rpcConfig, Set<String> receiveAddresses) {
         this.rpcConfig = rpcConfig;


### PR DESCRIPTION
All made package private, except for the map field in DataStore that seems to be used some. Aims to fix https://github.com/bisq-network/bisq2/issues/3415.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Reduced visibility of numerous internal classes, constructors, and methods from public to package-private across multiple modules.
  - Replaced explicit constructors and accessor methods with Lombok-generated versions to limit access within the package.
  - Adjusted getter and setter visibility for various fields, restricting access to package scope.
  - No changes to user-facing features or application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->