### PR TITLE
Disable all animation if deactivated in settings

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
@@ -103,7 +103,7 @@ public class Transitions {
     }
 
     public static FadeTransition fadeIn(Node node, int duration, @Nullable Runnable finishedHandler) {
-        FadeTransition fadeTransition = new FadeTransition(Duration.millis(getDuration(duration)), node);
+        FadeTransition fadeTransition = new FadeTransition(Duration.millis(effectiveDuration(duration)), node);
         if (node == null) {
             if (finishedHandler != null) {
                 finishedHandler.run();
@@ -184,7 +184,7 @@ public class Transitions {
         if (node == null) {
             return;
         }
-        FadeTransition fade = new FadeTransition(Duration.millis(getDuration(duration)), node);
+        FadeTransition fade = new FadeTransition(Duration.millis(effectiveDuration(duration)), node);
         node.setOpacity(0);
         fade.setFromValue(0);
         fade.setToValue(targetOpacity);
@@ -203,7 +203,7 @@ public class Transitions {
                                       double toValue,
                                       int duration,
                                       @Nullable Runnable finishedHandler) {
-        FadeTransition fade = new FadeTransition(Duration.millis(getDuration(duration)), node);
+        FadeTransition fade = new FadeTransition(Duration.millis(effectiveDuration(duration)), node);
         node.setOpacity(fromValue);
         fade.setFromValue(fromValue);
         fade.setToValue(toValue);
@@ -223,7 +223,7 @@ public class Transitions {
     }
 
     public static FadeTransition fadeOut(Node node, int duration, @Nullable Runnable finishedHandler) {
-        FadeTransition fade = new FadeTransition(Duration.millis(getDuration(duration)), node);
+        FadeTransition fade = new FadeTransition(Duration.millis(effectiveDuration(duration)), node);
         if (dontUseAnimations()) {
             node.setOpacity(0);
             if (finishedHandler != null) {
@@ -257,7 +257,7 @@ public class Transitions {
         }
 
         // With animations enabled, set up fade transition
-        FadeTransition fade = fadeOut(node, getDuration(duration), finishedHandler);
+        FadeTransition fade = fadeOut(node, effectiveDuration(duration), finishedHandler);
         fade.setInterpolator(Interpolator.EASE_IN);
         fade.setOnFinished(actionEvent -> removeNodeAndRunHandler(node, finishedHandler));
     }
@@ -309,12 +309,12 @@ public class Transitions {
         GaussianBlur blur = new GaussianBlur(0.0);
         Timeline timeline = new Timeline();
         KeyValue kv1 = new KeyValue(blur.radiusProperty(), blurRadius);
-        KeyFrame kf1 = new KeyFrame(Duration.millis(getDuration(duration)), kv1);
+        KeyFrame kf1 = new KeyFrame(Duration.millis(effectiveDuration(duration)), kv1);
         ColorAdjust darken = new ColorAdjust();
         darken.setBrightness(0.0);
         blur.setInput(darken);
         KeyValue kv2 = new KeyValue(darken.brightnessProperty(), brightness);
-        KeyFrame kf2 = new KeyFrame(Duration.millis(getDuration(duration)), kv2);
+        KeyFrame kf2 = new KeyFrame(Duration.millis(effectiveDuration(duration)), kv2);
         timeline.getKeyFrames().addAll(kf1, kf2);
         node.setEffect(blur);
         if (removeNode) {
@@ -357,12 +357,12 @@ public class Transitions {
         Timeline timeline = new Timeline();
         removeEffectTimeLineByNodeId.put(node.getId(), timeline);
         KeyValue kv1 = new KeyValue(gaussianBlur.radiusProperty(), 0.0);
-        KeyFrame kf1 = new KeyFrame(Duration.millis(getDuration(duration)), kv1);
+        KeyFrame kf1 = new KeyFrame(Duration.millis(effectiveDuration(duration)), kv1);
         timeline.getKeyFrames().add(kf1);
 
         ColorAdjust darken = (ColorAdjust) gaussianBlur.getInput();
         KeyValue kv2 = new KeyValue(darken.brightnessProperty(), 0.0);
-        KeyFrame kf2 = new KeyFrame(Duration.millis(getDuration(duration)), kv2);
+        KeyFrame kf2 = new KeyFrame(Duration.millis(effectiveDuration(duration)), kv2);
         timeline.getKeyFrames().add(kf2);
         timeline.setOnFinished(actionEvent -> {
             node.setEffect(null);
@@ -372,7 +372,7 @@ public class Transitions {
         timeline.play();
     }
 
-    public static int getDuration(int duration) {
+    public static int effectiveDuration(int duration) {
         return useAnimations() ? duration : 1;
     }
 
@@ -383,7 +383,7 @@ public class Transitions {
 
     public static void flapOut(Node node, Runnable onFinishedHandler) {
         if (useAnimations()) {
-            double duration = getDuration(DEFAULT_DURATION);
+            double duration = effectiveDuration(DEFAULT_DURATION);
             Interpolator interpolator = Interpolator.SPLINE(0.25, 0.1, 0.25, 1);
 
             node.setRotationAxis(Rotate.X_AXIS);
@@ -645,7 +645,7 @@ public class Transitions {
         double end = node.getHeight();
         Timeline timeline = new Timeline();
         if (useAnimations()) {
-            double duration = getDuration(DEFAULT_DURATION / 2);
+            double duration = effectiveDuration(DEFAULT_DURATION / 2);
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             node.setTranslateY(0);
             double start = node.getLayoutY();
@@ -676,7 +676,7 @@ public class Transitions {
     public static void slideDownFromCenterTop(Region node, Runnable onFinishedHandler) {
         double end = -node.getHeight();
         if (useAnimations()) {
-            double duration = getDuration(DEFAULT_DURATION);
+            double duration = effectiveDuration(DEFAULT_DURATION);
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             node.setTranslateY(0);
@@ -756,7 +756,7 @@ public class Transitions {
     public static void animateNavigationButtonMarks(Region node, double targetHeight, double targetY) {
         double startY = node.getLayoutY();
         if (useAnimations() || startY == 0) {
-            double duration = getDuration(DEFAULT_DURATION / 4);
+            double duration = effectiveDuration(DEFAULT_DURATION / 4);
             double startHeight = node.getHeight();
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
@@ -795,7 +795,7 @@ public class Transitions {
         if (useAnimations()) {
             double startWidth = node.getWidth();
             double startX = node.getLayoutX();
-            double duration = getDuration(DEFAULT_DURATION / 4);
+            double duration = effectiveDuration(DEFAULT_DURATION / 4);
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -836,7 +836,7 @@ public class Transitions {
     }
 
     public static void animateHeight(Region node, double targetHeight) {
-        animateHeight(node, node.getPrefHeight(), targetHeight, getDuration(DEFAULT_DURATION / 2), null);
+        animateHeight(node, node.getPrefHeight(), targetHeight, effectiveDuration(DEFAULT_DURATION / 2), null);
     }
 
     public static void animateHeight(Region node,
@@ -925,7 +925,7 @@ public class Transitions {
     }
 
     public static void animatePrefWidth(Region node, double targetWidth) {
-        animatePrefWidth(node, targetWidth, getDuration(DEFAULT_DURATION / 2), null);
+        animatePrefWidth(node, targetWidth, effectiveDuration(DEFAULT_DURATION / 2), null);
     }
 
     public static void animatePrefWidth(Region node,
@@ -955,7 +955,7 @@ public class Transitions {
     }
 
     public static void animateLayoutY(Region node, double targetY) {
-        animateLayoutY(node, targetY, getDuration(DEFAULT_DURATION / 2), null);
+        animateLayoutY(node, targetY, effectiveDuration(DEFAULT_DURATION / 2), null);
     }
 
     public static void animateLayoutY(Region node,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
@@ -111,7 +111,7 @@ public class Transitions {
             return fadeTransition;
         }
 
-        if (!useAnimations()) {
+        if (dontUseAnimations()) {
             node.setOpacity(1);
             if (finishedHandler != null) {
                 finishedHandler.run();
@@ -152,7 +152,7 @@ public class Transitions {
         double startX = node.getTranslateX();
         double targetX = slideOutRight ? node.getWidth() : -node.getWidth();
         node.setOpacity(1);
-        if (!useAnimations()) {
+        if (dontUseAnimations()) {
             node.setOpacity(1);
             node.setTranslateX(startX);
             if (finishedHandler != null) {
@@ -239,7 +239,7 @@ public class Transitions {
     }
 
     public static void fadeOutAndRemove(Node node, int duration, Runnable finishedHandler) {
-        if (!useAnimations()) {
+        if (dontUseAnimations()) {
             // When animations are disabled, skip animation and execute removal immediately
             removeNodeAndRunHandler(node, finishedHandler);
             return;
@@ -333,7 +333,7 @@ public class Transitions {
         if (node != null) {
             node.setMouseTransparent(false);
             Effect effect = node.getEffect();
-            if (!useAnimations() || !(effect instanceof GaussianBlur gaussianBlur)) {
+            if (dontUseAnimations() || !(effect instanceof GaussianBlur gaussianBlur)) {
                 node.setEffect(null);
                 return;
             }
@@ -984,6 +984,10 @@ public class Transitions {
             node.setScaleY(targetScale);
         }
         return timeline;
+    }
+
+    public static boolean dontUseAnimations() {
+        return !useAnimations();
     }
 
     public static boolean useAnimations() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
@@ -151,9 +151,8 @@ public class Transitions {
 
         double startX = node.getTranslateX();
         double targetX = slideOutRight ? node.getWidth() : -node.getWidth();
-        node.setOpacity(1);
         if (dontUseAnimations()) {
-            node.setOpacity(1);
+            node.setOpacity(0);
             node.setTranslateX(startX);
             if (finishedHandler != null) {
                 finishedHandler.run();
@@ -161,7 +160,7 @@ public class Transitions {
             return timeline;
         }
 
-
+        node.setOpacity(1);
         int duration = DEFAULT_DURATION / 4;
         ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
         keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -199,7 +198,11 @@ public class Transitions {
         return fade(node, fromValue, toValue, duration, null);
     }
 
-    public static FadeTransition fade(Node node, double fromValue, double toValue, int duration, @Nullable Runnable finishedHandler) {
+    public static FadeTransition fade(Node node,
+                                      double fromValue,
+                                      double toValue,
+                                      int duration,
+                                      @Nullable Runnable finishedHandler) {
         FadeTransition fade = new FadeTransition(Duration.millis(getDuration(duration)), node);
         node.setOpacity(fromValue);
         fade.setFromValue(fromValue);
@@ -221,6 +224,14 @@ public class Transitions {
 
     public static FadeTransition fadeOut(Node node, int duration, @Nullable Runnable finishedHandler) {
         FadeTransition fade = new FadeTransition(Duration.millis(getDuration(duration)), node);
+        if (dontUseAnimations()) {
+            node.setOpacity(0);
+            if (finishedHandler != null) {
+                finishedHandler.run();
+            }
+            return fade;
+        }
+
         fade.setFromValue(node.getOpacity());
         fade.setToValue(0.0);
         fade.play();
@@ -330,34 +341,35 @@ public class Transitions {
     }
 
     private static void removeEffect(Node node, int duration) {
-        if (node != null) {
-            node.setMouseTransparent(false);
-            Effect effect = node.getEffect();
-            if (dontUseAnimations() || !(effect instanceof GaussianBlur gaussianBlur)) {
-                node.setEffect(null);
-                return;
-            }
-
-            if (node.getId() == null) {
-                node.setId(StringUtils.createUid());
-            }
-            Timeline timeline = new Timeline();
-            removeEffectTimeLineByNodeId.put(node.getId(), timeline);
-            KeyValue kv1 = new KeyValue(gaussianBlur.radiusProperty(), 0.0);
-            KeyFrame kf1 = new KeyFrame(Duration.millis(getDuration(duration)), kv1);
-            timeline.getKeyFrames().add(kf1);
-
-            ColorAdjust darken = (ColorAdjust) gaussianBlur.getInput();
-            KeyValue kv2 = new KeyValue(darken.brightnessProperty(), 0.0);
-            KeyFrame kf2 = new KeyFrame(Duration.millis(getDuration(duration)), kv2);
-            timeline.getKeyFrames().add(kf2);
-            timeline.setOnFinished(actionEvent -> {
-                node.setEffect(null);
-                removeEffectTimeLineByNodeId.remove(node.getId());
-                node.setId(null);
-            });
-            timeline.play();
+        if (node == null) {
+            return;
         }
+        node.setMouseTransparent(false);
+        Effect effect = node.getEffect();
+        if (dontUseAnimations() || !(effect instanceof GaussianBlur gaussianBlur)) {
+            node.setEffect(null);
+            return;
+        }
+
+        if (node.getId() == null) {
+            node.setId(StringUtils.createUid());
+        }
+        Timeline timeline = new Timeline();
+        removeEffectTimeLineByNodeId.put(node.getId(), timeline);
+        KeyValue kv1 = new KeyValue(gaussianBlur.radiusProperty(), 0.0);
+        KeyFrame kf1 = new KeyFrame(Duration.millis(getDuration(duration)), kv1);
+        timeline.getKeyFrames().add(kf1);
+
+        ColorAdjust darken = (ColorAdjust) gaussianBlur.getInput();
+        KeyValue kv2 = new KeyValue(darken.brightnessProperty(), 0.0);
+        KeyFrame kf2 = new KeyFrame(Duration.millis(getDuration(duration)), kv2);
+        timeline.getKeyFrames().add(kf2);
+        timeline.setOnFinished(actionEvent -> {
+            node.setEffect(null);
+            removeEffectTimeLineByNodeId.remove(node.getId());
+            node.setId(null);
+        });
+        timeline.play();
     }
 
     public static int getDuration(int duration) {
@@ -368,7 +380,6 @@ public class Transitions {
         fadeOut(node1, CROSS_FADE_OUT_DURATION)
                 .setOnFinished(e -> Transitions.fadeIn(node2, CROSS_FADE_IN_DURATION));
     }
-
 
     public static void flapOut(Node node, Runnable onFinishedHandler) {
         if (useAnimations()) {
@@ -828,7 +839,11 @@ public class Transitions {
         animateHeight(node, node.getPrefHeight(), targetHeight, getDuration(DEFAULT_DURATION / 2), null);
     }
 
-    public static void animateHeight(Region node, double startHeight, double targetHeight, double duration, @Nullable Runnable onFinishedHandler) {
+    public static void animateHeight(Region node,
+                                     double startHeight,
+                                     double targetHeight,
+                                     double duration,
+                                     @Nullable Runnable onFinishedHandler) {
         if (useAnimations()) {
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
@@ -855,7 +870,11 @@ public class Transitions {
         });
     }
 
-    public static void animateMaxHeight(Region node, double startHeight, double targetHeight, double duration, @Nullable Runnable onFinishedHandler) {
+    public static void animateMaxHeight(Region node,
+                                        double startHeight,
+                                        double targetHeight,
+                                        double duration,
+                                        @Nullable Runnable onFinishedHandler) {
         if (useAnimations()) {
             node.setMinHeight(startHeight);
             node.setMaxHeight(startHeight);
@@ -880,7 +899,11 @@ public class Transitions {
         }
     }
 
-    public static Timeline animateScaleY(Region node, double start, double target, double duration, @Nullable Runnable onFinishedHandler) {
+    public static Timeline animateScaleY(Region node,
+                                         double start,
+                                         double target,
+                                         double duration,
+                                         @Nullable Runnable onFinishedHandler) {
         Timeline timeline = new Timeline();
         if (useAnimations()) {
             node.setScaleY(start);
@@ -905,7 +928,10 @@ public class Transitions {
         animatePrefWidth(node, targetWidth, getDuration(DEFAULT_DURATION / 2), null);
     }
 
-    public static void animatePrefWidth(Region node, double targetWidth, double duration, @Nullable Runnable finishedHandler) {
+    public static void animatePrefWidth(Region node,
+                                        double targetWidth,
+                                        double duration,
+                                        @Nullable Runnable finishedHandler) {
         if (useAnimations()) {
             double startWidth = node.getPrefWidth();
             Timeline timeline = new Timeline();
@@ -932,7 +958,10 @@ public class Transitions {
         animateLayoutY(node, targetY, getDuration(DEFAULT_DURATION / 2), null);
     }
 
-    public static void animateLayoutY(Region node, double targetY, double duration, @Nullable Runnable finishedHandler) {
+    public static void animateLayoutY(Region node,
+                                      double targetY,
+                                      double duration,
+                                      @Nullable Runnable finishedHandler) {
         if (useAnimations()) {
             double startY = node.getLayoutY();
             Timeline timeline = new Timeline();
@@ -998,7 +1027,11 @@ public class Transitions {
         animateWidth(pane, initialWidth, finalWidth, duration, null);
     }
 
-    public static void animateWidth(Pane pane, double initialWidth, double finalWidth, long duration, @Nullable Runnable finishedHandler) {
+    public static void animateWidth(Pane pane,
+                                    double initialWidth,
+                                    double finalWidth,
+                                    long duration,
+                                    @Nullable Runnable finishedHandler) {
         if (useAnimations()) {
             Timeline timeline = new Timeline(
                     new KeyFrame(Duration.millis(0),
@@ -1026,11 +1059,18 @@ public class Transitions {
         }
     }
 
-    public static void animateDividerPosition(SplitPane.Divider splitPaneDivider, double initialPosition, double finalPosition, long duration) {
+    public static void animateDividerPosition(SplitPane.Divider splitPaneDivider,
+                                              double initialPosition,
+                                              double finalPosition,
+                                              long duration) {
         animateDividerPosition(splitPaneDivider, initialPosition, finalPosition, duration, null);
     }
 
-    public static void animateDividerPosition(SplitPane.Divider splitPaneDivider, double initialPosition, double finalPosition, long duration, @Nullable Runnable finishedHandler) {
+    public static void animateDividerPosition(SplitPane.Divider splitPaneDivider,
+                                              double initialPosition,
+                                              double finalPosition,
+                                              long duration,
+                                              @Nullable Runnable finishedHandler) {
         if (useAnimations()) {
             Timeline timeline = new Timeline(
                     new KeyFrame(Duration.millis(0), new KeyValue(splitPaneDivider.positionProperty(), initialPosition, Interpolator.LINEAR)),

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/Transitions.java
@@ -111,7 +111,7 @@ public class Transitions {
             return fadeTransition;
         }
 
-        if (!getUseAnimations()) {
+        if (!useAnimations()) {
             node.setOpacity(1);
             if (finishedHandler != null) {
                 finishedHandler.run();
@@ -152,7 +152,7 @@ public class Transitions {
         double startX = node.getTranslateX();
         double targetX = slideOutRight ? node.getWidth() : -node.getWidth();
         node.setOpacity(1);
-        if (!getUseAnimations()) {
+        if (!useAnimations()) {
             node.setOpacity(1);
             node.setTranslateX(startX);
             if (finishedHandler != null) {
@@ -239,7 +239,7 @@ public class Transitions {
     }
 
     public static void fadeOutAndRemove(Node node, int duration, Runnable finishedHandler) {
-        if (!getUseAnimations()) {
+        if (!useAnimations()) {
             // When animations are disabled, skip animation and execute removal immediately
             removeNodeAndRunHandler(node, finishedHandler);
             return;
@@ -333,7 +333,7 @@ public class Transitions {
         if (node != null) {
             node.setMouseTransparent(false);
             Effect effect = node.getEffect();
-            if (!getUseAnimations() || !(effect instanceof GaussianBlur gaussianBlur)) {
+            if (!useAnimations() || !(effect instanceof GaussianBlur gaussianBlur)) {
                 node.setEffect(null);
                 return;
             }
@@ -361,7 +361,7 @@ public class Transitions {
     }
 
     public static int getDuration(int duration) {
-        return getUseAnimations() ? duration : 1;
+        return useAnimations() ? duration : 1;
     }
 
     public static void crossFade(Node node1, Node node2) {
@@ -371,7 +371,7 @@ public class Transitions {
 
 
     public static void flapOut(Node node, Runnable onFinishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double duration = getDuration(DEFAULT_DURATION);
             Interpolator interpolator = Interpolator.SPLINE(0.25, 0.1, 0.25, 1);
 
@@ -500,7 +500,7 @@ public class Transitions {
     public static Timeline slideInTop(Region node, int duration, Runnable onFinishedHandler) {
         double targetY = 0;
         Timeline timeline = new Timeline();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             double start = -node.getHeight();
             node.setTranslateY(start);
@@ -537,7 +537,7 @@ public class Transitions {
     public static Timeline slideOutTop(Region node, int duration, Runnable onFinishedHandler) {
         double targetY = -node.getHeight();
         Timeline timeline = new Timeline();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             double start = 0;
             node.setTranslateY(start);
@@ -561,7 +561,7 @@ public class Transitions {
         double targetY = -node.getHeight();
         double startY = 0;
         Timeline timeline = new Timeline();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             node.setTranslateY(startY);
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -600,7 +600,7 @@ public class Transitions {
     public static Timeline slideInHorizontal(Region node, int duration, Runnable onFinishedHandler, boolean slideLeft) {
         Timeline timeline = new Timeline();
         double end = node.getLayoutX();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             double start = slideLeft ?
                     node.getLayoutX() - node.getWidth() :
@@ -633,7 +633,7 @@ public class Transitions {
     public static Timeline slideOutBottom(Region node, Runnable onFinishedHandler) {
         double end = node.getHeight();
         Timeline timeline = new Timeline();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double duration = getDuration(DEFAULT_DURATION / 2);
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             node.setTranslateY(0);
@@ -664,7 +664,7 @@ public class Transitions {
 
     public static void slideDownFromCenterTop(Region node, Runnable onFinishedHandler) {
         double end = -node.getHeight();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double duration = getDuration(DEFAULT_DURATION);
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
@@ -688,7 +688,7 @@ public class Transitions {
     }
 
     public static void moveLeft(Region node, int targetX, int duration) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             double startX = node.getLayoutX();
@@ -705,7 +705,7 @@ public class Transitions {
     }
 
     public static void animateLeftNavigationWidth(Region node, double targetWidth, int duration) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double startWidth = node.getWidth();
             Interpolator interpolator = startWidth > targetWidth ? Interpolator.EASE_IN : Interpolator.EASE_OUT;
             Timeline timeline = new Timeline();
@@ -724,7 +724,7 @@ public class Transitions {
     }
 
     public static void animateLeftSubNavigation(Region node, double targetX, int duration) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double startX = node.getLayoutX();
             Interpolator interpolator = startX > targetX ? Interpolator.EASE_IN : Interpolator.EASE_OUT;
             Timeline timeline = new Timeline();
@@ -744,7 +744,7 @@ public class Transitions {
 
     public static void animateNavigationButtonMarks(Region node, double targetHeight, double targetY) {
         double startY = node.getLayoutY();
-        if (getUseAnimations() || startY == 0) {
+        if (useAnimations() || startY == 0) {
             double duration = getDuration(DEFAULT_DURATION / 4);
             double startHeight = node.getHeight();
             Timeline timeline = new Timeline();
@@ -781,7 +781,7 @@ public class Transitions {
     }
 
     public static void animateTabButtonMarks(Region node, double targetWidth, double targetX) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double startWidth = node.getWidth();
             double startX = node.getLayoutX();
             double duration = getDuration(DEFAULT_DURATION / 4);
@@ -829,7 +829,7 @@ public class Transitions {
     }
 
     public static void animateHeight(Region node, double startHeight, double targetHeight, double duration, @Nullable Runnable onFinishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -856,7 +856,7 @@ public class Transitions {
     }
 
     public static void animateMaxHeight(Region node, double startHeight, double targetHeight, double duration, @Nullable Runnable onFinishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             node.setMinHeight(startHeight);
             node.setMaxHeight(startHeight);
             Timeline timeline = new Timeline();
@@ -882,7 +882,7 @@ public class Transitions {
 
     public static Timeline animateScaleY(Region node, double start, double target, double duration, @Nullable Runnable onFinishedHandler) {
         Timeline timeline = new Timeline();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             node.setScaleY(start);
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(duration),
@@ -906,7 +906,7 @@ public class Transitions {
     }
 
     public static void animatePrefWidth(Region node, double targetWidth, double duration, @Nullable Runnable finishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double startWidth = node.getPrefWidth();
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
@@ -933,7 +933,7 @@ public class Transitions {
     }
 
     public static void animateLayoutY(Region node, double targetY, double duration, @Nullable Runnable finishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             double startY = node.getLayoutY();
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
@@ -961,7 +961,7 @@ public class Transitions {
                                  double targetOpacity,
                                  double fromScale, double targetScale) {
         Timeline timeline = new Timeline();
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(0),
                     new KeyValue(node.opacityProperty(), fromOpacity, Interpolator.LINEAR),
@@ -986,7 +986,7 @@ public class Transitions {
         return timeline;
     }
 
-    public static boolean getUseAnimations() {
+    public static boolean useAnimations() {
         return settingsService.getUseAnimations().get();
     }
 
@@ -995,7 +995,7 @@ public class Transitions {
     }
 
     public static void animateWidth(Pane pane, double initialWidth, double finalWidth, long duration, @Nullable Runnable finishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             Timeline timeline = new Timeline(
                     new KeyFrame(Duration.millis(0),
                             new KeyValue(pane.prefWidthProperty(), initialWidth, Interpolator.LINEAR),
@@ -1027,7 +1027,7 @@ public class Transitions {
     }
 
     public static void animateDividerPosition(SplitPane.Divider splitPaneDivider, double initialPosition, double finalPosition, long duration, @Nullable Runnable finishedHandler) {
-        if (getUseAnimations()) {
+        if (useAnimations()) {
             Timeline timeline = new Timeline(
                     new KeyFrame(Duration.millis(0), new KeyValue(splitPaneDivider.positionProperty(), initialPosition, Interpolator.LINEAR)),
                     new KeyFrame(Duration.millis(duration), new KeyValue(splitPaneDivider.positionProperty(), finalPosition, Interpolator.EASE_OUT))

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/ViewTransition.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/ViewTransition.java
@@ -52,7 +52,7 @@ public class ViewTransition {
         this.newView = newView;
         oldViewRoot = oldView != null ? oldView.getRoot() : null;
         newViewRoot = newView.getRoot();
-        if (!Transitions.getUseAnimations()) {
+        if (!Transitions.useAnimations()) {
             if (oldView != null) {
                 remove(oldViewRoot);
                 if (oldView instanceof TransitionedView) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabButton.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabButton.java
@@ -244,7 +244,7 @@ public class TabButton extends Pane implements Toggle {
         double rightX = numMessagesBadge.getWidth() + 8;
         double end = animateIn ? rightX : 0;
         double opacityEnd = animateIn ? 1 : 0;
-        if (Transitions.getUseAnimations()) {
+        if (Transitions.useAnimations()) {
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             double start = animateIn ? 0 : rightX;
             double opacityStart = animateIn ? 0 : 1;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/Badge.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/Badge.java
@@ -91,7 +91,7 @@ public class Badge extends StackPane {
         transition.setCycleCount(1);
         transition.setAutoReverse(true);
 
-        useAnimation = Transitions.getUseAnimations();
+        useAnimation = Transitions.useAnimations();
 
         getChildren().add(badge);
         getStyleClass().add("bisq-badge");
@@ -110,7 +110,7 @@ public class Badge extends StackPane {
     }
 
     public void setUseAnimation(boolean useAnimation) {
-        if (Transitions.getUseAnimations()) {
+        if (Transitions.useAnimations()) {
             this.useAnimation = useAnimation;
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/ProgressBarWithLabel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/ProgressBarWithLabel.java
@@ -102,7 +102,7 @@ public class ProgressBarWithLabel extends VBox {
             if (scheduler != null) {
                 scheduler.stop();
             }
-            if (Transitions.getUseAnimations() && animateEllipsis) {
+            if (Transitions.useAnimations() && animateEllipsis) {
                 scheduler = UIScheduler.run(() -> {
                     label.setText(getText() + postFix);
                     switch (postFix) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/ProgressBarWithLabel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/ProgressBarWithLabel.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.components.controls;
 
+import bisq.desktop.common.Transitions;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.threading.UIThread;
 import javafx.beans.property.DoubleProperty;
@@ -101,23 +102,28 @@ public class ProgressBarWithLabel extends VBox {
             if (scheduler != null) {
                 scheduler.stop();
             }
-            scheduler = UIScheduler.run(() -> {
+            if (Transitions.getUseAnimations() && animateEllipsis) {
+                scheduler = UIScheduler.run(() -> {
+                    label.setText(getText() + postFix);
+                    switch (postFix) {
+                        case "   ":
+                            postFix = ".  ";
+                            break;
+                        case ".  ":
+                            postFix = ".. ";
+                            break;
+                        case ".. ":
+                            postFix = "...";
+                            break;
+                        default:
+                            postFix = "   ";
+                            break;
+                    }
+                }).periodically(300, TimeUnit.MILLISECONDS);
+            } else {
+                postFix = "...";
                 label.setText(getText() + postFix);
-                switch (postFix) {
-                    case "   ":
-                        postFix = ".  ";
-                        break;
-                    case ".  ":
-                        postFix = ".. ";
-                        break;
-                    case ".. ":
-                        postFix = "...";
-                        break;
-                    default:
-                        postFix = "   ";
-                        break;
-                }
-            }).periodically(300, TimeUnit.MILLISECONDS);
+            }
         } else {
             postFix = "";
             if (scheduler != null) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/onboarding/video/BisqEasyVideoView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/onboarding/video/BisqEasyVideoView.java
@@ -394,7 +394,7 @@ public class BisqEasyVideoView extends View<StackPane, BisqEasyVideoModel, BisqE
             largeReplay.setOpacity(0);
         }
         pausePlayTimeline = new Timeline();
-        if (Transitions.getUseAnimations()) {
+        if (Transitions.useAnimations()) {
             ObservableList<KeyFrame> keyFrames = pausePlayTimeline.getKeyFrames();
             if (imageView.getOpacity() == 0) {
                 keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -468,7 +468,7 @@ public class BisqEasyVideoView extends View<StackPane, BisqEasyVideoModel, BisqE
         }
         if (controlsVBox.getOpacity() == 0) {
             restartCheckActivityScheduler();
-            if (Transitions.getUseAnimations()) {
+            if (Transitions.useAnimations()) {
                 showControlsTimeline = new Timeline();
                 ObservableList<KeyFrame> keyFrames = showControlsTimeline.getKeyFrames();
                 keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -490,7 +490,7 @@ public class BisqEasyVideoView extends View<StackPane, BisqEasyVideoModel, BisqE
             controlsVBox.setOpacity(1);
         }
         if (mediaPlayer != null && mediaPlayer.getStatus() == MediaPlayer.Status.PLAYING && controlsVBox.getOpacity() > 0) {
-            if (Transitions.getUseAnimations()) {
+            if (Transitions.useAnimations()) {
                 hideControlsTimeline = new Timeline();
                 ObservableList<KeyFrame> keyFrames = hideControlsTimeline.getKeyFrames();
                 keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -524,7 +524,7 @@ public class BisqEasyVideoView extends View<StackPane, BisqEasyVideoModel, BisqE
     }
 
     private void showVolumeSlider() {
-        if (Transitions.getUseAnimations()) {
+        if (Transitions.useAnimations()) {
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(0),
@@ -542,7 +542,7 @@ public class BisqEasyVideoView extends View<StackPane, BisqEasyVideoModel, BisqE
     }
 
     private void hideVolumeSlider() {
-        if (Transitions.getUseAnimations()) {
+        if (Transitions.useAnimations()) {
             Timeline timeline = new Timeline();
             ObservableList<KeyFrame> keyFrames = timeline.getKeyFrames();
             keyFrames.add(new KeyFrame(Duration.millis(0),

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.bisq_easy.wallet_guide.receive;
 
+import bisq.desktop.common.Transitions;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
@@ -97,20 +98,24 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         link2.setOnAction(e -> controller.onOpenLink2());
 
         // TODO (low prio) create carousel component for it (See https://github.com/bisq-network/bisq2/issues/1262)
-        image2.setOpacity(0);
-        scheduler1 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
-        fadeTransition1.setOnFinished(e -> {
-            if (scheduler2 != null) {
-                scheduler2.stop();
-            }
-            scheduler2 = UIScheduler.run(fadeTransition2::playFromStart).after(2000);
-        });
-        fadeTransition2.setOnFinished(e -> {
-            if (scheduler3 != null) {
-                scheduler3.stop();
-            }
-            scheduler3 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
-        });
+        if (Transitions.getUseAnimations()) {
+            image2.setOpacity(0);
+            scheduler1 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
+            fadeTransition1.setOnFinished(e -> {
+                if (scheduler2 != null) {
+                    scheduler2.stop();
+                }
+                scheduler2 = UIScheduler.run(fadeTransition2::playFromStart).after(2000);
+            });
+            fadeTransition2.setOnFinished(e -> {
+                if (scheduler3 != null) {
+                    scheduler3.stop();
+                }
+                scheduler3 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
+            });
+        } else {
+            image2.setOpacity(1);
+        }
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
@@ -98,8 +98,8 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         link2.setOnAction(e -> controller.onOpenLink2());
 
         // TODO (low prio) create carousel component for it (See https://github.com/bisq-network/bisq2/issues/1262)
+        image2.setOpacity(0);
         if (Transitions.getUseAnimations()) {
-            image2.setOpacity(0);
             scheduler1 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
             fadeTransition1.setOnFinished(e -> {
                 if (scheduler2 != null) {
@@ -114,7 +114,13 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
                 scheduler3 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
             });
         } else {
-            image2.setOpacity(1);
+            scheduler1 = UIScheduler.run(() -> {
+                if (image2.getOpacity() == 0) {
+                    image2.setOpacity(1);
+                } else {
+                    image2.setOpacity(0);
+                }
+            }).periodically(2000);
         }
     }
 
@@ -125,9 +131,11 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         link1.setOnAction(null);
         link2.setOnAction(null);
 
-        scheduler1.stop();
         fadeTransition1.stop();
         fadeTransition2.stop();
+        if (scheduler1 != null) {
+            scheduler1.stop();
+        }
         if (scheduler2 != null) {
             scheduler2.stop();
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
@@ -99,7 +99,7 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
 
         // TODO (low prio) create carousel component for it (See https://github.com/bisq-network/bisq2/issues/1262)
         image2.setOpacity(0);
-        if (Transitions.getUseAnimations()) {
+        if (Transitions.useAnimations()) {
             scheduler1 = UIScheduler.run(fadeTransition1::playFromStart).after(2000);
             fadeTransition1.setOnFinished(e -> {
                 if (scheduler2 != null) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListView.java
@@ -200,7 +200,7 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
     }
 
     private void fadeInScrollDownBadge() {
-        if (!Transitions.getUseAnimations()) {
+        if (!Transitions.useAnimations()) {
             scrollDownBadge.setOpacity(1);
             return;
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/left/LeftNavView.java
@@ -374,7 +374,7 @@ public class LeftNavView extends View<AnchorPane, LeftNavModel, LeftNavControlle
             UIScheduler.run(() -> Transitions.animateNavigationButtonMarks(selectionMarker,
                             buttonForHeight.getHeight(),
                             calculateTargetY()))
-                    .after(Transitions.getDuration(Transitions.DEFAULT_DURATION / 2));
+                    .after(Transitions.effectiveDuration(Transitions.DEFAULT_DURATION / 2));
         }
         updateSubmenu();
     }


### PR DESCRIPTION
Based on https://github.com/bisq-network/bisq2/pull/3424

The approach with the flags is not the best one as its easy to overlook and the finished state is not always that clear how to reach, as well we return timelines and we do not know if the caller is listening to onFinished handlers.

A better approach IMO is to use the `effectiveDuration` function for the duration which sets the duration to 1 ms in case useAnimations is false. This will removes all the extra handling and ensures the finished handlers are called.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized animation enablement checks across the app for consistency.
  - Improved handling of disabled animations, ensuring immediate application of end states and callbacks without animation delays.
  - Centralized and simplified node removal logic during animation transitions.
  - Enhanced code readability in animation-related methods.

- **Bug Fixes**
  - Prevented potential errors during cleanup by adding null checks to animation schedulers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->