### PR TITLE
Add SepaInstantAccount and SepaInstantAccountPayload messages into proto

### DIFF
--- a/account/src/main/java/bisq/account/accounts/CountryBasedAccount.java
+++ b/account/src/main/java/bisq/account/accounts/CountryBasedAccount.java
@@ -40,6 +40,21 @@ public abstract class CountryBasedAccount<P extends CountryBasedAccountPayload, 
         this.country = country;
     }
 
+    public static CountryBasedAccount<?, ?> fromProto(bisq.account.protobuf.Account proto) {
+        return switch (proto.getCountryBasedAccount().getMessageCase()) {
+            case BANKACCOUNT -> BankAccount.fromProto(proto);
+            case SEPAACCOUNT -> SepaAccount.fromProto(proto);
+            case SEPAINSTANTACCOUNT -> SepaInstantAccount.fromProto(proto);
+            case F2FACCOUNT -> F2FAccount.fromProto(proto);
+            case PIXACCOUNT -> PixAccount.fromProto(proto);
+            case STRIKEACCOUNT -> StrikeAccount.fromProto(proto);
+            case AMAZONGIFTCARDACCOUNT -> AmazonGiftCardAccount.fromProto(proto);
+            case UPIACCOUNT -> UpiAccount.fromProto(proto);
+            case BIZUMACCOUNT -> BizumAccount.fromProto(proto);
+            case MESSAGE_NOT_SET -> throw new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", proto);
+        };
+    }
+
     protected bisq.account.protobuf.CountryBasedAccount.Builder getCountryBasedAccountBuilder(boolean serializeForHash) {
         return bisq.account.protobuf.CountryBasedAccount.newBuilder()
                 .setCountry(country.toProto(serializeForHash));
@@ -53,19 +68,5 @@ public abstract class CountryBasedAccount<P extends CountryBasedAccountPayload, 
 
     private bisq.account.protobuf.CountryBasedAccount toCountryBasedAccountProto(boolean serializeForHash) {
         return resolveBuilder(getCountryBasedAccountBuilder(serializeForHash), serializeForHash).build();
-    }
-
-    public static CountryBasedAccount<?, ?> fromProto(bisq.account.protobuf.Account proto) {
-        return switch (proto.getCountryBasedAccount().getMessageCase()) {
-            case BANKACCOUNT -> BankAccount.fromProto(proto);
-            case SEPAACCOUNT -> SepaAccount.fromProto(proto);
-            case F2FACCOUNT -> F2FAccount.fromProto(proto);
-            case PIXACCOUNT -> PixAccount.fromProto(proto);
-            case STRIKEACCOUNT -> StrikeAccount.fromProto(proto);
-            case AMAZONGIFTCARDACCOUNT -> AmazonGiftCardAccount.fromProto(proto);
-            case UPIACCOUNT -> UpiAccount.fromProto(proto);
-            case BIZUMACCOUNT -> BizumAccount.fromProto(proto);
-            case MESSAGE_NOT_SET -> throw new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", proto);
-        };
     }
 }

--- a/account/src/main/java/bisq/account/accounts/CountryBasedAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/CountryBasedAccountPayload.java
@@ -48,19 +48,11 @@ public abstract class CountryBasedAccountPayload extends AccountPayload {
                 .setCountryBasedAccountPayload(toCountryBasedAccountPayloadProto(serializeForHash));
     }
 
-    private bisq.account.protobuf.CountryBasedAccountPayload toCountryBasedAccountPayloadProto(boolean serializeForHash) {
-        return resolveBuilder(getCountryBasedAccountPayloadBuilder(serializeForHash), serializeForHash).build();
-    }
-
-    protected bisq.account.protobuf.CountryBasedAccountPayload.Builder getCountryBasedAccountPayloadBuilder(boolean serializeForHash) {
-        return bisq.account.protobuf.CountryBasedAccountPayload.newBuilder()
-                .setCountryCode(countryCode);
-    }
-
     public static CountryBasedAccountPayload fromProto(bisq.account.protobuf.AccountPayload proto) {
         return switch (proto.getCountryBasedAccountPayload().getMessageCase()) {
             case BANKACCOUNTPAYLOAD -> BankAccountPayload.fromProto(proto);
             case SEPAACCOUNTPAYLOAD -> SepaAccountPayload.fromProto(proto);
+            case SEPAINSTANTACCOUNTPAYLOAD -> SepaInstantAccountPayload.fromProto(proto);
             case F2FACCOUNTPAYLOAD -> F2FAccountPayload.fromProto(proto);
             case PIXACCOUNTPAYLOAD -> PixAccountPayload.fromProto(proto);
             case STRIKEACCOUNTPAYLOAD -> StrikeAccountPayload.fromProto(proto);
@@ -69,5 +61,14 @@ public abstract class CountryBasedAccountPayload extends AccountPayload {
             case BIZUMACCOUNTPAYLOAD -> BizumAccountPayload.fromProto(proto);
             case MESSAGE_NOT_SET -> throw new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", proto);
         };
+    }
+
+    private bisq.account.protobuf.CountryBasedAccountPayload toCountryBasedAccountPayloadProto(boolean serializeForHash) {
+        return resolveBuilder(getCountryBasedAccountPayloadBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    protected bisq.account.protobuf.CountryBasedAccountPayload.Builder getCountryBasedAccountPayloadBuilder(boolean serializeForHash) {
+        return bisq.account.protobuf.CountryBasedAccountPayload.newBuilder()
+                .setCountryCode(countryCode);
     }
 }

--- a/account/src/main/java/bisq/account/accounts/SepaInstantAccount.java
+++ b/account/src/main/java/bisq/account/accounts/SepaInstantAccount.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.accounts;
+
+import bisq.account.payment_method.FiatPaymentMethod;
+import bisq.account.payment_method.FiatPaymentRail;
+import bisq.common.locale.Country;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public final class SepaInstantAccount extends CountryBasedAccount<SepaInstantAccountPayload, FiatPaymentMethod> {
+
+    private static final FiatPaymentMethod PAYMENT_METHOD = FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.SEPA_INSTANT);
+
+    public SepaInstantAccount(String accountName,
+                              SepaInstantAccountPayload sepaInstantAccountPayload,
+                              Country country) {
+        super(accountName, PAYMENT_METHOD, sepaInstantAccountPayload, country);
+    }
+
+    public static SepaInstantAccount fromProto(bisq.account.protobuf.Account proto) {
+        return new SepaInstantAccount(
+                proto.getAccountName(),
+                SepaInstantAccountPayload.fromProto(proto.getAccountPayload()),
+                Country.fromProto(proto.getCountryBasedAccount().getCountry()));
+    }
+
+    @Override
+    protected bisq.account.protobuf.CountryBasedAccount.Builder getCountryBasedAccountBuilder(boolean serializeForHash) {
+        return super.getCountryBasedAccountBuilder(serializeForHash)
+                .setSepaInstantAccount(toSepaInstantAccountProto(serializeForHash));
+    }
+
+    private bisq.account.protobuf.SepaInstantAccount toSepaInstantAccountProto(boolean serializeForHash) {
+        return resolveBuilder(getSepaInstantAccountBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    private bisq.account.protobuf.SepaInstantAccount.Builder getSepaInstantAccountBuilder(boolean serializeForHash) {
+        return bisq.account.protobuf.SepaInstantAccount.newBuilder();
+    }
+}

--- a/account/src/main/java/bisq/account/accounts/SepaInstantAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/SepaInstantAccountPayload.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.accounts;
+
+import bisq.account.protobuf.AccountPayload;
+import bisq.common.validation.NetworkDataValidation;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Slf4j
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public final class SepaInstantAccountPayload extends CountryBasedAccountPayload {
+    private final String holderName;
+    private final String iban;
+    private final String bic;
+    private final List<String> acceptedCountryCodes;
+
+    public SepaInstantAccountPayload(String id,
+                                     String paymentMethodName,
+                                     String holderName,
+                                     String iban,
+                                     String bic,
+                                     String countryCode,
+                                     List<String> acceptedCountryCodes) {
+        super(id, paymentMethodName, countryCode);
+        this.holderName = holderName;
+        this.iban = iban;
+        this.bic = bic;
+        this.acceptedCountryCodes = acceptedCountryCodes != null ? new ArrayList<>(acceptedCountryCodes) : new ArrayList<>();
+
+        verify();
+    }
+
+    public static SepaInstantAccountPayload fromProto(AccountPayload proto) {
+        var countryBasedAccountPayload = proto.getCountryBasedAccountPayload();
+        var sepaInstantPayload = countryBasedAccountPayload.getSepaInstantAccountPayload();
+
+        return new SepaInstantAccountPayload(
+                proto.getId(),
+                proto.getPaymentMethodName(),
+                sepaInstantPayload.getHolderName(),
+                sepaInstantPayload.getIban(),
+                sepaInstantPayload.getBic(),
+                countryBasedAccountPayload.getCountryCode(),
+                sepaInstantPayload.getAcceptedCountryCodesList()
+        );
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+        NetworkDataValidation.validateRequiredText(holderName, 100);
+        NetworkDataValidation.validateIbanFormat(iban);
+        NetworkDataValidation.validateBicFormat(bic);
+        acceptedCountryCodes.forEach(NetworkDataValidation::validateRequiredCode);
+    }
+
+    @Override
+    protected bisq.account.protobuf.CountryBasedAccountPayload.Builder getCountryBasedAccountPayloadBuilder(boolean serializeForHash) {
+        return super.getCountryBasedAccountPayloadBuilder(serializeForHash)
+                .setSepaInstantAccountPayload(toSepaInstantAccountPayloadProto(serializeForHash));
+    }
+
+    private bisq.account.protobuf.SepaInstantAccountPayload toSepaInstantAccountPayloadProto(boolean serializeForHash) {
+        return resolveBuilder(getSepaInstantAccountPayloadBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    private bisq.account.protobuf.SepaInstantAccountPayload.Builder getSepaInstantAccountPayloadBuilder(boolean serializeForHash) {
+        bisq.account.protobuf.SepaInstantAccountPayload.Builder builder = bisq.account.protobuf.SepaInstantAccountPayload.newBuilder()
+                .setHolderName(holderName)
+                .setIban(iban)
+                .setBic(bic);
+        builder.addAllAcceptedCountryCodes(acceptedCountryCodes);
+        return builder;
+    }
+}

--- a/account/src/main/proto/account.proto
+++ b/account/src/main/proto/account.proto
@@ -103,6 +103,7 @@ message CountryBasedAccountPayload {
     AmazonGiftCardAccountPayload amazonGiftCardAccountPayload = 14;
     UpiAccountPayload upiAccountPayload = 15;
     BizumAccountPayload bizumAccountPayload = 16;
+    SepaInstantAccountPayload sepaInstantAccountPayload = 17;
   }
 }
 message SepaAccountPayload {
@@ -110,6 +111,13 @@ message SepaAccountPayload {
   string iban = 2;
   string bic = 3;
 
+}
+
+message SepaInstantAccountPayload {
+  string holderName = 1;
+  string iban = 2;
+  string bic = 3;
+  repeated string acceptedCountryCodes = 5;
 }
 
 message F2FAccountPayload {
@@ -239,9 +247,13 @@ message CountryBasedAccount {
     AmazonGiftCardAccount amazonGiftCardAccount = 24;
     UpiAccount upiAccount = 25;
     BizumAccount bizumAccount = 26;
+    SepaInstantAccount sepaInstantAccount = 27;
   }
 }
 message SepaAccount {
+}
+
+message SepaInstantAccount {
 }
 
 message F2FAccount {

--- a/account/src/test/java/bisq/account/accounts/SepaInstantAccountPayloadTest.java
+++ b/account/src/test/java/bisq/account/accounts/SepaInstantAccountPayloadTest.java
@@ -1,0 +1,322 @@
+package bisq.account.accounts;
+
+import bisq.account.protobuf.AccountPayload;
+import bisq.account.protobuf.CountryBasedAccountPayload;
+import bisq.account.protobuf.SepaInstantAccountPayload;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SepaInstantAccountPayloadTest {
+
+    private static final AccountPayload PROTO = AccountPayload.newBuilder()
+            .setId("id")
+            .setPaymentMethodName("SEPA_INSTANT")
+            .setCountryBasedAccountPayload(
+                    CountryBasedAccountPayload.newBuilder()
+                            .setCountryCode("DE")
+                            .setSepaInstantAccountPayload(SepaInstantAccountPayload.newBuilder()
+                                    .setHolderName("holderName")
+                                    .setIban("DE89370400440532013000")
+                                    .setBic("DEUTDEBBXXX")
+                                    .addAllAcceptedCountryCodes(List.of("DE", "FR", "IT"))))
+            .build();
+
+    private static final bisq.account.accounts.SepaInstantAccountPayload PAYLOAD =
+            new bisq.account.accounts.SepaInstantAccountPayload(
+                    "id",
+                    "SEPA_INSTANT",
+                    "holderName",
+                    "DE89370400440532013000",
+                    "DEUTDEBBXXX",
+                    "DE",
+                    List.of("DE", "FR", "IT"));
+
+    @Test
+    void testToProto() {
+        assertEquals(PROTO, PAYLOAD.completeProto());
+    }
+
+    @Test
+    void testFromProto() {
+        assertEquals(PAYLOAD, bisq.account.accounts.SepaInstantAccountPayload.fromProto(PROTO));
+    }
+
+    @Test
+    void testToProtoWithEmptyAcceptedCountries() {
+        var payloadWithoutCountries = new bisq.account.accounts.SepaInstantAccountPayload(
+                "id",
+                "SEPA_INSTANT",
+                "holderName",
+                "DE89370400440532013000",
+                "DEUTDEBBXXX",
+                "DE",
+                null);
+
+        var protoWithoutCountries = AccountPayload.newBuilder()
+                .setId("id")
+                .setPaymentMethodName("SEPA_INSTANT")
+                .setCountryBasedAccountPayload(
+                        CountryBasedAccountPayload.newBuilder()
+                                .setCountryCode("DE")
+                                .setSepaInstantAccountPayload(SepaInstantAccountPayload.newBuilder()
+                                        .setHolderName("holderName")
+                                        .setIban("DE89370400440532013000")
+                                        .setBic("DEUTDEBBXXX")))
+                .build();
+
+        assertEquals(protoWithoutCountries, payloadWithoutCountries.completeProto());
+    }
+
+    @Test
+    void testToProtoWithEmptyAcceptedCountriesList() {
+        var payloadWithEmptyList = new bisq.account.accounts.SepaInstantAccountPayload(
+                "id",
+                "SEPA_INSTANT",
+                "holderName",
+                "DE89370400440532013000",
+                "DEUTDEBBXXX",
+                "DE",
+                Collections.emptyList());
+
+        var protoWithEmptyList = AccountPayload.newBuilder()
+                .setId("id")
+                .setPaymentMethodName("SEPA_INSTANT")
+                .setCountryBasedAccountPayload(
+                        CountryBasedAccountPayload.newBuilder()
+                                .setCountryCode("DE")
+                                .setSepaInstantAccountPayload(SepaInstantAccountPayload.newBuilder()
+                                        .setHolderName("holderName")
+                                        .setIban("DE89370400440532013000")
+                                        .setBic("DEUTDEBBXXX")))
+                .build();
+
+        assertEquals(protoWithEmptyList, payloadWithEmptyList.completeProto());
+    }
+
+    @Test
+    void testIbanValidation() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "INVALID-IBAN",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE")));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE12", // Too short
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE")));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DEAB370400440532013000", // Letters in check digits
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE")));
+    }
+
+    @Test
+    void testBicValidation() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "INVALID", // Too short
+                        "DE",
+                        List.of("DE")));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "12UTDEBBXXX", // Digits in bank code
+                        "DE",
+                        List.of("DE")));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "DEUT12BBXXX", // Digits in country code
+                        "DE",
+                        List.of("DE")));
+    }
+
+    @Test
+    void testHolderNameValidation() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "X".repeat(101), // >100 chars
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE")));
+    }
+
+    @Test
+    void testCountryCodeValidation() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("INVALIDCOUNTRYCODE"))); // Too long country code
+    }
+
+    @Test
+    void testEquals() {
+        bisq.account.accounts.SepaInstantAccountPayload payload1 = new bisq.account.accounts.SepaInstantAccountPayload(
+                "id",
+                "SEPA_INSTANT",
+                "holderName",
+                "DE89370400440532013000",
+                "DEUTDEBBXXX",
+                "DE",
+                List.of("DE", "FR", "IT"));
+
+        bisq.account.accounts.SepaInstantAccountPayload payload2 = new bisq.account.accounts.SepaInstantAccountPayload(
+                "id",
+                "SEPA_INSTANT",
+                "holderName",
+                "DE89370400440532013000",
+                "DEUTDEBBXXX",
+                "DE",
+                List.of("DE", "FR", "IT"));
+
+        assertEquals(payload1, payload2);
+        assertEquals(payload1.hashCode(), payload2.hashCode());
+
+        bisq.account.accounts.SepaInstantAccountPayload differentPayload = new bisq.account.accounts.SepaInstantAccountPayload(
+                "id",
+                "SEPA_INSTANT",
+                "differentHolder",
+                "DE89370400440532013000",
+                "DEUTDEBBXXX",
+                "DE",
+                List.of("DE", "FR", "IT"));
+
+        assertNotEquals(payload1, differentPayload);
+    }
+
+    @Test
+    void testNullHolderName() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        null,  // null holder name
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE", "FR", "IT"))
+        );
+    }
+
+    @Test
+    void testEmptyHolderName() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "",  // empty holder name
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE", "FR", "IT"))
+        );
+    }
+
+    @Test
+    void testBlankHolderName() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "   ",  // blank holder name (only whitespace)
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        List.of("DE", "FR", "IT"))
+        );
+    }
+
+    @Test
+    void testNullCountryCodeInList() {
+        List<String> listWithNull = new ArrayList<>();
+        listWithNull.add("DE");
+        listWithNull.add(null);
+        listWithNull.add("FR");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        listWithNull)
+        );
+    }
+
+    @Test
+    void testEmptyCountryCodeInList() {
+        List<String> listWithEmpty = List.of("DE", "", "FR");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        listWithEmpty)
+        );
+    }
+
+    @Test
+    void testBlankCountryCodeInList() {
+        List<String> listWithBlank = List.of("DE", "   ", "FR");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new bisq.account.accounts.SepaInstantAccountPayload(
+                        "id",
+                        "SEPA_INSTANT",
+                        "holderName",
+                        "DE89370400440532013000",
+                        "DEUTDEBBXXX",
+                        "DE",
+                        listWithBlank)
+        );
+    }
+}

--- a/account/src/test/java/bisq/account/accounts/SepaInstantAccountTest.java
+++ b/account/src/test/java/bisq/account/accounts/SepaInstantAccountTest.java
@@ -1,0 +1,83 @@
+package bisq.account.accounts;
+
+import bisq.account.protobuf.Account;
+import bisq.account.protobuf.AccountPayload;
+import bisq.account.protobuf.CountryBasedAccount;
+import bisq.account.protobuf.CountryBasedAccountPayload;
+import bisq.account.protobuf.FiatPaymentMethod;
+import bisq.account.protobuf.PaymentMethod;
+import bisq.account.protobuf.SepaInstantAccount;
+import bisq.account.protobuf.SepaInstantAccountPayload;
+import bisq.common.protobuf.Country;
+import bisq.common.protobuf.Region;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.lang.System.currentTimeMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+class SepaInstantAccountTest {
+
+    private static final bisq.account.protobuf.Account PROTO = Account.newBuilder()
+            .setAccountName("accountName")
+            .setCreationDate(123)
+            .setPaymentMethod(PaymentMethod.newBuilder()
+                    .setName("SEPA_INSTANT")
+                    .setFiatPaymentMethod(FiatPaymentMethod.newBuilder()))
+            .setAccountPayload(AccountPayload.newBuilder()
+                    .setId("id")
+                    .setPaymentMethodName("SEPA_INSTANT")
+                    .setCountryBasedAccountPayload(CountryBasedAccountPayload.newBuilder()
+                            .setCountryCode("DE")
+                            .setSepaInstantAccountPayload(SepaInstantAccountPayload.newBuilder()
+                                    .setHolderName("holderName")
+                                    .setIban("DE89370400440532013000")
+                                    .setBic("DEUTDEBBXXX")
+                                    .addAllAcceptedCountryCodes(List.of("DE", "FR", "IT")))))
+            .setCountryBasedAccount(CountryBasedAccount.newBuilder()
+                    .setCountry(Country.newBuilder()
+                            .setCode("DE")
+                            .setName("Germany")
+                            .setRegion(Region.newBuilder()
+                                    .setCode("EU")
+                                    .setName("Europe")))
+                    .setSepaInstantAccount(SepaInstantAccount.newBuilder()))
+            .build();
+
+    private static final bisq.account.accounts.SepaInstantAccount ACCOUNT = new bisq.account.accounts.SepaInstantAccount(
+            "accountName",
+            new bisq.account.accounts.SepaInstantAccountPayload(
+                    "id",
+                    "SEPA_INSTANT",
+                    "holderName",
+                    "DE89370400440532013000",
+                    "DEUTDEBBXXX",
+                    "DE",
+                    List.of("DE", "FR", "IT")),
+            new bisq.common.locale.Country(
+                    "DE",
+                    "Germany",
+                    new bisq.common.locale.Region("EU", "Europe")));
+
+    @Test
+    void testToProto() {
+        var result = ACCOUNT.completeProto();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .ignoringFields("creationDate_", "accountPayload_.memoizedHashCode", "memoizedHashCode")
+                .isEqualTo(PROTO);
+        assertThat(result.getCreationDate()).isCloseTo(currentTimeMillis(), offset(1000L));
+    }
+
+    @Test
+    void testFromProto() {
+        var result = bisq.account.accounts.SepaInstantAccount.fromProto(PROTO);
+        assertThat(result)
+                .usingRecursiveComparison()
+                .ignoringFields("creationDate")
+                .isEqualTo(ACCOUNT);
+        assertThat(result.getCreationDate()).isCloseTo(currentTimeMillis(), offset(1000L));
+    }
+}

--- a/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
+++ b/common/src/main/java/bisq/common/validation/NetworkDataValidation.java
@@ -19,6 +19,7 @@ package bisq.common.validation;
 
 import bisq.common.platform.Version;
 import bisq.common.util.DateUtils;
+import bisq.common.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.PublicKey;
@@ -91,6 +92,11 @@ public class NetworkDataValidation {
         text.ifPresent(e -> validateText(e, maxTextLength));
     }
 
+    public static void validateRequiredText(String text, int maxLength) {
+        checkArgument(!StringUtils.isEmpty(text), "Text must not be null or empty");
+        validateText(text, maxLength);
+    }
+
     public static void validateByteArray(byte[] bytes, int maxLength) {
         checkArgument(bytes.length <= maxLength,
                 "Byte array must not be longer than " + maxLength + ". bytes.length=" + bytes.length);
@@ -107,6 +113,11 @@ public class NetworkDataValidation {
     public static void validateCode(String code) {
         checkArgument(code.length() < 10,
                 "Code too long. code=" + code);
+    }
+
+    public static void validateRequiredCode(String code) {
+        checkArgument(!StringUtils.isEmpty(code), "Code must not be null or empty");
+        validateCode(code);
     }
 
     public static void validateBtcTxId(String txId) {
@@ -146,5 +157,20 @@ public class NetworkDataValidation {
     public static void validateBondUserName(String bondUserName) {
         checkArgument(bondUserName.length() < 100,
                 "Bond username too long. bondUserName=" + bondUserName);
+    }
+
+    // Format: country code (2 letters) + check digits (2 numbers) + BBAN (up to 30 alphanumeric chars)
+    public static void validateIbanFormat(String iban) {
+        checkArgument(!StringUtils.isEmpty(iban), "IBAN must not be null or empty");
+        checkArgument(iban.matches("[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}"),
+                "Invalid IBAN format. Must start with country code (2 letters) followed by check digits (2 numbers) and BBAN. iban=" + iban);
+    }
+
+    // Format: institution code (4 letters) + country code (2 letters) + location code (2 alphanumeric) +
+    // optional branch code (3 alphanumeric).
+    public static void validateBicFormat(String bic) {
+        checkArgument(!StringUtils.isEmpty(bic), "BIC must not be null or empty");
+        checkArgument(bic.matches("[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?"),
+                "Invalid BIC/SWIFT format. Must follow pattern of institution code (4 letters) + country code (2 letters) + location code (2 alphanumeric) + optional branch code (3 alphanumeric). bic=" + bic);
     }
 }


### PR DESCRIPTION
Corresponding java classes were created too and added unit-tests.

Part of #3441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for SEPA Instant accounts, enabling users to manage SEPA Instant payment accounts with holder name, IBAN, BIC, and accepted country codes.
  - Enhanced protobuf schema to include SEPA Instant account types for improved data handling.

- **Bug Fixes**
  - Improved deserialization logic to correctly handle SEPA Instant account types.

- **Tests**
  - Added comprehensive tests covering SEPA Instant account creation, validation, serialization, and deserialization to ensure accuracy and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->