### PR TITLE
auto-scale dropdownMenu icon to adapt high resolution screen

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenu.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/DropdownMenu.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 
 public class DropdownMenu extends HBox {
     public static final Double INITIAL_WIDTH = 24.0;
+    private static final double ICON_ONLY_FIT_SIZE = 20.0;
 
     private ImageView defaultIcon, activeIcon;
     @Getter
@@ -58,6 +59,7 @@ public class DropdownMenu extends HBox {
     @Setter
     private boolean openToTheRight = false;
     private Double prefWidth = null;
+    private final boolean isUseIconOnly;
 
     @SuppressWarnings("FieldCanBeLocal") // Need to keep a reference as used in WeakChangeListener
     private final ChangeListener<Window> windowListener;
@@ -67,12 +69,9 @@ public class DropdownMenu extends HBox {
     private final ChangeListener<Scene> sceneListener;
 
     public DropdownMenu(String defaultIconId, String activeIconId, boolean useIconOnly) {
-        defaultIcon = ImageUtil.getImageViewById(defaultIconId);
-        activeIcon = ImageUtil.getImageViewById(activeIconId);
-
-        buttonIcon = defaultIcon;
-
-        getChildren().addAll(hBox, buttonIcon);
+        this.isUseIconOnly = useIconOnly;
+        setIcons(defaultIconId, activeIconId);
+        getChildren().add(hBox);
         hBox.getStyleClass().add("dropdown-menu-content-hbox");
         hBox.setAlignment(Pos.BASELINE_LEFT);
 
@@ -116,6 +115,15 @@ public class DropdownMenu extends HBox {
     public void setIcons(String newDefaultIconId, String newActiveIconId) {
         ImageView newDefault = ImageUtil.getImageViewById(newDefaultIconId);
         ImageView newActive = ImageUtil.getImageViewById(newActiveIconId);
+
+        if (isUseIconOnly) {
+            newDefault.setFitWidth(ICON_ONLY_FIT_SIZE);
+            newDefault.setFitHeight(ICON_ONLY_FIT_SIZE);
+            newActive.setFitWidth(ICON_ONLY_FIT_SIZE);
+            newActive.setFitHeight(ICON_ONLY_FIT_SIZE);
+            newDefault.setPreserveRatio(true);
+            newActive.setPreserveRatio(true);
+        }
 
         this.defaultIcon = newDefault;
         this.activeIcon = newActive;


### PR DESCRIPTION
Testing on a high resolution screen is needed as my screen is just1080p.

On @HenrikJannsen's Mac M3 the notification dropdownMenu Icon is too small as following:
![image](https://github.com/user-attachments/assets/4a44515e-8f6e-450c-b94c-08c626950dc7)
 while the expectation should be like this:
 
![image](https://github.com/user-attachments/assets/c9fedb82-ba2c-4c1d-a07d-c35cba32667c)



please find more context in the issue #3376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved icon-only dropdown menus with consistent icon sizing for a more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->