### PR TITLE
Fix: Ensure DropdownMenu items are not truncated

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenu.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenu.java
@@ -95,7 +95,7 @@ public class DropdownMenu extends HBox {
                 isFirstRun = true;
                 // Once the contextMenu has calculated the width on the first render time we update the items
                 // so that they all have the same size.
-                prefWidth = contextMenu.getWidth() - 18; // Remove margins
+                prefWidth = contextMenu.getWidth();
                 updateMenuItemWidth();
             }
         };

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -1035,7 +1035,7 @@
 
 .dropdown-menu-popup .menu-item .dropdown-menu-item-content {
     -fx-background-color: transparent;
-    -fx-padding: 10;
+    -fx-padding: 10 10 10 18;
     -fx-cursor: hand;
 }
 


### PR DESCRIPTION
DropdownMenu Items are truncated as following:
![image](https://github.com/user-attachments/assets/125f081d-2ade-4888-9a75-721e5410e0a7)
![image](https://github.com/user-attachments/assets/d6ec093e-47cd-4783-ab5f-1a3dfde2f6fc)
![image](https://github.com/user-attachments/assets/3a0fe248-cb97-4b52-84ab-c969f98ea6b0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated dropdown menu item padding for improved alignment.
  - Adjusted dropdown menu width calculation for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->