### PR TITLE
Introduce TradeLifecycleState for enhanced trade management/future "History Views"

### DIFF
--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -100,6 +100,8 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
     // Set at protocol creation and not updated later, thus no need to be observable
     private final Observable<String> protocolVersion = new Observable<>();
 
+    private final Observable<TradeLifecycleState> lifecycleState = new Observable<>();
+
     public Trade(C contract,
                  State state,
                  boolean isBuyer,
@@ -107,14 +109,16 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                  Identity myIdentity,
                  T offer,
                  P taker,
-                 P maker) {
+                 P maker,
+                 TradeLifecycleState lifecycleState) {
         this(contract,
                 state,
                 createId(offer.getId(), taker.getNetworkId().getId(), contract.getTakeOfferDate()),
                 createRole(isBuyer, isTaker),
                 myIdentity,
                 taker,
-                maker);
+                maker,
+                lifecycleState);
     }
 
     protected Trade(C contract,
@@ -123,7 +127,8 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                     TradeRole tradeRole,
                     Identity myIdentity,
                     P taker,
-                    P maker) {
+                    P maker,
+                    TradeLifecycleState lifecycleState) {
         super(state);
 
         this.contract = contract;
@@ -132,6 +137,7 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
         this.myIdentity = myIdentity;
         this.taker = taker;
         this.maker = maker;
+        this.setLifecycleState(lifecycleState);
     }
 
     protected bisq.trade.protobuf.Trade.Builder getTradeBuilder(boolean serializeForHash) {
@@ -147,6 +153,7 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
         Optional.ofNullable(getErrorStackTrace()).ifPresent(builder::setErrorStackTrace);
         Optional.ofNullable(getPeersErrorMessage()).ifPresent(builder::setPeersErrorMessage);
         Optional.ofNullable(getPeersErrorStackTrace()).ifPresent(builder::setPeersErrorStackTrace);
+        Optional.ofNullable(getLifecycleState()).ifPresent(s -> builder.setLifecycleState(s.toProtoEnum()));
         return builder;
     }
 
@@ -209,6 +216,17 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
         return this.protocolVersion.get();
     }
 
+    public void setLifecycleState(TradeLifecycleState lifecycleState) {
+        this.lifecycleState.set(lifecycleState);
+    }
+
+    public TradeLifecycleState getLifecycleState() {
+        return this.lifecycleState.get();
+    }
+
+    public ReadOnlyObservable<TradeLifecycleState> lifecycleState() {
+        return lifecycleState;
+    }
 
     /* --------------------------------------------------------------------- */
     // Delegates

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -148,12 +148,12 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                 .setMyIdentity(myIdentity.toProto(serializeForHash))
                 .setTaker(taker.toProto(serializeForHash))
                 .setMaker(maker.toProto(serializeForHash))
-                .setState(getState().name());
+                .setState(getState().name())
+                .setLifecycleState(getLifecycleState().toProtoEnum());
         Optional.ofNullable(getErrorMessage()).ifPresent(builder::setErrorMessage);
         Optional.ofNullable(getErrorStackTrace()).ifPresent(builder::setErrorStackTrace);
         Optional.ofNullable(getPeersErrorMessage()).ifPresent(builder::setPeersErrorMessage);
         Optional.ofNullable(getPeersErrorStackTrace()).ifPresent(builder::setPeersErrorStackTrace);
-        Optional.ofNullable(getLifecycleState()).ifPresent(s -> builder.setLifecycleState(s.toProtoEnum()));
         return builder;
     }
 

--- a/trade/src/main/java/bisq/trade/TradeLifecycleState.java
+++ b/trade/src/main/java/bisq/trade/TradeLifecycleState.java
@@ -1,0 +1,21 @@
+package bisq.trade;
+
+import bisq.common.proto.ProtoEnum;
+import bisq.common.proto.ProtobufUtils;
+
+public enum TradeLifecycleState implements ProtoEnum {
+    ACTIVE,     // In progress, or completed but user hasn't moved it
+    HISTORICAL, // Finished and moved to history view
+    FAILED;     // Concluded with an FSM error
+
+    @Override
+    public bisq.trade.protobuf.TradeLifecycleState toProtoEnum() {
+        return bisq.trade.protobuf.TradeLifecycleState.valueOf(getProtobufEnumPrefix() + name());
+    }
+
+
+    public static TradeLifecycleState fromProto(bisq.trade.protobuf.TradeLifecycleState proto) {
+        return ProtobufUtils.enumFromProto(TradeLifecycleState.class, proto.name(), ACTIVE);
+    }
+
+}

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -26,6 +26,7 @@ import bisq.identity.Identity;
 import bisq.network.identity.NetworkId;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.trade.Trade;
+import bisq.trade.TradeLifecycleState;
 import bisq.trade.TradeParty;
 import bisq.trade.TradeRole;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
@@ -74,7 +75,8 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                 myIdentity,
                 offer,
                 new BisqEasyTradeParty(takerNetworkId),
-                new BisqEasyTradeParty(makerNetworkId));
+                new BisqEasyTradeParty(makerNetworkId),
+                TradeLifecycleState.ACTIVE);
 
         stateObservable().addObserver(state -> tradeState.set((BisqEasyTradeState) state));
     }
@@ -85,8 +87,9 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                          TradeRole tradeRole,
                          Identity myIdentity,
                          BisqEasyTradeParty taker,
-                         BisqEasyTradeParty maker) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker);
+                         BisqEasyTradeParty maker,
+                         TradeLifecycleState lifecycleState) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker,lifecycleState);
 
         stateObservable().addObserver(s -> tradeState.set((BisqEasyTradeState) s));
     }
@@ -122,7 +125,8 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                 TradeRole.fromProto(proto.getTradeRole()),
                 Identity.fromProto(proto.getMyIdentity()),
                 TradeParty.protoToBisqEasyTradeParty(proto.getTaker()),
-                TradeParty.protoToBisqEasyTradeParty(proto.getMaker()));
+                TradeParty.protoToBisqEasyTradeParty(proto.getMaker()),
+                TradeLifecycleState.fromProto(proto.getLifecycleState()));
         if (proto.hasErrorMessage()) {
             trade.setErrorMessage(proto.getErrorMessage());
         }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
@@ -26,6 +26,7 @@ import bisq.identity.Identity;
 import bisq.network.identity.NetworkId;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.trade.Trade;
+import bisq.trade.TradeLifecycleState;
 import bisq.trade.TradeParty;
 import bisq.trade.TradeRole;
 import bisq.trade.mu_sig.messages.grpc.TxConfirmationStatus;
@@ -84,7 +85,8 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                 myIdentity,
                 offer,
                 new MuSigTradeParty(takerNetworkId),
-                new MuSigTradeParty(makerNetworkId));
+                new MuSigTradeParty(makerNetworkId),
+                TradeLifecycleState.ACTIVE);
 
         stateObservable().addObserver(state -> tradeState.set((MuSigTradeState) state));
     }
@@ -95,8 +97,9 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                       TradeRole tradeRole,
                       Identity myIdentity,
                       MuSigTradeParty taker,
-                      MuSigTradeParty maker) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker);
+                      MuSigTradeParty maker,
+                      TradeLifecycleState lifecycleState) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker,lifecycleState);
 
         stateObservable().addObserver(s -> tradeState.set((MuSigTradeState) s));
     }
@@ -131,7 +134,8 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                 TradeRole.fromProto(proto.getTradeRole()),
                 Identity.fromProto(proto.getMyIdentity()),
                 TradeParty.protoToMuSigTradeParty(proto.getTaker()),
-                TradeParty.protoToMuSigTradeParty(proto.getMaker()));
+                TradeParty.protoToMuSigTradeParty(proto.getMaker()),
+                TradeLifecycleState.fromProto(proto.getLifecycleState()));
         if (proto.hasErrorMessage()) {
             trade.setErrorMessage(proto.getErrorMessage());
         }

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -18,13 +18,14 @@
 syntax = "proto3";
 
 package trade;
-option java_package = "bisq.trade.protobuf";
-option java_multiple_files = true;
 
-import "offer.proto";
-import "network_identity.proto";
 import "contract.proto";
 import "identity.proto";
+import "network_identity.proto";
+import "offer.proto";
+
+option java_package = "bisq.trade.protobuf";
+option java_multiple_files = true;
 
 message TradeParty {
   network.identity.NetworkId networkId = 1;
@@ -42,6 +43,14 @@ enum TradeRole{
   TRADEROLE_SELLER_AS_TAKER = 3;
   TRADEROLE_SELLER_AS_MAKER = 4;
 }
+
+enum TradeLifecycleState {
+  TRADELIFECYCLESTATE_UNSPECIFIED = 0;
+  TRADELIFECYCLESTATE_ACTIVE = 1;
+  TRADELIFECYCLESTATE_HISTORICAL = 2;
+  TRADELIFECYCLESTATE_FAILED = 3;
+}
+
 message Trade {
   string state = 1;
   string id = 2;
@@ -54,6 +63,7 @@ message Trade {
   optional string errorStackTrace = 9;
   optional string peersErrorMessage = 10;
   optional string peersErrorStackTrace = 11;
+  TradeLifecycleState lifecycleState = 12;
 
   oneof message {
     BisqEasyTrade bisqEasyTrade = 30;


### PR DESCRIPTION
**Description:**

Introduces a foundational `TradeLifecycleState` to `Trade` objects (including `BisqEasyTrade` and `MuSigTrade`) as a first step towards implementing the trade [history view](https://github.com/bisq-network/bisq2/issues/3124#issuecomment-2868677389).

**Next Steps (Planned, not in this PR):**

*   Modify `BisqEasyTradeService` and `BisqEasyTradeStore` to correctly handle the single `trades` set and implement methods for lifecycle state transitions.
*   Implement FSM Event Handlers to set `TradeLifecycleState.FAILED` on error.
*   Develop the UI components for "History" and "Failed Trades" tabs.
*   Implement the data pruning mechanism and transition to `REDACTED`.
*   Add UI elements for user-driven lifecycle changes.

I appreciate any feedback or suggestions on this initial set of changes!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new trade lifecycle state to categorize trades as Active, Historical, or Failed.
  - Trades now display and update their lifecycle state in the user interface.

- **Bug Fixes**
  - Improved handling of error messages related to trade peers.

- **Chores**
  - Enhanced trade data serialization to support the new lifecycle state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->