### PR TITLE
Add carousel component to wallet guide

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/containers/Carousel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/containers/Carousel.java
@@ -1,0 +1,331 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.containers;
+
+import bisq.desktop.common.Transitions;
+import bisq.desktop.common.threading.UIScheduler;
+import javafx.animation.ParallelTransition;
+import javafx.animation.TranslateTransition;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.shape.Rectangle;
+import javafx.util.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class Carousel extends BorderPane {
+    private final List<Node> items = new ArrayList<>();
+    private final IntegerProperty currentIndex = new SimpleIntegerProperty(0);
+    private final BooleanProperty isPlaying = new SimpleBooleanProperty(false);
+    @Getter
+    private final BooleanProperty showBottomDots = new SimpleBooleanProperty(true);
+    @Getter
+    private final BooleanProperty showArrows = new SimpleBooleanProperty(true);
+    private final StackPane itemStackPane;
+    private final Button leftArrowButton;
+    private final Button rightArrowButton;
+    @Getter
+    private final HBox indicatorsHBox;
+
+    @Setter
+    private int transitionDuration = 400;
+    @Setter
+    private int displayDuration = 3000;
+
+    private UIScheduler transitionScheduler;
+    private boolean isTransitioning = false;
+    private Node currentNode;
+    private Node nextNode;
+
+    private final ChangeListener<Number> currentIndexListener = (obs, oldVal, newVal) -> updateIndicators();
+
+    public Carousel() {
+        this(new ArrayList<>());
+    }
+
+    public Carousel(List<Node> items) {
+        getStyleClass().add("carousel");
+
+        Rectangle clipRectangle = new Rectangle();
+
+        itemStackPane = new StackPane();
+        itemStackPane.getStyleClass().add("carousel-item-container");
+
+        clipRectangle.widthProperty().bind(itemStackPane.widthProperty());
+        clipRectangle.heightProperty().bind(itemStackPane.heightProperty());
+        itemStackPane.setClip(clipRectangle);
+
+        leftArrowButton = new Button("❮");
+        leftArrowButton.getStyleClass().addAll("carousel-nav-arrow");
+        leftArrowButton.setOnAction(e -> previous());
+
+        rightArrowButton = new Button("❯");
+        rightArrowButton.getStyleClass().addAll("carousel-nav-arrow");
+        rightArrowButton.setOnAction(e -> next());
+
+        indicatorsHBox = new HBox(6);
+        indicatorsHBox.setAlignment(Pos.CENTER);
+        indicatorsHBox.getStyleClass().add("carousel-indicators");
+
+        VBox contentBox = new VBox(5);
+        contentBox.setAlignment(Pos.CENTER);
+        contentBox.getChildren().addAll(itemStackPane, indicatorsHBox);
+
+        setCenter(contentBox);
+        setLeft(leftArrowButton);
+        setRight(rightArrowButton);
+
+        BorderPane.setAlignment(leftArrowButton, Pos.CENTER);
+        BorderPane.setAlignment(rightArrowButton, Pos.CENTER);
+
+        indicatorsHBox.visibleProperty().bind(showBottomDots);
+        indicatorsHBox.managedProperty().bind(showBottomDots);
+
+        leftArrowButton.visibleProperty().bind(showArrows);
+        leftArrowButton.managedProperty().bind(showArrows);
+        rightArrowButton.visibleProperty().bind(showArrows);
+        rightArrowButton.managedProperty().bind(showArrows);
+
+        if (!items.isEmpty()) {
+            for (Node item : items) {
+                addItem(item);
+            }
+        }
+    }
+
+    public void addItem(Node item) {
+        items.add(item);
+
+        // If this is the first item, size the carousel according to the item dimensions
+        if (items.size() == 1) {
+            if (item instanceof ImageView imageView) {
+                double width = imageView.getFitWidth();
+                double height = imageView.getFitHeight();
+
+                if ((height == 0) || (width == 0)) {
+                    Image image = imageView.getImage();
+                    if (image != null) {
+                        if (width == 0) {
+                            width = image.getWidth();
+                        }
+
+                        if (height == 0) {
+                            height = image.getHeight();
+                        }
+                    }
+                }
+
+                itemStackPane.setPrefWidth(width);
+                itemStackPane.setPrefHeight(height);
+                itemStackPane.setMaxWidth(width);
+                itemStackPane.setMaxHeight(height);
+                itemStackPane.setMinWidth(width);
+                itemStackPane.setMinHeight(height);
+            } else if (item instanceof Region region) {
+                if (region.getPrefWidth() > 0 && region.getPrefHeight() > 0) {
+                    itemStackPane.setPrefWidth(region.getPrefWidth());
+                    itemStackPane.setPrefHeight(region.getPrefHeight());
+                    itemStackPane.setMaxWidth(region.getPrefWidth());
+                    itemStackPane.setMaxHeight(region.getPrefHeight());
+                    itemStackPane.setMinWidth(region.getPrefWidth());
+                    itemStackPane.setMinHeight(region.getPrefHeight());
+                }
+            }
+
+            setupInitialItem();
+        }
+
+        updateIndicators();
+        updateArrowVisibility();
+    }
+
+    public void start() {
+        if (items.size() <= 1) {
+            return;
+        }
+        currentIndex.removeListener(currentIndexListener);
+        currentIndex.addListener(currentIndexListener);
+        isPlaying.set(true);
+        scheduleNextTransition();
+    }
+
+    public void stop() {
+        isPlaying.set(false);
+
+        if (transitionScheduler != null) {
+            transitionScheduler.stop();
+            transitionScheduler = null;
+        }
+
+        currentIndex.removeListener(currentIndexListener);
+    }
+
+    public void next() {
+        if (items.size() <= 1 || isTransitioning) {
+            return;
+        }
+
+        int nextIndex = (currentIndex.get() + 1) % items.size();
+        transitionToIndex(nextIndex, true);
+    }
+
+    public void previous() {
+        if (items.size() <= 1 || isTransitioning) {
+            return;
+        }
+
+        int prevIndex = (currentIndex.get() - 1 + items.size()) % items.size();
+        transitionToIndex(prevIndex, false);
+    }
+
+    public void goToIndex(int index) {
+        if (index < 0 || index >= items.size() || index == currentIndex.get() || isTransitioning) {
+            return;
+        }
+
+        transitionToIndex(index, index > currentIndex.get());
+    }
+
+    private void setupInitialItem() {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        itemStackPane.getChildren().clear();
+        currentNode = items.get(currentIndex.get());
+        itemStackPane.getChildren().add(currentNode);
+    }
+
+    private void updateIndicators() {
+        indicatorsHBox.getChildren().clear();
+
+        if (items.size() <= 1) {
+            return;
+        }
+
+        for (int i = 0; i < items.size(); i++) {
+            StackPane dot = new StackPane();
+            dot.getStyleClass().add("carousel-indicator");
+
+            if (i == currentIndex.get()) {
+                dot.getStyleClass().add("active");
+            }
+
+            final int index = i;
+            dot.setOnMouseClicked(e -> goToIndex(index));
+
+            indicatorsHBox.getChildren().add(dot);
+        }
+    }
+
+    private void updateArrowVisibility() {
+        boolean hasMultipleItems = items.size() > 1;
+
+        // We don't need to set visibility directly here
+        // as it's controlled by the binding to showArrows property
+        leftArrowButton.setDisable(!hasMultipleItems);
+        rightArrowButton.setDisable(!hasMultipleItems);
+    }
+
+    private void transitionToIndex(int targetIndex, boolean goingForward) {
+        if (isTransitioning || items.isEmpty() || targetIndex == currentIndex.get()) {
+            return;
+        }
+
+        isTransitioning = true;
+
+        if (transitionScheduler != null) {
+            transitionScheduler.stop();
+            transitionScheduler = null;
+        }
+
+        Node currentItem = items.get(currentIndex.get());
+        Node targetItem = items.get(targetIndex);
+
+        if (Transitions.dontUseAnimations()) {
+            currentIndex.set(targetIndex);
+            itemStackPane.getChildren().clear();
+            currentNode = targetItem;
+            currentNode.setTranslateX(0);
+            itemStackPane.getChildren().add(currentNode);
+            isTransitioning = false;
+            if (isPlaying.get()) {
+                scheduleNextTransition();
+            }
+        } else {
+            nextNode = targetItem;
+            nextNode.setTranslateX(goingForward ? itemStackPane.getWidth() : -itemStackPane.getWidth());
+            itemStackPane.getChildren().add(nextNode);
+
+            ParallelTransition transition = createSlideTransition(currentItem, targetItem, goingForward);
+            transition.setOnFinished(e -> {
+                currentIndex.set(targetIndex);
+                itemStackPane.getChildren().clear();
+                currentNode = nextNode;
+                itemStackPane.getChildren().add(currentNode);
+                nextNode = null;
+                isTransitioning = false;
+
+                if (isPlaying.get()) {
+                    scheduleNextTransition();
+                }
+            });
+
+            transition.play();
+        }
+    }
+
+    private ParallelTransition createSlideTransition(Node currentItem, Node targetItem, boolean goingForward) {
+        int effectiveDurationMs = Transitions.effectiveDuration(transitionDuration);
+        Duration duration = Duration.millis(effectiveDurationMs);
+
+        TranslateTransition exitTransition = new TranslateTransition(duration, currentItem);
+        exitTransition.setToX(goingForward ? -itemStackPane.getWidth() : itemStackPane.getWidth());
+
+        TranslateTransition enterTransition = new TranslateTransition(duration, targetItem);
+        enterTransition.setToX(0);
+
+        return new ParallelTransition(exitTransition, enterTransition);
+    }
+
+    private void scheduleNextTransition() {
+        if (transitionScheduler != null) {
+            transitionScheduler.stop();
+        }
+
+        transitionScheduler = UIScheduler.run(this::next).after(displayDuration);
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/WalletGuideView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/WalletGuideView.java
@@ -17,11 +17,11 @@
 
 package bisq.desktop.main.content.bisq_easy.wallet_guide;
 
-import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.common.Styles;
 import bisq.desktop.common.view.TabView;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqIconButton;
+import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayModel;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
@@ -65,7 +65,7 @@ public class WalletGuideView extends TabView<WalletGuideModel, WalletGuideContro
         closeIconButton.setOnAction(e -> controller.onClose());
 
         root.setPrefWidth(OverlayModel.WIDTH);
-        root.setPrefHeight(OverlayModel.HEIGHT + 40);
+        root.setPrefHeight(OverlayModel.HEIGHT + 70);
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
@@ -74,30 +74,18 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         ImageView image1 = ImageUtil.getImageViewById("blue-wallet-tx");
         ImageView image2 = ImageUtil.getImageViewById("blue-wallet-qr");
 
-        double imageWidth = 250;
-        double imageHeight = 430;
-
-        image1.setFitWidth(imageWidth);
-        image1.setFitHeight(imageHeight);
-        image1.setPreserveRatio(true);
-
-        image2.setFitWidth(imageWidth);
-        image2.setFitHeight(imageHeight);
-        image2.setPreserveRatio(true);
+        configureImage(image1, 250, 430);
+        configureImage(image2, 250, 430);
 
         imageCarousel = new Carousel();
-        imageCarousel.setTransitionDuration(400);
-        imageCarousel.setDisplayDuration(3000);
         imageCarousel.addItem(image1);
         imageCarousel.addItem(image2);
 
-        VBox carouselContainer = new VBox();
-        carouselContainer.setAlignment(Pos.CENTER);
-        carouselContainer.getStyleClass().add("carousel-container");
-        carouselContainer.getChildren().add(imageCarousel);
-        carouselContainer.setPadding(new Insets(10, 0, 0, 0));
-
-        root.getChildren().addAll(vBox, carouselContainer);
+        root.getChildren().addAll(vBox,
+                new VBox(10, imageCarousel) {{
+                    setAlignment(Pos.CENTER);
+                    getStyleClass().add("carousel-container");
+                }});
         HBox.setHgrow(vBox, Priority.ALWAYS);
         root.setAlignment(Pos.TOP_LEFT);
     }
@@ -109,6 +97,7 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         link1.setOnAction(e -> controller.onOpenLink1());
         link2.setOnAction(e -> controller.onOpenLink2());
 
+        imageCarousel.initialize();
         imageCarousel.start();
     }
 
@@ -119,6 +108,12 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         link1.setOnAction(null);
         link2.setOnAction(null);
 
-        imageCarousel.stop();
+        imageCarousel.dispose();
+    }
+
+    private void configureImage(ImageView image, double width, double height) {
+        image.setFitWidth(width);
+        image.setFitHeight(height);
+        image.setPreserveRatio(true);
     }
 }

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -1120,3 +1120,86 @@
     -fx-text-fill: -fx-mid-text-color;
     -fx-font-family: "IBM Plex Sans Light";
 }
+
+/*******************************************************************************
+ *                                                                             *
+ * Carousel                                                                    *
+ *                                                                             *
+ ******************************************************************************/
+
+.carousel {
+    -fx-background-color: transparent;
+    -fx-padding: 0;
+    -fx-background-insets: 0;
+    -fx-border-width: 0;
+}
+
+.carousel-item-container {
+    -fx-background-color: transparent;
+    -fx-padding: 0;
+}
+
+.carousel-indicators {
+    -fx-spacing: 6;
+    -fx-padding: 5 0 0 0;
+    -fx-alignment: center;
+    -fx-min-height: 12;
+    -fx-pref-height: 12;
+    -fx-max-height: 12;
+}
+
+.carousel-indicator {
+    -fx-background-color: -bisq-mid-grey-20;
+    -fx-background-radius: 3;
+    -fx-min-width: 6;
+    -fx-min-height: 6;
+    -fx-max-width: 6;
+    -fx-max-height: 6;
+    -fx-pref-width: 6;
+    -fx-pref-height: 6;
+    -fx-cursor: hand;
+    -fx-opacity: 0.6;
+}
+
+.carousel-indicator:hover {
+    -fx-opacity: 0.8;
+    -fx-background-color: -bisq-mid-grey-10;
+}
+
+.carousel-indicator.active {
+    -fx-background-color: -bisq2-green;
+    -fx-opacity: 1.0;
+}
+
+.carousel-nav-arrow {
+    -fx-background-color: transparent;
+    -fx-background-radius: 2;
+    -fx-min-width: 20px;
+    -fx-min-height: 32px;
+    -fx-max-width: 20px;
+    -fx-max-height: 32px;
+    -fx-font-size: 14px;
+    -fx-text-fill: white;
+    -fx-padding: 0;
+    -fx-cursor: hand;
+    -fx-border-width: 0;
+    -fx-font-weight: bold;
+    -fx-alignment: center;
+    -fx-content-display: center;
+    -fx-opacity: 0.7;
+}
+
+.carousel-nav-arrow:hover {
+    -fx-background-color: -bisq-green-hover;
+    -fx-opacity: 0.9;
+}
+
+.carousel-nav-arrow:pressed {
+    -fx-background-color: -bisq-green-pressed;
+    -fx-opacity: 1.0;
+}
+
+.carousel-container {
+    -fx-spacing: 5;
+    -fx-padding: 0;
+}


### PR DESCRIPTION
This component is used in WalletGuideReceiveView

Fixed #1262

Sorry for bad branch-naming, branch with beauty name was broken by merge and I had to create a new one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new animated carousel component for displaying and cycling through images and content with manual and automatic navigation.
- **Enhancements**
  - Updated the wallet guide receive view to use the new carousel for smoother image transitions.
  - Increased the vertical size of the wallet guide view for improved layout.
- **Style**
  - Added dedicated styles for the carousel component, including navigation arrows and indicator dots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->