### PR TITLE
Handle redacted PartialSignatures

### DIFF
--- a/common/src/main/java/bisq/common/util/OptionalUtils.java
+++ b/common/src/main/java/bisq/common/util/OptionalUtils.java
@@ -1,8 +1,7 @@
 package bisq.common.util;
 
+import java.util.Arrays;
 import java.util.Optional;
-
-import static bisq.common.util.StringUtils.toNullIfEmpty;
 
 public class OptionalUtils {
 
@@ -12,5 +11,11 @@ public class OptionalUtils {
 
     public static Optional<String> normalize(Optional<String> optional) {
         return Optional.ofNullable(optional).orElse(Optional.empty());
+    }
+
+    // Using default equals method for an Optional<byte[]> would use comparison by reference not by value.
+    public static boolean optionalByteArrayEquals(Optional<byte[]> a, Optional<byte[]> b) {
+        return a.isPresent() == b.isPresent() &&
+                (a.isEmpty() || Arrays.equals(a.get(), b.get()));
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
@@ -29,6 +29,7 @@ import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
 import bisq.trade.mu_sig.messages.network.vo.NonceShares;
 import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import bisq.trade.mu_sig.messages.network.vo.PubKeyShares;
+import bisq.trade.mu_sig.messages.network.vo.RedactedPartialSignatures;
 import bisq.trade.mu_sig.messages.network.vo.SwapTxSignature;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -46,6 +47,7 @@ public final class MuSigTradeParty extends TradeParty {
     private Optional<NonceShares> peersNonceShares = Optional.empty();
     private Optional<PartialSignaturesMessage> myPartialSignaturesMessage = Optional.empty();
     private Optional<PartialSignatures> peersPartialSignatures = Optional.empty();
+    private Optional<RedactedPartialSignatures> peersRedactedPartialSignatures = Optional.empty();
     private Optional<DepositPsbt> myDepositPsbt = Optional.empty();
     private Optional<SwapTxSignatureResponse> mySwapTxSignatureResponse = Optional.empty();
     private Optional<SwapTxSignature> peersSwapTxSignature = Optional.empty();
@@ -63,6 +65,7 @@ public final class MuSigTradeParty extends TradeParty {
                            Optional<NonceShares> peersNonceShares,
                            Optional<PartialSignaturesMessage> myPartialSignaturesMessage,
                            Optional<PartialSignatures> peersPartialSignatures,
+                           Optional<RedactedPartialSignatures> peersRedactedPartialSignatures,
                            Optional<DepositPsbt> myDepositPsbt,
                            Optional<SwapTxSignatureResponse> mySwapTxSignatureResponse,
                            Optional<SwapTxSignature> peersSwapTxSignature,
@@ -76,6 +79,7 @@ public final class MuSigTradeParty extends TradeParty {
         this.peersNonceShares = peersNonceShares;
         this.myPartialSignaturesMessage = myPartialSignaturesMessage;
         this.peersPartialSignatures = peersPartialSignatures;
+        this.peersRedactedPartialSignatures = peersRedactedPartialSignatures;
         this.myDepositPsbt = myDepositPsbt;
         this.mySwapTxSignatureResponse = mySwapTxSignatureResponse;
         this.peersSwapTxSignature = peersSwapTxSignature;
@@ -92,6 +96,7 @@ public final class MuSigTradeParty extends TradeParty {
         peersNonceShares.ifPresent(e -> builder.setPeersNonceShares(e.toProto(serializeForHash)));
         myPartialSignaturesMessage.ifPresent(e -> builder.setMyPartialSignaturesMessage(e.toProto(serializeForHash)));
         peersPartialSignatures.ifPresent(e -> builder.setPeersPartialSignatures(e.toProto(serializeForHash)));
+        peersRedactedPartialSignatures.ifPresent(e -> builder.setPeersRedactedPartialSignatures(e.toProto(serializeForHash)));
         myDepositPsbt.ifPresent(e -> builder.setMyDepositPsbt(e.toProto(serializeForHash)));
         mySwapTxSignatureResponse.ifPresent(e -> builder.setMySwapTxSignatureResponse(e.toProto(serializeForHash)));
         peersSwapTxSignature.ifPresent(e -> builder.setPeersSwapTxSignature(e.toProto(serializeForHash)));
@@ -121,6 +126,9 @@ public final class MuSigTradeParty extends TradeParty {
                         : Optional.empty(),
                 muSigTradePartyProto.hasPeersPartialSignatures()
                         ? Optional.of(PartialSignatures.fromProto(muSigTradePartyProto.getPeersPartialSignatures()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasPeersRedactedPartialSignatures()
+                        ? Optional.of(RedactedPartialSignatures.fromProto(muSigTradePartyProto.getPeersRedactedPartialSignatures()))
                         : Optional.empty(),
                 muSigTradePartyProto.hasMyDepositPsbt()
                         ? Optional.of(DepositPsbt.fromProto(muSigTradePartyProto.getMyDepositPsbt()))
@@ -162,6 +170,10 @@ public final class MuSigTradeParty extends TradeParty {
 
     public void setPeersPartialSignatures(PartialSignatures peersPartialSignatures) {
         this.peersPartialSignatures = Optional.of(peersPartialSignatures);
+    }
+
+    public void setPeersRedactedPartialSignatures(RedactedPartialSignatures peersRedactedPartialSignatures) {
+        this.peersRedactedPartialSignatures = Optional.of(peersRedactedPartialSignatures);
     }
 
     public void setMyDepositPsbt(DepositPsbt myDepositPsbt) {

--- a/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigPaymentInitiatedEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/buyer_as_taker/MuSigPaymentInitiatedEventHandler.java
@@ -22,6 +22,7 @@ import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.handler.MuSigTradeEventHandlerAsMessageSender;
 import bisq.trade.mu_sig.messages.network.MuSigPaymentInitiatedMessage_E;
+import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 
 public final class MuSigPaymentInitiatedEventHandler extends MuSigTradeEventHandlerAsMessageSender<MuSigTrade, MuSigPaymentInitiatedEvent> {
     public MuSigPaymentInitiatedEventHandler(ServiceProvider serviceProvider, MuSigTrade model) {
@@ -39,11 +40,14 @@ public final class MuSigPaymentInitiatedEventHandler extends MuSigTradeEventHand
 
     @Override
     protected void sendMessage() {
+        PartialSignatures partialSignatures = PartialSignatures.from(trade.getMyself().getMyPartialSignaturesMessage().orElseThrow());
+        byte[] swapTxInputPartialSignature = partialSignatures.getSwapTxInputPartialSignature();
         send(new MuSigPaymentInitiatedMessage_E(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),
                 trade.getMyIdentity().getNetworkId(),
-                trade.getPeer().getNetworkId()));
+                trade.getPeer().getNetworkId(),
+                swapTxInputPartialSignature));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/seller_as_maker/MuSigPaymentReceiptConfirmedEventHandler.java
@@ -41,12 +41,10 @@ public final class MuSigPaymentReceiptConfirmedEventHandler extends MuSigTradeEv
     @Override
     public void process(MuSigPaymentReceiptConfirmedEvent event) {
         MuSigTradeParty peer = trade.getTaker();
-        // We got that from an earlier message
         PartialSignatures peersPartialSignatures = peer.getPeersPartialSignatures().orElseThrow();
 
         mySwapTxSignatureResponse = SwapTxSignatureResponse.fromProto(musigBlockingStub.signSwapTx(SwapTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
-                // NOW send the redacted buyer's swapTxInputPartialSignature:
                 .setSwapTxInputPeersPartialSignature(ByteString.copyFrom(peersPartialSignatures.getSwapTxInputPartialSignature()))
                 .build()));
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
@@ -19,6 +19,7 @@ package bisq.trade.mu_sig.messages.grpc;
 
 import bisq.common.proto.Proto;
 import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
+import bisq.trade.mu_sig.messages.network.vo.RedactedPartialSignatures;
 import com.google.protobuf.ByteString;
 import lombok.Getter;
 
@@ -32,6 +33,15 @@ public final class PartialSignaturesMessage implements Proto {
                 peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
                 peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
                 peersPartialSignatures.getSwapTxInputPartialSignature()
+        );
+    }
+
+    public static PartialSignaturesMessage from(RedactedPartialSignatures peersPartialSignatures) {
+        return new PartialSignaturesMessage(
+                peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
+                peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
+                peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
+                new byte[]{}
         );
     }
 
@@ -52,11 +62,19 @@ public final class PartialSignaturesMessage implements Proto {
 
     @Override
     public bisq.trade.protobuf.PartialSignaturesMessage.Builder getBuilder(boolean serializeForHash) {
-        return bisq.trade.protobuf.PartialSignaturesMessage.newBuilder()
+        bisq.trade.protobuf.PartialSignaturesMessage.Builder builder = bisq.trade.protobuf.PartialSignaturesMessage.newBuilder()
                 .setPeersWarningTxBuyerInputPartialSignature(ByteString.copyFrom(peersWarningTxBuyerInputPartialSignature))
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
                 .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature))
                 .setSwapTxInputPartialSignature(ByteString.copyFrom(swapTxInputPartialSignature));
+
+        // TODO  @stejbac: if swapTxInputPartialSignature is empty byte array,
+        //       passing that to setPeersPartialSignatures results in a backend error as it seems the backend expects
+        //       ByteString.EMPTY. With clearSwapTxInputPartialSignature we get ByteString.EMPTY.
+        if (swapTxInputPartialSignature.length == 0) {
+            builder.clearSwapTxInputPartialSignature();
+        }
+        return builder;
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentInitiatedMessage_E.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentInitiatedMessage_E.java
@@ -19,15 +19,15 @@ package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
 import com.google.protobuf.ByteString;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+
 @Slf4j
 @ToString(callSuper = true)
 @Getter
-@EqualsAndHashCode(callSuper = true)
 public final class MuSigPaymentInitiatedMessage_E extends MuSigTradeMessage {
     private final byte[] swapTxInputPartialSignature;
 
@@ -78,5 +78,20 @@ public final class MuSigPaymentInitiatedMessage_E extends MuSigTradeMessage {
     @Override
     public double getCostFactor() {
         return getCostFactor(0.1, 0.3);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MuSigPaymentInitiatedMessage_E that)) return false;
+        if (!super.equals(o)) return false;
+
+        return Arrays.equals(swapTxInputPartialSignature, that.swapTxInputPartialSignature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(swapTxInputPartialSignature);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentInitiatedMessage_E.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigPaymentInitiatedMessage_E.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
+import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -28,12 +29,16 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigPaymentInitiatedMessage_E extends MuSigTradeMessage {
+    private final byte[] swapTxInputPartialSignature;
+
     public MuSigPaymentInitiatedMessage_E(String id,
                                           String tradeId,
                                           String protocolVersion,
                                           NetworkId sender,
-                                          NetworkId receiver) {
+                                          NetworkId receiver,
+                                          byte[] swapTxInputPartialSignature) {
         super(id, tradeId, protocolVersion, sender, receiver);
+        this.swapTxInputPartialSignature = swapTxInputPartialSignature;
 
         verify();
     }
@@ -55,7 +60,8 @@ public final class MuSigPaymentInitiatedMessage_E extends MuSigTradeMessage {
     }
 
     private bisq.trade.protobuf.MuSigPaymentInitiatedMessage_E.Builder getMuSigPaymentInitiatedMessage_E(boolean serializeForHash) {
-        return bisq.trade.protobuf.MuSigPaymentInitiatedMessage_E.newBuilder();
+        return bisq.trade.protobuf.MuSigPaymentInitiatedMessage_E.newBuilder()
+                .setSwapTxInputPartialSignature(ByteString.copyFrom(swapTxInputPartialSignature));
     }
 
     public static MuSigPaymentInitiatedMessage_E fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -65,7 +71,8 @@ public final class MuSigPaymentInitiatedMessage_E extends MuSigTradeMessage {
                 proto.getTradeId(),
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
-                NetworkId.fromProto(proto.getReceiver()));
+                NetworkId.fromProto(proto.getReceiver()),
+                muSigMessageProto.getSwapTxInputPartialSignature().toByteArray());
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_C.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigSetupTradeMessage_C.java
@@ -19,7 +19,7 @@ package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
 import bisq.trade.mu_sig.messages.network.vo.NonceShares;
-import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
+import bisq.trade.mu_sig.messages.network.vo.RedactedPartialSignatures;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @EqualsAndHashCode(callSuper = true)
 public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
     private final NonceShares nonceShares;
-    private final PartialSignatures partialSignatures;
+    private final RedactedPartialSignatures redactedPartialSignatures;
 
     public MuSigSetupTradeMessage_C(String id,
                                     String tradeId,
@@ -39,10 +39,10 @@ public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
                                     NetworkId sender,
                                     NetworkId receiver,
                                     NonceShares nonceShares,
-                                    PartialSignatures partialSignatures) {
+                                    RedactedPartialSignatures redactedPartialSignatures) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.nonceShares = nonceShares;
-        this.partialSignatures = partialSignatures;
+        this.redactedPartialSignatures = redactedPartialSignatures;
 
         verify();
     }
@@ -66,7 +66,7 @@ public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
     private bisq.trade.protobuf.MuSigSetupTradeMessage_C.Builder getMuSigSetupTradeMessage_C(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigSetupTradeMessage_C.newBuilder()
                 .setNonceShares(nonceShares.toProto(serializeForHash))
-                .setPartialSignatures(partialSignatures.toProto(serializeForHash));
+                .setRedactedPartialSignatures(redactedPartialSignatures.toProto(serializeForHash));
     }
 
     public static MuSigSetupTradeMessage_C fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -78,7 +78,7 @@ public final class MuSigSetupTradeMessage_C extends MuSigTradeMessage {
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
                 NonceShares.fromProto(muSigMessageProto.getNonceShares()),
-                PartialSignatures.fromProto(muSigMessageProto.getPartialSignatures()));
+                RedactedPartialSignatures.fromProto(muSigMessageProto.getRedactedPartialSignatures()));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/buyer_as_taker/MuSigSetupTradeMessage_B_Handler.java
@@ -29,8 +29,8 @@ import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_B;
 import bisq.trade.mu_sig.messages.network.MuSigSetupTradeMessage_C;
 import bisq.trade.mu_sig.messages.network.vo.NonceShares;
-import bisq.trade.mu_sig.messages.network.vo.PartialSignatures;
 import bisq.trade.mu_sig.messages.network.vo.PubKeyShares;
+import bisq.trade.mu_sig.messages.network.vo.RedactedPartialSignatures;
 import bisq.trade.protobuf.NonceSharesRequest;
 import bisq.trade.protobuf.PartialSignaturesRequest;
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
@@ -105,17 +105,16 @@ public final class MuSigSetupTradeMessage_B_Handler extends MuSigTradeMessageHan
     @Override
     protected void sendMessage() {
         NonceShares nonceShares = NonceShares.from(myNonceSharesMessage);
-
-        // TODO redacting swapTxInputPartialSignature fails at MuSigPaymentReceiptConfirmedEventHandler
-        PartialSignatures partialSignatures =  PartialSignatures.from(myPartialSignaturesMessage);
-
+        // We do not expose swapTxInputPartialSignature at that stage to the peer, thus we use RedactedPartialSignatures
+        // Later once we initiate the payment we send the swapTxInputPartialSignature
+        RedactedPartialSignatures redactedPartialSignatures = RedactedPartialSignatures.from(myPartialSignaturesMessage);
         send(new MuSigSetupTradeMessage_C(StringUtils.createUid(),
                 trade.getId(),
                 trade.getProtocolVersion(),
                 trade.getMyself().getNetworkId(),
                 trade.getPeer().getNetworkId(),
                 nonceShares,
-                partialSignatures));
+                redactedPartialSignatures));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller_as_maker/MuSigSetupTradeMessage_C_Handler.java
@@ -71,10 +71,10 @@ public final class MuSigSetupTradeMessage_C_Handler extends MuSigTradeMessageHan
 
         // swapTxInputPartialSignature is not set in peersRedactedPartialSignatures, thus the
         // PartialSignaturesMessage has a cleared swapTxInputPartialSignature field.
-        PartialSignaturesMessage peersredactedPartialSignaturesMessage = PartialSignaturesMessage.from(peersRedactedPartialSignatures);
+        PartialSignaturesMessage peersRedactedPartialSignaturesMessage = PartialSignaturesMessage.from(peersRedactedPartialSignatures);
         DepositTxSignatureRequest depositTxSignatureRequest = DepositTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
-                .setPeersPartialSignatures(peersredactedPartialSignaturesMessage.toProto(true))
+                .setPeersPartialSignatures(peersRedactedPartialSignaturesMessage.toProto(true))
                 .build();
         myDepositPsbt = DepositPsbt.fromProto(musigBlockingStub.signDepositTx(depositTxSignatureRequest));
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/PartialSignatures.java
@@ -23,15 +23,21 @@ import com.google.protobuf.ByteString;
 import lombok.Getter;
 
 import java.util.Arrays;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Getter
 public final class PartialSignatures implements Proto {
     public static PartialSignatures from(PartialSignaturesMessage partialSignaturesMessage) {
+        Optional<byte[]> swapTxInputPartialSignature = partialSignaturesMessage.getSwapTxInputPartialSignature();
+        checkArgument(swapTxInputPartialSignature.isPresent(),
+                "swapTxInputPartialSignature must not be empty when creating PartialSignatures from PartialSignaturesMessage");
         return new PartialSignatures(
                 partialSignaturesMessage.getPeersWarningTxBuyerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersWarningTxSellerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersRedirectTxInputPartialSignature().clone(),
-                partialSignaturesMessage.getSwapTxInputPartialSignature().clone()
+                swapTxInputPartialSignature.get().clone()
         );
     }
 
@@ -48,7 +54,6 @@ public final class PartialSignatures implements Proto {
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
-    // todo swapTxInputPartialSignature can be empty byte array (redacted), consider to make optional or make 2 classes
     private final byte[] swapTxInputPartialSignature;
 
     private PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/RedactedPartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/vo/RedactedPartialSignatures.java
@@ -25,71 +25,53 @@ import lombok.Getter;
 import java.util.Arrays;
 
 @Getter
-public final class PartialSignatures implements Proto {
-    public static PartialSignatures from(PartialSignaturesMessage partialSignaturesMessage) {
-        return new PartialSignatures(
+public final class RedactedPartialSignatures implements Proto {
+    public static RedactedPartialSignatures from(PartialSignaturesMessage partialSignaturesMessage) {
+        return new RedactedPartialSignatures(
                 partialSignaturesMessage.getPeersWarningTxBuyerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersWarningTxSellerInputPartialSignature().clone(),
-                partialSignaturesMessage.getPeersRedirectTxInputPartialSignature().clone(),
-                partialSignaturesMessage.getSwapTxInputPartialSignature().clone()
-        );
-    }
-
-    public static PartialSignatures from(RedactedPartialSignatures partialSignatures,
-                                         byte[] swapTxInputPartialSignature) {
-        return new PartialSignatures(
-                partialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
-                partialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
-                partialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
-                swapTxInputPartialSignature.clone()
+                partialSignaturesMessage.getPeersRedirectTxInputPartialSignature().clone()
         );
     }
 
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
-    // todo swapTxInputPartialSignature can be empty byte array (redacted), consider to make optional or make 2 classes
-    private final byte[] swapTxInputPartialSignature;
 
-    private PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
-                              byte[] peersWarningTxSellerInputPartialSignature,
-                              byte[] peersRedirectTxInputPartialSignature,
-                              byte[] swapTxInputPartialSignature) {
+    private RedactedPartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
+                                      byte[] peersWarningTxSellerInputPartialSignature,
+                                      byte[] peersRedirectTxInputPartialSignature) {
         this.peersWarningTxBuyerInputPartialSignature = peersWarningTxBuyerInputPartialSignature;
         this.peersWarningTxSellerInputPartialSignature = peersWarningTxSellerInputPartialSignature;
         this.peersRedirectTxInputPartialSignature = peersRedirectTxInputPartialSignature;
-        this.swapTxInputPartialSignature = swapTxInputPartialSignature;
     }
 
     @Override
-    public bisq.trade.protobuf.PartialSignatures.Builder getBuilder(boolean serializeForHash) {
-        return bisq.trade.protobuf.PartialSignatures.newBuilder()
+    public bisq.trade.protobuf.RedactedPartialSignatures.Builder getBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.RedactedPartialSignatures.newBuilder()
                 .setPeersWarningTxBuyerInputPartialSignature(ByteString.copyFrom(peersWarningTxBuyerInputPartialSignature))
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
-                .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature))
-                .setSwapTxInputPartialSignature(ByteString.copyFrom(swapTxInputPartialSignature));
+                .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature));
     }
 
     @Override
-    public bisq.trade.protobuf.PartialSignatures toProto(boolean serializeForHash) {
+    public bisq.trade.protobuf.RedactedPartialSignatures toProto(boolean serializeForHash) {
         return getBuilder(serializeForHash).build();
     }
 
-    public static PartialSignatures fromProto(bisq.trade.protobuf.PartialSignatures proto) {
-        return new PartialSignatures(proto.getPeersWarningTxBuyerInputPartialSignature().toByteArray(),
+    public static RedactedPartialSignatures fromProto(bisq.trade.protobuf.RedactedPartialSignatures proto) {
+        return new RedactedPartialSignatures(proto.getPeersWarningTxBuyerInputPartialSignature().toByteArray(),
                 proto.getPeersWarningTxSellerInputPartialSignature().toByteArray(),
-                proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
-                proto.getSwapTxInputPartialSignature().toByteArray());
+                proto.getPeersRedirectTxInputPartialSignature().toByteArray());
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PartialSignatures that)) return false;
+        if (!(o instanceof RedactedPartialSignatures that)) return false;
 
         return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
                 Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
-                Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
-                Arrays.equals(swapTxInputPartialSignature, that.swapTxInputPartialSignature);
+                Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature);
     }
 
     @Override
@@ -97,7 +79,6 @@ public final class PartialSignatures implements Proto {
         int result = Arrays.hashCode(peersWarningTxBuyerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
-        result = 31 * result + Arrays.hashCode(swapTxInputPartialSignature);
         return result;
     }
 }

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -176,6 +176,12 @@ message PartialSignatures {
   optional bytes swapTxInputPartialSignature = 4;
 }
 
+message RedactedPartialSignatures {
+  bytes peersWarningTxBuyerInputPartialSignature = 1;
+  bytes peersWarningTxSellerInputPartialSignature = 2;
+  bytes peersRedirectTxInputPartialSignature = 3;
+}
+
 
 message SwapTxSignature {
   bytes swapTx = 1;
@@ -190,7 +196,8 @@ message MuSigTradeParty {
   optional  NonceShares peersNonceShares = 4;
   optional musigrpc.PartialSignaturesMessage myPartialSignaturesMessage = 5;
   optional PartialSignatures peersPartialSignatures = 6;
-  optional musigrpc.DepositPsbt myDepositPsbt = 7;
+  optional RedactedPartialSignatures peersRedactedPartialSignatures = 7;
+  optional musigrpc.DepositPsbt myDepositPsbt = 8;
   optional musigrpc.SwapTxSignatureResponse mySwapTxSignatureResponse = 9;
   optional SwapTxSignature peersSwapTxSignature = 10;
   optional musigrpc.CloseTradeResponse myCloseTradeResponse = 11;
@@ -235,7 +242,7 @@ message MuSigSetupTradeMessage_B {
 
 message MuSigSetupTradeMessage_C {
   NonceShares nonceShares = 1;
-  PartialSignatures partialSignatures = 2;
+  RedactedPartialSignatures redactedPartialSignatures = 2;
 }
 
 message MuSigSetupTradeMessage_D {
@@ -243,7 +250,7 @@ message MuSigSetupTradeMessage_D {
 }
 
 message MuSigPaymentInitiatedMessage_E {
-  // no additional fields; all data inherited from base class
+  bytes swapTxInputPartialSignature = 1;
 }
 
 message MuSigPaymentReceivedMessage_F {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for redacted partial signatures in MuSig trade messages, enhancing privacy by sharing only necessary signature components between peers.
  - Added handling and exchange of swap transaction input partial signatures in relevant trade message flows.

- **Bug Fixes**
  - Improved serialization to prevent backend errors when handling empty signature fields.

- **Refactor**
  - Updated message formats and internal handling to use redacted partial signatures instead of full signatures where appropriate, streamlining the signature exchange process.

- **Documentation**
  - Removed outdated or redundant inline comments for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->