### PR TITLE
Calling of verify() was absent in constructor of AchTransferAccountPayload

### DIFF
--- a/account/src/main/java/bisq/account/accounts/AchTransferAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/AchTransferAccountPayload.java
@@ -1,5 +1,6 @@
 package bisq.account.accounts;
 
+import bisq.common.validation.NetworkDataValidation;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -7,7 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 
-import static bisq.common.util.OptionalUtils.*;
+import static bisq.common.util.OptionalUtils.normalize;
+import static bisq.common.util.OptionalUtils.toOptional;
 
 @Slf4j
 @ToString
@@ -39,6 +41,14 @@ public final class AchTransferAccountPayload extends BankAccountPayload {
                 null,
                 null);
         this.holderAddress = normalize(holderAddress);
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+        holderAddress.ifPresent(holderAddress -> NetworkDataValidation.validateRequiredText(holderAddress, 100));
     }
 
     @Override

--- a/account/src/test/java/bisq/account/accounts/AchTransferAccountPayloadTest.java
+++ b/account/src/test/java/bisq/account/accounts/AchTransferAccountPayloadTest.java
@@ -18,7 +18,7 @@ class AchTransferAccountPayloadTest {
             .setId("id")
             .setPaymentMethodName("paymentMethodName")
             .setCountryBasedAccountPayload(CountryBasedAccountPayload.newBuilder()
-                    .setCountryCode("countryCode")
+                    .setCountryCode("US")
                     .setBankAccountPayload(BankAccountPayload.newBuilder()
                             .setHolderName("holderName")
                             .setAccountNr("accountNr")
@@ -34,7 +34,7 @@ class AchTransferAccountPayloadTest {
             .setId("id")
             .setPaymentMethodName("paymentMethodName")
             .setCountryBasedAccountPayload(CountryBasedAccountPayload.newBuilder()
-                    .setCountryCode("countryCode")
+                    .setCountryCode("US")
                     .setBankAccountPayload(BankAccountPayload.newBuilder()
                             .setHolderName("holderName")
                             .setAchTransferAccountPayload(AchTransferAccountPayload.newBuilder())))
@@ -42,13 +42,13 @@ class AchTransferAccountPayloadTest {
 
     private static final bisq.account.accounts.AchTransferAccountPayload PAYLOAD =
             new bisq.account.accounts.AchTransferAccountPayload(
-                    "id", "paymentMethodName", "countryCode",
+                    "id", "paymentMethodName", "US",
                     Optional.of("holderName"), Optional.of("bankName"), Optional.of("branchId"),
                     Optional.of("accountNr"), Optional.of("accountType"), Optional.of("holderAddress")
             );
     private static final bisq.account.accounts.AchTransferAccountPayload PAYLOAD_OPTIONALS_NOT_SET =
             new bisq.account.accounts.AchTransferAccountPayload(
-                    "id", "paymentMethodName", "countryCode",
+                    "id", "paymentMethodName", "US",
                     Optional.of("holderName"), null, null, null, null, null
             );
 

--- a/account/src/test/java/bisq/account/accounts/AchTransferAccountTest.java
+++ b/account/src/test/java/bisq/account/accounts/AchTransferAccountTest.java
@@ -6,7 +6,8 @@ import bisq.account.protobuf.BankAccount;
 import bisq.account.protobuf.BankAccountPayload;
 import bisq.account.protobuf.CountryBasedAccount;
 import bisq.account.protobuf.CountryBasedAccountPayload;
-import bisq.account.protobuf.*;
+import bisq.account.protobuf.FiatPaymentMethod;
+import bisq.account.protobuf.PaymentMethod;
 import bisq.common.protobuf.Country;
 import bisq.common.protobuf.Region;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class AchTransferAccountTest {
                     .setId("id")
                     .setPaymentMethodName("ACH_TRANSFER")
                     .setCountryBasedAccountPayload(CountryBasedAccountPayload.newBuilder()
-                            .setCountryCode("countryCode")
+                            .setCountryCode("US")
                             .setBankAccountPayload(BankAccountPayload.newBuilder()
                                     .setBankName("bankName")
                                     .setAchTransferAccountPayload(
@@ -37,7 +38,7 @@ class AchTransferAccountTest {
             )
             .setCountryBasedAccount(CountryBasedAccount.newBuilder()
                     .setCountry(Country.newBuilder()
-                            .setCode("countryCode")
+                            .setCode("US")
                             .setName("countryName")
                             .setRegion(Region.newBuilder()
                                     .setCode("regionCode")
@@ -49,10 +50,10 @@ class AchTransferAccountTest {
     private static final AchTransferAccount ACCOUNT = new AchTransferAccount(
             "accountName",
             new AchTransferAccountPayload("id", "ACH_TRANSFER",
-                    "countryCode", null, Optional.of("bankName"),
+                    "US", null, Optional.of("bankName"),
                     null, null, null, null),
             new bisq.common.locale.Country(
-                    "countryCode",
+                    "US",
                     "countryName",
                     new bisq.common.locale.Region("regionCode", "regionName")));
 


### PR DESCRIPTION
Add call of verify() into constructor of AchTransferAccountPayload

Fixed AchTransferAccountPayloadTest/AchTransferAccountTest which become broken. Before this fix, verify() never wasn't called and tests were passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for ACH transfer account creation to ensure address information is verified during setup.

- **Tests**
  - Updated test data to use a specific country code ("US") instead of a placeholder for ACH transfer account tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->