### PR TITLE
Don't use Lombok @EqualsAndHashCode if arrays are used

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Controller.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/create/step2/CreateNewProfileStep2Controller.java
@@ -27,12 +27,13 @@ import bisq.i18n.Res;
 import bisq.security.pow.ProofOfWork;
 import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.KeyPair;
+import java.util.Arrays;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -42,7 +43,6 @@ public class CreateNewProfileStep2Controller implements InitWithDataController<C
 
     @Getter
     @ToString
-    @EqualsAndHashCode
     public static final class InitData {
         private final KeyPair keyPair;
         private final byte[] pubKeyHash;
@@ -60,6 +60,27 @@ public class CreateNewProfileStep2Controller implements InitWithDataController<C
             this.proofOfWork = proofOfWork;
             this.nickName = nickName;
             this.nym = nym;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof InitData initData)) return false;
+
+            return Objects.equals(keyPair, initData.keyPair) &&
+                    Arrays.equals(pubKeyHash, initData.pubKeyHash) &&
+                    Objects.equals(proofOfWork, initData.proofOfWork) &&
+                    Objects.equals(nickName, initData.nickName) &&
+                    Objects.equals(nym, initData.nym);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hashCode(keyPair);
+            result = 31 * result + Arrays.hashCode(pubKeyHash);
+            result = 31 * result + Objects.hashCode(proofOfWork);
+            result = 31 * result + Objects.hashCode(nickName);
+            result = 31 * result + Objects.hashCode(nym);
+            return result;
         }
     }
 

--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/bisq1_bridge/dto/dao/TxOutput.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/bisq1_bridge/dto/dao/TxOutput.java
@@ -17,11 +17,19 @@
 
 package bisq.oracle_node.bisq1_bridge.dto.dao;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Objects;
 
-@Data
+@Getter
+@Setter
+@RequiredArgsConstructor
+@ToString
 public final class TxOutput {
     private int index;
     private long value;
@@ -44,4 +52,37 @@ public final class TxOutput {
     // The unlockBlockHeight is stored in the first output of the UNLOCK tx.
     private int unlockBlockHeight;
     private TxOutputKey key;
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TxOutput txOutput)) return false;
+
+        return index == txOutput.index &&
+                value == txOutput.value &&
+                blockHeight == txOutput.blockHeight &&
+                lockTime == txOutput.lockTime &&
+                unlockBlockHeight == txOutput.unlockBlockHeight &&
+                Objects.equals(txId, txOutput.txId) &&
+                Objects.equals(pubKeyScript, txOutput.pubKeyScript) &&
+                Objects.equals(address, txOutput.address) &&
+                Arrays.equals(opReturnData, txOutput.opReturnData) &&
+                txOutputType == txOutput.txOutputType &&
+                Objects.equals(key, txOutput.key);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = index;
+        result = 31 * result + Long.hashCode(value);
+        result = 31 * result + Objects.hashCode(txId);
+        result = 31 * result + Objects.hashCode(pubKeyScript);
+        result = 31 * result + Objects.hashCode(address);
+        result = 31 * result + Arrays.hashCode(opReturnData);
+        result = 31 * result + blockHeight;
+        result = 31 * result + Objects.hashCode(txOutputType);
+        result = 31 * result + lockTime;
+        result = 31 * result + unlockBlockHeight;
+        result = 31 * result + Objects.hashCode(key);
+        return result;
+    }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/hash_set/HashSetFilterEntry.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/filter/hash_set/HashSetFilterEntry.java
@@ -21,14 +21,12 @@ import bisq.common.encoding.Hex;
 import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 @Getter
-@EqualsAndHashCode
 public final class HashSetFilterEntry implements NetworkProto, Comparable<HashSetFilterEntry> {
     private final byte[] hash;
     private final int sequenceNumber;
@@ -72,5 +70,19 @@ public final class HashSetFilterEntry implements NetworkProto, Comparable<HashSe
                 "hash (as hex)=" + Hex.encode(hash) +
                 ", sequenceNumber=" + sequenceNumber +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof HashSetFilterEntry that)) return false;
+
+        return sequenceNumber == that.sequenceNumber && Arrays.equals(hash, that.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(hash);
+        result = 31 * result + sequenceNumber;
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedSequentialData.java
@@ -22,11 +22,12 @@ import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.p2p.services.data.storage.DistributedData;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * Data which ensures that the sequence of add or remove request is maintained correctly.
@@ -34,7 +35,6 @@ import java.util.Date;
  */
 @Slf4j
 @Getter
-@EqualsAndHashCode
 public final class AuthenticatedSequentialData implements NetworkProto {
     public static AuthenticatedSequentialData from(AuthenticatedSequentialData data, int sequenceNumber) {
         return from(data, sequenceNumber, data.getCreated());
@@ -108,5 +108,24 @@ public final class AuthenticatedSequentialData implements NetworkProto {
                 ",\r\n          pubKeyHash=" + Hex.encode(pubKeyHash) +
                 ",\r\n          authenticatedData=" + authenticatedData +
                 "\r\n}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AuthenticatedSequentialData that)) return false;
+
+        return sequenceNumber == that.sequenceNumber &&
+                created == that.created &&
+                Objects.equals(authenticatedData, that.authenticatedData) &&
+                Arrays.equals(pubKeyHash, that.pubKeyHash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(authenticatedData);
+        result = 31 * result + sequenceNumber;
+        result = 31 * result + Long.hashCode(created);
+        result = 31 * result + Arrays.hashCode(pubKeyHash);
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RefreshAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RefreshAuthenticatedDataRequest.java
@@ -26,7 +26,6 @@ import bisq.security.DigestUtil;
 import bisq.security.SignatureUtil;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,9 +34,9 @@ import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 
 @Getter
-@EqualsAndHashCode
 @Slf4j
 public final class RefreshAuthenticatedDataRequest implements AuthenticatedDataRequest {
     private static final int VERSION = 1;
@@ -61,11 +60,9 @@ public final class RefreshAuthenticatedDataRequest implements AuthenticatedDataR
     }
 
 
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final MetaData metaData;
 
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;
 
@@ -197,5 +194,28 @@ public final class RefreshAuthenticatedDataRequest implements AuthenticatedDataR
                 ",\r\n     signature=" + Hex.encode(signature) +
                 ",\r\n     created=" + new Date(created) + " (" + created + ")" +
                 "\r\n}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RefreshAuthenticatedDataRequest that)) return false;
+
+        return sequenceNumber == that.sequenceNumber &&
+                created == that.created &&
+                Arrays.equals(hash, that.hash) &&
+                Arrays.equals(ownerPublicKeyBytes, that.ownerPublicKeyBytes) &&
+                Objects.equals(ownerPublicKey, that.ownerPublicKey) &&
+                Arrays.equals(signature, that.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(hash);
+        result = 31 * result + Arrays.hashCode(ownerPublicKeyBytes);
+        result = 31 * result + Objects.hashCode(ownerPublicKey);
+        result = 31 * result + sequenceNumber;
+        result = 31 * result + Arrays.hashCode(signature);
+        result = 31 * result + Long.hashCode(created);
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
@@ -28,7 +28,6 @@ import bisq.security.DigestUtil;
 import bisq.security.SignatureUtil;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -38,11 +37,11 @@ import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 
 // Data size about 200-250 bytes
 @Getter
-@EqualsAndHashCode
 @Slf4j
 public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRequest, RemoveDataRequest {
     private static final int VERSION = 1;
@@ -64,11 +63,9 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
                 signature);
     }
 
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;
 
@@ -231,5 +228,30 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
                 ",\r\n     signature=" + Hex.encode(signature) +
                 ",\r\n     created=" + new Date(created) + " (" + created + ")" +
                 "\r\n}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RemoveAuthenticatedDataRequest that)) return false;
+
+        return sequenceNumber == that.sequenceNumber &&
+                created == that.created &&
+                Arrays.equals(hash, that.hash) &&
+                Arrays.equals(ownerPublicKeyBytes, that.ownerPublicKeyBytes) &&
+                Objects.equals(ownerPublicKey, that.ownerPublicKey) &&
+                Arrays.equals(signature, that.signature) &&
+                Objects.equals(metaDataFromDistributedData, that.metaDataFromDistributedData);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(hash);
+        result = 31 * result + Arrays.hashCode(ownerPublicKeyBytes);
+        result = 31 * result + Objects.hashCode(ownerPublicKey);
+        result = 31 * result + sequenceNumber;
+        result = 31 * result + Arrays.hashCode(signature);
+        result = 31 * result + Long.hashCode(created);
+        result = 31 * result + Objects.hashCode(metaDataFromDistributedData);
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
@@ -24,12 +24,13 @@ import bisq.network.p2p.services.data.storage.auth.AuthenticatedData;
 import bisq.security.SignatureUtil;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -38,7 +39,6 @@ import java.util.Optional;
  * the authorizedDistributedData object, which will return a hard coded set of pubKeys.
  */
 @Slf4j
-@EqualsAndHashCode(callSuper = true)
 @Getter
 public final class AuthorizedData extends AuthenticatedData {
     private final Optional<byte[]> signature;
@@ -163,5 +163,24 @@ public final class AuthorizedData extends AuthenticatedData {
                 ",\r\n               authorizedPublicKeyBytes=" + Hex.encode(authorizedPublicKeyBytes) +
                 ",\r\n               distributedData=" + distributedData +
                 "\r\n} ";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AuthorizedData that)) return false;
+        if (!super.equals(o)) return false;
+
+        return Objects.equals(signature, that.signature) &&
+                Arrays.equals(authorizedPublicKeyBytes, that.authorizedPublicKeyBytes) &&
+                Objects.equals(authorizedPublicKey, that.authorizedPublicKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Objects.hashCode(signature);
+        result = 31 * result + Arrays.hashCode(authorizedPublicKeyBytes);
+        result = 31 * result + Objects.hashCode(authorizedPublicKey);
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/AddMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/AddMailboxRequest.java
@@ -25,7 +25,6 @@ import bisq.security.DigestUtil;
 import bisq.security.SignatureUtil;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,10 +32,10 @@ import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
-@EqualsAndHashCode
 @Getter
 public final class AddMailboxRequest implements MailboxRequest, AddDataRequest {
 
@@ -63,8 +62,8 @@ public final class AddMailboxRequest implements MailboxRequest, AddDataRequest {
     private final PublicKey senderPublicKey;
 
     private AddMailboxRequest(MailboxSequentialData mailboxSequentialData,
-                             byte[] signature,
-                             PublicKey senderPublicKey) {
+                              byte[] signature,
+                              PublicKey senderPublicKey) {
         this(mailboxSequentialData, signature, senderPublicKey.getEncoded(), senderPublicKey);
     }
 
@@ -187,5 +186,24 @@ public final class AddMailboxRequest implements MailboxRequest, AddDataRequest {
                 ", senderPublicKeyBytes=" + Hex.encode(senderPublicKeyBytes) +
                 ", senderPublicKey=" + Hex.encode(senderPublicKey.getEncoded()) +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AddMailboxRequest that)) return false;
+
+        return Objects.equals(mailboxSequentialData, that.mailboxSequentialData) &&
+                Arrays.equals(signature, that.signature) &&
+                Arrays.equals(senderPublicKeyBytes, that.senderPublicKeyBytes) &&
+                Objects.equals(senderPublicKey, that.senderPublicKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(mailboxSequentialData);
+        result = 31 * result + Arrays.hashCode(signature);
+        result = 31 * result + Arrays.hashCode(senderPublicKeyBytes);
+        result = 31 * result + Objects.hashCode(senderPublicKey);
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxSequentialData.java
@@ -22,15 +22,15 @@ import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 
 @Getter
-@EqualsAndHashCode
 public final class MailboxSequentialData implements NetworkProto {
     private final MailboxData mailboxData;
     private final byte[] senderPublicKeyHash;
@@ -135,7 +135,8 @@ public final class MailboxSequentialData implements NetworkProto {
     }
 
     public boolean isExpired() {
-        return (System.currentTimeMillis() - created) > Math.min(MailboxData.MAX_TLL, mailboxData.getMetaData().getTtl());
+        return (System.currentTimeMillis() - created) >
+                Math.min(MailboxData.MAX_TLL, mailboxData.getMetaData().getTtl());
     }
 
     @Override
@@ -149,5 +150,30 @@ public final class MailboxSequentialData implements NetworkProto {
                 ", receiversPubKey=" + Hex.encode(receiversPubKey.getEncoded()) +
                 ", mailboxData=" + mailboxData +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MailboxSequentialData that)) return false;
+
+        return created == that.created &&
+                sequenceNumber == that.sequenceNumber &&
+                Objects.equals(mailboxData, that.mailboxData) &&
+                Arrays.equals(senderPublicKeyHash, that.senderPublicKeyHash) &&
+                Arrays.equals(receiversPublicKeyHash, that.receiversPublicKeyHash) &&
+                Arrays.equals(receiversPubKeyBytes, that.receiversPubKeyBytes) &&
+                Objects.equals(receiversPubKey, that.receiversPubKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(mailboxData);
+        result = 31 * result + Arrays.hashCode(senderPublicKeyHash);
+        result = 31 * result + Arrays.hashCode(receiversPublicKeyHash);
+        result = 31 * result + Arrays.hashCode(receiversPubKeyBytes);
+        result = 31 * result + Long.hashCode(created);
+        result = 31 * result + sequenceNumber;
+        result = 31 * result + Objects.hashCode(receiversPubKey);
+        return result;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
@@ -27,7 +27,6 @@ import bisq.security.DigestUtil;
 import bisq.security.SignatureUtil;
 import bisq.security.keys.KeyGeneration;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -37,11 +36,11 @@ import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 
 // Data size about 200-250 bytes
 @Slf4j
-@EqualsAndHashCode
 @Getter
 public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataRequest {
     private static final int VERSION = 1;
@@ -61,11 +60,9 @@ public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataReq
                 created);
     }
 
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;
 
@@ -214,5 +211,28 @@ public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataReq
                 ", created=" + new Date(created) + " (" + created + ")" +
                 ", receiverPublicKey=" + receiverPublicKey +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RemoveMailboxRequest that)) return false;
+
+        return created == that.created &&
+                Arrays.equals(hash, that.hash) &&
+                Arrays.equals(receiverPublicKeyBytes, that.receiverPublicKeyBytes) &&
+                Arrays.equals(signature, that.signature) &&
+                Objects.equals(receiverPublicKey, that.receiverPublicKey) &&
+                Objects.equals(metaDataFromDistributedData, that.metaDataFromDistributedData);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(hash);
+        result = 31 * result + Arrays.hashCode(receiverPublicKeyBytes);
+        result = 31 * result + Arrays.hashCode(signature);
+        result = 31 * result + Long.hashCode(created);
+        result = 31 * result + Objects.hashCode(receiverPublicKey);
+        result = 31 * result + Objects.hashCode(metaDataFromDistributedData);
+        return result;
     }
 }

--- a/security/src/main/java/bisq/security/AesSecretKey.java
+++ b/security/src/main/java/bisq/security/AesSecretKey.java
@@ -17,14 +17,12 @@
 
 package bisq.security;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import javax.crypto.SecretKey;
 import java.util.Arrays;
 
 @Getter
-@EqualsAndHashCode
 public class AesSecretKey implements SecretKey {
     public static AesSecretKey getClone(AesSecretKey key) {
         return new AesSecretKey(Arrays.copyOf(key.getEncoded(), key.getEncoded().length));
@@ -56,5 +54,17 @@ public class AesSecretKey implements SecretKey {
         /*return "AESSecretKey{" +
                 "\r\n     encoded=" + Hex.encode(encoded) +
                 "\r\n}";*/
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof AesSecretKey that)) return false;
+
+        return Arrays.equals(encoded, that.encoded);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(encoded);
     }
 }

--- a/security/src/main/java/bisq/security/ConfidentialData.java
+++ b/security/src/main/java/bisq/security/ConfidentialData.java
@@ -21,15 +21,15 @@ import bisq.common.encoding.Hex;
 import bisq.common.proto.NetworkProto;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 @Getter
-@EqualsAndHashCode
 public final class ConfidentialData implements NetworkProto {
     private static final int MAX_SIZE_CIPHERTEXT = 20_000;
 
@@ -96,5 +96,24 @@ public final class ConfidentialData implements NetworkProto {
                 ", cipherText=" + Hex.encode(cipherText) +
                 ", signature=" + Hex.encode(signature) +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ConfidentialData that)) return false;
+
+        return Arrays.equals(senderPublicKey, that.senderPublicKey) &&
+                Arrays.equals(iv, that.iv) &&
+                Arrays.equals(cipherText, that.cipherText) &&
+                Arrays.equals(signature, that.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(senderPublicKey);
+        result = 31 * result + Arrays.hashCode(iv);
+        result = 31 * result + Arrays.hashCode(cipherText);
+        result = 31 * result + Arrays.hashCode(signature);
+        return result;
     }
 }

--- a/security/src/main/java/bisq/security/EncryptedData.java
+++ b/security/src/main/java/bisq/security/EncryptedData.java
@@ -20,8 +20,9 @@ package bisq.security;
 import bisq.common.encoding.Hex;
 import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 /**
  * <p>An instance of EncryptedData is a holder for an initialization vector and encrypted bytes.</p>
@@ -30,7 +31,6 @@ import lombok.Getter;
  * private key bytes were encrypted. You need these for decryption.</p>
  */
 @Getter
-@EqualsAndHashCode
 public final class EncryptedData implements PersistableProto {
     private final byte[] iv;
     private final byte[] cipherText;
@@ -62,5 +62,19 @@ public final class EncryptedData implements PersistableProto {
                 "\r\n     iv=" + Hex.encode(iv) +
                 ",\r\n     cipherText=" + Hex.encode(cipherText) +
                 "\r\n}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof EncryptedData that)) return false;
+
+        return Arrays.equals(iv, that.iv) && Arrays.equals(cipherText, that.cipherText);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(iv);
+        result = 31 * result + Arrays.hashCode(cipherText);
+        return result;
     }
 }

--- a/security/src/main/java/bisq/security/ScryptParameters.java
+++ b/security/src/main/java/bisq/security/ScryptParameters.java
@@ -19,14 +19,14 @@ package bisq.security;
 
 import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+
 @Slf4j
 @Getter
-@EqualsAndHashCode
 @ToString
 public class ScryptParameters implements PersistableProto {
     public static final int KEY_LENGTH = 32; // 256 bits.
@@ -87,5 +87,26 @@ public class ScryptParameters implements PersistableProto {
                 proto.getBlockSize(),
                 proto.getParallelization(),
                 proto.getKeyLength());
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof ScryptParameters that)) return false;
+
+        return cost == that.cost &&
+                blockSize == that.blockSize &&
+                parallelization == that.parallelization &&
+                keyLength == that.keyLength &&
+                Arrays.equals(salt, that.salt);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(salt);
+        result = 31 * result + cost;
+        result = 31 * result + blockSize;
+        result = 31 * result + parallelization;
+        result = 31 * result + keyLength;
+        return result;
     }
 }

--- a/security/src/main/java/bisq/security/keys/I2pKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/I2pKeyPair.java
@@ -3,15 +3,15 @@ package bisq.security.keys;
 import bisq.common.proto.PersistableProto;
 import bisq.security.protobuf.I2PKeyPair;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.Objects;
 
 public class I2pKeyPair implements PersistableProto {
     @ToString.Exclude
     private final byte[] privateKey;
     private final byte[] publicKey;
-    @EqualsAndHashCode.Include
     @Getter
     private final String destination;
 
@@ -42,5 +42,17 @@ public class I2pKeyPair implements PersistableProto {
         return new I2pKeyPair(proto.getPrivateKey().toByteArray(),
                 proto.getPublicKey().toByteArray(),
                 proto.getDestination());
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof I2pKeyPair that)) return false;
+
+        return Objects.equals(destination, that.destination);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(destination);
     }
 }

--- a/security/src/main/java/bisq/security/keys/KeyBundle.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundle.java
@@ -1,17 +1,16 @@
 package bisq.security.keys;
 
 import bisq.common.proto.PersistableProto;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.security.KeyPair;
+import java.util.Arrays;
+import java.util.Objects;
 
 @ToString
 @Getter
-@EqualsAndHashCode
 public class KeyBundle implements PersistableProto {
-    @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private final KeyPair keyPair;
     private final TorKeyPair torKeyPair;
@@ -52,5 +51,24 @@ public class KeyBundle implements PersistableProto {
                 KeyPairProtoUtil.fromProto(proto.getKeyPair()),
                 TorKeyPair.fromProto(proto.getTorKeyPair())/*,
                 I2pKeyPair.fromProto(proto.getI2PKeyPair())*/);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof KeyBundle keyBundle)) return false;
+
+        return Objects.equals(torKeyPair, keyBundle.torKeyPair) &&
+                Objects.equals(keyId, keyBundle.keyId) &&
+                Arrays.equals(encodedPrivateKey, keyBundle.encodedPrivateKey) &&
+                Arrays.equals(encodedPublicKey, keyBundle.encodedPublicKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(torKeyPair);
+        result = 31 * result + Objects.hashCode(keyId);
+        result = 31 * result + Arrays.hashCode(encodedPrivateKey);
+        result = 31 * result + Arrays.hashCode(encodedPublicKey);
+        return result;
     }
 }

--- a/security/src/main/java/bisq/security/keys/TorKeyPair.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyPair.java
@@ -2,22 +2,21 @@ package bisq.security.keys;
 
 import bisq.common.proto.PersistableProto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.crypto.digests.SHA512Digest;
 
+import java.util.Objects;
+
 @Slf4j
 @Getter
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
 public class TorKeyPair implements PersistableProto {
     @ToString.Exclude
     private final byte[] privateKey;
     @ToString.Exclude
     private final byte[] publicKey;
-    @EqualsAndHashCode.Include
     @Getter
     private final String onionAddress;
 
@@ -79,5 +78,17 @@ public class TorKeyPair implements PersistableProto {
         secretScalar[31] |= 64;
 
         return secretScalar;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof TorKeyPair that)) return false;
+
+        return Objects.equals(onionAddress, that.onionAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(onionAddress);
     }
 }

--- a/security/src/main/java/bisq/security/pow/ProofOfWork.java
+++ b/security/src/main/java/bisq/security/pow/ProofOfWork.java
@@ -22,18 +22,17 @@ import bisq.common.proto.NetworkProto;
 import bisq.common.util.MathUtils;
 import bisq.common.validation.NetworkDataValidation;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Optional;
 
 // TODO (refactor, low prio) use Optional instead of Nullable
 // Borrowed from: https://github.com/bisq-network/bisq
 @Slf4j
 @Getter
-@EqualsAndHashCode
 public final class ProofOfWork implements NetworkProto {
     // With HashCashV2 we use the 20 byte hash of the serialized message for the payload
     // instead the serialized message as in HashCash(V1)
@@ -120,5 +119,28 @@ public final class ProofOfWork implements NetworkProto {
                 "\nsolution=" + Hex.encode(solution) +
                 "\npayload=" + Hex.encode(payload) +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ProofOfWork that)) return false;
+
+        return counter == that.counter &&
+                Double.compare(difficulty, that.difficulty) == 0 &&
+                duration == that.duration &&
+                Arrays.equals(payload, that.payload) &&
+                Arrays.equals(challenge, that.challenge) &&
+                Arrays.equals(solution, that.solution);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(payload);
+        result = 31 * result + Long.hashCode(counter);
+        result = 31 * result + Arrays.hashCode(challenge);
+        result = 31 * result + Double.hashCode(difficulty);
+        result = 31 * result + Arrays.hashCode(solution);
+        result = 31 * result + Long.hashCode(duration);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/CloseTradeRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/CloseTradeRequest.java
@@ -19,11 +19,12 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 @Getter
-@EqualsAndHashCode
 public final class CloseTradeRequest implements Proto {
     private final String tradeId;
     private final byte[] myOutputPeersPrvKeyShare;
@@ -56,5 +57,22 @@ public final class CloseTradeRequest implements Proto {
                 proto.getTradeId(),
                 proto.getMyOutputPeersPrvKeyShare().toByteArray(),
                 proto.getSwapTx().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof CloseTradeRequest that)) return false;
+
+        return Objects.equals(tradeId, that.tradeId) &&
+                Arrays.equals(myOutputPeersPrvKeyShare, that.myOutputPeersPrvKeyShare) &&
+                Arrays.equals(swapTx, that.swapTx);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(tradeId);
+        result = 31 * result + Arrays.hashCode(myOutputPeersPrvKeyShare);
+        result = 31 * result + Arrays.hashCode(swapTx);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/CloseTradeResponse.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/CloseTradeResponse.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class CloseTradeResponse implements Proto {
     private final byte[] peerOutputPrvKeyShare;
 
@@ -44,5 +44,17 @@ public final class CloseTradeResponse implements Proto {
 
     public static CloseTradeResponse fromProto(bisq.trade.protobuf.CloseTradeResponse proto) {
         return new CloseTradeResponse(proto.getPeerOutputPrvKeyShare().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof CloseTradeResponse that)) return false;
+
+        return Arrays.equals(peerOutputPrvKeyShare, that.peerOutputPrvKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(peerOutputPrvKeyShare);
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/DepositPsbt.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/DepositPsbt.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class DepositPsbt implements Proto {
     private final byte[] depositPsbt;
 
@@ -44,5 +44,17 @@ public final class DepositPsbt implements Proto {
 
     public static DepositPsbt fromProto(bisq.trade.protobuf.DepositPsbt proto) {
         return new DepositPsbt(proto.getDepositPsbt().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DepositPsbt that)) return false;
+
+        return Arrays.equals(depositPsbt, that.depositPsbt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(depositPsbt);
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
@@ -20,11 +20,12 @@ package bisq.trade.mu_sig.messages.grpc;
 import bisq.common.proto.Proto;
 import bisq.trade.mu_sig.messages.network.vo.NonceShares;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 @Getter
-@EqualsAndHashCode
 public final class NonceSharesMessage implements Proto {
     public static NonceSharesMessage from(NonceShares nonceShares) {
         return new NonceSharesMessage(
@@ -53,15 +54,15 @@ public final class NonceSharesMessage implements Proto {
     private final byte[] sellersRedirectTxInputNonceShare;
 
     private NonceSharesMessage(String warningTxFeeBumpAddress,
-                              String redirectTxFeeBumpAddress,
-                              byte[] halfDepositPsbt,
-                              byte[] swapTxInputNonceShare,
-                              byte[] buyersWarningTxBuyerInputNonceShare,
-                              byte[] buyersWarningTxSellerInputNonceShare,
-                              byte[] sellersWarningTxBuyerInputNonceShare,
-                              byte[] sellersWarningTxSellerInputNonceShare,
-                              byte[] buyersRedirectTxInputNonceShare,
-                              byte[] sellersRedirectTxInputNonceShare) {
+                               String redirectTxFeeBumpAddress,
+                               byte[] halfDepositPsbt,
+                               byte[] swapTxInputNonceShare,
+                               byte[] buyersWarningTxBuyerInputNonceShare,
+                               byte[] buyersWarningTxSellerInputNonceShare,
+                               byte[] sellersWarningTxBuyerInputNonceShare,
+                               byte[] sellersWarningTxSellerInputNonceShare,
+                               byte[] buyersRedirectTxInputNonceShare,
+                               byte[] sellersRedirectTxInputNonceShare) {
         this.warningTxFeeBumpAddress = warningTxFeeBumpAddress;
         this.redirectTxFeeBumpAddress = redirectTxFeeBumpAddress;
         this.halfDepositPsbt = halfDepositPsbt;
@@ -105,5 +106,36 @@ public final class NonceSharesMessage implements Proto {
                 proto.getSellersWarningTxSellerInputNonceShare().toByteArray(),
                 proto.getBuyersRedirectTxInputNonceShare().toByteArray(),
                 proto.getSellersRedirectTxInputNonceShare().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NonceSharesMessage that)) return false;
+
+        return Objects.equals(warningTxFeeBumpAddress, that.warningTxFeeBumpAddress) &&
+                Objects.equals(redirectTxFeeBumpAddress, that.redirectTxFeeBumpAddress) &&
+                Arrays.equals(halfDepositPsbt, that.halfDepositPsbt) &&
+                Arrays.equals(swapTxInputNonceShare, that.swapTxInputNonceShare) &&
+                Arrays.equals(buyersWarningTxBuyerInputNonceShare, that.buyersWarningTxBuyerInputNonceShare) &&
+                Arrays.equals(buyersWarningTxSellerInputNonceShare, that.buyersWarningTxSellerInputNonceShare) &&
+                Arrays.equals(sellersWarningTxBuyerInputNonceShare, that.sellersWarningTxBuyerInputNonceShare) &&
+                Arrays.equals(sellersWarningTxSellerInputNonceShare, that.sellersWarningTxSellerInputNonceShare) &&
+                Arrays.equals(buyersRedirectTxInputNonceShare, that.buyersRedirectTxInputNonceShare) &&
+                Arrays.equals(sellersRedirectTxInputNonceShare, that.sellersRedirectTxInputNonceShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(warningTxFeeBumpAddress);
+        result = 31 * result + Objects.hashCode(redirectTxFeeBumpAddress);
+        result = 31 * result + Arrays.hashCode(halfDepositPsbt);
+        result = 31 * result + Arrays.hashCode(swapTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersWarningTxBuyerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersWarningTxSellerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersWarningTxBuyerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersWarningTxSellerInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersRedirectTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersRedirectTxInputNonceShare);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesRequest.java
@@ -19,11 +19,12 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 @Getter
-@EqualsAndHashCode
 public final class NonceSharesRequest implements Proto {
     private final String tradeId;
     private final byte[] buyerOutputPeersPubKeyShare;
@@ -79,5 +80,32 @@ public final class NonceSharesRequest implements Proto {
                 proto.getTradeAmount(),
                 proto.getBuyersSecurityDeposit(),
                 proto.getSellersSecurityDeposit());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NonceSharesRequest that)) return false;
+
+        return depositTxFeeRate == that.depositTxFeeRate &&
+                preparedTxFeeRate == that.preparedTxFeeRate &&
+                tradeAmount == that.tradeAmount &&
+                buyersSecurityDeposit == that.buyersSecurityDeposit &&
+                sellersSecurityDeposit == that.sellersSecurityDeposit &&
+                Objects.equals(tradeId, that.tradeId) &&
+                Arrays.equals(buyerOutputPeersPubKeyShare, that.buyerOutputPeersPubKeyShare) &&
+                Arrays.equals(sellerOutputPeersPubKeyShare, that.sellerOutputPeersPubKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(tradeId);
+        result = 31 * result + Arrays.hashCode(buyerOutputPeersPubKeyShare);
+        result = 31 * result + Arrays.hashCode(sellerOutputPeersPubKeyShare);
+        result = 31 * result + Long.hashCode(depositTxFeeRate);
+        result = 31 * result + Long.hashCode(preparedTxFeeRate);
+        result = 31 * result + Long.hashCode(tradeAmount);
+        result = 31 * result + Long.hashCode(buyersSecurityDeposit);
+        result = 31 * result + Long.hashCode(sellersSecurityDeposit);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
@@ -20,11 +20,11 @@ package bisq.trade.mu_sig.messages.grpc;
 import bisq.common.proto.Proto;
 import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class PartialSignaturesMessage implements Proto {
     public static PartialSignaturesMessage from(PartialSignatures peersPartialSignatures) {
         return new PartialSignaturesMessage(
@@ -69,5 +69,24 @@ public final class PartialSignaturesMessage implements Proto {
                 proto.getPeersWarningTxSellerInputPartialSignature().toByteArray(),
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
                 proto.getSwapTxInputPartialSignature().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PartialSignaturesMessage that)) return false;
+
+        return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
+                Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
+                Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
+                Arrays.equals(swapTxInputPartialSignature, that.swapTxInputPartialSignature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(peersWarningTxBuyerInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(swapTxInputPartialSignature);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PubKeySharesResponse.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PubKeySharesResponse.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class PubKeySharesResponse implements Proto {
     private final byte[] buyerOutputPubKeyShare;
     private final byte[] sellerOutputPubKeyShare;
@@ -54,5 +54,22 @@ public final class PubKeySharesResponse implements Proto {
         return new PubKeySharesResponse(proto.getBuyerOutputPubKeyShare().toByteArray(),
                 proto.getSellerOutputPubKeyShare().toByteArray(),
                 proto.getCurrentBlockHeight());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PubKeySharesResponse that)) return false;
+
+        return currentBlockHeight == that.currentBlockHeight &&
+                Arrays.equals(buyerOutputPubKeyShare, that.buyerOutputPubKeyShare) &&
+                Arrays.equals(sellerOutputPubKeyShare, that.sellerOutputPubKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(buyerOutputPubKeyShare);
+        result = 31 * result + Arrays.hashCode(sellerOutputPubKeyShare);
+        result = 31 * result + currentBlockHeight;
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/SwapTxSignatureRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/SwapTxSignatureRequest.java
@@ -19,11 +19,12 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 @Getter
-@EqualsAndHashCode
 public final class SwapTxSignatureRequest implements Proto {
     private final String tradeId;
     private final byte[] swapTxInputPeersPartialSignature;
@@ -47,5 +48,20 @@ public final class SwapTxSignatureRequest implements Proto {
 
     public static SwapTxSignatureRequest fromProto(bisq.trade.protobuf.SwapTxSignatureRequest proto) {
         return new SwapTxSignatureRequest(proto.getTradeId(), proto.getSwapTxInputPeersPartialSignature().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SwapTxSignatureRequest that)) return false;
+
+        return Objects.equals(tradeId, that.tradeId) &&
+                Arrays.equals(swapTxInputPeersPartialSignature, that.swapTxInputPeersPartialSignature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(tradeId);
+        result = 31 * result + Arrays.hashCode(swapTxInputPeersPartialSignature);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/SwapTxSignatureResponse.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/SwapTxSignatureResponse.java
@@ -19,11 +19,11 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
-@EqualsAndHashCode
 public final class SwapTxSignatureResponse implements Proto {
     private final byte[] swapTx;
     private final byte[] peerOutputPrvKeyShare;
@@ -47,5 +47,20 @@ public final class SwapTxSignatureResponse implements Proto {
 
     public static SwapTxSignatureResponse fromProto(bisq.trade.protobuf.SwapTxSignatureResponse proto) {
         return new SwapTxSignatureResponse(proto.getSwapTx().toByteArray(), proto.getPeerOutputPrvKeyShare().toByteArray());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SwapTxSignatureResponse that)) return false;
+
+        return Arrays.equals(swapTx, that.swapTx) &&
+                Arrays.equals(peerOutputPrvKeyShare, that.peerOutputPrvKeyShare);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(swapTx);
+        result = 31 * result + Arrays.hashCode(peerOutputPrvKeyShare);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/TxConfirmationStatus.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/TxConfirmationStatus.java
@@ -19,13 +19,13 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Arrays;
+
 @ToString
 @Getter
-@EqualsAndHashCode
 public final class TxConfirmationStatus implements Proto {
     private final byte[] tx;
     private final int currentBlockHeight;
@@ -56,5 +56,22 @@ public final class TxConfirmationStatus implements Proto {
         return new TxConfirmationStatus(proto.getTx().toByteArray(),
                 proto.getCurrentBlockHeight(),
                 proto.getNumConfirmations());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TxConfirmationStatus status)) return false;
+
+        return currentBlockHeight == status.currentBlockHeight &&
+                numConfirmations == status.numConfirmations &&
+                Arrays.equals(tx, status.tx);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(tx);
+        result = 31 * result + currentBlockHeight;
+        result = 31 * result + numConfirmations;
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/SwapTxSignature.java
@@ -69,5 +69,4 @@ public final class SwapTxSignature implements Proto {
         result = 31 * result + Arrays.hashCode(peerOutputPrvKeyShare);
         return result;
     }
-
 }

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -29,11 +29,12 @@ import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedDistributedData;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Set;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
@@ -41,14 +42,12 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_100_DAYS;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
-@EqualsAndHashCode
 @Getter
 public final class AuthorizedProofOfBurnData implements AuthorizedDistributedData {
     private static final int VERSION = 1;
 
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
     private transient final MetaData metaData = new MetaData(TTL_100_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
-    @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;
     private final long blockTime;
@@ -64,7 +63,6 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
     // and use default `@ExcludeForHash` instead.
     @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
-    @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 
     public AuthorizedProofOfBurnData(long blockTime,
@@ -77,12 +75,12 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     }
 
     private AuthorizedProofOfBurnData(int version,
-                                     long blockTime,
-                                     long amount,
-                                     byte[] hash,
-                                     int blockHeight,
-                                     String txId,
-                                     boolean staticPublicKeysProvided) {
+                                      long blockTime,
+                                      long amount,
+                                      byte[] hash,
+                                      int blockHeight,
+                                      String txId,
+                                      boolean staticPublicKeysProvided) {
         this.version = version;
         this.blockTime = blockTime;
         this.amount = amount;
@@ -179,5 +177,28 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
                 ",\r\n                    staticPublicKeysProvided=" + staticPublicKeysProvided() +
                 ",\r\n                    authorizedPublicKeys=" + getAuthorizedPublicKeys() +
                 "\r\n}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AuthorizedProofOfBurnData that)) return false;
+
+        return blockTime == that.blockTime &&
+                amount == that.amount &&
+                blockHeight == that.blockHeight &&
+                Objects.equals(metaData, that.metaData) &&
+                Arrays.equals(hash, that.hash) &&
+                Objects.equals(txId, that.txId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(metaData);
+        result = 31 * result + Long.hashCode(blockTime);
+        result = 31 * result + Long.hashCode(amount);
+        result = 31 * result + Arrays.hashCode(hash);
+        result = 31 * result + blockHeight;
+        result = 31 * result + Objects.hashCode(txId);
+        return result;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/3504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved reliability of equality and hash code checks for various features, especially those involving byte array data, by introducing explicit comparison logic.
  - Enhanced consistency of object comparison across multiple areas in the application.
- **Style**
  - Minor formatting and import adjustments for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->