### PR TITLE
Bugfix/clearnet handshake challenge using wrong peer address

### DIFF
--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -116,10 +116,14 @@ application {
         }
     }
       
-    network = {
+    network {
         version = 1
 
         supportedTransportTypes = ["TOR"]
+        # For Clearnet seed setup, replace with your seed node public ip
+        # supportedTransportTypes = ["TOR", "CLEAR"]
+        # clearPublicAddress = "10.0.0.158:8000"
+
         features = ["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH","AUTHORIZATION_HASH_CASH_V2"]
 
         serviceNode {

--- a/common/src/main/java/bisq/common/facades/FacadeProvider.java
+++ b/common/src/main/java/bisq/common/facades/FacadeProvider.java
@@ -17,6 +17,8 @@
 
 package bisq.common.facades;
 
+import bisq.common.network.AndroidDeviceLocalhostFacade;
+import bisq.common.network.AndroidEmulatorLocalhostFacade;
 import bisq.common.network.DefaultLocalhostFacade;
 import bisq.common.network.LocalhostFacade;
 
@@ -29,7 +31,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class FacadeProvider {
     private static JdkFacade jdkFacade;
     private static GuavaFacade guavaFacade;
-    private static LocalhostFacade localhostFacade = new DefaultLocalhostFacade();
+    private static LocalhostFacade localhostFacade;
+    private static boolean isAndroidEmulator = false;
+    private static boolean isAndroidDevice = false;
 
     public static void setJdkFacade(JdkFacade jdkFacade) {
         FacadeProvider.jdkFacade = jdkFacade;
@@ -49,8 +53,25 @@ public class FacadeProvider {
         return guavaFacade;
     }
 
+    public static void setIsAndroidEmulator(boolean value) {
+        isAndroidEmulator = value;
+    }
+    
+    public static void setIsAndroidDevice(boolean value) {
+        isAndroidDevice = value;
+    }
+
     public static LocalhostFacade getLocalhostFacade() {
-        return localhostFacade;
+        if (localhostFacade == null) {
+            if (isAndroidEmulator) {
+                localhostFacade = new AndroidEmulatorLocalhostFacade();
+            } else if (isAndroidDevice) {
+                localhostFacade = new AndroidDeviceLocalhostFacade();
+            } else {
+                localhostFacade = new DefaultLocalhostFacade();
+            }
+        }
+        return checkNotNull(localhostFacade, "localhostFacade must not be null");
     }
 
     public static void setLocalhostFacade(LocalhostFacade localhostFacade) {

--- a/common/src/main/java/bisq/common/network/AndroidDeviceLocalhostFacade.java
+++ b/common/src/main/java/bisq/common/network/AndroidDeviceLocalhostFacade.java
@@ -1,0 +1,55 @@
+package bisq.common.network;
+
+import lombok.extern.slf4j.Slf4j;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+
+@Slf4j
+public class AndroidDeviceLocalhostFacade implements LocalhostFacade {
+    
+    public Address toMyLocalhost(int port) {
+        String deviceIp = getDeviceIpAddress();
+        log.info("Android device using IP address: {}", deviceIp);
+        return new Address(deviceIp, port);
+    }
+
+    public Address toPeersLocalhost(Address address) {
+        // For real devices, we don't need to modify peer addresses
+        return address;
+    }
+    
+    private String getDeviceIpAddress() {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // Skip loopback interfaces
+                if (iface.isLoopback() || !iface.isUp()) {
+                    continue;
+                }
+                
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    String ip = addr.getHostAddress();
+                    
+                    // Skip IPv6 addresses
+                    if (ip.contains(":")) {
+                        continue;
+                    }
+                    
+                    // Found a valid IPv4 address
+                    log.debug("Found device IP: {} on interface: {}", ip, iface.getDisplayName());
+                    return ip;
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error getting device IP address", e);
+        }
+        
+        // Fallback to default localhost if we couldn't find a better address
+        log.warn("Could not determine device IP, falling back to 127.0.0.1");
+        return "127.0.0.1";
+    }
+}

--- a/network/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/network/src/main/java/bisq/network/NetworkService.java
@@ -151,7 +151,16 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
 
 
         seedAddressesByTransportFromConfig = config.getSeedAddressesByTransport();
-        serviceNodesByTransport = new ServiceNodesByTransport(config.getConfigByTransportType(),
+
+        Optional<String> publicAddress = config.getPublicAddress();
+        if (publicAddress.isEmpty()) {
+            log.error("CLEAR: No Public Address Configured");
+        } else {
+            log.info("Using configured public address: {}", publicAddress.get());
+        }
+
+        serviceNodesByTransport = new ServiceNodesByTransport(
+                config.getConfigByTransportType(),
                 config.getServiceNodeConfig(),
                 config.getPeerGroupServiceConfigByTransport(),
                 seedAddressesByTransportFromConfig,
@@ -166,7 +175,8 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
                 dataService,
                 messageDeliveryStatusService,
                 resendMessageService,
-                memoryReportService);
+                memoryReportService,
+                publicAddress);  // Pass the public address
         persistence = persistenceService.getOrCreatePersistence(this, DbSubDirectory.CACHE, persistableStore);
     }
 

--- a/network/network/src/main/java/bisq/network/NetworkServiceConfig.java
+++ b/network/network/src/main/java/bisq/network/NetworkServiceConfig.java
@@ -78,6 +78,13 @@ public final class NetworkServiceConfig {
         Map<TransportType, Integer> defaultPortByTransportType = createDefaultPortByTransportType(config);
         Map<TransportType, TransportConfig> configByTransportType = createConfigByTransportType(config, baseDir);
 
+        Optional<String> clearPublicAddress = Optional.empty();
+        try {
+            clearPublicAddress = Optional.of(config.getString("clearPublicAddress"));
+        } catch (Exception e) {
+            // do nth
+        }
+
         return new NetworkServiceConfig(baseDir.toAbsolutePath().toString(),
                 config.getInt("version"),
                 supportedTransportTypes,
@@ -89,7 +96,8 @@ public final class NetworkServiceConfig {
                 peerGroupServiceConfigByTransport,
                 defaultPortByTransportType,
                 seedAddressesByTransport,
-                Optional.empty());
+                Optional.empty(),
+                clearPublicAddress);
     }
 
     private static Map<TransportType, Integer> createDefaultPortByTransportType(Config config) {
@@ -177,6 +185,7 @@ public final class NetworkServiceConfig {
     private final Map<TransportType, Integer> defaultPortByTransportType;
     private final Map<TransportType, Set<Address>> seedAddressesByTransport;
     private final Optional<String> socks5ProxyAddress;
+    private final Optional<String> publicAddress;
 
     public NetworkServiceConfig(String baseDir,
                                 int version,
@@ -189,7 +198,8 @@ public final class NetworkServiceConfig {
                                 Map<TransportType, PeerGroupManager.Config> peerGroupServiceConfigByTransport,
                                 Map<TransportType, Integer> defaultPortByTransportType,
                                 Map<TransportType, Set<Address>> seedAddressesByTransport,
-                                Optional<String> socks5ProxyAddress) {
+                                Optional<String> socks5ProxyAddress,
+                                Optional<String> publicAddress) {
         this.baseDir = baseDir;
         this.version = version;
         this.supportedTransportTypes = supportedTransportTypes;
@@ -202,6 +212,7 @@ public final class NetworkServiceConfig {
         this.defaultPortByTransportType = filterMap(supportedTransportTypes, defaultPortByTransportType);
         this.seedAddressesByTransport = filterMap(supportedTransportTypes, seedAddressesByTransport);
         this.socks5ProxyAddress = socks5ProxyAddress;
+        this.publicAddress = publicAddress;
     }
 
     // In case our config contains not supported transport types we remove them
@@ -210,5 +221,9 @@ public final class NetworkServiceConfig {
         return map.entrySet().stream()
                 .filter(e -> supportedTransportTypes.contains(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Optional<String> getPublicAddress() {
+        return publicAddress;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/ServiceNodesByTransport.java
+++ b/network/network/src/main/java/bisq/network/p2p/ServiceNodesByTransport.java
@@ -89,7 +89,8 @@ public class ServiceNodesByTransport {
                                    Optional<DataService> dataService,
                                    Optional<MessageDeliveryStatusService> messageDeliveryStatusService,
                                    Optional<ResendMessageService> resendMessageService,
-                                   MemoryReportService memoryReportService) {
+                                   MemoryReportService memoryReportService,
+                                   Optional<String> publicAddress) {
         this.supportedTransportTypes = supportedTransportTypes;
 
         authorizationService = new AuthorizationService(authorizationServiceConfig,
@@ -107,7 +108,8 @@ public class ServiceNodesByTransport {
                     transportConfig.getUserNodeSocketTimeout(),
                     transportConfig.getDevModeDelayInMs(),
                     transportConfig.getSendMessageThrottleTime(),
-                    transportConfig.getReceiveMessageThrottleTime());
+                    transportConfig.getReceiveMessageThrottleTime(),
+                    publicAddress);  // Pass the public address
             Set<Address> seedAddresses = seedAddressesByTransport.get(transportType);
             checkNotNull(seedAddresses, "Seed nodes must be setup for %s", transportType);
             PeerGroupManager.Config peerGroupServiceConfig = peerGroupServiceConfigByTransport.get(transportType);

--- a/network/network/src/main/java/bisq/network/p2p/node/NodesById.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/NodesById.java
@@ -77,7 +77,18 @@ public class NodesById implements Node.Listener {
     /* --------------------------------------------------------------------- */
 
     public Node createAndConfigNode(NetworkId networkId, boolean isDefaultNode) {
-        Node node = new Node(networkId, isDefaultNode, nodeConfig, banList, keyBundleService, transportService, networkLoadSnapshot, authorizationService);
+        // Get the nullable clearnet public address from the node config
+        Optional<String> publicAddress = nodeConfig.getPublicAddress();
+        Node node = new Node(networkId, 
+                            isDefaultNode, 
+                            nodeConfig, 
+                            banList, 
+                            keyBundleService, 
+                            transportService, 
+                            networkLoadSnapshot, 
+                            authorizationService,
+                            publicAddress);
+        
         map.put(networkId, node);
         node.addListener(this);
         listeners.forEach(listener -> {

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
@@ -114,6 +114,9 @@ public class AuthorizationService {
             log.warn("Not supported authorizationTokenType {}", authorizationTokenType);
             return false;
         }
+        
+        log.debug("Verifying authorization with my address: {}", myAddress);
+        
         return supportedServices.get(authorizationTokenType).isAuthorized(message,
                 authorizationToken,
                 currentNetworkLoad,

--- a/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/handshake/ConnectionHandshake.java
@@ -232,6 +232,7 @@ public final class ConnectionHandshake {
                     peerAddress.getFullAddress(),
                     0,
                     peersFeatures);
+            log.debug("Client creating token with peer address: {}", peerAddress.getFullAddress());
             NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(token, request);
             long ts = System.currentTimeMillis();
             networkEnvelopeSocket.send(requestNetworkEnvelope);
@@ -320,8 +321,12 @@ public final class ConnectionHandshake {
                     NetworkLoad.INITIAL_NETWORK_LOAD,
                     StringUtils.createUid(),
                     myAddress.getFullAddress());
+            log.debug("Server verifying token with my address: {}", myAddress.getFullAddress());
             if (!isAuthorized) {
-                throw new ConnectionException(AUTHORIZATION_FAILED, "Authorization of inbound connection request failed. AuthorizationToken=" + requestNetworkEnvelope.getAuthorizationToken());
+                log.warn("Authorization failed. Server address: {}, Client capability address: {}", 
+                        myAddress.getFullAddress(), request.getCapability().getAddress().getFullAddress());
+                throw new ConnectionException(AUTHORIZATION_FAILED,
+                        "Authorization of inbound connection request failed. AuthorizationToken=" + requestNetworkEnvelope.getAuthorizationToken());
             }
 
             if (!OnionAddressValidation.verify(myAddress, peerAddress, request.getSignatureDate(), request.getAddressOwnershipProof())) {


### PR DESCRIPTION
 - fix bug on CLEARNET: using the wrong peer address causes handshake challenge to fail
 - add seed node public ip conf for clear testing
 - improved Android LocalhostFacade to setup normal device, and emulator (not core to the issue but an enhancement)
 - improved logs whilst debugging the issue

How to test this PR?
 - uninstall your android node app from a real device if its installed
 - setup the android.conf file to use your LAN ip address of your seed node computer
 - reinstall the app and follow the prompts, you should be able to see the offers and trade (before it would show no offers, no data on homescreen either)