### PR TITLE
Add reason for ban to moderator UI

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BisqIconButton.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BisqIconButton.java
@@ -58,6 +58,10 @@ public class BisqIconButton extends Button {
         return button;
     }
 
+    public static Button createInfoIconButton() {
+        return createInfoIconButton("");
+    }
+
     public static Button createInfoIconButton(String tooltipText) {
         Button button = AwesomeDude.createIconButton(AwesomeIcon.INFO_SIGN);
         button.getStyleClass().add("icon-button");

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -173,7 +173,7 @@ public abstract class Overlay<T extends Overlay<T>> {
     protected Button actionButton, secondaryActionButton;
     private HBox buttonBox;
     protected Button closeButton;
-    private Region content;
+    protected Region content;
 
     private HPos buttonAlignment = HPos.RIGHT;
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
@@ -1,0 +1,217 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.overlay;
+
+import bisq.i18n.Res;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+@Slf4j
+public class TextInputDialog extends Popup {
+    private static final int DEFAULT_MAX_LENGTH = 1000;
+    private static final int PREFERRED_WIDTH = 520;
+
+    private final TextArea inputTextArea;
+    private final Label counterLabel;
+    private final Label descriptionLabel;
+    private final Button confirmButton;
+    private final Button cancelButton;
+
+    private Consumer<String> inputConsumer;
+    private Predicate<String> validator;
+    private int maxLength = DEFAULT_MAX_LENGTH;
+    private String confirmButtonText = Res.get("action.save");
+    private String cancelButtonText = Res.get("action.cancel");
+    private boolean showCounter = true;
+
+    public TextInputDialog(String headline) {
+        this(headline, null);
+    }
+
+    public TextInputDialog(String headline, String fieldLabel) {
+        if (headline != null) {
+            headline(headline);
+        }
+
+        hideCloseButton();
+
+        GridPane gridPane = new GridPane();
+        gridPane.setHgap(10);
+        gridPane.setVgap(10);
+        gridPane.setPadding(new Insets(15, 20, 10, 14));
+        gridPane.setPrefWidth(PREFERRED_WIDTH);
+
+        ColumnConstraints columnConstraints = new ColumnConstraints();
+        columnConstraints.setHgrow(Priority.ALWAYS);
+        columnConstraints.setFillWidth(true);
+        columnConstraints.setPercentWidth(100);
+        gridPane.getColumnConstraints().add(columnConstraints);
+
+        descriptionLabel = new Label();
+        descriptionLabel.setWrapText(true);
+        descriptionLabel.setManaged(false);
+        descriptionLabel.setVisible(false);
+        descriptionLabel.setMaxWidth(Double.MAX_VALUE);
+
+        inputTextArea = new TextArea(fieldLabel);
+        inputTextArea.setMaxWidth(Double.MAX_VALUE);
+
+        counterLabel = new Label(Res.get("component.TextInputDialog.text.characters.remaining", maxLength));
+        counterLabel.setManaged(showCounter);
+        counterLabel.setVisible(showCounter);
+
+        inputTextArea.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null && newValue.length() > maxLength) {
+                int caretPosition = inputTextArea.getCaretPosition();
+                double scrollLeft = inputTextArea.getScrollLeft();
+                double scrollTop = inputTextArea.getScrollTop();
+
+                inputTextArea.setText(oldValue);
+
+                // Try to restore the caret and scrollbars position
+                int newCaretPos = Math.min(caretPosition, oldValue.length());
+                inputTextArea.positionCaret(newCaretPos);
+
+                inputTextArea.setScrollLeft(scrollLeft);
+                inputTextArea.setScrollTop(scrollTop);
+
+                return;
+            }
+            updateRemainingCharsCount();
+        });
+
+        confirmButton = new Button(confirmButtonText);
+        cancelButton = new Button(cancelButtonText);
+
+        confirmButton.getStyleClass().add("action-button");
+        confirmButton.setDefaultButton(true);
+
+        HBox buttonBox = new HBox(10, confirmButton, cancelButton);
+        buttonBox.setPadding(new Insets(10, 0, 0, 0));
+        buttonBox.setAlignment(Pos.CENTER_RIGHT);
+
+        int rowIndex = 0;
+        gridPane.add(descriptionLabel, 0, rowIndex++);
+        gridPane.add(inputTextArea, 0, rowIndex++);
+        gridPane.add(counterLabel, 0, rowIndex++);
+        gridPane.add(buttonBox, 0, rowIndex);
+
+        confirmButton.setOnAction(e -> {
+            String input = inputTextArea.getText();
+            if (validator != null && !validator.test(input)) {
+                return;
+            }
+
+            if (inputConsumer != null) {
+                inputConsumer.accept(input);
+            }
+            hide();
+        });
+
+        cancelButton.setOnAction(e -> hide());
+
+        GridPane.setHgrow(inputTextArea, Priority.ALWAYS);
+        GridPane.setHgrow(buttonBox, Priority.ALWAYS);
+        GridPane.setHgrow(descriptionLabel, Priority.ALWAYS);
+        GridPane.setHgrow(counterLabel, Priority.ALWAYS);
+
+        content(gridPane);
+    }
+
+    public TextInputDialog setPromptText(String prompt) {
+        inputTextArea.setPromptText(prompt);
+        return this;
+    }
+
+    public TextInputDialog setInputFieldDescription(String instructions) {
+        if (instructions != null && !instructions.isEmpty()) {
+            descriptionLabel.setText(instructions);
+            descriptionLabel.setManaged(true);
+            descriptionLabel.setVisible(true);
+        }
+        return this;
+    }
+
+    public TextInputDialog setMaxLength(int maxLength) {
+        this.maxLength = maxLength;
+        updateRemainingCharsCount();
+        return this;
+    }
+
+    public TextInputDialog setConfirmButtonText(String text) {
+        confirmButtonText = text;
+        if (confirmButton != null) {
+            confirmButton.setText(text);
+        }
+        return this;
+    }
+
+    public TextInputDialog setCancelButtonText(String text) {
+        cancelButtonText = text;
+        if (cancelButton != null) {
+            cancelButton.setText(text);
+        }
+        return this;
+    }
+
+    public TextInputDialog showCounter(boolean show) {
+        showCounter = show;
+        if (counterLabel != null) {
+            counterLabel.setManaged(show);
+            counterLabel.setVisible(show);
+        }
+        return this;
+    }
+
+    public TextInputDialog validator(Predicate<String> validator) {
+        this.validator = validator;
+        return this;
+    }
+
+    public TextInputDialog onResult(Consumer<String> inputConsumer) {
+        this.inputConsumer = inputConsumer;
+        return this;
+    }
+
+    public static Optional<String> show(String headline, String fieldLabel) {
+        TextInputDialog dialog = new TextInputDialog(headline, fieldLabel);
+        String[] result = {null};
+
+        dialog.onResult(text -> result[0] = text);
+        dialog.show();
+
+        return Optional.ofNullable(result[0]);
+    }
+
+    private void updateRemainingCharsCount() {
+        int remaining = maxLength - (inputTextArea.getText() != null ? inputTextArea.getText().length() : 0);
+        counterLabel.setText(Res.get("component.TextInputDialog.text.characters.remaining", remaining));
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
@@ -28,8 +28,6 @@ import java.util.function.Consumer;
 
 @Slf4j
 public class TextInputDialog extends Popup {
-    private static final int PREFERRED_WIDTH = 520;
-
     private final MaterialTextArea inputTextArea = new MaterialTextArea();
     @Nullable
     private Consumer<String> inputHandler;
@@ -39,7 +37,6 @@ public class TextInputDialog extends Popup {
     }
 
     public TextInputDialog(String headline, String text) {
-        //inputTextArea.setPrefWidth(PREFERRED_WIDTH);
         inputTextArea.setMinHeight(100);
         inputTextArea.setMaxHeight(inputTextArea.getMinHeight());
 
@@ -55,8 +52,8 @@ public class TextInputDialog extends Popup {
             if (inputTextArea.validate()) {
                 if (inputHandler != null) {
                     inputHandler.accept(inputTextArea.getText());
-                    hide();
                 }
+                hide();
             }
         });
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/TextInputDialog.java
@@ -17,201 +17,92 @@
 
 package bisq.desktop.components.overlay;
 
-import bisq.i18n.Res;
+import bisq.desktop.components.controls.MaterialTextArea;
+import bisq.desktop.components.controls.validator.ValidatorBase;
 import javafx.geometry.Insets;
-import javafx.geometry.Pos;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
-import javafx.scene.control.TextArea;
-import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 @Slf4j
 public class TextInputDialog extends Popup {
-    private static final int DEFAULT_MAX_LENGTH = 1000;
     private static final int PREFERRED_WIDTH = 520;
 
-    private final TextArea inputTextArea;
-    private final Label counterLabel;
-    private final Label descriptionLabel;
-    private final Button confirmButton;
-    private final Button cancelButton;
-
-    private Consumer<String> inputConsumer;
-    private Predicate<String> validator;
-    private int maxLength = DEFAULT_MAX_LENGTH;
-    private String confirmButtonText = Res.get("action.save");
-    private String cancelButtonText = Res.get("action.cancel");
-    private boolean showCounter = true;
+    private final MaterialTextArea inputTextArea = new MaterialTextArea();
+    @Nullable
+    private Consumer<String> inputHandler;
 
     public TextInputDialog(String headline) {
-        this(headline, null);
+        this(headline, "");
     }
 
-    public TextInputDialog(String headline, String fieldLabel) {
+    public TextInputDialog(String headline, String text) {
+        //inputTextArea.setPrefWidth(PREFERRED_WIDTH);
+        inputTextArea.setMinHeight(100);
+        inputTextArea.setMaxHeight(inputTextArea.getMinHeight());
+
+        content(inputTextArea);
+
         if (headline != null) {
             headline(headline);
         }
+        // instruction("");
 
-        hideCloseButton();
-
-        GridPane gridPane = new GridPane();
-        gridPane.setHgap(10);
-        gridPane.setVgap(10);
-        gridPane.setPadding(new Insets(15, 20, 10, 14));
-        gridPane.setPrefWidth(PREFERRED_WIDTH);
-
-        ColumnConstraints columnConstraints = new ColumnConstraints();
-        columnConstraints.setHgrow(Priority.ALWAYS);
-        columnConstraints.setFillWidth(true);
-        columnConstraints.setPercentWidth(100);
-        gridPane.getColumnConstraints().add(columnConstraints);
-
-        descriptionLabel = new Label();
-        descriptionLabel.setWrapText(true);
-        descriptionLabel.setManaged(false);
-        descriptionLabel.setVisible(false);
-        descriptionLabel.setMaxWidth(Double.MAX_VALUE);
-
-        inputTextArea = new TextArea(fieldLabel);
-        inputTextArea.setMaxWidth(Double.MAX_VALUE);
-
-        counterLabel = new Label(Res.get("component.TextInputDialog.text.characters.remaining", maxLength));
-        counterLabel.setManaged(showCounter);
-        counterLabel.setVisible(showCounter);
-
-        inputTextArea.textProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null && newValue.length() > maxLength) {
-                int caretPosition = inputTextArea.getCaretPosition();
-                double scrollLeft = inputTextArea.getScrollLeft();
-                double scrollTop = inputTextArea.getScrollTop();
-
-                inputTextArea.setText(oldValue);
-
-                // Try to restore the caret and scrollbars position
-                int newCaretPos = Math.min(caretPosition, oldValue.length());
-                inputTextArea.positionCaret(newCaretPos);
-
-                inputTextArea.setScrollLeft(scrollLeft);
-                inputTextArea.setScrollTop(scrollTop);
-
-                return;
+        doCloseOnAction = false;
+        onAction(() -> {
+            if (inputTextArea.validate()) {
+                if (inputHandler != null) {
+                    inputHandler.accept(inputTextArea.getText());
+                    hide();
+                }
             }
-            updateRemainingCharsCount();
         });
-
-        confirmButton = new Button(confirmButtonText);
-        cancelButton = new Button(cancelButtonText);
-
-        confirmButton.getStyleClass().add("action-button");
-        confirmButton.setDefaultButton(true);
-
-        HBox buttonBox = new HBox(10, confirmButton, cancelButton);
-        buttonBox.setPadding(new Insets(10, 0, 0, 0));
-        buttonBox.setAlignment(Pos.CENTER_RIGHT);
-
-        int rowIndex = 0;
-        gridPane.add(descriptionLabel, 0, rowIndex++);
-        gridPane.add(inputTextArea, 0, rowIndex++);
-        gridPane.add(counterLabel, 0, rowIndex++);
-        gridPane.add(buttonBox, 0, rowIndex);
-
-        confirmButton.setOnAction(e -> {
-            String input = inputTextArea.getText();
-            if (validator != null && !validator.test(input)) {
-                return;
-            }
-
-            if (inputConsumer != null) {
-                inputConsumer.accept(input);
-            }
-            hide();
-        });
-
-        cancelButton.setOnAction(e -> hide());
-
-        GridPane.setHgrow(inputTextArea, Priority.ALWAYS);
-        GridPane.setHgrow(buttonBox, Priority.ALWAYS);
-        GridPane.setHgrow(descriptionLabel, Priority.ALWAYS);
-        GridPane.setHgrow(counterLabel, Priority.ALWAYS);
-
-        content(gridPane);
     }
 
-    public TextInputDialog setPromptText(String prompt) {
-        inputTextArea.setPromptText(prompt);
+
+    /* --------------------------------------------------------------------- */
+    // Popup
+    /* --------------------------------------------------------------------- */
+    @Override
+    protected void addContent() {
+        super.addContent();
+        GridPane.setMargin(content, new Insets(3, 0, 50, 0));
+    }
+
+    @Override
+    protected TextInputDialog cast() {
         return this;
     }
 
-    public TextInputDialog setInputFieldDescription(String instructions) {
-        if (instructions != null && !instructions.isEmpty()) {
-            descriptionLabel.setText(instructions);
-            descriptionLabel.setManaged(true);
-            descriptionLabel.setVisible(true);
-        }
+
+    /* --------------------------------------------------------------------- */
+    // MaterialTextArea delegates
+    /* --------------------------------------------------------------------- */
+
+    public TextInputDialog promptText(String value) {
+        inputTextArea.setPromptText(value);
         return this;
     }
 
-    public TextInputDialog setMaxLength(int maxLength) {
-        this.maxLength = maxLength;
-        updateRemainingCharsCount();
+    public TextInputDialog description(String value) {
+        inputTextArea.setDescription(value);
         return this;
     }
 
-    public TextInputDialog setConfirmButtonText(String text) {
-        confirmButtonText = text;
-        if (confirmButton != null) {
-            confirmButton.setText(text);
-        }
+    public TextInputDialog helpText(String value) {
+        inputTextArea.setHelpText(value);
         return this;
     }
 
-    public TextInputDialog setCancelButtonText(String text) {
-        cancelButtonText = text;
-        if (cancelButton != null) {
-            cancelButton.setText(text);
-        }
+    public TextInputDialog validator(ValidatorBase validator) {
+        inputTextArea.setValidator(validator);
         return this;
     }
 
-    public TextInputDialog showCounter(boolean show) {
-        showCounter = show;
-        if (counterLabel != null) {
-            counterLabel.setManaged(show);
-            counterLabel.setVisible(show);
-        }
+    public TextInputDialog onResult(Consumer<String> inputHandler) {
+        this.inputHandler = inputHandler;
         return this;
-    }
-
-    public TextInputDialog validator(Predicate<String> validator) {
-        this.validator = validator;
-        return this;
-    }
-
-    public TextInputDialog onResult(Consumer<String> inputConsumer) {
-        this.inputConsumer = inputConsumer;
-        return this;
-    }
-
-    public static Optional<String> show(String headline, String fieldLabel) {
-        TextInputDialog dialog = new TextInputDialog(headline, fieldLabel);
-        String[] result = {null};
-
-        dialog.onResult(text -> result[0] = text);
-        dialog.show();
-
-        return Optional.ofNullable(result[0]);
-    }
-
-    private void updateRemainingCharsCount() {
-        int remaining = maxLength - (inputTextArea.getText() != null ? inputTextArea.getText().length() : 0);
-        counterLabel.setText(Res.get("component.TextInputDialog.text.characters.remaining", remaining));
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
@@ -41,18 +41,14 @@ import bisq.user.banned.BannedUserProfileData;
 import bisq.user.banned.BannedUserService;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
-import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
+import javafx.scene.Cursor;
+import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 import lombok.EqualsAndHashCode;
@@ -262,15 +258,16 @@ public class BannedUserProfileTable {
         private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getBanReasonCellFactory() {
             return column -> new TableCell<>() {
                 private final Label banReason = new Label();
-                private final Button icon = BisqIconButton.createIconButton(AwesomeIcon.EXTERNAL_LINK);
+                private final Button icon = BisqIconButton.createInfoIconButton();
+
                 private final HBox hBox = new HBox(banReason, icon);
                 private final BisqTooltip tooltip = new BisqTooltip(BisqTooltip.Style.DARK);
 
                 {
-                    icon.setMinWidth(30);
-                    HBox.setHgrow(icon, Priority.ALWAYS);
+                    icon.setMouseTransparent(true);
                     HBox.setMargin(icon, new Insets(0, 10, 0, 10));
                     hBox.setAlignment(Pos.CENTER_LEFT);
+                    hBox.setCursor(Cursor.HAND);
                 }
 
                 @Override
@@ -282,20 +279,24 @@ public class BannedUserProfileTable {
                         banReason.setText(StringUtils.truncate(banReasonText, 30));
                         banReason.setMaxHeight(30);
                         tooltip.setText(banReasonText);
-                        banReason.setTooltip(tooltip);
+                        Tooltip.install(hBox, tooltip);
 
-                        icon.setOnAction(e -> new Popup()
-                                .headline(Res.get("authorizedRole.moderator.bannedUserProfile.table.banReason.popup.headline"))
-                                .information(banReasonText)
-                                .actionButtonText(Res.get("action.copyToClipboard"))
-                                .onAction(() -> ClipboardUtil.copyToClipboard(banReasonText))
-                                .show());
+                        hBox.setOnMouseClicked(e -> onShowPopup(banReasonText));
                         setGraphic(hBox);
                     } else {
-                        icon.setOnAction(null);
-                        banReason.setTooltip(null);
+                        hBox.setOnMouseClicked(null);
+                        Tooltip.uninstall(hBox, tooltip);
                         setGraphic(null);
                     }
+                }
+
+                private static void onShowPopup(String text) {
+                    new Popup()
+                            .headline(Res.get("authorizedRole.moderator.bannedUserProfile.table.banReason.popup.headline"))
+                            .information(text)
+                            .actionButtonText(Res.get("action.copyToClipboard"))
+                            .onAction(() -> ClipboardUtil.copyToClipboard(text))
+                            .show();
                 }
             };
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
@@ -21,22 +21,30 @@ import bisq.bisq_easy.NavigationTarget;
 import bisq.bonded_roles.bonded_role.BondedRole;
 import bisq.chat.ChatChannelDomain;
 import bisq.common.observable.Pin;
+import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIThread;
+import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.view.Navigation;
+import bisq.desktop.components.controls.BisqIconButton;
+import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.RichTableView;
 import bisq.desktop.main.content.components.UserProfileIcon;
 import bisq.i18n.Res;
 import bisq.network.SendMessageResult;
+import bisq.support.moderator.BannedUserModeratorData;
 import bisq.support.moderator.ModeratorService;
 import bisq.user.banned.BannedUserProfileData;
 import bisq.user.banned.BannedUserService;
 import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -44,6 +52,7 @@ import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 import lombok.EqualsAndHashCode;
@@ -53,6 +62,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class BannedUserProfileTable {
     @Getter
@@ -73,11 +83,13 @@ public class BannedUserProfileTable {
         private final Model model;
         private final BannedUserService bannedUserService;
         private final ModeratorService moderatorService;
+        private final UserProfileService userProfileService;
         private Pin bannedUserListItemsPin;
 
         private Controller(ServiceProvider serviceProvider) {
             bannedUserService = serviceProvider.getUserService().getBannedUserService();
             moderatorService = serviceProvider.getSupportService().getModeratorService();
+            userProfileService = serviceProvider.getUserService().getUserProfileService();
 
             model = new Model();
             view = new View(model, this);
@@ -86,7 +98,7 @@ public class BannedUserProfileTable {
         @Override
         public void onActivate() {
             bannedUserListItemsPin = FxBindings.<BannedUserProfileData, View.ListItem>bind(model.getListItems())
-                    .map(View.ListItem::new)
+                    .map(data -> View.ListItem.from(data, userProfileService, moderatorService))
                     .to(bannedUserService.getBannedUserProfileDataSet());
         }
 
@@ -171,7 +183,31 @@ public class BannedUserProfileTable {
                     .left()
                     .comparator(Comparator.comparing(ListItem::getUserName))
                     .valueSupplier(ListItem::getUserName)
-                    .setCellFactory(getUserProfileCellFactory())
+                    .setCellFactory(createUserProfileCellFactory(
+                            ListItem::getUserName,
+                            item -> Optional.of(item.getUserProfile())
+                    ))
+                    .build());
+
+            richTableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
+                    .title(Res.get("authorizedRole.moderator.bannedUserProfile.table.reporter"))
+                    .minWidth(150)
+                    .left()
+                    .comparator(Comparator.comparing(ListItem::getReporterUserName))
+                    .valueSupplier(ListItem::getReporterUserName)
+                    .setCellFactory(createUserProfileCellFactory(
+                            ListItem::getReporterUserName,
+                            ListItem::getReporterUserProfile
+                    ))
+                    .build());
+
+            richTableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
+                    .title(Res.get("authorizedRole.moderator.bannedUserProfile.table.banReason"))
+                    .minWidth(200)
+                    .left()
+                    .comparator(Comparator.comparing(ListItem::getBanReason))
+                    .valueSupplier(ListItem::getBanReason)
+                    .setCellFactory(getBanReasonCellFactory())
                     .build());
             richTableView.getColumns().add(new BisqTableColumn.Builder<ListItem>()
                     .isSortable(false)
@@ -187,7 +223,9 @@ public class BannedUserProfileTable {
                     .build());
         }
 
-        private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getUserProfileCellFactory() {
+        private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> createUserProfileCellFactory(
+                Function<ListItem, String> userNameExtractor,
+                Function<ListItem, Optional<UserProfile>> userProfileExtractor) {
             return column -> new TableCell<>() {
                 private final Label userName = new Label();
                 private final UserProfileIcon userProfileIcon = new UserProfileIcon();
@@ -203,11 +241,59 @@ public class BannedUserProfileTable {
                     super.updateItem(item, empty);
 
                     if (item != null && !empty) {
-                        userName.setText(item.getUserName());
-                        userProfileIcon.setUserProfile(item.getUserProfile());
-                        setGraphic(hBox);
+                        userName.setText(userNameExtractor.apply(item));
+
+                        Optional<UserProfile> profileOpt = userProfileExtractor.apply(item);
+                        if (profileOpt.isPresent()) {
+                            userProfileIcon.setUserProfile(profileOpt.get());
+                            setGraphic(hBox);
+                        } else {
+                            userProfileIcon.dispose();
+                            setGraphic(userName);
+                        }
                     } else {
                         userProfileIcon.dispose();
+                        setGraphic(null);
+                    }
+                }
+            };
+        }
+
+        private Callback<TableColumn<ListItem, ListItem>, TableCell<ListItem, ListItem>> getBanReasonCellFactory() {
+            return column -> new TableCell<>() {
+                private final Label banReason = new Label();
+                private final Button icon = BisqIconButton.createIconButton(AwesomeIcon.EXTERNAL_LINK);
+                private final HBox hBox = new HBox(banReason, icon);
+                private final BisqTooltip tooltip = new BisqTooltip(BisqTooltip.Style.DARK);
+
+                {
+                    icon.setMinWidth(30);
+                    HBox.setHgrow(icon, Priority.ALWAYS);
+                    HBox.setMargin(icon, new Insets(0, 10, 0, 10));
+                    hBox.setAlignment(Pos.CENTER_LEFT);
+                }
+
+                @Override
+                protected void updateItem(ListItem item, boolean empty) {
+                    super.updateItem(item, empty);
+
+                    if (item != null && !empty) {
+                        String banReasonText = StringUtils.toOptional(item.getBanReason()).orElse(Res.get("data.na"));
+                        banReason.setText(StringUtils.truncate(banReasonText, 30));
+                        banReason.setMaxHeight(30);
+                        tooltip.setText(banReasonText);
+                        banReason.setTooltip(tooltip);
+
+                        icon.setOnAction(e -> new Popup()
+                                .headline(Res.get("authorizedRole.moderator.bannedUserProfile.table.banReason.popup.headline"))
+                                .information(banReasonText)
+                                .actionButtonText(Res.get("action.copyToClipboard"))
+                                .onAction(() -> ClipboardUtil.copyToClipboard(banReasonText))
+                                .show());
+                        setGraphic(hBox);
+                    } else {
+                        icon.setOnAction(null);
+                        banReason.setTooltip(null);
                         setGraphic(null);
                     }
                 }
@@ -260,12 +346,44 @@ public class BannedUserProfileTable {
 
             private final UserProfile userProfile;
             private final String userName;
+            private final String reporterUserProfileId;
+            private final String reporterUserName;
+            private final Optional<UserProfile> reporterUserProfile;
+            private final String banReason;
 
-            private ListItem(BannedUserProfileData bannedUserProfileData) {
+            public static ListItem from(BannedUserProfileData data,
+                                        UserProfileService userProfileService,
+                                        ModeratorService moderatorService) {
+                return new ListItem(data, userProfileService, moderatorService);
+            }
+
+            private ListItem(BannedUserProfileData bannedUserProfileData,
+                             UserProfileService userProfileService,
+                             ModeratorService moderatorService) {
                 this.bannedUserProfileData = bannedUserProfileData;
 
                 userProfile = bannedUserProfileData.getUserProfile();
                 userName = userProfile.getUserName();
+                String accusedUserProfileId = userProfile.getId();
+
+                Optional<BannedUserModeratorData> moderatorDataOpt = moderatorService.findBannedUserModeratorData(accusedUserProfileId);
+
+                banReason = moderatorDataOpt
+                        .map(BannedUserModeratorData::getBanReason)
+                        .flatMap(StringUtils::toOptional)
+                        .orElse(Res.get("data.na"));
+
+                reporterUserProfileId = moderatorDataOpt
+                        .map(BannedUserModeratorData::getReporterUserProfileId)
+                        .orElse(null);
+
+                reporterUserProfile = Optional.ofNullable(reporterUserProfileId)
+                        .filter(id -> !id.isEmpty())
+                        .flatMap(userProfileService::findUserProfile);
+
+                reporterUserName = reporterUserProfile
+                        .map(UserProfile::getUserName)
+                        .orElse(Res.get("data.na"));
             }
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
@@ -31,6 +31,7 @@ import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqIconButton;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.overlay.Popup;
+import bisq.desktop.components.overlay.TextInputDialog;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.DateColumnUtil;
 import bisq.desktop.components.table.DateTableItem;
@@ -122,7 +123,13 @@ public class ReportToModeratorTable {
         }
 
         void onBan(ReportToModeratorMessage message) {
-            moderatorService.banReportedUser(message);
+            new TextInputDialog(Res.get("authorizedRole.moderator.banDialog.headline"))
+                    .setPromptText(Res.get("authorizedRole.moderator.banDialog.reason.prompt"))
+                    .setInputFieldDescription(Res.get("authorizedRole.moderator.banDialog.details"))
+                    .setConfirmButtonText(Res.get("authorizedRole.moderator.banDialog.action.ban"))
+                    .setMaxLength(500)
+                    .onResult(banReason -> moderatorService.banReportedUser(message, banReason))
+                    .show();
         }
 
         void onDeleteMessage(ReportToModeratorMessage message) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
@@ -30,6 +30,7 @@ import bisq.desktop.common.view.Navigation;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqIconButton;
 import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.validator.TextMaxLengthValidator;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.components.overlay.TextInputDialog;
 import bisq.desktop.components.table.BisqTableColumn;
@@ -123,12 +124,15 @@ public class ReportToModeratorTable {
         }
 
         void onBan(ReportToModeratorMessage message) {
+            int maxLength = 1000;
             new TextInputDialog(Res.get("authorizedRole.moderator.banDialog.headline"))
-                    .setPromptText(Res.get("authorizedRole.moderator.banDialog.reason.prompt"))
-                    .setInputFieldDescription(Res.get("authorizedRole.moderator.banDialog.details"))
-                    .setConfirmButtonText(Res.get("authorizedRole.moderator.banDialog.action.ban"))
-                    .setMaxLength(500)
+                    .promptText(Res.get("authorizedRole.moderator.banDialog.reason.prompt"))
+                    .description(Res.get("authorizedRole.moderator.banDialog.description"))
+                    .helpText(Res.get("authorizedRole.moderator.banDialog.helpText"))
                     .onResult(banReason -> moderatorService.banReportedUser(message, banReason))
+                    .validator(new TextMaxLengthValidator(maxLength, Res.get("validation.tooLong", maxLength)))
+                    .actionButtonText(Res.get("authorizedRole.moderator.banDialog.action.ban"))
+                    .width(800)
                     .show();
         }
 
@@ -329,12 +333,11 @@ public class ReportToModeratorTable {
                         tooltip.setText(item.getMessage());
                         message.setTooltip(tooltip);
 
-                       // icon.setOnAction(e -> ClipboardUtil.copyToClipboard(item.getMessage()));
                         icon.setOnAction(e -> new Popup()
                                 .headline(Res.get("authorizedRole.moderator.table.message.popup.headline"))
                                 .information(item.getMessage())
                                 .actionButtonText(Res.get("action.copyToClipboard"))
-                                .onAction(()-> ClipboardUtil.copyToClipboard(item.getMessage()))
+                                .onAction(() -> ClipboardUtil.copyToClipboard(item.getMessage()))
                                 .show());
                         setGraphic(hBox);
                     } else {

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -96,8 +96,17 @@ authorizedRole.moderator.table.delete=Delete
 
 authorizedRole.moderator.table.message.popup.headline=Reporters message
 
+authorizedRole.moderator.banDialog.headline=Enter a ban reason
+authorizedRole.moderator.banDialog.details=This information will be stored locally and won't be visible to other moderators or the banned user
+authorizedRole.moderator.banDialog.reason.prompt=Enter ban reason...
+authorizedRole.moderator.banDialog.action.ban=Ban
+
 authorizedRole.moderator.bannedUserProfile.table.headline=Banned user profiles
 authorizedRole.moderator.bannedUserProfile.table.userProfile=User profile
+authorizedRole.moderator.bannedUserProfile.table.reporter=Reporter
+authorizedRole.moderator.bannedUserProfile.table.banReason=Ban Reason
+authorizedRole.moderator.bannedUserProfile.table.banReason.popup.headline=Ban Reason
+
 authorizedRole.moderator.bannedUserProfile.table.contact=Contact
 
 authorizedRole.moderator.table.removeBan=Remove ban

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -96,10 +96,11 @@ authorizedRole.moderator.table.delete=Delete
 
 authorizedRole.moderator.table.message.popup.headline=Reporters message
 
-authorizedRole.moderator.banDialog.headline=Enter a ban reason
-authorizedRole.moderator.banDialog.details=This information will be stored locally and won't be visible to other moderators or the banned user
-authorizedRole.moderator.banDialog.reason.prompt=Enter ban reason...
-authorizedRole.moderator.banDialog.action.ban=Ban
+authorizedRole.moderator.banDialog.headline=Enter reason for banning that user
+authorizedRole.moderator.banDialog.description=Reason for ban
+authorizedRole.moderator.banDialog.helpText=This data is persisted is not shared on the network but persisted locally.
+authorizedRole.moderator.banDialog.reason.prompt=Enter reason...
+authorizedRole.moderator.banDialog.action.ban=Ban user
 
 authorizedRole.moderator.bannedUserProfile.table.headline=Banned user profiles
 authorizedRole.moderator.bannedUserProfile.table.userProfile=User profile

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -143,3 +143,7 @@ component.standardTable.filter.tooltip=Filter by {0}
 component.standardTable.numEntries=Number of entries: {0}
 component.standardTable.csv.plainValue={0} (plain value)
 
+####################################################################
+# TextInputDialog
+####################################################################
+component.TextInputDialog.text.characters.remaining={0} characters remaining

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -142,8 +142,3 @@ component.standardTable.filter.showAll=Show all
 component.standardTable.filter.tooltip=Filter by {0}
 component.standardTable.numEntries=Number of entries: {0}
 component.standardTable.csv.plainValue={0} (plain value)
-
-####################################################################
-# TextInputDialog
-####################################################################
-component.TextInputDialog.text.characters.remaining={0} characters remaining

--- a/support/src/main/java/bisq/support/moderator/BannedUserModeratorData.java
+++ b/support/src/main/java/bisq/support/moderator/BannedUserModeratorData.java
@@ -51,7 +51,7 @@ public final class BannedUserModeratorData implements PersistableProto {
         return bisq.support.protobuf.BannedUserModeratorData.newBuilder()
                 .setReporterUserProfileId(reporterUserProfileId)
                 .setAccusedUserProfileId(accusedUserProfileId)
-                .setReportMessage(reportersMessage)
+                .setReportersMessage(reportersMessage)
                 .setBanReason(banReason);
     }
 
@@ -64,7 +64,7 @@ public final class BannedUserModeratorData implements PersistableProto {
         return new BannedUserModeratorData(
                 proto.getReporterUserProfileId(),
                 proto.getAccusedUserProfileId(),
-                proto.getReportMessage(),
+                proto.getReportersMessage(),
                 proto.getBanReason());
     }
 

--- a/support/src/main/java/bisq/support/moderator/BannedUserModeratorData.java
+++ b/support/src/main/java/bisq/support/moderator/BannedUserModeratorData.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.moderator;
+
+import bisq.common.proto.PersistableProto;
+import bisq.common.proto.ProtoResolver;
+import bisq.common.proto.UnresolvableProtobufMessageException;
+import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@ToString
+@EqualsAndHashCode
+public final class BannedUserModeratorData implements PersistableProto {
+    private final String reporterUserProfileId;
+    private final String accusedUserProfileId;
+    private final String reportersMessage;
+    private final String banReason;
+
+    public BannedUserModeratorData(String reporterUserProfileId,
+                                   String accusedUserProfileId,
+                                   String reportersMessage,
+                                   String banReason) {
+        this.reporterUserProfileId = reporterUserProfileId;
+        this.accusedUserProfileId = accusedUserProfileId;
+        this.reportersMessage = reportersMessage;
+        this.banReason = banReason;
+    }
+
+    @Override
+    public bisq.support.protobuf.BannedUserModeratorData.Builder getBuilder(boolean serializeForHash) {
+        return bisq.support.protobuf.BannedUserModeratorData.newBuilder()
+                .setReporterUserProfileId(reporterUserProfileId)
+                .setAccusedUserProfileId(accusedUserProfileId)
+                .setReportMessage(reportersMessage)
+                .setBanReason(banReason);
+    }
+
+    @Override
+    public bisq.support.protobuf.BannedUserModeratorData toProto(boolean serializeForHash) {
+        return getBuilder(serializeForHash).build();
+    }
+
+    public static BannedUserModeratorData fromProto(bisq.support.protobuf.BannedUserModeratorData proto) {
+        return new BannedUserModeratorData(
+                proto.getReporterUserProfileId(),
+                proto.getAccusedUserProfileId(),
+                proto.getReportMessage(),
+                proto.getBanReason());
+    }
+
+    public static ProtoResolver<PersistableProto> getResolver() {
+        return any -> {
+            try {
+                return fromProto(any.unpack(bisq.support.protobuf.BannedUserModeratorData.class));
+            } catch (InvalidProtocolBufferException e) {
+                throw new UnresolvableProtobufMessageException(e);
+            }
+        };
+    }
+}

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -43,7 +43,7 @@ message ReportToModeratorMessage {
 message BannedUserModeratorData {
   string reporterUserProfileId = 1;
   string accusedUserProfileId = 2;
-  string reportMessage = 3;
+  string reportersMessage = 3;
   string banReason = 4;
 }
 

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -39,6 +39,15 @@ message ReportToModeratorMessage {
   string message = 4;
   chat.ChatChannelDomain chatChannelDomain = 5;
 }
+
+message BannedUserModeratorData {
+  string reporterUserProfileId = 1;
+  string accusedUserProfileId = 2;
+  string reportMessage = 3;
+  string banReason = 4;
+}
+
 message ModeratorStore {
   repeated ReportToModeratorMessage reportToModeratorMessages = 1;
+  repeated BannedUserModeratorData bannedUserModeratorData = 2;
 }

--- a/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
+++ b/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
@@ -33,8 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Set;
 
-import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
-import static bisq.network.p2p.services.data.storage.MetaData.TTL_100_DAYS;
+import static bisq.network.p2p.services.data.storage.MetaData.*;
 
 @Slf4j
 @EqualsAndHashCode


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq2/pull/3412

@mvp1983 
See commit comments why it was required to change things. The PR did take too many roundtrips therefore I decided to do it myself based on that existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dialog for moderators to input a ban reason when banning users, with validation and clipboard support.
  - Enhanced the banned user profiles table to display the reporter's information and the ban reason, with popups for detailed viewing and copying.
  - Introduced a reusable multi-line text input dialog component.
  - Introduced new localization entries for ban dialogs and banned user profile details.

- **Improvements**
  - Improved UI elements for interacting with banned user data, including tooltips and info icons.
  - Streamlined user profile cell rendering for better consistency.
  - Added convenience for creating info icon buttons without tooltips.

- **Bug Fixes**
  - Corrected action handling for copying message text in moderator reports.

- **Chores**
  - Updated internal data persistence and protobuf schema to support storage of ban reasons and reporter information.
  - Extended moderator services and stores to manage ban reason data.
  - Minor cleanup in localization files and code imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->