### PR TITLE
Set arrow up as key shortcut to edit last sent message

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -205,6 +205,10 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
         doSendMessage(text);
     }
 
+    void onArrowUpKeyPressed() {
+        chatMessagesListController.editMyLastMessage();
+    }
+
     void onUserProfileSelected(UserProfile user) {
         String content = model.getTextInput().get().replaceAll("@[a-zA-Z\\d]*$", "@" + user.getUserName() + " ");
         model.getTextInput().set(content);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -54,7 +54,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
     public final static String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
 
     private final BisqTextArea inputField = new BisqTextArea();
-    private final EventHandler<KeyEvent> enterKeyPressedHandler = this::processEnterKeyPressed;
+    private final EventHandler<KeyEvent> keyPressedHandler = this::processKeyPressed;
     private final Button sendButton = new Button();
     private final Pane messagesListView;
     private final VBox emptyMessageList;
@@ -109,7 +109,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
             }
         });
 
-        inputField.addEventFilter(KEY_PRESSED, enterKeyPressedHandler);
+        inputField.addEventFilter(KEY_PRESSED, keyPressedHandler);
 
         sendButton.setOnAction(event -> {
             controller.onSendMessage(inputField.getText().trim());
@@ -148,7 +148,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
 
         myProfileCatHashImageView.setOnMouseClicked(null);
         inputField.setOnKeyPressed(null);
-        inputField.removeEventFilter(KEY_PRESSED, enterKeyPressedHandler);
+        inputField.removeEventFilter(KEY_PRESSED, keyPressedHandler);
         sendButton.setOnAction(null);
         userMentionPopup.cleanup();
     }
@@ -230,7 +230,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
         userProfileSelectionRoot.disableProperty().unbind();
     }
 
-    private void processEnterKeyPressed(KeyEvent keyEvent) {
+    private void processKeyPressed(KeyEvent keyEvent) {
         if (keyEvent.getCode() == KeyCode.ENTER) {
             keyEvent.consume();
             if (keyEvent.isShiftDown()) {
@@ -240,6 +240,11 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
             } else if (!inputField.getText().isEmpty()) {
                 controller.onSendMessage(inputField.getText().trim());
                 inputField.clear();
+            }
+        } else if (keyEvent.getCode() == KeyCode.UP) {
+            keyEvent.consume();
+            if (inputField.getText().isEmpty() || inputField.getCaretPosition() == 0) {
+                controller.onArrowUpKeyPressed();
             }
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -110,6 +110,7 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
     private final MarketPriceService marketPriceService;
     private final UserIdentityService userIdentityService;
     private final BooleanProperty showHighlighted = new SimpleBooleanProperty();
+    private final BooleanProperty setAsEditing = new SimpleBooleanProperty();
 
     // Delivery status
     private final Set<Pin> mapPins = new HashSet<>();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -87,6 +87,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -309,6 +310,14 @@ public class ChatMessagesListController implements Controller {
     public void setSearchPredicate(Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> predicate) {
         model.setSearchPredicate(Objects.requireNonNullElseGet(predicate, () -> e -> true));
         updatePredicate();
+    }
+
+    public void editMyLastMessage() {
+        Optional<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> messageListItem = model.getChatMessages()
+                .stream()
+                .filter(ChatMessageListItem::isMyMessage)
+                .max(Comparator.comparing((ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) -> item.getChatMessage().getDate()));
+        messageListItem.ifPresent(item -> item.getSetAsEditing().set(true));
     }
 
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.chat.message_container.list.message_box;
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.controls.BisqTextArea;
@@ -35,11 +36,14 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.Subscription;
 
 public final class MyTextMessageBox extends BubbleMessageBox {
     private final static String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
     private MessageDeliveryStatusBox messageDeliveryStatusBox;
 
+    private final Subscription setAsEditedPin;
     private BisqMenuItem editAction, deleteAction;
     private BisqTextArea editInputField;
     private Button saveEditButton, cancelEditButton;
@@ -76,6 +80,15 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, actionsHBox);
 
         editFieldEnterKeyFilter = createEditFieldEnterKeyFilter(item, controller);
+
+        setAsEditedPin = EasyBind.subscribe(item.getSetAsEditing(), setAsEditing -> {
+            if (setAsEditing) {
+                UIThread.runOnNextRenderFrame(() -> {
+                    onEditMessage();
+                    item.getSetAsEditing().set(false);
+                });
+            }
+        });
     }
 
     @Override
@@ -225,5 +238,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
 
         messageDeliveryStatusBox.dispose();
         editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldEnterKeyFilter);
+
+        setAsEditedPin.unsubscribe();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -43,7 +43,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
     private final static String EDITED_POST_FIX = " " + Res.get("chat.message.wasEdited");
     private MessageDeliveryStatusBox messageDeliveryStatusBox;
 
-    private final Subscription setAsEditedPin;
+    private final Subscription setAsEditingPin;
     private BisqMenuItem editAction, deleteAction;
     private BisqTextArea editInputField;
     private Button saveEditButton, cancelEditButton;
@@ -81,7 +81,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
 
         editFieldEnterKeyFilter = createEditFieldEnterKeyFilter(item, controller);
 
-        setAsEditedPin = EasyBind.subscribe(item.getSetAsEditing(), setAsEditing -> {
+        setAsEditingPin = EasyBind.subscribe(item.getSetAsEditing(), setAsEditing -> {
             if (setAsEditing) {
                 UIThread.runOnNextRenderFrame(() -> {
                     onEditMessage();
@@ -239,6 +239,6 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         messageDeliveryStatusBox.dispose();
         editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldEnterKeyFilter);
 
-        setAsEditedPin.unsubscribe();
+        setAsEditingPin.unsubscribe();
     }
 }


### PR DESCRIPTION
Resolves #3477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to quickly edit your last sent chat message by pressing the UP arrow key when the chat input is empty or the caret is at the start.

- **Improvements**
  - Enhanced chat input handling to support both Enter (send message) and UP arrow (edit last message) key actions for a smoother messaging experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->