### PR TITLE
Add take and remove offer functionality in new MuSig offerbook

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
@@ -26,6 +26,7 @@ import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
+import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.mu_sig.create_offer.MuSigCreateOfferController;
 import bisq.desktop.main.content.mu_sig.take_offer.MuSigTakeOfferController;
 import bisq.desktop.navigation.NavigationTarget;
@@ -38,6 +39,8 @@ import bisq.settings.CookieKey;
 import bisq.settings.FavouriteMarketsService;
 import bisq.settings.SettingsService;
 import bisq.user.banned.BannedUserService;
+import bisq.user.banned.RateLimitExceededException;
+import bisq.user.banned.UserProfileBannedException;
 import bisq.user.profile.UserProfileService;
 import lombok.Getter;
 import org.fxmisc.easybind.EasyBind;
@@ -165,6 +168,28 @@ public class MuSigOfferbookController implements Controller {
 
     void onTakeOffer(MuSigOffer offer) {
         Navigation.navigateTo(NavigationTarget.MU_SIG_TAKE_OFFER, new MuSigTakeOfferController.InitData(offer));
+    }
+
+    void onRemoveOffer(MuSigOffer muSigOffer) {
+        new Popup().warning(Res.get("muSig.offerbook.removeOffer.confirmation"))
+                .actionButtonText(Res.get("confirmation.yes"))
+                .onAction(() -> doRemoveOffer(muSigOffer))
+                .closeButtonText(Res.get("confirmation.no"))
+                .show();
+    }
+
+    private void doRemoveOffer(MuSigOffer muSigOffer) {
+        try {
+            muSigService.removeOffer(muSigOffer);
+        } catch (UserProfileBannedException e) {
+            UIThread.run(() -> {
+                // We do not inform banned users about being banned
+            });
+        } catch (RateLimitExceededException e) {
+            UIThread.run(() -> {
+                new Popup().warning(Res.get("muSig.offerbook.rateLimitsExceeded.removeOffer.warning")).show();
+            });
+        }
     }
 
     private void maybeSelectFirst() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookView.java
@@ -407,7 +407,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
                         //  If using grey-transparent-outlined-button we have a white label. Quick fix is to use opacity with a while style...
                         takeOfferButton.getStyleClass().add("white-transparent-outlined-button");
                         takeOfferButton.setOpacity(0.5);
-//                        takeOfferButton.setOnAction(e -> controller.onRemoveOffer(item.getOffer()));
+                        takeOfferButton.setOnAction(e -> controller.onRemoveOffer(item.getOffer()));
                     } else {
                         takeOfferButton.setText(item.getTakeOfferButtonText());
                         takeOfferButton.setOpacity(1);

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -47,9 +47,9 @@ muSig.offerbook.table.cell.intent.remove=Remove
 muSig.offerbook.createOffer.buy=Create offer to buy BTC
 muSig.offerbook.createOffer.sell=Create offer to sell BTC
 
+muSig.offerbook.removeOffer.confirmation=Are you sure you want to delete this offer?
 muSig.offerbook.rateLimitsExceeded.removeOffer.warning=You cannot remove that offer because you have exceeded the rate limit.\n\
   Please try to use a different offer.
-
 
 muSig.offerbook.marketHeader.title=Market for trading with {0}
 muSig.offerbook.table.header.peerProfile=Peer profile


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to take or remove offers directly from the offer book, with appropriate navigation and confirmation dialogs.
- **User Experience**
  - Users now receive a confirmation prompt before removing an offer and are shown a warning if rate limits are exceeded.
  - Added localized confirmation message for offer removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->