### PR TITLE
Do not reuse grpc messages for trade protocol messages

### DIFF
--- a/contract/src/main/java/bisq/contract/ContractSignatureData.java
+++ b/contract/src/main/java/bisq/contract/ContractSignatureData.java
@@ -22,20 +22,35 @@ import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Objects;
 
 @Slf4j
 @Getter
-@EqualsAndHashCode
 public class ContractSignatureData implements NetworkProto {
     private final byte[] contractHash;
     private final byte[] signature;
     private final PublicKey publicKey;
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof ContractSignatureData that)) return false;
+
+        return Arrays.equals(contractHash, that.contractHash) && Arrays.equals(signature, that.signature) && Objects.equals(publicKey, that.publicKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(contractHash);
+        result = 31 * result + Arrays.hashCode(signature);
+        result = 31 * result + Objects.hashCode(publicKey);
+        return result;
+    }
 
     public ContractSignatureData(byte[] contractHash, byte[] signature, PublicKey publicKey) {
         this.contractHash = contractHash;

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.mu_sig;
 
+import bisq.common.data.ByteArray;
 import bisq.network.identity.NetworkId;
 import bisq.trade.TradeParty;
 import bisq.trade.mu_sig.messages.grpc.CloseTradeResponse;
@@ -49,7 +50,7 @@ public final class MuSigTradeParty extends TradeParty {
     private Optional<SwapTxSignatureResponse> mySwapTxSignatureResponse = Optional.empty();
     private Optional<SwapTxSignature> peersSwapTxSignature = Optional.empty();
     private Optional<CloseTradeResponse> myCloseTradeResponse = Optional.empty();
-    private Optional<byte[]> peersOutputPrvKeyShare = Optional.empty();
+    private Optional<ByteArray> peersOutputPrvKeyShare = Optional.empty();
 
     public MuSigTradeParty(NetworkId networkId) {
         super(networkId);
@@ -66,7 +67,7 @@ public final class MuSigTradeParty extends TradeParty {
                            Optional<SwapTxSignatureResponse> mySwapTxSignatureResponse,
                            Optional<SwapTxSignature> peersSwapTxSignature,
                            Optional<CloseTradeResponse> myCloseTradeResponse,
-                           Optional<byte[]> peersOutputPrvKeyShare) {
+                           Optional<ByteArray> peersOutputPrvKeyShare) {
         super(networkId);
 
         this.myPubKeySharesResponse = myPubKeySharesResponse;
@@ -79,6 +80,7 @@ public final class MuSigTradeParty extends TradeParty {
         this.mySwapTxSignatureResponse = mySwapTxSignatureResponse;
         this.peersSwapTxSignature = peersSwapTxSignature;
         this.myCloseTradeResponse = myCloseTradeResponse;
+        this.peersOutputPrvKeyShare = peersOutputPrvKeyShare;
     }
 
     @Override
@@ -93,6 +95,7 @@ public final class MuSigTradeParty extends TradeParty {
         myDepositPsbt.ifPresent(e -> builder.setMyDepositPsbt(e.toProto(serializeForHash)));
         mySwapTxSignatureResponse.ifPresent(e -> builder.setMySwapTxSignatureResponse(e.toProto(serializeForHash)));
         myCloseTradeResponse.ifPresent(e -> builder.setMyCloseTradeResponse(e.toProto(serializeForHash)));
+        peersOutputPrvKeyShare.ifPresent(e -> builder.setPeersOutputPrvKeyShare(e.toProto(serializeForHash)));
         return getTradePartyBuilder(serializeForHash).setMuSigTradeParty(builder);
     }
 
@@ -131,7 +134,7 @@ public final class MuSigTradeParty extends TradeParty {
                         ? Optional.of(CloseTradeResponse.fromProto(muSigTradePartyProto.getMyCloseTradeResponse()))
                         : Optional.empty(),
                 muSigTradePartyProto.hasPeersOutputPrvKeyShare()
-                        ? Optional.of(muSigTradePartyProto.getPeersOutputPrvKeyShare().toByteArray())
+                        ? Optional.of(ByteArray.fromProto(muSigTradePartyProto.getPeersOutputPrvKeyShare()))
                         : Optional.empty()
         );
     }
@@ -176,7 +179,7 @@ public final class MuSigTradeParty extends TradeParty {
         this.myCloseTradeResponse = Optional.of(myCloseTradeResponse);
     }
 
-    public void setPeersOutputPrvKeyShare(byte[] peersOutputPrvKeyShare) {
+    public void setPeersOutputPrvKeyShare(ByteArray peersOutputPrvKeyShare) {
         this.peersOutputPrvKeyShare = Optional.of(peersOutputPrvKeyShare);
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
@@ -94,6 +94,7 @@ public final class MuSigTradeParty extends TradeParty {
         peersPartialSignatures.ifPresent(e -> builder.setPeersPartialSignatures(e.toProto(serializeForHash)));
         myDepositPsbt.ifPresent(e -> builder.setMyDepositPsbt(e.toProto(serializeForHash)));
         mySwapTxSignatureResponse.ifPresent(e -> builder.setMySwapTxSignatureResponse(e.toProto(serializeForHash)));
+        peersSwapTxSignature.ifPresent(e -> builder.setPeersSwapTxSignature(e.toProto(serializeForHash)));
         myCloseTradeResponse.ifPresent(e -> builder.setMyCloseTradeResponse(e.toProto(serializeForHash)));
         peersOutputPrvKeyShare.ifPresent(e -> builder.setPeersOutputPrvKeyShare(e.toProto(serializeForHash)));
         return getTradePartyBuilder(serializeForHash).setMuSigTradeParty(builder);

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
@@ -25,6 +25,10 @@ import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
 import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
+import bisq.trade.mu_sig.messages.network.vo.NonceShares;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
+import bisq.trade.mu_sig.messages.network.vo.PubKeyShares;
+import bisq.trade.mu_sig.messages.network.vo.SwapTxSignature;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -35,43 +39,60 @@ import java.util.Optional;
 @EqualsAndHashCode(callSuper = true)
 @Getter
 public final class MuSigTradeParty extends TradeParty {
-    private Optional<PubKeySharesResponse> pubKeySharesResponse = Optional.empty();
-    private Optional<NonceSharesMessage> nonceSharesMessage = Optional.empty();
-    private Optional<PartialSignaturesMessage> partialSignaturesMessage = Optional.empty();
-    private Optional<DepositPsbt> depositPsbt = Optional.empty();
-    private Optional<SwapTxSignatureResponse> swapTxSignatureResponse = Optional.empty();
-    private Optional<CloseTradeResponse> closeTradeResponse = Optional.empty();
+    private Optional<PubKeySharesResponse> myPubKeySharesResponse = Optional.empty();
+    private Optional<PubKeyShares> peersPubKeyShares = Optional.empty();
+    private Optional<NonceSharesMessage> myNonceSharesMessage = Optional.empty();
+    private Optional<NonceShares> peersNonceShares = Optional.empty();
+    private Optional<PartialSignaturesMessage> myPartialSignaturesMessage = Optional.empty();
+    private Optional<PartialSignatures> peersPartialSignatures = Optional.empty();
+    private Optional<DepositPsbt> myDepositPsbt = Optional.empty();
+    private Optional<SwapTxSignatureResponse> mySwapTxSignatureResponse = Optional.empty();
+    private Optional<SwapTxSignature> peersSwapTxSignature = Optional.empty();
+    private Optional<CloseTradeResponse> myCloseTradeResponse = Optional.empty();
+    private Optional<byte[]> peersOutputPrvKeyShare = Optional.empty();
 
     public MuSigTradeParty(NetworkId networkId) {
         super(networkId);
     }
 
     public MuSigTradeParty(NetworkId networkId,
-                           Optional<PubKeySharesResponse> pubKeySharesResponse,
-                           Optional<NonceSharesMessage> nonceSharesMessage,
-                           Optional<PartialSignaturesMessage> partialSignaturesMessage,
-                           Optional<DepositPsbt> depositPsbt,
-                           Optional<SwapTxSignatureResponse> swapTxSignatureResponse,
-                           Optional<CloseTradeResponse> closeTradeResponse) {
+                           Optional<PubKeySharesResponse> myPubKeySharesResponse,
+                           Optional<PubKeyShares> peersPubKeyShares,
+                           Optional<NonceSharesMessage> myNonceSharesMessage,
+                           Optional<NonceShares> peersNonceShares,
+                           Optional<PartialSignaturesMessage> myPartialSignaturesMessage,
+                           Optional<PartialSignatures> peersPartialSignatures,
+                           Optional<DepositPsbt> myDepositPsbt,
+                           Optional<SwapTxSignatureResponse> mySwapTxSignatureResponse,
+                           Optional<SwapTxSignature> peersSwapTxSignature,
+                           Optional<CloseTradeResponse> myCloseTradeResponse,
+                           Optional<byte[]> peersOutputPrvKeyShare) {
         super(networkId);
 
-        this.pubKeySharesResponse = pubKeySharesResponse;
-        this.nonceSharesMessage = nonceSharesMessage;
-        this.partialSignaturesMessage = partialSignaturesMessage;
-        this.depositPsbt = depositPsbt;
-        this.swapTxSignatureResponse = swapTxSignatureResponse;
-        this.closeTradeResponse = closeTradeResponse;
+        this.myPubKeySharesResponse = myPubKeySharesResponse;
+        this.peersPubKeyShares = peersPubKeyShares;
+        this.myNonceSharesMessage = myNonceSharesMessage;
+        this.peersNonceShares = peersNonceShares;
+        this.myPartialSignaturesMessage = myPartialSignaturesMessage;
+        this.peersPartialSignatures = peersPartialSignatures;
+        this.myDepositPsbt = myDepositPsbt;
+        this.mySwapTxSignatureResponse = mySwapTxSignatureResponse;
+        this.peersSwapTxSignature = peersSwapTxSignature;
+        this.myCloseTradeResponse = myCloseTradeResponse;
     }
 
     @Override
     public bisq.trade.protobuf.TradeParty.Builder getBuilder(boolean serializeForHash) {
         bisq.trade.protobuf.MuSigTradeParty.Builder builder = bisq.trade.protobuf.MuSigTradeParty.newBuilder();
-        pubKeySharesResponse.ifPresent(e -> builder.setPubKeySharesResponse(e.toProto(serializeForHash)));
-        nonceSharesMessage.ifPresent(e -> builder.setNonceSharesMessage(e.toProto(serializeForHash)));
-        partialSignaturesMessage.ifPresent(e -> builder.setPartialSignaturesMessage(e.toProto(serializeForHash)));
-        depositPsbt.ifPresent(e -> builder.setDepositPsbt(e.toProto(serializeForHash)));
-        swapTxSignatureResponse.ifPresent(e -> builder.setSwapTxSignatureResponse(e.toProto(serializeForHash)));
-        closeTradeResponse.ifPresent(e -> builder.setCloseTradeResponse(e.toProto(serializeForHash)));
+        myPubKeySharesResponse.ifPresent(e -> builder.setMyPubKeySharesResponse(e.toProto(serializeForHash)));
+        peersPubKeyShares.ifPresent(e -> builder.setPeersPubKeyShares(e.toProto(serializeForHash)));
+        myNonceSharesMessage.ifPresent(e -> builder.setMyNonceSharesMessage(e.toProto(serializeForHash)));
+        peersNonceShares.ifPresent(e -> builder.setPeersNonceShares(e.toProto(serializeForHash)));
+        myPartialSignaturesMessage.ifPresent(e -> builder.setMyPartialSignaturesMessage(e.toProto(serializeForHash)));
+        peersPartialSignatures.ifPresent(e -> builder.setPeersPartialSignatures(e.toProto(serializeForHash)));
+        myDepositPsbt.ifPresent(e -> builder.setMyDepositPsbt(e.toProto(serializeForHash)));
+        mySwapTxSignatureResponse.ifPresent(e -> builder.setMySwapTxSignatureResponse(e.toProto(serializeForHash)));
+        myCloseTradeResponse.ifPresent(e -> builder.setMyCloseTradeResponse(e.toProto(serializeForHash)));
         return getTradePartyBuilder(serializeForHash).setMuSigTradeParty(builder);
     }
 
@@ -79,48 +100,83 @@ public final class MuSigTradeParty extends TradeParty {
         bisq.trade.protobuf.MuSigTradeParty muSigTradePartyProto = proto.getMuSigTradeParty();
         return new MuSigTradeParty(
                 NetworkId.fromProto(proto.getNetworkId()),
-                muSigTradePartyProto.hasPubKeySharesResponse()
-                        ? Optional.of(PubKeySharesResponse.fromProto(muSigTradePartyProto.getPubKeySharesResponse()))
+                muSigTradePartyProto.hasMyPubKeySharesResponse()
+                        ? Optional.of(PubKeySharesResponse.fromProto(muSigTradePartyProto.getMyPubKeySharesResponse()))
                         : Optional.empty(),
-                muSigTradePartyProto.hasNonceSharesMessage()
-                        ? Optional.of(NonceSharesMessage.fromProto(muSigTradePartyProto.getNonceSharesMessage()))
+                muSigTradePartyProto.hasPeersPubKeyShares()
+                        ? Optional.of(PubKeyShares.fromProto(muSigTradePartyProto.getPeersPubKeyShares()))
                         : Optional.empty(),
-                muSigTradePartyProto.hasPartialSignaturesMessage()
-                        ? Optional.of(PartialSignaturesMessage.fromProto(muSigTradePartyProto.getPartialSignaturesMessage()))
+                muSigTradePartyProto.hasMyNonceSharesMessage()
+                        ? Optional.of(NonceSharesMessage.fromProto(muSigTradePartyProto.getMyNonceSharesMessage()))
                         : Optional.empty(),
-                muSigTradePartyProto.hasDepositPsbt()
-                        ? Optional.of(DepositPsbt.fromProto(muSigTradePartyProto.getDepositPsbt()))
+                muSigTradePartyProto.hasPeersNonceShares()
+                        ? Optional.of(NonceShares.fromProto(muSigTradePartyProto.getPeersNonceShares()))
                         : Optional.empty(),
-                muSigTradePartyProto.hasSwapTxSignatureResponse()
-                        ? Optional.of(SwapTxSignatureResponse.fromProto(muSigTradePartyProto.getSwapTxSignatureResponse()))
+                muSigTradePartyProto.hasMyPartialSignaturesMessage()
+                        ? Optional.of(PartialSignaturesMessage.fromProto(muSigTradePartyProto.getMyPartialSignaturesMessage()))
                         : Optional.empty(),
-                muSigTradePartyProto.hasCloseTradeResponse()
-                        ? Optional.of(CloseTradeResponse.fromProto(muSigTradePartyProto.getCloseTradeResponse()))
+                muSigTradePartyProto.hasPeersPartialSignatures()
+                        ? Optional.of(PartialSignatures.fromProto(muSigTradePartyProto.getPeersPartialSignatures()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasMyDepositPsbt()
+                        ? Optional.of(DepositPsbt.fromProto(muSigTradePartyProto.getMyDepositPsbt()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasMySwapTxSignatureResponse()
+                        ? Optional.of(SwapTxSignatureResponse.fromProto(muSigTradePartyProto.getMySwapTxSignatureResponse()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasPeersSwapTxSignature()
+                        ? Optional.of(SwapTxSignature.fromProto(muSigTradePartyProto.getPeersSwapTxSignature()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasMyCloseTradeResponse()
+                        ? Optional.of(CloseTradeResponse.fromProto(muSigTradePartyProto.getMyCloseTradeResponse()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasPeersOutputPrvKeyShare()
+                        ? Optional.of(muSigTradePartyProto.getPeersOutputPrvKeyShare().toByteArray())
                         : Optional.empty()
         );
     }
 
-    public void setPubKeySharesResponse(PubKeySharesResponse pubKeySharesResponse) {
-        this.pubKeySharesResponse = Optional.of(pubKeySharesResponse);
+    public void setMyPubKeySharesResponse(PubKeySharesResponse myPubKeySharesResponse) {
+        this.myPubKeySharesResponse = Optional.of(myPubKeySharesResponse);
     }
 
-    public void setNonceSharesMessage(NonceSharesMessage nonceSharesMessage) {
-        this.nonceSharesMessage = Optional.of(nonceSharesMessage);
+    public void setPeersPubKeySharesResponse(PubKeyShares peersPubKeyShares) {
+        this.peersPubKeyShares = Optional.of(peersPubKeyShares);
     }
 
-    public void setPartialSignaturesMessage(PartialSignaturesMessage partialSignaturesMessage) {
-        this.partialSignaturesMessage = Optional.of(partialSignaturesMessage);
+    public void setMyNonceSharesMessage(NonceSharesMessage myNonceSharesMessage) {
+        this.myNonceSharesMessage = Optional.of(myNonceSharesMessage);
     }
 
-    public void setDepositPsbt(DepositPsbt depositPsbt) {
-        this.depositPsbt = Optional.of(depositPsbt);
+    public void setPeersNonceShares(NonceShares peersNonceShares) {
+        this.peersNonceShares = Optional.of(peersNonceShares);
     }
 
-    public void setSwapTxSignatureResponse(SwapTxSignatureResponse swapTxSignatureResponse) {
-        this.swapTxSignatureResponse = Optional.of(swapTxSignatureResponse);
+    public void setMyPartialSignaturesMessage(PartialSignaturesMessage myPartialSignaturesMessage) {
+        this.myPartialSignaturesMessage = Optional.of(myPartialSignaturesMessage);
     }
 
-    public void setCloseTradeResponse(CloseTradeResponse closeTradeResponse) {
-        this.closeTradeResponse = Optional.of(closeTradeResponse);
+    public void setPeersPartialSignatures(PartialSignatures peersPartialSignatures) {
+        this.peersPartialSignatures = Optional.of(peersPartialSignatures);
+    }
+
+    public void setMyDepositPsbt(DepositPsbt myDepositPsbt) {
+        this.myDepositPsbt = Optional.of(myDepositPsbt);
+    }
+
+    public void setMySwapTxSignatureResponse(SwapTxSignatureResponse mySwapTxSignatureResponse) {
+        this.mySwapTxSignatureResponse = Optional.of(mySwapTxSignatureResponse);
+    }
+
+    public void setPeersSwapTxSignature(SwapTxSignature peersSwapTxSignature) {
+        this.peersSwapTxSignature = Optional.of(peersSwapTxSignature);
+    }
+
+    public void setMyCloseTradeResponse(CloseTradeResponse myCloseTradeResponse) {
+        this.myCloseTradeResponse = Optional.of(myCloseTradeResponse);
+    }
+
+    public void setPeersOutputPrvKeyShare(byte[] peersOutputPrvKeyShare) {
+        this.peersOutputPrvKeyShare = Optional.of(peersOutputPrvKeyShare);
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -403,7 +403,7 @@ public final class MuSigTradeService implements PersistenceClient<MuSigTradeStor
 
         // todo we dont want to create a thread for each trade... but lets see how real impl. will look like
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
-            DepositPsbt depositPsbt = trade.getMyself().getDepositPsbt().orElseThrow();
+            DepositPsbt depositPsbt = trade.getMyself().getMyDepositPsbt().orElseThrow();
             SubscribeTxConfirmationStatusRequest request = SubscribeTxConfirmationStatusRequest.newBuilder()
                     .setTradeId(tradeId)
                     .setDepositPsbt(depositPsbt.toProto(true))

--- a/trade/src/main/java/bisq/trade/mu_sig/README.md
+++ b/trade/src/main/java/bisq/trade/mu_sig/README.md
@@ -1,8 +1,10 @@
 ### Setup for musig trade protocol
 
-Clone the Bisq Musig project from https://github.com/bisq-network/bisq-musig, follow the instructions in rpc readme file.
+Clone the Bisq Musig project from https://github.com/bisq-network/bisq-musig, follow the instructions in rpc readme
+file.
 
-As long branch https://github.com/stejbac/bisq-musig/tree/add-more-rpc-integration-tests is not merged, use that as that comes with support for custom ports.
+As long branch https://github.com/stejbac/bisq-musig/tree/add-more-rpc-integration-tests is not merged, use that as that
+comes with support for custom ports.
 You need to run 2 instances for the 2 trade peers with different ports.
 
 `cargo run --bin musigd -- --port 50090`
@@ -11,6 +13,7 @@ You need to run 2 instances for the 2 trade peers with different ports.
 Start Bisq apps with the distinct port:
 
 Alice:
+
 ```
 -Dapplication.appName=bisq2_Alice
 -Dapplication.network.supportedTransportTypes.2=CLEAR
@@ -19,6 +22,7 @@ Alice:
 ```
 
 Bob:
+
 ```
 -Dapplication.appName=bisq2_Bob
 -Dapplication.network.supportedTransportTypes.2=CLEAR

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigBuyersCooperativeCloseTimeoutEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigBuyersCooperativeCloseTimeoutEventHandler.java
@@ -53,7 +53,7 @@ public final class MuSigBuyersCooperativeCloseTimeoutEventHandler extends MuSigT
     protected void commit() {
         MuSigTradeParty mySelf = trade.getMaker();
 
-        mySelf.setCloseTradeResponse(myCloseTradeResponse);
+        mySelf.setMyCloseTradeResponse(myCloseTradeResponse);
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigBuyersCooperativeCloseTimeoutEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigBuyersCooperativeCloseTimeoutEventHandler.java
@@ -58,7 +58,7 @@ public final class MuSigBuyersCooperativeCloseTimeoutEventHandler extends MuSigT
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Buyer did not receive peers swapTxSignature and the timeout got triggered\n." +
+        sendLogMessage("Buyer did not receive peers swapTxSignature and the timeout got triggered.\n" +
                 "Buyer created his closeTradeResponse and force-close the trade.");
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigBuyersCooperativeCloseTimeoutEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigBuyersCooperativeCloseTimeoutEventHandler.java
@@ -23,7 +23,6 @@ import bisq.trade.mu_sig.MuSigTradeParty;
 import bisq.trade.mu_sig.handler.MuSigTradeEventHandler;
 import bisq.trade.mu_sig.messages.grpc.CloseTradeResponse;
 import bisq.trade.protobuf.CloseTradeRequest;
-import bisq.trade.protobuf.MusigGrpc;
 import com.google.protobuf.ByteString;
 
 public final class MuSigBuyersCooperativeCloseTimeoutEventHandler extends MuSigTradeEventHandler<MuSigTrade, MuSigBuyersCooperativeCloseTimeoutEvent> {
@@ -43,7 +42,6 @@ public final class MuSigBuyersCooperativeCloseTimeoutEventHandler extends MuSigT
         // TODO get swap tx from bitcoin network
         //ByteString swapTx = swapTxSignatureResponse.getSwapTx();
         byte[] swapTx = new byte[]{};
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         CloseTradeRequest closeTradeRequest = CloseTradeRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setSwapTx(ByteString.copyFrom(swapTx))

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
@@ -73,8 +73,7 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
 
     @Override
     protected void sendMessage() {
-        PubKeyShares peersPubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare().clone(),
-                myPubKeySharesResponse.getSellerOutputPubKeyShare().clone());
+        PubKeyShares pubKeyShares = PubKeyShares.from(myPubKeySharesResponse);
 
         send(new MuSigSetupTradeMessage_A(StringUtils.createUid(),
                 trade.getId(),
@@ -83,7 +82,7 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
                 trade.getPeer().getNetworkId(),
                 contract,
                 myContractSignatureData,
-                peersPubKeyShares));
+                pubKeyShares));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
@@ -28,7 +28,6 @@ import bisq.trade.mu_sig.MuSigTradeParty;
 import bisq.trade.mu_sig.handler.MuSigTradeEventHandlerAsMessageSender;
 import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_A;
-import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protobuf.PubKeySharesRequest;
 import bisq.trade.protobuf.Role;
 import bisq.user.profile.UserProfile;
@@ -49,7 +48,6 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
     @Override
     public void process(MuSigTakeOfferEvent event) {
         try {
-            MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
             bisq.trade.protobuf.PubKeySharesResponse proto = musigBlockingStub.initTrade(PubKeySharesRequest.newBuilder()
                     .setTradeId(trade.getId())
                     .setMyRole(Role.BUYER_AS_TAKER)

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
@@ -73,8 +73,9 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
 
     @Override
     protected void sendMessage() {
-        PubKeyShares peersPubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare(),
-                myPubKeySharesResponse.getSellerOutputPubKeyShare());
+        PubKeyShares peersPubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare().clone(),
+                myPubKeySharesResponse.getSellerOutputPubKeyShare().clone());
+
         send(new MuSigSetupTradeMessage_A(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigTakeOfferEventHandler.java
@@ -28,6 +28,7 @@ import bisq.trade.mu_sig.MuSigTradeParty;
 import bisq.trade.mu_sig.handler.MuSigTradeEventHandlerAsMessageSender;
 import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_A;
+import bisq.trade.mu_sig.messages.network.vo.PubKeyShares;
 import bisq.trade.protobuf.PubKeySharesRequest;
 import bisq.trade.protobuf.Role;
 import bisq.user.profile.UserProfile;
@@ -37,7 +38,7 @@ import java.util.Optional;
 
 @Slf4j
 public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMessageSender<MuSigTrade, MuSigTakeOfferEvent> {
-    private PubKeySharesResponse myPubKeyShares;
+    private PubKeySharesResponse myPubKeySharesResponse;
     private ContractSignatureData myContractSignatureData;
     private MuSigContract contract;
 
@@ -52,7 +53,7 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
                     .setTradeId(trade.getId())
                     .setMyRole(Role.BUYER_AS_TAKER)
                     .build());
-            myPubKeyShares = PubKeySharesResponse.fromProto(proto);
+            myPubKeySharesResponse = PubKeySharesResponse.fromProto(proto);
 
             contract = trade.getContract();
             myContractSignatureData = serviceProvider.getContractService().signContract(contract,
@@ -67,11 +68,13 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
     protected void commit() {
         MuSigTradeParty mySelf = trade.getTaker();
         mySelf.getContractSignatureData().set(myContractSignatureData);
-        mySelf.setPubKeySharesResponse(myPubKeyShares);
+        mySelf.setMyPubKeySharesResponse(myPubKeySharesResponse);
     }
 
     @Override
     protected void sendMessage() {
+        PubKeyShares peersPubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare(),
+                myPubKeySharesResponse.getSellerOutputPubKeyShare());
         send(new MuSigSetupTradeMessage_A(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),
@@ -79,7 +82,7 @@ public final class MuSigTakeOfferEventHandler extends MuSigTradeEventHandlerAsMe
                 trade.getPeer().getNetworkId(),
                 contract,
                 myContractSignatureData,
-                myPubKeyShares));
+                peersPubKeyShares));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
@@ -25,7 +25,6 @@ import bisq.trade.mu_sig.handler.MuSigTradeEventHandlerAsMessageSender;
 import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
 import bisq.trade.mu_sig.messages.network.MuSigPaymentReceivedMessage_F;
-import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protobuf.SwapTxSignatureRequest;
 import com.google.protobuf.ByteString;
 
@@ -42,7 +41,6 @@ public final class MuSigPaymentReceiptConfirmedEventHandler extends MuSigTradeEv
         // We got that from an earlier message
         PartialSignaturesMessage buyerPartialSignaturesMessage = buyerAsTaker.getPartialSignaturesMessage().orElseThrow();
 
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         sellerSwapTxSignatureResponse = SwapTxSignatureResponse.fromProto(musigBlockingStub.signSwapTx(SwapTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
                 // NOW send the redacted buyer's swapTxInputPartialSignature:

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
@@ -22,14 +22,15 @@ import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeParty;
 import bisq.trade.mu_sig.handler.MuSigTradeEventHandlerAsMessageSender;
-import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
 import bisq.trade.mu_sig.messages.network.MuSigPaymentReceivedMessage_F;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
+import bisq.trade.mu_sig.messages.network.vo.SwapTxSignature;
 import bisq.trade.protobuf.SwapTxSignatureRequest;
 import com.google.protobuf.ByteString;
 
 public final class MuSigPaymentReceiptConfirmedEventHandler extends MuSigTradeEventHandlerAsMessageSender<MuSigTrade, MuSigPaymentReceiptConfirmedEvent> {
-    private SwapTxSignatureResponse sellerSwapTxSignatureResponse;
+    private SwapTxSignatureResponse mySwapTxSignatureResponse;
 
     public MuSigPaymentReceiptConfirmedEventHandler(ServiceProvider serviceProvider, MuSigTrade model) {
         super(serviceProvider, model);
@@ -37,14 +38,14 @@ public final class MuSigPaymentReceiptConfirmedEventHandler extends MuSigTradeEv
 
     @Override
     public void process(MuSigPaymentReceiptConfirmedEvent event) {
-        MuSigTradeParty buyerAsTaker = trade.getTaker();
+        MuSigTradeParty peer = trade.getTaker();
         // We got that from an earlier message
-        PartialSignaturesMessage buyerPartialSignaturesMessage = buyerAsTaker.getPartialSignaturesMessage().orElseThrow();
+        PartialSignatures peersPartialSignatures = peer.getPeersPartialSignatures().orElseThrow();
 
-        sellerSwapTxSignatureResponse = SwapTxSignatureResponse.fromProto(musigBlockingStub.signSwapTx(SwapTxSignatureRequest.newBuilder()
+        mySwapTxSignatureResponse = SwapTxSignatureResponse.fromProto(musigBlockingStub.signSwapTx(SwapTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
                 // NOW send the redacted buyer's swapTxInputPartialSignature:
-                .setSwapTxInputPeersPartialSignature(ByteString.copyFrom(buyerPartialSignaturesMessage.getSwapTxInputPartialSignature()))
+                .setSwapTxInputPeersPartialSignature(ByteString.copyFrom(peersPartialSignatures.getSwapTxInputPartialSignature()))
                 .build()));
 
         //ClosureType.COOPERATIVE
@@ -53,19 +54,20 @@ public final class MuSigPaymentReceiptConfirmedEventHandler extends MuSigTradeEv
 
     @Override
     protected void commit() {
-        MuSigTradeParty sellerAsMaker = trade.getMaker();
-        sellerAsMaker.setSwapTxSignatureResponse(sellerSwapTxSignatureResponse);
+        MuSigTradeParty mySelf = trade.getMaker();
+        mySelf.setMySwapTxSignatureResponse(mySwapTxSignatureResponse);
     }
 
     @Override
     protected void sendMessage() {
-        // TODO do we want to send the full SwapTxSignatureResponse?
+        SwapTxSignature peersSwapTxSignature = new SwapTxSignature(mySwapTxSignatureResponse.getSwapTx(),
+                mySwapTxSignatureResponse.getPeerOutputPrvKeyShare());
         send(new MuSigPaymentReceivedMessage_F(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),
                 trade.getMyIdentity().getNetworkId(),
                 trade.getPeer().getNetworkId(),
-                sellerSwapTxSignatureResponse));
+                peersSwapTxSignature));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
@@ -60,8 +60,7 @@ public final class MuSigPaymentReceiptConfirmedEventHandler extends MuSigTradeEv
 
     @Override
     protected void sendMessage() {
-        SwapTxSignature peersSwapTxSignature = new SwapTxSignature(mySwapTxSignatureResponse.getSwapTx(),
-                mySwapTxSignatureResponse.getPeerOutputPrvKeyShare());
+        SwapTxSignature peersSwapTxSignature = SwapTxSignature.from(mySwapTxSignatureResponse);
         send(new MuSigPaymentReceivedMessage_F(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigSellersCooperativeCloseTimeoutEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigSellersCooperativeCloseTimeoutEventHandler.java
@@ -50,7 +50,7 @@ public final class MuSigSellersCooperativeCloseTimeoutEventHandler extends MuSig
     protected void commit() {
         MuSigTradeParty mySelf = trade.getMaker();
 
-        mySelf.setCloseTradeResponse(myCloseTradeResponse);
+        mySelf.setMyCloseTradeResponse(myCloseTradeResponse);
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigSellersCooperativeCloseTimeoutEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigSellersCooperativeCloseTimeoutEventHandler.java
@@ -55,7 +55,7 @@ public final class MuSigSellersCooperativeCloseTimeoutEventHandler extends MuSig
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Seller did not receive peers closeTradeResponse and the timeout got triggered\n." +
+        sendLogMessage("Seller did not receive peers closeTradeResponse and the timeout got triggered.\n" +
                 "Seller created his closeTradeResponse and force-close the trade.");
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigSellersCooperativeCloseTimeoutEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigSellersCooperativeCloseTimeoutEventHandler.java
@@ -23,7 +23,6 @@ import bisq.trade.mu_sig.MuSigTradeParty;
 import bisq.trade.mu_sig.handler.MuSigTradeEventHandler;
 import bisq.trade.mu_sig.messages.grpc.CloseTradeResponse;
 import bisq.trade.protobuf.CloseTradeRequest;
-import bisq.trade.protobuf.MusigGrpc;
 
 public final class MuSigSellersCooperativeCloseTimeoutEventHandler extends MuSigTradeEventHandler<MuSigTrade, MuSigSellersCooperativeCloseTimeoutEvent> {
     private CloseTradeResponse myCloseTradeResponse;
@@ -40,7 +39,6 @@ public final class MuSigSellersCooperativeCloseTimeoutEventHandler extends MuSig
 
         // ClosureType.UNCOOPERATIVE
         // *** SELLER FORCE-CLOSES TRADE ***
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         //TODO isn't here the swap Tx needed to pass?
         CloseTradeRequest closeTradeRequest = CloseTradeRequest.newBuilder()
                 .setTradeId(trade.getId())

--- a/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeEventHandler.java
@@ -23,6 +23,7 @@ import bisq.network.SendMessageResult;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeService;
+import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protocol.handler.TradeEventHandler;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,11 +33,13 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public abstract class MuSigTradeEventHandler<T extends MuSigTrade, E extends Event> extends TradeEventHandler<T, E> {
     protected final MuSigTradeService muSigTradeService;
+    protected final MusigGrpc.MusigBlockingStub musigBlockingStub;
 
     protected MuSigTradeEventHandler(ServiceProvider serviceProvider, T trade) {
         super(serviceProvider, trade);
 
         muSigTradeService = serviceProvider.getMuSigTradeService();
+        musigBlockingStub = muSigTradeService.getMusigBlockingStub();
     }
 
     public final void handle(Event event) {

--- a/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeEventHandlerAsMessageSender.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeEventHandlerAsMessageSender.java
@@ -23,6 +23,7 @@ import bisq.network.SendMessageResult;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeService;
+import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protocol.handler.TradeEventHandlerAsMessageSender;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,11 +33,13 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public abstract class MuSigTradeEventHandlerAsMessageSender<T extends MuSigTrade, E extends Event> extends TradeEventHandlerAsMessageSender<T, E> {
     protected final MuSigTradeService muSigTradeService;
+    protected final MusigGrpc.MusigBlockingStub musigBlockingStub;
 
     protected MuSigTradeEventHandlerAsMessageSender(ServiceProvider serviceProvider, T trade) {
         super(serviceProvider, trade);
 
         muSigTradeService = serviceProvider.getMuSigTradeService();
+        musigBlockingStub = muSigTradeService.getMusigBlockingStub();
     }
 
     public final void handle(Event event) {

--- a/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeMessageHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeMessageHandler.java
@@ -23,6 +23,7 @@ import bisq.network.SendMessageResult;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeService;
+import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protocol.handler.TradeMessageHandler;
 import bisq.trade.protocol.messages.TradeMessage;
 import lombok.extern.slf4j.Slf4j;
@@ -33,11 +34,13 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public abstract class MuSigTradeMessageHandler<T extends MuSigTrade, M extends TradeMessage> extends TradeMessageHandler<T, M> {
     protected final MuSigTradeService muSigTradeService;
+    protected final MusigGrpc.MusigBlockingStub musigBlockingStub;
 
     protected MuSigTradeMessageHandler(ServiceProvider serviceProvider, T trade) {
         super(serviceProvider, trade);
 
         muSigTradeService = serviceProvider.getMuSigTradeService();
+        musigBlockingStub = muSigTradeService.getMusigBlockingStub();
     }
 
     public final void handle(Event event) {

--- a/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeMessageHandlerAsMessageSender.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/handler/MuSigTradeMessageHandlerAsMessageSender.java
@@ -23,6 +23,7 @@ import bisq.network.SendMessageResult;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeService;
+import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protocol.handler.TradeMessageHandlerAsMessageSender;
 import bisq.trade.protocol.messages.TradeMessage;
 import lombok.extern.slf4j.Slf4j;
@@ -33,11 +34,13 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public abstract class MuSigTradeMessageHandlerAsMessageSender<T extends MuSigTrade, M extends TradeMessage> extends TradeMessageHandlerAsMessageSender<T, M> {
     protected final MuSigTradeService muSigTradeService;
+    protected final MusigGrpc.MusigBlockingStub musigBlockingStub;
 
     protected MuSigTradeMessageHandlerAsMessageSender(ServiceProvider serviceProvider, T trade) {
         super(serviceProvider, trade);
 
         muSigTradeService = serviceProvider.getMuSigTradeService();
+        musigBlockingStub = muSigTradeService.getMusigBlockingStub();
     }
 
     public final void handle(Event event) {

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/DepositTxSignatureRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/DepositTxSignatureRequest.java
@@ -28,7 +28,7 @@ public final class DepositTxSignatureRequest implements Proto {
     private final PartialSignaturesMessage peersPartialSignatures;
 
     public DepositTxSignatureRequest(String tradeId,
-            PartialSignaturesMessage peersPartialSignatures) {
+                                     PartialSignaturesMessage peersPartialSignatures) {
         this.tradeId = tradeId;
         this.peersPartialSignatures = peersPartialSignatures;
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
+import bisq.trade.mu_sig.messages.network.vo.NonceShares;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,6 +26,21 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 public final class NonceSharesMessage implements Proto {
+    public static NonceSharesMessage from(NonceShares nonceShares) {
+        return new NonceSharesMessage(
+                nonceShares.getWarningTxFeeBumpAddress(),
+                nonceShares.getRedirectTxFeeBumpAddress(),
+                nonceShares.getHalfDepositPsbt(),
+                nonceShares.getSwapTxInputNonceShare(),
+                nonceShares.getBuyersWarningTxBuyerInputNonceShare(),
+                nonceShares.getBuyersWarningTxSellerInputNonceShare(),
+                nonceShares.getSellersWarningTxBuyerInputNonceShare(),
+                nonceShares.getSellersWarningTxSellerInputNonceShare(),
+                nonceShares.getBuyersRedirectTxInputNonceShare(),
+                nonceShares.getSellersRedirectTxInputNonceShare()
+        );
+    }
+
     private final String warningTxFeeBumpAddress;
     private final String redirectTxFeeBumpAddress;
     private final byte[] halfDepositPsbt;
@@ -36,7 +52,7 @@ public final class NonceSharesMessage implements Proto {
     private final byte[] buyersRedirectTxInputNonceShare;
     private final byte[] sellersRedirectTxInputNonceShare;
 
-    public NonceSharesMessage(String warningTxFeeBumpAddress,
+    private NonceSharesMessage(String warningTxFeeBumpAddress,
                               String redirectTxFeeBumpAddress,
                               byte[] halfDepositPsbt,
                               byte[] swapTxInputNonceShare,

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesRequest.java
@@ -35,13 +35,13 @@ public final class NonceSharesRequest implements Proto {
     private final long sellersSecurityDeposit;
 
     public NonceSharesRequest(String tradeId,
-            byte[] buyerOutputPeersPubKeyShare,
-            byte[] sellerOutputPeersPubKeyShare,
-            long depositTxFeeRate,
-            long preparedTxFeeRate,
-            long tradeAmount,
-            long buyersSecurityDeposit,
-            long sellersSecurityDeposit) {
+                              byte[] buyerOutputPeersPubKeyShare,
+                              byte[] sellerOutputPeersPubKeyShare,
+                              long depositTxFeeRate,
+                              long preparedTxFeeRate,
+                              long tradeAmount,
+                              long buyersSecurityDeposit,
+                              long sellersSecurityDeposit) {
         this.tradeId = tradeId;
         this.buyerOutputPeersPubKeyShare = buyerOutputPeersPubKeyShare;
         this.sellerOutputPeersPubKeyShare = sellerOutputPeersPubKeyShare;

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,6 +26,15 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 public final class PartialSignaturesMessage implements Proto {
+    public static PartialSignaturesMessage from(PartialSignatures peersPartialSignatures) {
+        return new PartialSignaturesMessage(
+                peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
+                peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
+                peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
+                peersPartialSignatures.getSwapTxInputPartialSignature()
+        );
+    }
+
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/TxConfirmationStatus.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/TxConfirmationStatus.java
@@ -32,8 +32,8 @@ public final class TxConfirmationStatus implements Proto {
     private final int numConfirmations;
 
     public TxConfirmationStatus(byte[] tx,
-            int currentBlockHeight,
-            int numConfirmations) {
+                                int currentBlockHeight,
+                                int numConfirmations) {
         this.tx = tx;
         this.currentBlockHeight = currentBlockHeight;
         this.numConfirmations = numConfirmations;

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCooperativeClosureMessage_G.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCooperativeClosureMessage_G.java
@@ -19,15 +19,16 @@ package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+
 @Slf4j
 @ToString(callSuper = true)
 @Getter
-@EqualsAndHashCode(callSuper = true)
+//@EqualsAndHashCode(callSuper = true)
 public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
     private final byte[] peerOutputPrvKeyShare;
 
@@ -78,5 +79,20 @@ public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
     @Override
     public double getCostFactor() {
         return getCostFactor(0.1, 0.3);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MuSigCooperativeClosureMessage_G that)) return false;
+        if (!super.equals(o)) return false;
+
+        return Arrays.equals(peerOutputPrvKeyShare, that.peerOutputPrvKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(peerOutputPrvKeyShare);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCooperativeClosureMessage_G.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCooperativeClosureMessage_G.java
@@ -17,27 +17,26 @@
 
 package bisq.trade.mu_sig.messages.network;
 
+import bisq.common.data.ByteArray;
 import bisq.network.identity.NetworkId;
-import com.google.protobuf.ByteString;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
-
 @Slf4j
 @ToString(callSuper = true)
 @Getter
-//@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
-    private final byte[] peerOutputPrvKeyShare;
+    private final ByteArray peerOutputPrvKeyShare;
 
     public MuSigCooperativeClosureMessage_G(String id,
                                             String tradeId,
                                             String protocolVersion,
                                             NetworkId sender,
                                             NetworkId receiver,
-                                            byte[] peerOutputPrvKeyShare) {
+                                            ByteArray peerOutputPrvKeyShare) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.peerOutputPrvKeyShare = peerOutputPrvKeyShare;
 
@@ -62,7 +61,7 @@ public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
 
     private bisq.trade.protobuf.MuSigCooperativeClosureMessage_G.Builder getMuSigCooperativeClosureMessage_G(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigCooperativeClosureMessage_G.newBuilder()
-                .setPeerOutputPrvKeyShare(ByteString.copyFrom(peerOutputPrvKeyShare));
+                .setPeerOutputPrvKeyShare(peerOutputPrvKeyShare.toProto(serializeForHash));
     }
 
     public static MuSigCooperativeClosureMessage_G fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -73,26 +72,11 @@ public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
-                muSigMessageProto.getPeerOutputPrvKeyShare().toByteArray());
+                ByteArray.fromProto(muSigMessageProto.getPeerOutputPrvKeyShare()));
     }
 
     @Override
     public double getCostFactor() {
         return getCostFactor(0.1, 0.3);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof MuSigCooperativeClosureMessage_G that)) return false;
-        if (!super.equals(o)) return false;
-
-        return Arrays.equals(peerOutputPrvKeyShare, that.peerOutputPrvKeyShare);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + Arrays.hashCode(peerOutputPrvKeyShare);
-        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCooperativeClosureMessage_G.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCooperativeClosureMessage_G.java
@@ -18,7 +18,7 @@
 package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
-import bisq.trade.mu_sig.messages.grpc.CloseTradeResponse;
+import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -29,17 +29,16 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
-    private final CloseTradeResponse closeTradeResponse;
+    private final byte[] peerOutputPrvKeyShare;
 
     public MuSigCooperativeClosureMessage_G(String id,
                                             String tradeId,
                                             String protocolVersion,
                                             NetworkId sender,
                                             NetworkId receiver,
-                                            CloseTradeResponse closeTradeResponse) {
+                                            byte[] peerOutputPrvKeyShare) {
         super(id, tradeId, protocolVersion, sender, receiver);
-        this.closeTradeResponse = closeTradeResponse;
+        this.peerOutputPrvKeyShare = peerOutputPrvKeyShare;
 
         verify();
     }
@@ -62,7 +61,7 @@ public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
 
     private bisq.trade.protobuf.MuSigCooperativeClosureMessage_G.Builder getMuSigCooperativeClosureMessage_G(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigCooperativeClosureMessage_G.newBuilder()
-                .setCloseTradeResponse(closeTradeResponse.toProto(serializeForHash));
+                .setPeerOutputPrvKeyShare(ByteString.copyFrom(peerOutputPrvKeyShare));
     }
 
     public static MuSigCooperativeClosureMessage_G fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -73,7 +72,7 @@ public final class MuSigCooperativeClosureMessage_G extends MuSigTradeMessage {
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
-                CloseTradeResponse.fromProto(muSigMessageProto.getCloseTradeResponse()));
+                muSigMessageProto.getPeerOutputPrvKeyShare().toByteArray());
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentInitiatedMessage_E.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentInitiatedMessage_E.java
@@ -28,8 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigPaymentInitiatedMessage_E extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
-
     public MuSigPaymentInitiatedMessage_E(String id,
                                           String tradeId,
                                           String protocolVersion,

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentReceivedMessage_F.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentReceivedMessage_F.java
@@ -18,7 +18,7 @@
 package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
-import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
+import bisq.trade.mu_sig.messages.network.vo.SwapTxSignature;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -29,17 +29,16 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigPaymentReceivedMessage_F extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
-    private final SwapTxSignatureResponse swapTxSignatureResponse;
+    private final SwapTxSignature swapTxSignature;
 
     public MuSigPaymentReceivedMessage_F(String id,
                                          String tradeId,
                                          String protocolVersion,
                                          NetworkId sender,
                                          NetworkId receiver,
-                                         SwapTxSignatureResponse swapTxSignatureResponse) {
+                                         SwapTxSignature swapTxSignature) {
         super(id, tradeId, protocolVersion, sender, receiver);
-        this.swapTxSignatureResponse = swapTxSignatureResponse;
+        this.swapTxSignature = swapTxSignature;
 
         verify();
     }
@@ -62,7 +61,7 @@ public final class MuSigPaymentReceivedMessage_F extends MuSigTradeMessage {
 
     private bisq.trade.protobuf.MuSigPaymentReceivedMessage_F.Builder getMuSigPaymentReceivedMessage_F(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigPaymentReceivedMessage_F.newBuilder()
-                .setSwapTxSignatureResponse(swapTxSignatureResponse.toProto(serializeForHash));
+                .setSwapTxSignature(swapTxSignature.toProto(serializeForHash));
     }
 
     public static MuSigPaymentReceivedMessage_F fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -73,7 +72,7 @@ public final class MuSigPaymentReceivedMessage_F extends MuSigTradeMessage {
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
-                SwapTxSignatureResponse.fromProto(muSigMessageProto.getSwapTxSignatureResponse()));
+                SwapTxSignature.fromProto(muSigMessageProto.getSwapTxSignature()));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_A.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_A.java
@@ -20,7 +20,7 @@ package bisq.trade.mu_sig.messages.network;
 import bisq.contract.ContractSignatureData;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.network.identity.NetworkId;
-import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
+import bisq.trade.mu_sig.messages.network.vo.PubKeyShares;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -31,10 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigSetupTradeMessage_A extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
     private final MuSigContract contract;
     private final ContractSignatureData contractSignatureData;
-    private final PubKeySharesResponse pubKeySharesResponse;
+    private final PubKeyShares pubKeyShares;
 
     public MuSigSetupTradeMessage_A(String id,
                                     String tradeId,
@@ -43,11 +42,11 @@ public final class MuSigSetupTradeMessage_A extends MuSigTradeMessage {
                                     NetworkId receiver,
                                     MuSigContract contract,
                                     ContractSignatureData contractSignatureData,
-                                    PubKeySharesResponse pubKeySharesResponse) {
+                                    PubKeyShares pubKeyShares) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.contract = contract;
         this.contractSignatureData = contractSignatureData;
-        this.pubKeySharesResponse = pubKeySharesResponse;
+        this.pubKeyShares = pubKeyShares;
 
         verify();
     }
@@ -72,7 +71,7 @@ public final class MuSigSetupTradeMessage_A extends MuSigTradeMessage {
         return bisq.trade.protobuf.MuSigSetupTradeMessage_A.newBuilder()
                 .setContract(contract.toProto(serializeForHash))
                 .setContractSignatureData(contractSignatureData.toProto(serializeForHash))
-                .setPubKeySharesResponse(pubKeySharesResponse.toProto(serializeForHash));
+                .setPubKeyShares(pubKeyShares.toProto(serializeForHash));
     }
 
     public static MuSigSetupTradeMessage_A fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -85,7 +84,7 @@ public final class MuSigSetupTradeMessage_A extends MuSigTradeMessage {
                 NetworkId.fromProto(proto.getReceiver()),
                 MuSigContract.fromProto(muSigMessageProto.getContract()),
                 ContractSignatureData.fromProto(muSigMessageProto.getContractSignatureData()),
-                PubKeySharesResponse.fromProto(muSigMessageProto.getPubKeySharesResponse()));
+                PubKeyShares.fromProto(muSigMessageProto.getPubKeyShares()));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_B.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_B.java
@@ -20,8 +20,8 @@ package bisq.trade.mu_sig.messages.network;
 import bisq.contract.ContractSignatureData;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.network.identity.NetworkId;
-import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
-import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
+import bisq.trade.mu_sig.messages.network.vo.NonceShares;
+import bisq.trade.mu_sig.messages.network.vo.PubKeyShares;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -32,11 +32,10 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigSetupTradeMessage_B extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
     private final MuSigContract contract;
     private final ContractSignatureData contractSignatureData;
-    private final PubKeySharesResponse pubKeySharesResponse;
-    private final NonceSharesMessage nonceSharesMessage;
+    private final PubKeyShares pubKeyShares;
+    private final NonceShares nonceShares;
 
     public MuSigSetupTradeMessage_B(String id,
                                     String tradeId,
@@ -45,13 +44,13 @@ public final class MuSigSetupTradeMessage_B extends MuSigTradeMessage {
                                     NetworkId receiver,
                                     MuSigContract contract,
                                     ContractSignatureData contractSignatureData,
-                                    PubKeySharesResponse pubKeySharesResponse,
-                                    NonceSharesMessage nonceSharesMessage) {
+                                    PubKeyShares pubKeyShares,
+                                    NonceShares nonceShares) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.contract = contract;
         this.contractSignatureData = contractSignatureData;
-        this.pubKeySharesResponse = pubKeySharesResponse;
-        this.nonceSharesMessage = nonceSharesMessage;
+        this.pubKeyShares = pubKeyShares;
+        this.nonceShares = nonceShares;
 
         verify();
     }
@@ -76,8 +75,8 @@ public final class MuSigSetupTradeMessage_B extends MuSigTradeMessage {
         return bisq.trade.protobuf.MuSigSetupTradeMessage_B.newBuilder()
                 .setContract(contract.toProto(serializeForHash))
                 .setContractSignatureData(contractSignatureData.toProto(serializeForHash))
-                .setPubKeySharesResponse(pubKeySharesResponse.toProto(serializeForHash))
-                .setNonceSharesMessage(nonceSharesMessage.toProto(serializeForHash));
+                .setPubKeyShares(pubKeyShares.toProto(serializeForHash))
+                .setNonceShares(nonceShares.toProto(serializeForHash));
     }
 
     public static MuSigSetupTradeMessage_B fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -90,8 +89,8 @@ public final class MuSigSetupTradeMessage_B extends MuSigTradeMessage {
                 NetworkId.fromProto(proto.getReceiver()),
                 MuSigContract.fromProto(muSigMessageProto.getContract()),
                 ContractSignatureData.fromProto(muSigMessageProto.getContractSignatureData()),
-                PubKeySharesResponse.fromProto(muSigMessageProto.getPubKeySharesResponse()),
-                NonceSharesMessage.fromProto(muSigMessageProto.getNonceSharesMessage()));
+                PubKeyShares.fromProto(muSigMessageProto.getPubKeyShares()),
+                NonceShares.fromProto(muSigMessageProto.getNonceShares()));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_C.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_C.java
@@ -18,8 +18,8 @@
 package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
-import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
-import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
+import bisq.trade.mu_sig.messages.network.vo.NonceShares;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -30,20 +30,19 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
-    private final NonceSharesMessage nonceSharesMessage;
-    private final PartialSignaturesMessage partialSignaturesMessage;
+    private final NonceShares nonceShares;
+    private final PartialSignatures partialSignatures;
 
     public MuSigSetupTradeMessage_C(String id,
                                     String tradeId,
                                     String protocolVersion,
                                     NetworkId sender,
                                     NetworkId receiver,
-                                    NonceSharesMessage nonceSharesMessage,
-                                    PartialSignaturesMessage partialSignaturesMessage) {
+                                    NonceShares nonceShares,
+                                    PartialSignatures partialSignatures) {
         super(id, tradeId, protocolVersion, sender, receiver);
-        this.nonceSharesMessage = nonceSharesMessage;
-        this.partialSignaturesMessage = partialSignaturesMessage;
+        this.nonceShares = nonceShares;
+        this.partialSignatures = partialSignatures;
 
         verify();
     }
@@ -66,8 +65,8 @@ public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
 
     private bisq.trade.protobuf.MuSigSetupTradeMessage_C.Builder getMuSigSetupTradeMessage_C(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigSetupTradeMessage_C.newBuilder()
-                .setNonceSharesMessage(nonceSharesMessage.toProto(serializeForHash))
-                .setPartialSignaturesMessage(partialSignaturesMessage.toProto(serializeForHash));
+                .setNonceShares(nonceShares.toProto(serializeForHash))
+                .setPartialSignatures(partialSignatures.toProto(serializeForHash));
     }
 
     public static MuSigSetupTradeMessage_C fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -78,9 +77,10 @@ public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
-                NonceSharesMessage.fromProto(muSigMessageProto.getNonceSharesMessage()),
-                PartialSignaturesMessage.fromProto(muSigMessageProto.getPartialSignaturesMessage()));
+                NonceShares.fromProto(muSigMessageProto.getNonceShares()),
+                PartialSignatures.fromProto(muSigMessageProto.getPartialSignatures()));
     }
+
     @Override
     public double getCostFactor() {
         return getCostFactor(0.1, 0.3);

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_D.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_D.java
@@ -18,7 +18,7 @@
 package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
-import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -29,17 +29,16 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigSetupTradeMessage_D extends MuSigTradeMessage {
-    public final static int MAX_LENGTH = 1000;
-    private final PartialSignaturesMessage partialSignaturesMessage;
+    private final PartialSignatures partialSignatures;
 
     public MuSigSetupTradeMessage_D(String id,
                                     String tradeId,
                                     String protocolVersion,
                                     NetworkId sender,
                                     NetworkId receiver,
-                                    PartialSignaturesMessage partialSignaturesMessage) {
+                                    PartialSignatures partialSignatures) {
         super(id, tradeId, protocolVersion, sender, receiver);
-        this.partialSignaturesMessage = partialSignaturesMessage;
+        this.partialSignatures = partialSignatures;
 
         verify();
     }
@@ -62,7 +61,7 @@ public final class MuSigSetupTradeMessage_D extends MuSigTradeMessage {
 
     private bisq.trade.protobuf.MuSigSetupTradeMessage_D.Builder getMuSigSetupTradeMessage_D(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigSetupTradeMessage_D.newBuilder()
-                .setPartialSignaturesMessage(partialSignaturesMessage.toProto(serializeForHash));
+                .setPartialSignatures(partialSignatures.toProto(serializeForHash));
     }
 
     public static MuSigSetupTradeMessage_D fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -73,7 +72,7 @@ public final class MuSigSetupTradeMessage_D extends MuSigTradeMessage {
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
-                PartialSignaturesMessage.fromProto(muSigMessageProto.getPartialSignaturesMessage()));
+                PartialSignatures.fromProto(muSigMessageProto.getPartialSignatures()));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
@@ -69,7 +69,7 @@ public final class MuSigPaymentReceivedMessage_F_Handler extends MuSigTradeMessa
 
     @Override
     protected void sendMessage() {
-        byte[] peerOutputPrvKeyShare = myCloseTradeResponse.getPeerOutputPrvKeyShare();
+        byte[] peerOutputPrvKeyShare = myCloseTradeResponse.getPeerOutputPrvKeyShare().clone();
         send(new MuSigCooperativeClosureMessage_G(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
@@ -79,7 +79,7 @@ public final class MuSigPaymentReceivedMessage_F_Handler extends MuSigTradeMessa
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Buyer confirmed to have received the payment and closed the trade.\n." +
+        sendLogMessage("Buyer confirmed to have received the payment and closed the trade..\n" +
                 "Buyer sent his closeTradeResponse to the seller.");
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.mu_sig.messages.network.handler.buyer_as_taker;
 
+import bisq.common.data.ByteArray;
 import bisq.common.util.StringUtils;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
@@ -75,7 +76,7 @@ public final class MuSigPaymentReceivedMessage_F_Handler extends MuSigTradeMessa
                 trade.getProtocolVersion(),
                 trade.getMyIdentity().getNetworkId(),
                 trade.getPeer().getNetworkId(),
-                peerOutputPrvKeyShare));
+                new ByteArray(peerOutputPrvKeyShare)));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigPaymentReceivedMessage_F_Handler.java
@@ -27,7 +27,6 @@ import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
 import bisq.trade.mu_sig.messages.network.MuSigCooperativeClosureMessage_G;
 import bisq.trade.mu_sig.messages.network.MuSigPaymentReceivedMessage_F;
 import bisq.trade.protobuf.CloseTradeRequest;
-import bisq.trade.protobuf.MusigGrpc;
 import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -52,7 +51,6 @@ public final class MuSigPaymentReceivedMessage_F_Handler extends MuSigTradeMessa
 
         // ClosureType.COOPERATIVE
         // *** BUYER CLOSES TRADE ***
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         CloseTradeRequest closeTradeRequest = CloseTradeRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setMyOutputPeersPrvKeyShare(ByteString.copyFrom(peersSwapTxSignature.getPeerOutputPrvKeyShare()))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
@@ -118,26 +118,25 @@ public final class MuSigSetupTradeMessage_B_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendMessage() {
-        // TODO we probably don't want to send all the data here
         NonceShares nonceShares = new NonceShares(
                 myNonceShares.getWarningTxFeeBumpAddress(),
                 myNonceShares.getRedirectTxFeeBumpAddress(),
-                myNonceShares.getHalfDepositPsbt(),
-                myNonceShares.getSwapTxInputNonceShare(),
-                myNonceShares.getBuyersWarningTxBuyerInputNonceShare(),
-                myNonceShares.getBuyersWarningTxSellerInputNonceShare(),
-                myNonceShares.getSellersWarningTxBuyerInputNonceShare(),
-                myNonceShares.getSellersWarningTxSellerInputNonceShare(),
-                myNonceShares.getBuyersRedirectTxInputNonceShare(),
-                myNonceShares.getSellersRedirectTxInputNonceShare()
+                myNonceShares.getHalfDepositPsbt().clone(),
+                myNonceShares.getSwapTxInputNonceShare().clone(),
+                myNonceShares.getBuyersWarningTxBuyerInputNonceShare().clone(),
+                myNonceShares.getBuyersWarningTxSellerInputNonceShare().clone(),
+                myNonceShares.getSellersWarningTxBuyerInputNonceShare().clone(),
+                myNonceShares.getSellersWarningTxSellerInputNonceShare().clone(),
+                myNonceShares.getBuyersRedirectTxInputNonceShare().clone(),
+                myNonceShares.getSellersRedirectTxInputNonceShare().clone()
         );
 
         // TODO redacting swapTxInputPartialSignature fails at MuSigPaymentReceiptConfirmedEventHandler
         PartialSignatures partialSignatures = new PartialSignatures(
-                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
-                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
-                myPartialSignatures.getPeersRedirectTxInputPartialSignature(),
-                myPartialSignatures.getSwapTxInputPartialSignature()
+                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
+                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
+                myPartialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
+                myPartialSignatures.getSwapTxInputPartialSignature().clone()
                 // new byte[]{}
         );
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
@@ -29,7 +29,6 @@ import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_B;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_C;
-import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protobuf.NonceSharesRequest;
 import bisq.trade.protobuf.PartialSignaturesRequest;
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
@@ -66,7 +65,6 @@ public final class MuSigSetupTradeMessage_B_Handler extends MuSigTradeMessageHan
 
         // Request NonceSharesMessage from rust server
 
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         NonceSharesRequest nonceSharesRequest = NonceSharesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setBuyerOutputPeersPubKeyShare(ByteString.copyFrom(peersPubKeyShares.getBuyerOutputPubKeyShare()))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
@@ -79,19 +79,7 @@ public final class MuSigSetupTradeMessage_B_Handler extends MuSigTradeMessageHan
                 .build();
         myNonceShares = NonceSharesMessage.fromProto(musigBlockingStub.getNonceShares(nonceSharesRequest));
 
-        // todo maybe adjust grpc api
-        NonceSharesMessage peersNonceSharesMessage = new NonceSharesMessage(
-                peersNonceShares.getWarningTxFeeBumpAddress(),
-                peersNonceShares.getRedirectTxFeeBumpAddress(),
-                peersNonceShares.getHalfDepositPsbt(),
-                peersNonceShares.getSwapTxInputNonceShare(),
-                peersNonceShares.getBuyersWarningTxBuyerInputNonceShare(),
-                peersNonceShares.getBuyersWarningTxSellerInputNonceShare(),
-                peersNonceShares.getSellersWarningTxBuyerInputNonceShare(),
-                peersNonceShares.getSellersWarningTxSellerInputNonceShare(),
-                peersNonceShares.getBuyersRedirectTxInputNonceShare(),
-                peersNonceShares.getSellersRedirectTxInputNonceShare()
-        );
+        NonceSharesMessage peersNonceSharesMessage =  NonceSharesMessage.from(peersNonceShares);
 
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
@@ -118,27 +106,10 @@ public final class MuSigSetupTradeMessage_B_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendMessage() {
-        NonceShares nonceShares = new NonceShares(
-                myNonceShares.getWarningTxFeeBumpAddress(),
-                myNonceShares.getRedirectTxFeeBumpAddress(),
-                myNonceShares.getHalfDepositPsbt().clone(),
-                myNonceShares.getSwapTxInputNonceShare().clone(),
-                myNonceShares.getBuyersWarningTxBuyerInputNonceShare().clone(),
-                myNonceShares.getBuyersWarningTxSellerInputNonceShare().clone(),
-                myNonceShares.getSellersWarningTxBuyerInputNonceShare().clone(),
-                myNonceShares.getSellersWarningTxSellerInputNonceShare().clone(),
-                myNonceShares.getBuyersRedirectTxInputNonceShare().clone(),
-                myNonceShares.getSellersRedirectTxInputNonceShare().clone()
-        );
+        NonceShares nonceShares = NonceShares.from(myNonceShares);
 
         // TODO redacting swapTxInputPartialSignature fails at MuSigPaymentReceiptConfirmedEventHandler
-        PartialSignatures partialSignatures = new PartialSignatures(
-                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
-                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
-                myPartialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
-                myPartialSignatures.getSwapTxInputPartialSignature().clone()
-                // new byte[]{}
-        );
+        PartialSignatures partialSignatures =  PartialSignatures.from(myPartialSignatures);
 
         send(new MuSigSetupTradeMessage_C(StringUtils.createUid(),
                 trade.getId(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
@@ -114,7 +114,7 @@ public final class MuSigSetupTradeMessage_B_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Buyer received peers pubKeyShares\n." +
+        sendLogMessage("Buyer received peers pubKeyShares.\n" +
                 "Buyer created his nonceShares and partialSignatures.\n " +
                 "Buyer sent his nonceShares and his partialSignatures to seller.");
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_D_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_D_Handler.java
@@ -49,13 +49,7 @@ public final class MuSigSetupTradeMessage_D_Handler extends MuSigTradeMessageHan
     protected void process(MuSigSetupTradeMessage_D message) {
         peersPartialSignatures = message.getPartialSignatures();
 
-        PartialSignaturesMessage peersPartialSignaturesMessage = new PartialSignaturesMessage(
-                peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
-                peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
-                peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
-                peersPartialSignatures.getSwapTxInputPartialSignature()
-        );
-
+        PartialSignaturesMessage peersPartialSignaturesMessage =  PartialSignaturesMessage.from(peersPartialSignatures);
         DepositTxSignatureRequest depositTxSignatureRequest = DepositTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersPartialSignatures(peersPartialSignaturesMessage.toProto(true))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_D_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_D_Handler.java
@@ -77,7 +77,7 @@ public final class MuSigSetupTradeMessage_D_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Seller received peers partialSignatures\n." +
+        sendLogMessage("Seller received peers partialSignatures.\n" +
                 "Seller created his partialSignatures.");
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_D_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_D_Handler.java
@@ -25,7 +25,6 @@ import bisq.trade.mu_sig.messages.grpc.DepositPsbt;
 import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_D;
 import bisq.trade.protobuf.DepositTxSignatureRequest;
-import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protobuf.PublishDepositTxRequest;
 import bisq.trade.protobuf.TxConfirmationStatus;
 import lombok.extern.slf4j.Slf4j;
@@ -49,7 +48,6 @@ public final class MuSigSetupTradeMessage_D_Handler extends MuSigTradeMessageHan
     protected void process(MuSigSetupTradeMessage_D message) {
         peersPartialSignatures = message.getPartialSignaturesMessage();
 
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         DepositTxSignatureRequest depositTxSignatureRequest = DepositTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersPartialSignatures(peersPartialSignatures.toProto(true))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
@@ -66,7 +66,7 @@ public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMe
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Seller received peers closeTradeResponse\n." +
+        sendLogMessage("Seller received peers closeTradeResponse.\n" +
                 "Seller created his closeTradeResponse.");
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.mu_sig.messages.network.handler.seller_as_maker;
 
+import bisq.common.data.ByteArray;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeParty;
@@ -29,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMessageHandler<MuSigTrade, MuSigCooperativeClosureMessage_G> {
-    private byte[] peersOutputPrvKeyShare;
+    private ByteArray peersOutputPrvKeyShare;
     private CloseTradeResponse myCloseTradeResponse;
 
     public MuSigCooperativeClosureMessage_G_Handler(ServiceProvider serviceProvider, MuSigTrade model) {
@@ -50,7 +51,7 @@ public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMe
         // *** SELLER CLOSES TRADE ***
         CloseTradeRequest closeTradeRequest = CloseTradeRequest.newBuilder()
                 .setTradeId(trade.getId())
-                .setMyOutputPeersPrvKeyShare(ByteString.copyFrom(peersOutputPrvKeyShare))
+                .setMyOutputPeersPrvKeyShare(ByteString.copyFrom(peersOutputPrvKeyShare.getBytes()))
                 .build();
         myCloseTradeResponse = CloseTradeResponse.fromProto(musigBlockingStub.closeTrade(closeTradeRequest));
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMessageHandler<MuSigTrade, MuSigCooperativeClosureMessage_G> {
-    private CloseTradeResponse peersCloseTradeResponse;
+    private byte[] peersOutputPrvKeyShare;
     private CloseTradeResponse myCloseTradeResponse;
 
     public MuSigCooperativeClosureMessage_G_Handler(ServiceProvider serviceProvider, MuSigTrade model) {
@@ -42,7 +42,7 @@ public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMe
 
     @Override
     protected void process(MuSigCooperativeClosureMessage_G message) {
-        peersCloseTradeResponse = message.getCloseTradeResponse();
+        peersOutputPrvKeyShare = message.getPeerOutputPrvKeyShare();
 
         muSigTradeService.stopCooperativeCloseTimeout(trade);
 
@@ -50,7 +50,7 @@ public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMe
         // *** SELLER CLOSES TRADE ***
         CloseTradeRequest closeTradeRequest = CloseTradeRequest.newBuilder()
                 .setTradeId(trade.getId())
-                .setMyOutputPeersPrvKeyShare(ByteString.copyFrom(peersCloseTradeResponse.getPeerOutputPrvKeyShare()))
+                .setMyOutputPeersPrvKeyShare(ByteString.copyFrom(peersOutputPrvKeyShare))
                 .build();
         myCloseTradeResponse = CloseTradeResponse.fromProto(musigBlockingStub.closeTrade(closeTradeRequest));
     }
@@ -60,8 +60,8 @@ public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMe
         MuSigTradeParty peer = trade.getTaker();
         MuSigTradeParty mySelf = trade.getMaker();
 
-        mySelf.setCloseTradeResponse(myCloseTradeResponse);
-        peer.setCloseTradeResponse(peersCloseTradeResponse);
+        mySelf.setMyCloseTradeResponse(myCloseTradeResponse);
+        peer.setPeersOutputPrvKeyShare(peersOutputPrvKeyShare);
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigCooperativeClosureMessage_G_Handler.java
@@ -24,7 +24,6 @@ import bisq.trade.mu_sig.handler.MuSigTradeMessageHandler;
 import bisq.trade.mu_sig.messages.grpc.CloseTradeResponse;
 import bisq.trade.mu_sig.messages.network.MuSigCooperativeClosureMessage_G;
 import bisq.trade.protobuf.CloseTradeRequest;
-import bisq.trade.protobuf.MusigGrpc;
 import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,7 +48,6 @@ public final class MuSigCooperativeClosureMessage_G_Handler extends MuSigTradeMe
 
         // ClosureType.COOPERATIVE
         // *** SELLER CLOSES TRADE ***
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         CloseTradeRequest closeTradeRequest = CloseTradeRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setMyOutputPeersPrvKeyShare(ByteString.copyFrom(peersCloseTradeResponse.getPeerOutputPrvKeyShare()))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
@@ -105,22 +105,21 @@ public final class MuSigSetupTradeMessage_A_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendMessage() {
-        PubKeyShares pubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare(),
-                myPubKeySharesResponse.getSellerOutputPubKeyShare());
+        PubKeyShares pubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare().clone(),
+                myPubKeySharesResponse.getSellerOutputPubKeyShare().clone());
 
         NonceShares nonceShares = new NonceShares(
                 myNonceShares.getWarningTxFeeBumpAddress(),
                 myNonceShares.getRedirectTxFeeBumpAddress(),
-                myNonceShares.getHalfDepositPsbt(),
-                myNonceShares.getSwapTxInputNonceShare(),
-                myNonceShares.getBuyersWarningTxBuyerInputNonceShare(),
-                myNonceShares.getBuyersWarningTxSellerInputNonceShare(),
-                myNonceShares.getSellersWarningTxBuyerInputNonceShare(),
-                myNonceShares.getSellersWarningTxSellerInputNonceShare(),
-                myNonceShares.getBuyersRedirectTxInputNonceShare(),
-                myNonceShares.getSellersRedirectTxInputNonceShare()
+                myNonceShares.getHalfDepositPsbt().clone(),
+                myNonceShares.getSwapTxInputNonceShare().clone(),
+                myNonceShares.getBuyersWarningTxBuyerInputNonceShare().clone(),
+                myNonceShares.getBuyersWarningTxSellerInputNonceShare().clone(),
+                myNonceShares.getSellersWarningTxBuyerInputNonceShare().clone(),
+                myNonceShares.getSellersWarningTxSellerInputNonceShare().clone(),
+                myNonceShares.getBuyersRedirectTxInputNonceShare().clone(),
+                myNonceShares.getSellersRedirectTxInputNonceShare().clone()
         );
-        //todo redact fields in sellerNonceSharesMessage?
 
         send(new MuSigSetupTradeMessage_B(StringUtils.createUid(),
                 trade.getId(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
@@ -29,7 +29,6 @@ import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
 import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_A;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_B;
-import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protobuf.NonceSharesRequest;
 import bisq.trade.protobuf.PubKeySharesRequest;
 import bisq.trade.protobuf.Role;
@@ -71,7 +70,6 @@ public final class MuSigSetupTradeMessage_A_Handler extends MuSigTradeMessageHan
     protected void process(MuSigSetupTradeMessage_A message) {
         peersPubKeyShares = message.getPubKeySharesResponse();
 
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         PubKeySharesRequest pubKeySharesRequest = PubKeySharesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setMyRole(Role.SELLER_AS_MAKER)

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
@@ -39,7 +39,6 @@ import java.security.GeneralSecurityException;
 
 @Slf4j
 public final class MuSigSetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerAsMessageSender<MuSigTrade, MuSigSetupTradeMessage_A> {
-
     private PubKeySharesResponse myPubKeyShares;
     private PubKeySharesResponse peersPubKeyShares;
     private NonceSharesMessage myNonceShares;
@@ -119,7 +118,7 @@ public final class MuSigSetupTradeMessage_A_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Seller received peers pubKeyShares\n." +
+        sendLogMessage("Seller received peers pubKeyShares.\n" +
                 "Seller created his pubKeyShares and nonceShares.\n " +
                 "Seller sent his pubKeyShares and his nonceShares to buyer.");
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_A_Handler.java
@@ -105,21 +105,8 @@ public final class MuSigSetupTradeMessage_A_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendMessage() {
-        PubKeyShares pubKeyShares = new PubKeyShares(myPubKeySharesResponse.getBuyerOutputPubKeyShare().clone(),
-                myPubKeySharesResponse.getSellerOutputPubKeyShare().clone());
-
-        NonceShares nonceShares = new NonceShares(
-                myNonceShares.getWarningTxFeeBumpAddress(),
-                myNonceShares.getRedirectTxFeeBumpAddress(),
-                myNonceShares.getHalfDepositPsbt().clone(),
-                myNonceShares.getSwapTxInputNonceShare().clone(),
-                myNonceShares.getBuyersWarningTxBuyerInputNonceShare().clone(),
-                myNonceShares.getBuyersWarningTxSellerInputNonceShare().clone(),
-                myNonceShares.getSellersWarningTxBuyerInputNonceShare().clone(),
-                myNonceShares.getSellersWarningTxSellerInputNonceShare().clone(),
-                myNonceShares.getBuyersRedirectTxInputNonceShare().clone(),
-                myNonceShares.getSellersRedirectTxInputNonceShare().clone()
-        );
+        PubKeyShares pubKeyShares = PubKeyShares.from(myPubKeySharesResponse);
+        NonceShares nonceShares = NonceShares.from(myNonceShares);
 
         send(new MuSigSetupTradeMessage_B(StringUtils.createUid(),
                 trade.getId(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
@@ -136,11 +136,12 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
     @Override
     protected void sendMessage() {
         PartialSignatures partialSignatures = new PartialSignatures(
-                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
-                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
-                myPartialSignatures.getPeersRedirectTxInputPartialSignature(),
-                myPartialSignatures.getSwapTxInputPartialSignature()
+                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
+                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
+                myPartialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
+                myPartialSignatures.getSwapTxInputPartialSignature().clone()
         );
+
         send(new MuSigSetupTradeMessage_D(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
@@ -29,7 +29,6 @@ import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_C;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_D;
 import bisq.trade.protobuf.DepositTxSignatureRequest;
-import bisq.trade.protobuf.MusigGrpc;
 import bisq.trade.protobuf.PartialSignaturesRequest;
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
 import com.google.common.collect.ImmutableMap;
@@ -58,7 +57,6 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
         peersNonceShares = message.getNonceSharesMessage();
         peersPartialSignatures = message.getPartialSignaturesMessage();
 
-        MusigGrpc.MusigBlockingStub musigBlockingStub = muSigTradeService.getMusigBlockingStub();
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersNonceShares(peersNonceShares.toProto(true))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
@@ -60,19 +60,7 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
         peersPartialSignatures = message.getPartialSignatures();
 
 
-        // todo maybe adjust grpc api
-        NonceSharesMessage peersNonceSharesMessage = new NonceSharesMessage(
-                peersNonceShares.getWarningTxFeeBumpAddress(),
-                peersNonceShares.getRedirectTxFeeBumpAddress(),
-                peersNonceShares.getHalfDepositPsbt(),
-                peersNonceShares.getSwapTxInputNonceShare(),
-                peersNonceShares.getBuyersWarningTxBuyerInputNonceShare(),
-                peersNonceShares.getBuyersWarningTxSellerInputNonceShare(),
-                peersNonceShares.getSellersWarningTxBuyerInputNonceShare(),
-                peersNonceShares.getSellersWarningTxSellerInputNonceShare(),
-                peersNonceShares.getBuyersRedirectTxInputNonceShare(),
-                peersNonceShares.getSellersRedirectTxInputNonceShare()
-        );
+        NonceSharesMessage peersNonceSharesMessage =  NonceSharesMessage.from(peersNonceShares);
 
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
@@ -81,12 +69,7 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
                 .build();
         myPartialSignatures = PartialSignaturesMessage.fromProto(musigBlockingStub.getPartialSignatures(partialSignaturesRequest));
 
-        PartialSignaturesMessage peersPartialSignaturesMessage = new PartialSignaturesMessage(
-                peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
-                peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
-                peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
-                peersPartialSignatures.getSwapTxInputPartialSignature()
-        );
+        PartialSignaturesMessage peersPartialSignaturesMessage =  PartialSignaturesMessage.from(peersPartialSignatures);
 
         // TODO
         //       @stejbac: redacting would make sense at senders side, but then it fails at MuSigPaymentReceiptConfirmedEventHandler.
@@ -135,12 +118,7 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendMessage() {
-        PartialSignatures partialSignatures = new PartialSignatures(
-                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
-                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
-                myPartialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
-                myPartialSignatures.getSwapTxInputPartialSignature().clone()
-        );
+        PartialSignatures partialSignatures =  PartialSignatures.from(myPartialSignatures);
 
         send(new MuSigSetupTradeMessage_D(StringUtils.createUid(),
                 trade.getId(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
@@ -28,6 +28,8 @@ import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
 import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_C;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_D;
+import bisq.trade.mu_sig.messages.network.vo.NonceShares;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import bisq.trade.protobuf.DepositTxSignatureRequest;
 import bisq.trade.protobuf.PartialSignaturesRequest;
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
@@ -39,9 +41,9 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHandlerAsMessageSender<MuSigTrade, MuSigSetupTradeMessage_C> {
-    private NonceSharesMessage peersNonceShares;
+    private NonceShares peersNonceShares;
     private PartialSignaturesMessage myPartialSignatures;
-    private PartialSignaturesMessage peersPartialSignatures;
+    private PartialSignatures peersPartialSignatures;
     private DepositPsbt myDepositPsbt;
 
     public MuSigSetupTradeMessage_C_Handler(ServiceProvider serviceProvider, MuSigTrade model) {
@@ -54,20 +56,50 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void process(MuSigSetupTradeMessage_C message) {
-        peersNonceShares = message.getNonceSharesMessage();
-        peersPartialSignatures = message.getPartialSignaturesMessage();
+        peersNonceShares = message.getNonceShares();
+        peersPartialSignatures = message.getPartialSignatures();
+
+
+        // todo maybe adjust grpc api
+        NonceSharesMessage peersNonceSharesMessage = new NonceSharesMessage(
+                peersNonceShares.getWarningTxFeeBumpAddress(),
+                peersNonceShares.getRedirectTxFeeBumpAddress(),
+                peersNonceShares.getHalfDepositPsbt(),
+                peersNonceShares.getSwapTxInputNonceShare(),
+                peersNonceShares.getBuyersWarningTxBuyerInputNonceShare(),
+                peersNonceShares.getBuyersWarningTxSellerInputNonceShare(),
+                peersNonceShares.getSellersWarningTxBuyerInputNonceShare(),
+                peersNonceShares.getSellersWarningTxSellerInputNonceShare(),
+                peersNonceShares.getBuyersRedirectTxInputNonceShare(),
+                peersNonceShares.getSellersRedirectTxInputNonceShare()
+        );
 
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
-                .setPeersNonceShares(peersNonceShares.toProto(true))
+                .setPeersNonceShares(peersNonceSharesMessage.toProto(true))
                 .addAllReceivers(mockReceivers())
                 .build();
         myPartialSignatures = PartialSignaturesMessage.fromProto(musigBlockingStub.getPartialSignatures(partialSignaturesRequest));
 
+        PartialSignaturesMessage peersPartialSignaturesMessage = new PartialSignaturesMessage(
+                peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
+                peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
+                peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
+                peersPartialSignatures.getSwapTxInputPartialSignature()
+        );
+
+        // TODO
+        //       @stejbac: redacting would make sense at senders side, but then it fails at MuSigPaymentReceiptConfirmedEventHandler.
+        //       if swapTxInputPartialSignature is empty byte array (redacted by the peer),
+        //       passing that to setPeersPartialSignatures results in a backend error.
+        //       Currently redaction is done on the sellers side, with clearSwapTxInputPartialSignature which results in
+        //       ByteString.EMPTY.
+        var signaturesProto = peersPartialSignaturesMessage.toProto(true)
+                .toBuilder()
+                .clearSwapTxInputPartialSignature();
         DepositTxSignatureRequest depositTxSignatureRequest = DepositTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
-                // REDACT buyer's swapTxInputPartialSignature:
-                .setPeersPartialSignatures(peersPartialSignatures.toProto(true).toBuilder().clearSwapTxInputPartialSignature())
+                .setPeersPartialSignatures(signaturesProto)
                 .build();
         myDepositPsbt = DepositPsbt.fromProto(musigBlockingStub.signDepositTx(depositTxSignatureRequest));
 
@@ -94,21 +126,27 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
         MuSigTradeParty peer = trade.getTaker();
         MuSigTradeParty mySelf = trade.getMaker();
 
-        mySelf.setPartialSignaturesMessage(myPartialSignatures);
-        mySelf.setDepositPsbt(myDepositPsbt);
+        mySelf.setMyPartialSignaturesMessage(myPartialSignatures);
+        mySelf.setMyDepositPsbt(myDepositPsbt);
 
-        peer.setNonceSharesMessage(peersNonceShares);
-        peer.setPartialSignaturesMessage(peersPartialSignatures);
+        peer.setPeersNonceShares(peersNonceShares);
+        peer.setPeersPartialSignatures(peersPartialSignatures);
     }
 
     @Override
     protected void sendMessage() {
+        PartialSignatures partialSignatures = new PartialSignatures(
+                myPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
+                myPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
+                myPartialSignatures.getPeersRedirectTxInputPartialSignature(),
+                myPartialSignatures.getSwapTxInputPartialSignature()
+        );
         send(new MuSigSetupTradeMessage_D(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),
                 trade.getMyIdentity().getNetworkId(),
                 trade.getPeer().getNetworkId(),
-                myPartialSignatures));
+                partialSignatures));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
@@ -113,7 +113,7 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Seller received peers nonceShares and partialSignatures\n." +
+        sendLogMessage("Seller received peers nonceShares and partialSignatures.\n" +
                 "Seller created his nonceShares and partialSignatures.\n " +
                 "Seller sent his nonceShares and his partialSignatures to buyer.");
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/NonceShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/NonceShares.java
@@ -19,11 +19,12 @@ package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 @Getter
-@EqualsAndHashCode
 public final class NonceShares implements Proto {
     private final String warningTxFeeBumpAddress;
     private final String redirectTxFeeBumpAddress;
@@ -89,5 +90,36 @@ public final class NonceShares implements Proto {
                 proto.getSellersWarningTxSellerInputNonceShare().toByteArray(),
                 proto.getBuyersRedirectTxInputNonceShare().toByteArray(),
                 proto.getSellersRedirectTxInputNonceShare().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NonceShares that)) return false;
+
+        return Objects.equals(warningTxFeeBumpAddress, that.warningTxFeeBumpAddress) &&
+                Objects.equals(redirectTxFeeBumpAddress, that.redirectTxFeeBumpAddress) &&
+                Arrays.equals(halfDepositPsbt, that.halfDepositPsbt) &&
+                Arrays.equals(swapTxInputNonceShare, that.swapTxInputNonceShare) &&
+                Arrays.equals(buyersWarningTxBuyerInputNonceShare, that.buyersWarningTxBuyerInputNonceShare) &&
+                Arrays.equals(buyersWarningTxSellerInputNonceShare, that.buyersWarningTxSellerInputNonceShare) &&
+                Arrays.equals(sellersWarningTxBuyerInputNonceShare, that.sellersWarningTxBuyerInputNonceShare) &&
+                Arrays.equals(sellersWarningTxSellerInputNonceShare, that.sellersWarningTxSellerInputNonceShare) &&
+                Arrays.equals(buyersRedirectTxInputNonceShare, that.buyersRedirectTxInputNonceShare) &&
+                Arrays.equals(sellersRedirectTxInputNonceShare, that.sellersRedirectTxInputNonceShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(warningTxFeeBumpAddress);
+        result = 31 * result + Objects.hashCode(redirectTxFeeBumpAddress);
+        result = 31 * result + Arrays.hashCode(halfDepositPsbt);
+        result = 31 * result + Arrays.hashCode(swapTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersWarningTxBuyerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersWarningTxSellerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersWarningTxBuyerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersWarningTxSellerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersRedirectTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersRedirectTxInputNonceShare);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/NonceShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/NonceShares.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
+import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -26,6 +27,21 @@ import java.util.Objects;
 
 @Getter
 public final class NonceShares implements Proto {
+    public static NonceShares from(NonceSharesMessage nonceSharesMessage) {
+        return new NonceShares(
+                nonceSharesMessage.getWarningTxFeeBumpAddress(),
+                nonceSharesMessage.getRedirectTxFeeBumpAddress(),
+                nonceSharesMessage.getHalfDepositPsbt().clone(),
+                nonceSharesMessage.getSwapTxInputNonceShare().clone(),
+                nonceSharesMessage.getBuyersWarningTxBuyerInputNonceShare().clone(),
+                nonceSharesMessage.getBuyersWarningTxSellerInputNonceShare().clone(),
+                nonceSharesMessage.getSellersWarningTxBuyerInputNonceShare().clone(),
+                nonceSharesMessage.getSellersWarningTxSellerInputNonceShare().clone(),
+                nonceSharesMessage.getBuyersRedirectTxInputNonceShare().clone(),
+                nonceSharesMessage.getSellersRedirectTxInputNonceShare().clone()
+        );
+    }
+
     private final String warningTxFeeBumpAddress;
     private final String redirectTxFeeBumpAddress;
     private final byte[] halfDepositPsbt;
@@ -37,7 +53,7 @@ public final class NonceShares implements Proto {
     private final byte[] buyersRedirectTxInputNonceShare;
     private final byte[] sellersRedirectTxInputNonceShare;
 
-    public NonceShares(String warningTxFeeBumpAddress,
+    private NonceShares(String warningTxFeeBumpAddress,
                        String redirectTxFeeBumpAddress,
                        byte[] halfDepositPsbt,
                        byte[] swapTxInputNonceShare,

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/NonceShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/NonceShares.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.trade.mu_sig.messages.grpc;
+package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
@@ -24,7 +24,7 @@ import lombok.Getter;
 
 @Getter
 @EqualsAndHashCode
-public final class NonceSharesMessage implements Proto {
+public final class NonceShares implements Proto {
     private final String warningTxFeeBumpAddress;
     private final String redirectTxFeeBumpAddress;
     private final byte[] halfDepositPsbt;
@@ -36,16 +36,16 @@ public final class NonceSharesMessage implements Proto {
     private final byte[] buyersRedirectTxInputNonceShare;
     private final byte[] sellersRedirectTxInputNonceShare;
 
-    public NonceSharesMessage(String warningTxFeeBumpAddress,
-                              String redirectTxFeeBumpAddress,
-                              byte[] halfDepositPsbt,
-                              byte[] swapTxInputNonceShare,
-                              byte[] buyersWarningTxBuyerInputNonceShare,
-                              byte[] buyersWarningTxSellerInputNonceShare,
-                              byte[] sellersWarningTxBuyerInputNonceShare,
-                              byte[] sellersWarningTxSellerInputNonceShare,
-                              byte[] buyersRedirectTxInputNonceShare,
-                              byte[] sellersRedirectTxInputNonceShare) {
+    public NonceShares(String warningTxFeeBumpAddress,
+                       String redirectTxFeeBumpAddress,
+                       byte[] halfDepositPsbt,
+                       byte[] swapTxInputNonceShare,
+                       byte[] buyersWarningTxBuyerInputNonceShare,
+                       byte[] buyersWarningTxSellerInputNonceShare,
+                       byte[] sellersWarningTxBuyerInputNonceShare,
+                       byte[] sellersWarningTxSellerInputNonceShare,
+                       byte[] buyersRedirectTxInputNonceShare,
+                       byte[] sellersRedirectTxInputNonceShare) {
         this.warningTxFeeBumpAddress = warningTxFeeBumpAddress;
         this.redirectTxFeeBumpAddress = redirectTxFeeBumpAddress;
         this.halfDepositPsbt = halfDepositPsbt;
@@ -59,8 +59,8 @@ public final class NonceSharesMessage implements Proto {
     }
 
     @Override
-    public bisq.trade.protobuf.NonceSharesMessage.Builder getBuilder(boolean serializeForHash) {
-        return bisq.trade.protobuf.NonceSharesMessage.newBuilder()
+    public bisq.trade.protobuf.NonceShares.Builder getBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.NonceShares.newBuilder()
                 .setWarningTxFeeBumpAddress(warningTxFeeBumpAddress)
                 .setRedirectTxFeeBumpAddress(redirectTxFeeBumpAddress)
                 .setHalfDepositPsbt(ByteString.copyFrom(halfDepositPsbt))
@@ -74,12 +74,12 @@ public final class NonceSharesMessage implements Proto {
     }
 
     @Override
-    public bisq.trade.protobuf.NonceSharesMessage toProto(boolean serializeForHash) {
+    public bisq.trade.protobuf.NonceShares toProto(boolean serializeForHash) {
         return getBuilder(serializeForHash).build();
     }
 
-    public static NonceSharesMessage fromProto(bisq.trade.protobuf.NonceSharesMessage proto) {
-        return new NonceSharesMessage(proto.getWarningTxFeeBumpAddress(),
+    public static NonceShares fromProto(bisq.trade.protobuf.NonceShares proto) {
+        return new NonceShares(proto.getWarningTxFeeBumpAddress(),
                 proto.getRedirectTxFeeBumpAddress(),
                 proto.getHalfDepositPsbt().toByteArray(),
                 proto.getSwapTxInputNonceShare().toByteArray(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class PartialSignatures implements Proto {
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
@@ -60,5 +60,24 @@ public final class PartialSignatures implements Proto {
                 proto.getPeersWarningTxSellerInputPartialSignature().toByteArray(),
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
                 proto.getSwapTxInputPartialSignature().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PartialSignatures that)) return false;
+
+        return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
+                Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
+                Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
+                Arrays.equals(swapTxInputPartialSignature, that.swapTxInputPartialSignature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(peersWarningTxBuyerInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(swapTxInputPartialSignature);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
+import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -25,13 +26,22 @@ import java.util.Arrays;
 
 @Getter
 public final class PartialSignatures implements Proto {
+    public static PartialSignatures from(PartialSignaturesMessage partialSignaturesMessage) {
+        return new PartialSignatures(
+                partialSignaturesMessage.getPeersWarningTxBuyerInputPartialSignature().clone(),
+                partialSignaturesMessage.getPeersWarningTxSellerInputPartialSignature().clone(),
+                partialSignaturesMessage.getPeersRedirectTxInputPartialSignature().clone(),
+                partialSignaturesMessage.getSwapTxInputPartialSignature().clone()
+        );
+    }
+
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
     // todo swapTxInputPartialSignature can be empty byte array (redacted), consider to make optional or make 2 classes
     private final byte[] swapTxInputPartialSignature;
 
-    public PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
+    private PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
                              byte[] peersWarningTxSellerInputPartialSignature,
                              byte[] peersRedirectTxInputPartialSignature,
                              byte[] swapTxInputPartialSignature) {

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
@@ -15,7 +15,7 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.trade.mu_sig.messages.grpc;
+package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
@@ -24,16 +24,17 @@ import lombok.Getter;
 
 @Getter
 @EqualsAndHashCode
-public final class PartialSignaturesMessage implements Proto {
+public final class PartialSignatures implements Proto {
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
+    // todo swapTxInputPartialSignature can be empty byte array (redacted), consider to make optional or make 2 classes
     private final byte[] swapTxInputPartialSignature;
 
-    public PartialSignaturesMessage(byte[] peersWarningTxBuyerInputPartialSignature,
-                                    byte[] peersWarningTxSellerInputPartialSignature,
-                                    byte[] peersRedirectTxInputPartialSignature,
-                                    byte[] swapTxInputPartialSignature) {
+    public PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
+                             byte[] peersWarningTxSellerInputPartialSignature,
+                             byte[] peersRedirectTxInputPartialSignature,
+                             byte[] swapTxInputPartialSignature) {
         this.peersWarningTxBuyerInputPartialSignature = peersWarningTxBuyerInputPartialSignature;
         this.peersWarningTxSellerInputPartialSignature = peersWarningTxSellerInputPartialSignature;
         this.peersRedirectTxInputPartialSignature = peersRedirectTxInputPartialSignature;
@@ -41,8 +42,8 @@ public final class PartialSignaturesMessage implements Proto {
     }
 
     @Override
-    public bisq.trade.protobuf.PartialSignaturesMessage.Builder getBuilder(boolean serializeForHash) {
-        return bisq.trade.protobuf.PartialSignaturesMessage.newBuilder()
+    public bisq.trade.protobuf.PartialSignatures.Builder getBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.PartialSignatures.newBuilder()
                 .setPeersWarningTxBuyerInputPartialSignature(ByteString.copyFrom(peersWarningTxBuyerInputPartialSignature))
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
                 .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature))
@@ -50,12 +51,12 @@ public final class PartialSignaturesMessage implements Proto {
     }
 
     @Override
-    public bisq.trade.protobuf.PartialSignaturesMessage toProto(boolean serializeForHash) {
+    public bisq.trade.protobuf.PartialSignatures toProto(boolean serializeForHash) {
         return getBuilder(serializeForHash).build();
     }
 
-    public static PartialSignaturesMessage fromProto(bisq.trade.protobuf.PartialSignaturesMessage proto) {
-        return new PartialSignaturesMessage(proto.getPeersWarningTxBuyerInputPartialSignature().toByteArray(),
+    public static PartialSignatures fromProto(bisq.trade.protobuf.PartialSignatures proto) {
+        return new PartialSignatures(proto.getPeersWarningTxBuyerInputPartialSignature().toByteArray(),
                 proto.getPeersWarningTxSellerInputPartialSignature().toByteArray(),
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
                 proto.getSwapTxInputPartialSignature().toByteArray());

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PubKeyShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PubKeyShares.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
+import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -25,10 +26,15 @@ import java.util.Arrays;
 
 @Getter
 public final class PubKeyShares implements Proto {
+    public static PubKeyShares from(PubKeySharesResponse pubKeySharesResponse) {
+        return new PubKeyShares(pubKeySharesResponse.getBuyerOutputPubKeyShare().clone(),
+                pubKeySharesResponse.getSellerOutputPubKeyShare().clone());
+    }
+
     private final byte[] buyerOutputPubKeyShare;
     private final byte[] sellerOutputPubKeyShare;
 
-    public PubKeyShares(byte[] buyerOutputPubKeyShare,
+    private PubKeyShares(byte[] buyerOutputPubKeyShare,
                         byte[] sellerOutputPubKeyShare) {
         this.buyerOutputPubKeyShare = buyerOutputPubKeyShare;
         this.sellerOutputPubKeyShare = sellerOutputPubKeyShare;

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PubKeyShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PubKeyShares.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class PubKeyShares implements Proto {
     private final byte[] buyerOutputPubKeyShare;
     private final byte[] sellerOutputPubKeyShare;
@@ -49,5 +49,20 @@ public final class PubKeyShares implements Proto {
     public static PubKeyShares fromProto(bisq.trade.protobuf.PubKeyShares proto) {
         return new PubKeyShares(proto.getBuyerOutputPubKeyShare().toByteArray(),
                 proto.getSellerOutputPubKeyShare().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PubKeyShares that)) return false;
+
+        return Arrays.equals(buyerOutputPubKeyShare, that.buyerOutputPubKeyShare) &&
+                Arrays.equals(sellerOutputPubKeyShare, that.sellerOutputPubKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(buyerOutputPubKeyShare);
+        result = 31 * result + Arrays.hashCode(sellerOutputPubKeyShare);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PubKeyShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PubKeyShares.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network.vo;
+
+import bisq.common.proto.Proto;
+import com.google.protobuf.ByteString;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public final class PubKeyShares implements Proto {
+    private final byte[] buyerOutputPubKeyShare;
+    private final byte[] sellerOutputPubKeyShare;
+
+    public PubKeyShares(byte[] buyerOutputPubKeyShare,
+                        byte[] sellerOutputPubKeyShare) {
+        this.buyerOutputPubKeyShare = buyerOutputPubKeyShare;
+        this.sellerOutputPubKeyShare = sellerOutputPubKeyShare;
+    }
+
+    @Override
+    public bisq.trade.protobuf.PubKeyShares.Builder getBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.PubKeyShares.newBuilder()
+                .setBuyerOutputPubKeyShare(ByteString.copyFrom(buyerOutputPubKeyShare))
+                .setSellerOutputPubKeyShare(ByteString.copyFrom(sellerOutputPubKeyShare));
+    }
+
+    @Override
+    public bisq.trade.protobuf.PubKeyShares toProto(boolean serializeForHash) {
+        return getBuilder(serializeForHash).build();
+    }
+
+    public static PubKeyShares fromProto(bisq.trade.protobuf.PubKeyShares proto) {
+        return new PubKeyShares(proto.getBuyerOutputPubKeyShare().toByteArray(),
+                proto.getSellerOutputPubKeyShare().toByteArray());
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class SwapTxSignature implements Proto {
     private final byte[] swapTx;
     private final byte[] peerOutputPrvKeyShare;
@@ -48,4 +48,20 @@ public final class SwapTxSignature implements Proto {
     public static SwapTxSignature fromProto(bisq.trade.protobuf.SwapTxSignature proto) {
         return new SwapTxSignature(proto.getSwapTx().toByteArray(), proto.getPeerOutputPrvKeyShare().toByteArray());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SwapTxSignature that)) return false;
+
+        return Arrays.equals(swapTx, that.swapTx) &&
+                Arrays.equals(peerOutputPrvKeyShare, that.peerOutputPrvKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(swapTx);
+        result = 31 * result + Arrays.hashCode(peerOutputPrvKeyShare);
+        return result;
+    }
+
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network.vo;
+
+import bisq.common.proto.Proto;
+import com.google.protobuf.ByteString;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public final class SwapTxSignature implements Proto {
+    private final byte[] swapTx;
+    private final byte[] peerOutputPrvKeyShare;
+
+    public SwapTxSignature(byte[] swapTx, byte[] peerOutputPrvKeyShare) {
+        this.swapTx = swapTx;
+        this.peerOutputPrvKeyShare = peerOutputPrvKeyShare;
+    }
+
+    @Override
+    public bisq.trade.protobuf.SwapTxSignature.Builder getBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.SwapTxSignature.newBuilder()
+                .setSwapTx(ByteString.copyFrom(swapTx))
+                .setPeerOutputPrvKeyShare(ByteString.copyFrom(peerOutputPrvKeyShare));
+    }
+
+    @Override
+    public bisq.trade.protobuf.SwapTxSignature toProto(boolean serializeForHash) {
+        return getBuilder(serializeForHash).build();
+    }
+
+    public static SwapTxSignature fromProto(bisq.trade.protobuf.SwapTxSignature proto) {
+        return new SwapTxSignature(proto.getSwapTx().toByteArray(), proto.getPeerOutputPrvKeyShare().toByteArray());
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.network.vo;
 
 import bisq.common.proto.Proto;
+import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -25,10 +26,15 @@ import java.util.Arrays;
 
 @Getter
 public final class SwapTxSignature implements Proto {
+    public static SwapTxSignature from(SwapTxSignatureResponse swapTxSignatureResponse) {
+        return new SwapTxSignature(swapTxSignatureResponse.getSwapTx(),
+                swapTxSignatureResponse.getPeerOutputPrvKeyShare());
+    }
+
     private final byte[] swapTx;
     private final byte[] peerOutputPrvKeyShare;
 
-    public SwapTxSignature(byte[] swapTx, byte[] peerOutputPrvKeyShare) {
+    private SwapTxSignature(byte[] swapTx, byte[] peerOutputPrvKeyShare) {
         this.swapTx = swapTx;
         this.peerOutputPrvKeyShare = peerOutputPrvKeyShare;
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigBuyerAsTakerProtocol.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigBuyerAsTakerProtocol.java
@@ -38,8 +38,6 @@ import bisq.trade.mu_sig.messages.network.handler.buyer_as_taker.MuSigPaymentRec
 import bisq.trade.mu_sig.messages.network.handler.buyer_as_taker.MuSigSetupTradeMessage_B_Handler;
 import bisq.trade.mu_sig.messages.network.handler.buyer_as_taker.MuSigSetupTradeMessage_D_Handler;
 
-import static bisq.trade.mu_sig.protocol.MuSigTradeState.FAILED;
-import static bisq.trade.mu_sig.protocol.MuSigTradeState.FAILED_AT_PEER;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.BUYER_AS_TAKER_CLOSED_TRADE;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.BUYER_AS_TAKER_CREATED_NONCE_SHARES_AND_PARTIAL_SIGNATURES;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.BUYER_AS_TAKER_FORCE_CLOSED_TRADE;
@@ -47,6 +45,8 @@ import static bisq.trade.mu_sig.protocol.MuSigTradeState.BUYER_AS_TAKER_INITIALI
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.BUYER_AS_TAKER_INITIATED_PAYMENT;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.BUYER_AS_TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.DEPOSIT_TX_CONFIRMED;
+import static bisq.trade.mu_sig.protocol.MuSigTradeState.FAILED;
+import static bisq.trade.mu_sig.protocol.MuSigTradeState.FAILED_AT_PEER;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.INIT;
 
 

--- a/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigSellerAsMakerProtocol.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigSellerAsMakerProtocol.java
@@ -38,9 +38,9 @@ import bisq.trade.mu_sig.messages.network.handler.seller_as_maker.MuSigPaymentIn
 import bisq.trade.mu_sig.messages.network.handler.seller_as_maker.MuSigSetupTradeMessage_A_Handler;
 import bisq.trade.mu_sig.messages.network.handler.seller_as_maker.MuSigSetupTradeMessage_C_Handler;
 
+import static bisq.trade.mu_sig.protocol.MuSigTradeState.DEPOSIT_TX_CONFIRMED;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.FAILED;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.FAILED_AT_PEER;
-import static bisq.trade.mu_sig.protocol.MuSigTradeState.DEPOSIT_TX_CONFIRMED;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.INIT;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.SELLER_AS_MAKER_CLOSED_TRADE;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.SELLER_AS_MAKER_CONFIRMED_PAYMENT_RECEIPT;

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -148,13 +148,52 @@ message BisqEasyReportErrorMessage {
 
 
 // MuSig
+
+// Value objects for network messages (based on grpc messages)
+message PubKeyShares {
+  bytes buyerOutputPubKeyShare = 1;
+  bytes sellerOutputPubKeyShare = 2;
+}
+
+message NonceShares {
+  string warningTxFeeBumpAddress = 1;
+  string redirectTxFeeBumpAddress = 2;
+  bytes halfDepositPsbt = 3;
+  bytes swapTxInputNonceShare = 4;
+  bytes buyersWarningTxBuyerInputNonceShare = 5;
+  bytes buyersWarningTxSellerInputNonceShare = 6;
+  bytes sellersWarningTxBuyerInputNonceShare = 7;
+  bytes sellersWarningTxSellerInputNonceShare = 8;
+  bytes buyersRedirectTxInputNonceShare = 9;
+  bytes sellersRedirectTxInputNonceShare = 10;
+}
+
+message PartialSignatures {
+  bytes peersWarningTxBuyerInputPartialSignature = 1;
+  bytes peersWarningTxSellerInputPartialSignature = 2;
+  bytes peersRedirectTxInputPartialSignature = 3;
+  optional bytes swapTxInputPartialSignature = 4;
+}
+
+
+message SwapTxSignature {
+  bytes swapTx = 1;
+  bytes peerOutputPrvKeyShare = 2;
+}
+
+// Trade domain
 message MuSigTradeParty {
-  musigrpc.PubKeySharesResponse pubKeySharesResponse = 1;
-  musigrpc.NonceSharesMessage nonceSharesMessage = 2;
-  musigrpc.PartialSignaturesMessage partialSignaturesMessage = 3;
-  musigrpc.DepositPsbt depositPsbt = 4;
-  musigrpc.SwapTxSignatureResponse swapTxSignatureResponse = 5;
-  musigrpc.CloseTradeResponse closeTradeResponse = 6;
+  optional musigrpc.PubKeySharesResponse myPubKeySharesResponse = 1;
+  optional PubKeyShares peersPubKeyShares = 2;
+  optional musigrpc.NonceSharesMessage myNonceSharesMessage = 3;
+  optional  NonceShares peersNonceShares = 4;
+  optional musigrpc.PartialSignaturesMessage myPartialSignaturesMessage = 5;
+  optional PartialSignatures peersPartialSignatures = 6;
+  optional musigrpc.DepositPsbt myDepositPsbt = 7;
+  optional musigrpc.SwapTxSignatureResponse mySwapTxSignatureResponse = 9;
+  optional SwapTxSignature peersSwapTxSignature = 10;
+  optional musigrpc.CloseTradeResponse myCloseTradeResponse = 11;
+  optional  bytes peersOutputPrvKeyShare = 12;
 }
 
 message MuSigTrade {
@@ -183,23 +222,23 @@ message MuSigTradeMessage {
 message MuSigSetupTradeMessage_A {
   contract.Contract contract = 1;
   contract.ContractSignatureData contractSignatureData = 2;
-  musigrpc.PubKeySharesResponse pubKeySharesResponse = 3;
+  PubKeyShares pubKeyShares = 3;
 }
 
 message MuSigSetupTradeMessage_B {
   contract.Contract contract = 1;
   contract.ContractSignatureData contractSignatureData = 2;
-  musigrpc.PubKeySharesResponse pubKeySharesResponse = 3;
-  musigrpc.NonceSharesMessage nonceSharesMessage = 4;
+  PubKeyShares pubKeyShares = 3;
+  NonceShares nonceShares = 4;
 }
 
 message MuSigSetupTradeMessage_C {
-  musigrpc.NonceSharesMessage nonceSharesMessage = 1;
-  musigrpc.PartialSignaturesMessage partialSignaturesMessage = 2;
+  NonceShares nonceShares = 1;
+  PartialSignatures partialSignatures = 2;
 }
 
 message MuSigSetupTradeMessage_D {
-  musigrpc.PartialSignaturesMessage partialSignaturesMessage = 1;
+  PartialSignatures partialSignatures = 1;
 }
 
 message MuSigPaymentInitiatedMessage_E {
@@ -207,9 +246,9 @@ message MuSigPaymentInitiatedMessage_E {
 }
 
 message MuSigPaymentReceivedMessage_F {
-  musigrpc.SwapTxSignatureResponse swapTxSignatureResponse = 1;
+  SwapTxSignature swapTxSignature = 1;
 }
 
 message MuSigCooperativeClosureMessage_G {
-  musigrpc.CloseTradeResponse closeTradeResponse = 1;
+  bytes peerOutputPrvKeyShare = 1;
 }

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 
 package trade;
 
+import "common.proto";
 import "contract.proto";
 import "identity.proto";
 import "network_identity.proto";
@@ -193,7 +194,7 @@ message MuSigTradeParty {
   optional musigrpc.SwapTxSignatureResponse mySwapTxSignatureResponse = 9;
   optional SwapTxSignature peersSwapTxSignature = 10;
   optional musigrpc.CloseTradeResponse myCloseTradeResponse = 11;
-  optional  bytes peersOutputPrvKeyShare = 12;
+  optional common.ByteArray peersOutputPrvKeyShare = 12;
 }
 
 message MuSigTrade {
@@ -250,5 +251,5 @@ message MuSigPaymentReceivedMessage_F {
 }
 
 message MuSigCooperativeClosureMessage_G {
-  bytes peerOutputPrvKeyShare = 1;
+  common.ByteArray peerOutputPrvKeyShare = 1;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new value objects for public key shares, nonce shares, partial signatures, and swap transaction signatures, improving clarity and separation of local and peer data in trade messages.
  - Added new fields to support more granular tracking of local and peer party data throughout the trade protocol.

- **Refactor**
  - Refactored message and handler logic to use new value objects instead of previous message types.
  - Updated protocol messages to distinguish between "my" and "peer" data for all key trade components.
  - Simplified and clarified data handling in cooperative close and payment received messages.
  - Added direct access to gRPC stubs in event handler classes to streamline communication.
  - Reorganized imports and renamed fields for improved clarity and consistency.

- **Documentation**
  - Improved formatting and readability of protocol setup instructions.

- **Style**
  - Enhanced code formatting and consistency in several classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->