### PR TITLE
Fix: Make text size consistent between chat balloon and edit balloon

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/BubbleMessageBox.java
@@ -322,7 +322,7 @@ public abstract class BubbleMessageBox extends MessageBox {
         label.maxWidthProperty().unbind();
         label.setWrapText(true);
         label.setPadding(new Insets(10));
-        label.getStyleClass().addAll("text-fill-white", "medium-text", "font-default");
+        label.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
         return label;
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -103,6 +103,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
     private void setUpEditFunctionality() {
         // edit
         editInputField = new BisqTextArea();
+        editInputField.getStyleClass().addAll("text-fill-white", "normal-text", "font-default");
         editInputField.setId("chat-messages-edit-text-area");
         editInputField.setMinWidth(150);
         editInputField.setVisible(false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated chat message text to use a standard style for improved readability.
  - Enhanced the appearance of the chat message editing area with new text and font styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->