### PR TITLE
Add further improvements in editing experience

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -87,6 +87,7 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
                 this::mentionUserHandler,
                 this::showChatUserDetailsHandler,
                 this::replyHandler,
+                this::requestFocusInputTextFieldHandler,
                 chatChannelDomain);
 
         model = new ChatMessageContainerModel(chatChannelDomain);
@@ -162,6 +163,11 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
             model.getFocusInputTextField().set(null);
             model.getFocusInputTextField().set(true);
         }
+    }
+
+    private void requestFocusInputTextFieldHandler() {
+        model.getFocusInputTextField().set(null);
+        model.getFocusInputTextField().set(true);
     }
 
     private void showChatUserDetailsHandler(ChatMessage chatMessage) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -248,8 +248,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
                 keyEvent.consume();
                 controller.onArrowUpKeyPressed();
             } else {
-                // Need to normalize text to ensure cross-OS compatibility
-                String normalizedText = StringUtils.normalizeText(inputField.getText());
+                String normalizedText = StringUtils.normalizeLineBreaks(inputField.getText());
                 // If no line break is found from the start to the caret position, it means we are in the first line, so we should move to the start
                 if (normalizedText.indexOf(System.lineSeparator(), 0, inputField.getCaretPosition()) == -1) {
                     // Only consume event in this case, otherwise allow falling back to default behavior

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -242,9 +242,19 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
                 inputField.clear();
             }
         } else if (keyEvent.getCode() == KeyCode.UP) {
-            keyEvent.consume();
             if (inputField.getText().isEmpty() || inputField.getCaretPosition() == 0) {
+                // Only consume event in this case, otherwise allow falling back to default behavior
+                keyEvent.consume();
                 controller.onArrowUpKeyPressed();
+            } else {
+                // Need to normalize text to ensure cross-OS compatibility
+                String normalizedText = inputField.getText().replaceAll("\r\n|\n|\r", System.lineSeparator());
+                // If no line break is found from the start to the caret position, it means we are in the first line, so we should move to the start
+                if (normalizedText.indexOf(System.lineSeparator(), 0, inputField.getCaretPosition()) == -1) {
+                    // Only consume event in this case, otherwise allow falling back to default behavior
+                    keyEvent.consume();
+                    inputField.positionCaret(0);
+                }
             }
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.chat.message_container;
 
+import bisq.common.util.StringUtils;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.cathash.CatHash;
@@ -248,7 +249,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
                 controller.onArrowUpKeyPressed();
             } else {
                 // Need to normalize text to ensure cross-OS compatibility
-                String normalizedText = inputField.getText().replaceAll("\r\n|\n|\r", System.lineSeparator());
+                String normalizedText = StringUtils.normalizeText(inputField.getText());
                 // If no line break is found from the start to the caret position, it means we are in the first line, so we should move to the start
                 if (normalizedText.indexOf(System.lineSeparator(), 0, inputField.getCaretPosition()) == -1) {
                     // Only consume event in this case, otherwise allow falling back to default behavior

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -501,6 +501,11 @@ public class ChatMessagesListController implements Controller {
         checkArgument(chatMessage instanceof PublicChatMessage);
         checkArgument(model.isMyMessage(chatMessage));
 
+        if (chatMessage.getText().isPresent() && chatMessage.getText().get().equals(editedText)) {
+            // Nothing was changed, thus no need for saving.
+            return;
+        }
+
         if (editedText.length() > ChatMessage.MAX_TEXT_LENGTH) {
             new Popup().warning(Res.get("validation.tooLong", ChatMessage.MAX_TEXT_LENGTH)).show();
             return;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -110,6 +110,7 @@ public class ChatMessagesListController implements Controller {
     private final SettingsService settingsService;
     private final Consumer<UserProfile> mentionUserHandler;
     private final Consumer<ChatMessage> replyHandler;
+    private final Runnable requestFocusInputTextFieldHandler;
     private final Consumer<ChatMessage> showChatUserDetailsHandler;
     private final ChatMessagesListModel model;
     @Getter
@@ -133,6 +134,7 @@ public class ChatMessagesListController implements Controller {
                                       Consumer<UserProfile> mentionUserHandler,
                                       Consumer<ChatMessage> showChatUserDetailsHandler,
                                       Consumer<ChatMessage> replyHandler,
+                                      Runnable requestFocusInputTextFieldHandler,
                                       ChatChannelDomain chatChannelDomain) {
         chatService = serviceProvider.getChatService();
         chatNotificationService = chatService.getChatNotificationService();
@@ -153,6 +155,7 @@ public class ChatMessagesListController implements Controller {
         this.mentionUserHandler = mentionUserHandler;
         this.showChatUserDetailsHandler = showChatUserDetailsHandler;
         this.replyHandler = replyHandler;
+        this.requestFocusInputTextFieldHandler = requestFocusInputTextFieldHandler;
 
         model = new ChatMessagesListModel(userIdentityService, chatChannelDomain);
         view = new ChatMessagesListView(model, this);
@@ -487,6 +490,11 @@ public class ChatMessagesListController implements Controller {
 
         userProfileService.findUserProfile(chatMessage.getAuthorUserProfileId())
                 .ifPresent(this::createAndSelectTwoPartyPrivateChatChannel);
+    }
+
+    public void onSaveEditedMessageUsingEnterKeyShortcut(ChatMessage chatMessage, String editedText) {
+        onSaveEditedMessage(chatMessage, editedText);
+        requestFocusInputTextFieldHandler.run();
     }
 
     public void onSaveEditedMessage(ChatMessage chatMessage, String editedText) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -49,7 +49,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
     private Button saveEditButton, cancelEditButton;
     private HBox editButtonsHBox;
 
-    private final javafx.event.EventHandler<KeyEvent> editFieldEnterKeyFilter;
+    private final javafx.event.EventHandler<KeyEvent> editFieldKeyFilter;
 
     public MyTextMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                             ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
@@ -77,7 +77,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         messageHBox.getChildren().setAll(Spacer.fillHBox(), activeReactionsDisplayHBox, messageBgHBox);
         contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, actionsHBox);
 
-        editFieldEnterKeyFilter = createEditFieldEnterKeyFilter(item, controller);
+        editFieldKeyFilter = createEditFieldEnterKeyFilter(item, controller);
 
         setAsEditingPin = EasyBind.subscribe(item.getSetAsEditing(), setAsEditing -> {
             if (setAsEditing) {
@@ -131,6 +131,9 @@ public final class MyTextMessageBox extends BubbleMessageBox {
                     controller.onSaveEditedMessageUsingEnterKeyShortcut(item.getChatMessage(), editInputField.getText().trim());
                     onCloseEditMessage(); // This will remove the filter
                 }
+            } else if (keyEvent.getCode() == KeyCode.ESCAPE) {
+                keyEvent.consume();
+                onCloseEditMessage();
             }
         };
     }
@@ -203,7 +206,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         editButtonsHBox.setManaged(true);
         message.setVisible(false);
         message.setManaged(false);
-        editInputField.addEventFilter(KeyEvent.KEY_PRESSED, editFieldEnterKeyFilter);
+        editInputField.addEventFilter(KeyEvent.KEY_PRESSED, editFieldKeyFilter);
     }
 
     private void onCloseEditMessage() {
@@ -213,8 +216,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         editButtonsHBox.setManaged(false);
         message.setVisible(true);
         message.setManaged(true);
-
-        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldEnterKeyFilter);
+        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldKeyFilter);
     }
 
     @Override
@@ -235,7 +237,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         userProfileIcon.dispose();
 
         messageDeliveryStatusBox.dispose();
-        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldEnterKeyFilter);
+        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldKeyFilter);
 
         setAsEditingPin.unsubscribe();
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -56,7 +56,6 @@ public final class MyTextMessageBox extends BubbleMessageBox {
                             ChatMessagesListController controller) {
         super(item, list, controller);
 
-
         quotedMessageVBox.setId("chat-message-quote-box-my-msg");
         setUpEditFunctionality();
         message.setAlignment(Pos.CENTER_RIGHT);
@@ -72,7 +71,6 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         HBox.setMargin(userProfileIconVbox, new Insets(7.5, 0, -5, 5));
         HBox.setMargin(editInputField, new Insets(6, -10, -25, 0));
         messageBgHBox.getChildren().setAll(messageVBox, userProfileIconVbox);
-
 
         activeReactionsDisplayHBox.getStyleClass().add("my-text-message-box-active-reactions");
         editInputField.maxWidthProperty().bind(message.widthProperty());
@@ -130,7 +128,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
                     editInputField.setText(newText);
                     editInputField.positionCaret(caretPos + 1);
                 } else if (!editInputField.getText().trim().isEmpty()) { // trim() here is good
-                    controller.onSaveEditedMessage(item.getChatMessage(), editInputField.getText().trim());
+                    controller.onSaveEditedMessageUsingEnterKeyShortcut(item.getChatMessage(), editInputField.getText().trim());
                     onCloseEditMessage(); // This will remove the filter
                 }
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -134,6 +134,15 @@ public final class MyTextMessageBox extends BubbleMessageBox {
             } else if (keyEvent.getCode() == KeyCode.ESCAPE) {
                 keyEvent.consume();
                 onCloseEditMessage();
+            } else if (keyEvent.getCode() == KeyCode.UP) {
+                // Need to normalize text to ensure cross-OS compatibility
+                String normalizedText = editInputField.getText().replaceAll("\r\n|\n|\r", System.lineSeparator());
+                // If no line break is found from the start to the caret position, it means we are in the first line, so we should move to the start
+                if (normalizedText.indexOf(System.lineSeparator(), 0, editInputField.getCaretPosition()) == -1) {
+                    // Only consume event in this case, otherwise allow falling back to default behavior
+                    keyEvent.consume();
+                    editInputField.positionCaret(0);
+                }
             }
         };
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -136,8 +136,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
                 keyEvent.consume();
                 onCloseEditMessage();
             } else if (keyEvent.getCode() == KeyCode.UP) {
-                // Need to normalize text to ensure cross-OS compatibility
-                String normalizedText = StringUtils.normalizeText(editInputField.getText());
+                String normalizedText = StringUtils.normalizeLineBreaks(editInputField.getText());
                 // If no line break is found from the start to the caret position, it means we are in the first line, so we should move to the start
                 if (normalizedText.indexOf(System.lineSeparator(), 0, editInputField.getCaretPosition()) == -1) {
                     // Only consume event in this case, otherwise allow falling back to default behavior

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.chat.message_container.list.message_box;
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.util.StringUtils;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqMenuItem;
@@ -136,7 +137,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
                 onCloseEditMessage();
             } else if (keyEvent.getCode() == KeyCode.UP) {
                 // Need to normalize text to ensure cross-OS compatibility
-                String normalizedText = editInputField.getText().replaceAll("\r\n|\n|\r", System.lineSeparator());
+                String normalizedText = StringUtils.normalizeText(editInputField.getText());
                 // If no line break is found from the start to the caret position, it means we are in the first line, so we should move to the start
                 if (normalizedText.indexOf(System.lineSeparator(), 0, editInputField.getCaretPosition()) == -1) {
                     // Only consume event in this case, otherwise allow falling back to default behavior

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -49,7 +49,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
     private Button saveEditButton, cancelEditButton;
     private HBox editButtonsHBox;
 
-    private final javafx.event.EventHandler<KeyEvent> editFieldKeyFilter;
+    private final javafx.event.EventHandler<KeyEvent> editInputFieldKeyPressedFilter;
 
     public MyTextMessageBox(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
                             ListView<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> list,
@@ -77,7 +77,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         messageHBox.getChildren().setAll(Spacer.fillHBox(), activeReactionsDisplayHBox, messageBgHBox);
         contentVBox.getChildren().setAll(userNameAndDateHBox, messageHBox, editButtonsHBox, actionsHBox);
 
-        editFieldKeyFilter = createEditFieldEnterKeyFilter(item, controller);
+        editInputFieldKeyPressedFilter = createEditInputFieldKeyPressedFilter(item, controller);
 
         setAsEditingPin = EasyBind.subscribe(item.getSetAsEditing(), setAsEditing -> {
             if (setAsEditing) {
@@ -116,8 +116,8 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         HBox.setMargin(deleteAction, ACTION_ITEMS_MARGIN);
     }
 
-    private EventHandler<KeyEvent> createEditFieldEnterKeyFilter(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
-                                                                 ChatMessagesListController controller) {
+    private EventHandler<KeyEvent> createEditInputFieldKeyPressedFilter(ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,
+                                                                        ChatMessagesListController controller) {
         return keyEvent -> {
             if (keyEvent.getCode() == KeyCode.ENTER) {
                 keyEvent.consume(); // Good practice
@@ -215,7 +215,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         editButtonsHBox.setManaged(true);
         message.setVisible(false);
         message.setManaged(false);
-        editInputField.addEventFilter(KeyEvent.KEY_PRESSED, editFieldKeyFilter);
+        editInputField.addEventFilter(KeyEvent.KEY_PRESSED, editInputFieldKeyPressedFilter);
     }
 
     private void onCloseEditMessage() {
@@ -225,7 +225,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         editButtonsHBox.setManaged(false);
         message.setVisible(true);
         message.setManaged(true);
-        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldKeyFilter);
+        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editInputFieldKeyPressedFilter);
     }
 
     @Override
@@ -246,7 +246,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
         userProfileIcon.dispose();
 
         messageDeliveryStatusBox.dispose();
-        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editFieldKeyFilter);
+        editInputField.removeEventFilter(KeyEvent.KEY_PRESSED, editInputFieldKeyPressedFilter);
 
         setAsEditingPin.unsubscribe();
     }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -248,4 +248,8 @@ public class StringUtils {
         }
         return string.replace(PlatformUtils.getHomeDirectory(), "<HOME_DIR>");
     }
+
+    public static String normalizeText(String text) {
+        return text.replaceAll("\r\n|\n|\r", Matcher.quoteReplacement(System.lineSeparator()));
+    }
 }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -249,7 +249,17 @@ public class StringUtils {
         return string.replace(PlatformUtils.getHomeDirectory(), "<HOME_DIR>");
     }
 
-    public static String normalizeText(String text) {
+    /**
+      * Normalizes line breaks in the provided text to use the system's default line separator.
+      * This ensures consistent text handling across different operating systems (Windows, Unix/Linux, Mac).
+      *
+      * @param text The text to normalize, may be null
+      * @return The normalized text with consistent line separators, or null if input was null
+      */
+    public static String normalizeLineBreaks(String text) {
+        if (text == null) {
+            return null;
+        }
         return text.replaceAll("\r\n|\n|\r", Matcher.quoteReplacement(System.lineSeparator()));
     }
 }


### PR DESCRIPTION
Resolves #3499

* Return focus to input field after saving using ENTER key shortcut.
* Prevent from saving unmodified message.
* Add shortcut to close editing mode using ESC key as shortcut.
* Add shortcut in text area to jump to the beginning when using UP arrow while in the first line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved keyboard navigation and editing in chat: pressing Escape cancels editing, and pressing Up moves the caret to the start of the text if on the first line.
	- After editing and saving a chat message with the Enter key, the input field is automatically refocused for quicker message entry.

- **Bug Fixes**
	- Prevents unnecessary message updates when edited text is unchanged.

- **Style**
	- Enhanced handling of line breaks and caret positioning for a smoother chat editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->