### PR TITLE
Fix market badge issue in the long run

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookController.java
@@ -96,7 +96,6 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         bisqEasyOfferbookMessageService = serviceProvider.getBisqEasyService().getBisqEasyOfferbookMessageService();
 
         bisqEasyOfferbookModel = getModel();
-        createMarketChannels();
 
         marketChannelItemsPredicate = item ->
                 model.getMarketFilterPredicate().test(item) &&
@@ -129,6 +128,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
     public void onActivate() {
         super.onActivate();
 
+        createMarketChannels();
         model.getMarketSelectorSearchText().set("");
 
         showMarketSelectionListCollapsedSettingsPin = FxBindings.bindBiDir(model.getShowMarketSelectionListCollapsed())
@@ -283,6 +283,7 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
         model.getMarketChannelItems().removeListener(marketChannelItemListener);
         marketNumOffersListeners.forEach((item, changeListener) -> item.getNumOffers().removeListener(changeListener));
         model.getMarketChannelItems().forEach(MarketChannelItem::dispose);
+        model.getMarketChannelItems().clear();
 
         resetSelectedChildTarget();
     }
@@ -425,54 +426,4 @@ public final class BisqEasyOfferbookController extends ChatController<BisqEasyOf
                     .ifPresent(MarketChannelItem::refreshNotifications);
         });
     }
-
-/*
-    private void bindOfferMessages(BisqEasyOfferbookChannel channel) {
-        model.getOfferbookListItems().clear();
-        offerMessagesPin = channel.getChatMessages().addObserver(new CollectionObserver<>() {
-            @Override
-            public void add(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
-                Optional<UserProfile> userProfile = userProfileService.findUserProfile(bisqEasyOfferbookMessage.getAuthorUserProfileId());
-                boolean shouldAddOfferMessage = bisqEasyOfferbookMessage.hasBisqEasyOffer()
-                        && bisqEasyOfferbookMessage.getBisqEasyOffer().isPresent()
-                        && userProfile.isPresent();
-                if (shouldAddOfferMessage) {
-                    UIThread.runOnNextRenderFrame(() -> {
-                        if (model.getOfferbookListItems().stream()
-                                .noneMatch(item -> item.getBisqEasyOfferbookMessage().equals(bisqEasyOfferbookMessage))) {
-                            OfferbookListItem item = new OfferbookListItem(bisqEasyOfferbookMessage,
-                                    userProfile.get(),
-                                    reputationService,
-                                    marketPriceService);
-                            model.getOfferbookListItems().add(item);
-                        }
-                    });
-                }
-            }
-
-            @Override
-            public void remove(Object element) {
-                if (element instanceof BisqEasyOfferbookMessage && ((BisqEasyOfferbookMessage) element).hasBisqEasyOffer()) {
-                    UIThread.runOnNextRenderFrame(() -> {
-                        BisqEasyOfferbookMessage offerMessage = (BisqEasyOfferbookMessage) element;
-                        Optional<OfferbookListItem> toRemove = model.getOfferbookListItems().stream()
-                                .filter(item -> item.getBisqEasyOfferbookMessage().getId().equals(offerMessage.getId()))
-                                .findAny();
-                        toRemove.ifPresent(item -> {
-                            item.dispose();
-                            model.getOfferbookListItems().remove(item);
-                        });
-                    });
-                }
-            }
-
-            @Override
-            public void clear() {
-                UIThread.runOnNextRenderFrame(() -> {
-                    model.getOfferbookListItems().forEach(OfferbookListItem::dispose);
-                    model.getOfferbookListItems().clear();
-                });
-            }
-        });
-    }*/
 }


### PR DESCRIPTION
Fixed #2781

Actually, bug could be observed if a user left OfferBookTab and returned again.

Issue was that createMarketChannels() called in constructor of BisqEasyOfferbookController (which called only once), but onActivate-onDeactivate were called many times (when the user leaves/enters OfferBook). In onDeactivate, for each marketChannel was called dispose(), which unbind Pin of chatMessages and updateNumOffers method stops to be called.

Actually, the solution looks simple, but I spent a lot of time, researching different places (even checked Badge component). When I was ready to give up, my eyes touched the problem ) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the activation and deactivation process for the offer book view, ensuring better resource management.
  - Removed outdated and unused code for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->