### PR TITLE
Fix max length of addresses to 62 chars.

### DIFF
--- a/common/src/main/java/bisq/common/validation/BitcoinAddressValidation.java
+++ b/common/src/main/java/bisq/common/validation/BitcoinAddressValidation.java
@@ -27,9 +27,9 @@ import java.util.regex.Pattern;
  */
 public class BitcoinAddressValidation {
     public static final int MIN_LENGTH = 25;
-    public static final int MAX_LENGTH = 60;
+    public static final int MAX_LENGTH = 62;
     private static final Pattern BASE_58_PATTERN = Pattern.compile("^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$");
-    private static final Pattern BECH32_PATTERN = Pattern.compile("^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,60}$");
+    private static final Pattern BECH32_PATTERN = Pattern.compile("^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,62}$");
 
     /**
      * Checks if the given string is a Bitcoin address.


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/3507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Expanded support for Bech32 Bitcoin addresses by increasing the maximum allowed address length from 60 to 62 characters. This improves compatibility with longer valid addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->