### PR TITLE
Fix(Tor): Robust control port polling for embedded Tor startup

### DIFF
--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
@@ -70,8 +70,8 @@ public class TorControlProtocol implements AutoCloseable {
         if (closeInProgress) {
             return;
         }
-        closeInProgress = true; // Stays true after close attempt
-        log.debug("Closing TorControlProtocol resources for control socket related to port (if known).");
+        closeInProgress = true;
+        log.debug("Closing TorControlProtocol resources.");
         try {
             if (controlSocket != null && !controlSocket.isClosed()) {
                 controlSocket.close();
@@ -87,7 +87,7 @@ public class TorControlProtocol implements AutoCloseable {
             log.warn("Exception while closing TorControlReader.", e);
         }
         outputStream = Optional.empty();
-        // closeInProgress remains true
+        closeInProgress = false;
     }
 
     public void authenticate(PasswordDigest passwordDigest) {
@@ -269,6 +269,11 @@ public class TorControlProtocol implements AutoCloseable {
         while (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
             Socket attemptSocket = new Socket();
             try {
+                // The Tor Control Port communication is typically unencrypted. 
+                // This is considered safe because the connection is made to 127.0.0.1 (localhost),
+                // ensuring that the communication does not leave the local machine and is not 
+                // exposed to external networks. Authentication (via cookie or password) 
+                // is handled by the Tor control protocol itself after connection.
                 var socketAddress = new InetSocketAddress("127.0.0.1", port);
                 log.debug("Attempting to connect to Tor control port {} ({}/{})", socketAddress, connectionAttempt + 1, MAX_CONNECTION_ATTEMPTS);
                 attemptSocket.connect(socketAddress);


### PR DESCRIPTION
While running the Bisq 2 http-api in a docker container, I ran into Tor timing issues, that prevented the containerized Bisq 2 instance to connect via Tor.

- Implements a robust polling mechanism in ControlPortFilePoller to reliably detect the correct Tor control port. The poller repeatedly attempts to parse the port from the control port file, confirming stability before proceeding.
- Prevents race conditions where the application could connect to a stale or incorrect port, which previously led to CannotConnectWithTorException errors.
- Improves reliability of embedded Tor initialization, especially in fast or containerized environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability and stability when connecting to the Tor network by enhancing socket lifecycle management, retries, and resource cleanup.
	- Enhanced control port polling with scheduled checks, failure tracking, and stability verification to reduce connection issues.

- **Chores**
	- Added detailed logging for better monitoring and troubleshooting of Tor connection and polling processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->