### PR TITLE
Add favourite markets list view in MuSig offerbook

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
@@ -64,7 +64,7 @@ public class MuSigOfferbookController implements Controller {
     private final IdentityService identityService;
     private final BannedUserService bannedUserService;
     private final FavouriteMarketsService favouriteMarketsService;
-//    private final Predicate<MarketItem> marketItemsPredicate;
+    private final Predicate<MarketItem> marketItemsPredicate;
     private final Predicate<MarketItem> favouriteMarketItemsPredicate;
     private Pin offersPin, selectedMarketPin, favouriteMarketsPin;
     private Subscription selectedMarketItemPin;
@@ -81,11 +81,11 @@ public class MuSigOfferbookController implements Controller {
         model = new MuSigOfferbookModel();
         view = new MuSigOfferbookView(model, this);
 
-//        marketItemsPredicate = item ->
-//                model.getMarketFilterPredicate().test(item) &&
+        marketItemsPredicate = item ->
+                model.getMarketFilterPredicate().test(item) &&
 //                        model.getMarketSearchTextPredicate().test(item) &&
 //                        model.getMarketPricePredicate().test(item) &&
-//                        !item.getIsFavourite().get();
+                        !item.getIsFavourite().get();
         favouriteMarketItemsPredicate = item -> item.getIsFavourite().get();
     }
 
@@ -189,7 +189,6 @@ public class MuSigOfferbookController implements Controller {
 
         updateFilteredMarketItems();
         updateFavouriteMarketItems();
-        maybeSelectFirst();
     }
 
     @Override
@@ -314,8 +313,8 @@ public class MuSigOfferbookController implements Controller {
     }
 
     private void updateFilteredMarketItems() {
-//        model.getFilteredMarketItems().setPredicate(null);
-//        model.getFilteredMarketItems().setPredicate(marketItemsPredicate);
+        model.getFilteredMarketItems().setPredicate(null);
+        model.getFilteredMarketItems().setPredicate(marketItemsPredicate);
     }
 
     private void updateFavouriteMarketItems() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
@@ -323,13 +323,13 @@ public class MuSigOfferbookController implements Controller {
         // Thus, we trigger a change of the predicate to force a refresh.
         model.getFavouriteMarketItems().setPredicate(null);
         model.getFavouriteMarketItems().setPredicate(favouriteMarketItemsPredicate);
-        model.getFavouritesListViewHeightChanged().set(false);
-        model.getFavouritesListViewHeightChanged().set(true);
+        model.getFavouritesListViewNeedsHeightUpdate().set(false);
+        model.getFavouritesListViewNeedsHeightUpdate().set(true);
     }
 
     private Optional<MarketItem> findMarketItem(Market market) {
         return model.getMarketItems().stream()
                 .filter(e -> e.getMarket().equals(market))
-                .findFirst();
+                .findAny();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
@@ -48,6 +48,7 @@ import org.fxmisc.easybind.Subscription;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -63,7 +64,9 @@ public class MuSigOfferbookController implements Controller {
     private final IdentityService identityService;
     private final BannedUserService bannedUserService;
     private final FavouriteMarketsService favouriteMarketsService;
-    private Pin offersPin, selectedMarketPin;
+//    private final Predicate<MarketItem> marketItemsPredicate;
+    private final Predicate<MarketItem> favouriteMarketItemsPredicate;
+    private Pin offersPin, selectedMarketPin, favouriteMarketsPin;
     private Subscription selectedMarketItemPin;
 
     public MuSigOfferbookController(ServiceProvider serviceProvider) {
@@ -77,6 +80,13 @@ public class MuSigOfferbookController implements Controller {
 
         model = new MuSigOfferbookModel();
         view = new MuSigOfferbookView(model, this);
+
+//        marketItemsPredicate = item ->
+//                model.getMarketFilterPredicate().test(item) &&
+//                        model.getMarketSearchTextPredicate().test(item) &&
+//                        model.getMarketPricePredicate().test(item) &&
+//                        !item.getIsFavourite().get();
+        favouriteMarketItemsPredicate = item -> item.getIsFavourite().get();
     }
 
     @Override
@@ -145,11 +155,48 @@ public class MuSigOfferbookController implements Controller {
                         .ifPresent(item -> model.getSelectedMarketItem().set(item));
             }
         });
+
+        favouriteMarketsPin = settingsService.getFavouriteMarkets().addObserver(new CollectionObserver<>() {
+            @Override
+            public void add(Market market) {
+                UIThread.run(() -> {
+                    findMarketItem(market).ifPresent(item -> item.getIsFavourite().set(true));
+                    updateFilteredMarketItems();
+                    updateFavouriteMarketItems();
+                });
+            }
+
+            @Override
+            public void remove(Object element) {
+                if (element instanceof Market market) {
+                    UIThread.run(() -> {
+                        findMarketItem(market).ifPresent(item -> item.getIsFavourite().set(false));
+                        updateFilteredMarketItems();
+                        updateFavouriteMarketItems();
+                    });
+                }
+            }
+
+            @Override
+            public void clear() {
+                UIThread.run(() -> {
+                    model.getMarketItems().forEach(item -> item.getIsFavourite().set(false));
+                    updateFilteredMarketItems();
+                    updateFavouriteMarketItems();
+                });
+            }
+        });
+
+        updateFilteredMarketItems();
+        updateFavouriteMarketItems();
+        maybeSelectFirst();
     }
 
     @Override
     public void onDeactivate() {
         offersPin.unbind();
+        favouriteMarketsPin.unbind();
+
         model.getMuSigOfferListItems().forEach(MuSigOfferListItem::dispose);
         model.getMuSigOfferListItems().clear();
         model.getMuSigOfferIds().clear();
@@ -264,5 +311,26 @@ public class MuSigOfferbookController implements Controller {
             model.getMarketDescription().set("");
             model.getMarketPrice().set("");
         }
+    }
+
+    private void updateFilteredMarketItems() {
+//        model.getFilteredMarketItems().setPredicate(null);
+//        model.getFilteredMarketItems().setPredicate(marketItemsPredicate);
+    }
+
+    private void updateFavouriteMarketItems() {
+        // FilteredList has no API for refreshing/invalidating so that the tableView gets updated.
+        // Calling refresh on the tableView also did not refresh the collection.
+        // Thus, we trigger a change of the predicate to force a refresh.
+        model.getFavouriteMarketItems().setPredicate(null);
+        model.getFavouriteMarketItems().setPredicate(favouriteMarketItemsPredicate);
+        model.getFavouritesListViewHeightChanged().set(false);
+        model.getFavouritesListViewHeightChanged().set(true);
+    }
+
+    private Optional<MarketItem> findMarketItem(Market market) {
+        return model.getMarketItems().stream()
+                .filter(e -> e.getMarket().equals(market))
+                .findFirst();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookModel.java
@@ -60,7 +60,7 @@ public class MuSigOfferbookModel implements Model {
     private final ObjectProperty<MarketItem> selectedMarketItem = new SimpleObjectProperty<>();
 
     @Setter
-    private BooleanProperty favouritesListViewHeightChanged = new SimpleBooleanProperty();
+    private BooleanProperty favouritesListViewNeedsHeightUpdate = new SimpleBooleanProperty();
     @Setter
     private Predicate<MarketItem> marketFilterPredicate = marketItem -> true;
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookModel.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 @Slf4j
 @Getter
@@ -60,4 +61,6 @@ public class MuSigOfferbookModel implements Model {
 
     @Setter
     private BooleanProperty favouritesListViewHeightChanged = new SimpleBooleanProperty();
+    @Setter
+    private Predicate<MarketItem> marketFilterPredicate = marketItem -> true;
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookModel.java
@@ -18,7 +18,9 @@
 package bisq.desktop.main.content.mu_sig.offerbook;
 
 import bisq.desktop.common.view.Model;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -27,6 +29,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
@@ -54,4 +57,7 @@ public class MuSigOfferbookModel implements Model {
     private final SortedList<MarketItem> sortedMarketItems = new SortedList<>(filteredMarketItems);
     private final FilteredList<MarketItem> favouriteMarketItems = new FilteredList<>(marketItems);
     private final ObjectProperty<MarketItem> selectedMarketItem = new SimpleObjectProperty<>();
+
+    @Setter
+    private BooleanProperty favouritesListViewHeightChanged = new SimpleBooleanProperty();
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookView.java
@@ -62,6 +62,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
     private static final double LIST_CELL_HEIGHT = 53;
     private static final double MARKET_LIST_WIDTH = 210;
     private static final double SIDE_PADDING = 40;
+    private static final double FAVOURITES_TABLE_PADDING = 21;
 
     private final RichTableView<MuSigOfferListItem> muSigOfferListView;
     private final BisqTableView<MarketItem> marketListView, favouritesListView;
@@ -72,7 +73,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
     private VBox marketListVBox;
     private Label marketListTitle, marketHeaderIcon, marketTitle, marketDescription, marketPrice;
     private Button createOfferButton;
-    private Subscription selectedMarketItemPin, marketListViewSelectionPin, favouritesListViewHeightChangedPin,
+    private Subscription selectedMarketItemPin, marketListViewSelectionPin, favouritesListViewNeedsHeightUpdatePin,
             favouritesListViewSelectionPin;
 
     public MuSigOfferbookView(MuSigOfferbookModel model, MuSigOfferbookController controller) {
@@ -144,10 +145,9 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
         });
         model.getFavouriteMarketItems().addListener(favouriteItemsChangeListener);
 
-        favouritesListViewHeightChangedPin = EasyBind.subscribe(model.getFavouritesListViewHeightChanged(), heightChanged -> {
-            if (heightChanged) {
-                double padding = 21;
-                double tableViewHeight = (model.getFavouriteMarketItems().size() * LIST_CELL_HEIGHT) + padding;
+        favouritesListViewNeedsHeightUpdatePin = EasyBind.subscribe(model.getFavouritesListViewNeedsHeightUpdate(), needsUpdate -> {
+            if (needsUpdate) {
+                double tableViewHeight = (model.getFavouriteMarketItems().size() * LIST_CELL_HEIGHT) + FAVOURITES_TABLE_PADDING;
                 updateFavouritesTableViewHeight(tableViewHeight);
             }
         });
@@ -171,7 +171,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
         selectedMarketItemPin.unsubscribe();
         marketListViewSelectionPin.unsubscribe();
         favouritesListViewSelectionPin.unsubscribe();
-        favouritesListViewHeightChangedPin.unsubscribe();
+        favouritesListViewNeedsHeightUpdatePin.unsubscribe();
 
         createOfferButton.setOnAction(null);
 
@@ -539,5 +539,6 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
         favouritesListView.setMinHeight(height);
         favouritesListView.setPrefHeight(height);
         favouritesListView.setMaxHeight(height);
+        model.getFavouritesListViewNeedsHeightUpdate().set(false);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated favourites list view that displays user-marked markets separately.
  - The favourites list updates automatically in response to changes in the user's favourites.
  - The height of the favourites list view dynamically adjusts based on the number of items for better visibility.
- **Improvements**
  - Enhanced filtering capabilities for market items, allowing more flexible list updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->