### PR TITLE
Skip .log files during backup

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesController.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.content.support.resources;
 
-import bisq.desktop.navigation.NavigationTarget;
 import bisq.common.file.FileUtils;
 import bisq.common.observable.Pin;
 import bisq.common.platform.PlatformUtils;
@@ -30,6 +29,7 @@ import bisq.desktop.common.utils.FileChooserUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.components.overlay.Popup;
+import bisq.desktop.navigation.NavigationTarget;
 import bisq.i18n.Res;
 import bisq.persistence.PersistenceService;
 import bisq.settings.SettingsService;
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Set;
 
 @Slf4j
 public class ResourcesController implements Controller {
@@ -117,7 +118,8 @@ public class ResourcesController implements Controller {
                             return;
                         }
                         try {
-                            FileUtils.copyDirectory(baseDir, destination);
+                            // Files with .log extension are not necessary to include in the backup, so we exclude them from the copy
+                            FileUtils.copyDirectory(baseDir, destination, Set.of("log"));
                             new Popup().feedback(Res.get("support.resources.backup.success", destination)).show();
                         } catch (IOException e) {
                             new Popup().error(e).show();


### PR DESCRIPTION
Fixed #2897

Added additional param to FileUtils.copyDirectory method which is responsible for skipped file extensions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved backup functionality to exclude files with the ".log" extension from being copied, resulting in cleaner and more relevant backups.

- **Bug Fixes**
  - Ensured that backup operations no longer include unnecessary log files, reducing backup size and clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->