### PR TITLE
Fix: Incorrect display of BTC range amounts in Bisq Easy Trade Wizard Review

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/ReviewDataDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/ReviewDataDisplay.java
@@ -20,15 +20,11 @@ package bisq.desktop.main.content.bisq_easy.components;
 import bisq.common.currency.TradeCurrency;
 import bisq.common.data.Pair;
 import bisq.common.data.Triple;
-import bisq.common.monetary.Monetary;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BitcoinAmountDisplay;
 import bisq.i18n.Res;
-import bisq.presentation.formatters.AmountFormatter;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
@@ -68,10 +64,6 @@ public class ReviewDataDisplay {
         controller.model.getToSendAmountDescription().set(value);
     }
 
-    public void setToSendAmount(String value) {
-        controller.model.getToSendAmount().set(value);
-    }
-
     public void setToSendCode(String value) {
         controller.model.getToSendCode().set(value);
         controller.model.getIsSendBtc().set(TradeCurrency.isBtc(value));
@@ -79,10 +71,6 @@ public class ReviewDataDisplay {
 
     public void setToReceiveAmountDescription(String value) {
         controller.model.getToReceiveAmountDescription().set(value);
-    }
-
-    public void setToReceiveAmount(String value) {
-        controller.model.getToReceiveAmount().set(value);
     }
 
     public void setToReceiveCode(String value) {
@@ -102,20 +90,20 @@ public class ReviewDataDisplay {
         controller.model.getBitcoinPaymentMethod().set(value);
     }
 
-    public void setToSendMinAmount(Monetary value) {
+    public void setToSendMinAmount(String value) {
         controller.model.getToSendMinAmount().set(value);
     }
 
-    public void setToSendMaxAmount(Monetary value) {
-        controller.model.getToSendMaxAmount().set(value);
+    public void setToSendMaxOrFixedAmount(String value) {
+        controller.model.getToSendMaxOrFixedAmount().set(value);
     }
 
-    public void setToReceiveMinAmount(Monetary value) {
+    public void setToReceiveMinAmount(String value) {
         controller.model.getToReceiveMinAmount().set(value);
     }
 
-    public void setToReceiveMaxAmount(Monetary value) {
-        controller.model.getToReceiveMaxAmount().set(value);
+    public void setToReceiveMaxOrFixedAmount(String value) {
+        controller.model.getToReceiveMaxOrFixedAmount().set(value);
     }
 
     public void setFiatPaymentMethod(String value) {
@@ -146,10 +134,8 @@ public class ReviewDataDisplay {
         private final BooleanProperty isRangeAmount = new SimpleBooleanProperty();
         private final StringProperty direction = new SimpleStringProperty();
         private final StringProperty toSendAmountDescription = new SimpleStringProperty();
-        private final StringProperty toSendAmount = new SimpleStringProperty();
         private final StringProperty toSendCode = new SimpleStringProperty();
         private final StringProperty toReceiveAmountDescription = new SimpleStringProperty();
-        private final StringProperty toReceiveAmount = new SimpleStringProperty();
         private final StringProperty toReceiveCode = new SimpleStringProperty();
         private final StringProperty bitcoinPaymentMethodDescription = new SimpleStringProperty();
         private final StringProperty bitcoinPaymentMethod = new SimpleStringProperty();
@@ -157,30 +143,27 @@ public class ReviewDataDisplay {
         private final StringProperty fiatPaymentMethod = new SimpleStringProperty();
         private final BooleanProperty isSendBtc = new SimpleBooleanProperty(false);
         private final BooleanProperty isReceiveBtc = new SimpleBooleanProperty(false);
-        private final ObjectProperty<Monetary> toSendMinAmount = new SimpleObjectProperty<>();
-        private final ObjectProperty<Monetary> toSendMaxAmount = new SimpleObjectProperty<>();
-        private final ObjectProperty<Monetary> toReceiveMinAmount = new SimpleObjectProperty<>();
-        private final ObjectProperty<Monetary> toReceiveMaxAmount = new SimpleObjectProperty<>();
+        private final StringProperty toSendMinAmount = new SimpleStringProperty();
+        private final StringProperty toSendMaxOrFixedAmount = new SimpleStringProperty();
+        private final StringProperty toReceiveMinAmount = new SimpleStringProperty();
+        private final StringProperty toReceiveMaxOrFixedAmount = new SimpleStringProperty();
     }
 
     private static class View extends bisq.desktop.common.view.View<HBox, Model, Controller> {
         private static final double HEIGHT = 61;
+        private static final String DASH_SYMBOL = "\u2013"; // Unicode for "–"
 
         private final Triple<Text, Label, VBox> direction, paymentMethod;
         private final Triple<Triple<Text, Text, Text>, HBox, VBox> toSend, toReceive;
-
-        private final BitcoinAmountDisplay toSendBitcoinAmountDisplay = new BitcoinAmountDisplay();
-        private final BitcoinAmountDisplay toReceiveBitcoinAmountDisplay = new BitcoinAmountDisplay();
 
         private final VBox rangeAmountVBox = new VBox(0);
         private Subscription isRangeAmountPin, isSendBtcPin, isReceiveBtcPin;
 
         private final BitcoinAmountDisplay toSendBitcoinMinAmountDisplay = new BitcoinAmountDisplay("0", false);
-        private final BitcoinAmountDisplay toSendBitcoinMaxAmountDisplay = new BitcoinAmountDisplay("0", false);
-        private static final String DASH_SYMBOL = "\u2013"; // Unicode for "–"
+        private final BitcoinAmountDisplay toSendBitcoinMaxOrFixedAmountDisplay = new BitcoinAmountDisplay("0", false);
         private final Label dashLabel = new Label(DASH_SYMBOL);
         private final BitcoinAmountDisplay toReceiveBitcoinMinAmountDisplay = new BitcoinAmountDisplay("0", false);
-        private final BitcoinAmountDisplay toReceiveBitcoinMaxAmountDisplay = new BitcoinAmountDisplay("0", false);
+        private final BitcoinAmountDisplay toReceiveBitcoinMaxOrFixedAmountDisplay = new BitcoinAmountDisplay("0", false);
 
         private View(Model model, Controller controller) {
             super(new HBox(), model, controller);
@@ -192,12 +175,10 @@ public class ReviewDataDisplay {
             dashLabel.getStyleClass().add("bisq-easy-trade-wizard-review-header-value");
             dashLabel.setAlignment(Pos.CENTER);
 
-            configureBitcoinAmountDisplay(toSendBitcoinAmountDisplay);
-            configureBitcoinAmountDisplay(toReceiveBitcoinAmountDisplay);
             configureBitcoinAmountDisplay(toSendBitcoinMinAmountDisplay);
-            configureBitcoinAmountDisplay(toSendBitcoinMaxAmountDisplay);
+            configureBitcoinAmountDisplay(toSendBitcoinMaxOrFixedAmountDisplay);
             configureBitcoinAmountDisplay(toReceiveBitcoinMinAmountDisplay);
-            configureBitcoinAmountDisplay(toReceiveBitcoinMaxAmountDisplay);
+            configureBitcoinAmountDisplay(toReceiveBitcoinMaxOrFixedAmountDisplay);
 
             direction = getElements(Res.get("bisqEasy.tradeState.header.direction"));
             toSend = getAmountElements();
@@ -209,97 +190,63 @@ public class ReviewDataDisplay {
         protected void onViewAttached() {
             direction.getSecond().textProperty().bind(model.getDirection());
             toSend.getFirst().getFirst().textProperty().bind(model.getToSendAmountDescription());
-            toSend.getFirst().getSecond().textProperty().bind(model.getToSendAmount());
+            toSend.getFirst().getSecond().textProperty().bind(model.getToSendMaxOrFixedAmount());
             toSend.getFirst().getThird().textProperty().bind(model.getToSendCode());
             toReceive.getFirst().getFirst().textProperty().bind(model.getToReceiveAmountDescription());
-            toReceive.getFirst().getSecond().textProperty().bind(model.getToReceiveAmount());
+            toReceive.getFirst().getSecond().textProperty().bind(model.getToReceiveMaxOrFixedAmount());
             toReceive.getFirst().getThird().textProperty().bind(model.getToReceiveCode());
             paymentMethod.getFirst().textProperty().bind(model.getFiatPaymentMethodDescription());
             paymentMethod.getSecond().textProperty().bind(model.getFiatPaymentMethod());
 
-            toSendBitcoinAmountDisplay.getBtcAmount().bind(model.getToSendAmount());
-            toReceiveBitcoinAmountDisplay.getBtcAmount().bind(model.getToReceiveAmount());
 
-            EasyBind.subscribe(model.getToSendMinAmount(), monetary -> {
-                toSendBitcoinMinAmountDisplay.setBtcAmount(monetary != null ? AmountFormatter.formatBaseAmount(monetary) : "");
-            });
-            EasyBind.subscribe(model.getToSendMaxAmount(), monetary -> {
-                toSendBitcoinMaxAmountDisplay.setBtcAmount(monetary != null ? AmountFormatter.formatBaseAmount(monetary) : "");
-            });
-            EasyBind.subscribe(model.getToReceiveMinAmount(), monetary -> {
-                toReceiveBitcoinMinAmountDisplay.setBtcAmount(monetary != null ? AmountFormatter.formatBaseAmount(monetary) : "");
-            });
-            EasyBind.subscribe(model.getToReceiveMaxAmount(), monetary -> {
-                toReceiveBitcoinMaxAmountDisplay.setBtcAmount(monetary != null ? AmountFormatter.formatBaseAmount(monetary) : "");
-            });
+            toSendBitcoinMinAmountDisplay.getBtcAmount().bind(model.getToSendMinAmount());
+            toSendBitcoinMaxOrFixedAmountDisplay.getBtcAmount().bind(model.getToSendMaxOrFixedAmount());
+            toReceiveBitcoinMinAmountDisplay.getBtcAmount().bind(model.getToReceiveMinAmount());
+            toReceiveBitcoinMaxOrFixedAmountDisplay.getBtcAmount().bind(model.getToReceiveMaxOrFixedAmount());
 
-            isSendBtcPin = EasyBind.subscribe(
-                    EasyBind.combine(model.getIsSendBtc(), model.getIsRangeAmount(), Pair::new
-                    ),
-                    combinedValues -> {
-                        boolean isSendBtc = combinedValues.getFirst();
-                        boolean isRangeAmount = combinedValues.getSecond();
+            isSendBtcPin = EasyBind.subscribe(EasyBind.combine(model.getIsSendBtc(), model.getIsRangeAmount(), Pair::new), combinedValues -> {
+                boolean isSendBtc = combinedValues.getFirst();
+                boolean isRangeAmount = combinedValues.getSecond();
 
-                        HBox amountHBox = toSend.getSecond();
-                        amountHBox.getChildren().clear();
+                HBox amountHBox = toSend.getSecond();
+                amountHBox.getChildren().clear();
 
-                        if (isSendBtc) {
-                            if (isRangeAmount) {
-                                amountHBox.getChildren().addAll(
-                                        toSendBitcoinMinAmountDisplay,
-                                        dashLabel,
-                                        toSendBitcoinMaxAmountDisplay,
-                                        toSend.getFirst().getThird()
-                                );
-                            } else {
-                                amountHBox.getChildren().add(toSendBitcoinAmountDisplay);
-                            }
-                            amountHBox.setAlignment(Pos.CENTER_LEFT);
-                            VBox.setMargin(toSend.getSecond(), new Insets(-11, 0, 0, 0));
-                        } else {
-                            amountHBox.getChildren().addAll(
-                                    toSend.getFirst().getSecond(),
-                                    toSend.getFirst().getThird()
-                            );
-                            amountHBox.setAlignment(Pos.BASELINE_LEFT);
-                            VBox.setMargin(toSend.getSecond(), new Insets(0, 0, 0, 0));
-                        }
+                if (isSendBtc) {
+                    if (isRangeAmount) {
+                        amountHBox.getChildren().addAll(toSendBitcoinMinAmountDisplay, dashLabel, toSendBitcoinMaxOrFixedAmountDisplay, toSend.getFirst().getThird());
+                    } else {
+                        amountHBox.getChildren().addAll(toSendBitcoinMaxOrFixedAmountDisplay, toSend.getFirst().getThird());
                     }
-            );
+                    amountHBox.setAlignment(Pos.CENTER_LEFT);
+                    VBox.setMargin(toSend.getSecond(), new Insets(-11, 0, 0, 0));
+                } else {
+                    amountHBox.getChildren().addAll(toSend.getFirst().getSecond(), toSend.getFirst().getThird());
+                    amountHBox.setAlignment(Pos.BASELINE_LEFT);
+                    VBox.setMargin(toSend.getSecond(), new Insets(0, 0, 0, 0));
+                }
+            });
 
-            isReceiveBtcPin = EasyBind.subscribe(
-                    EasyBind.combine(model.getIsReceiveBtc(), model.getIsRangeAmount(), Pair::new
-                    ),
-                    combinedValues -> {
-                        boolean isReceiveBtc = combinedValues.getFirst();
-                        boolean isRangeAmount = combinedValues.getSecond();
+            isReceiveBtcPin = EasyBind.subscribe(EasyBind.combine(model.getIsReceiveBtc(), model.getIsRangeAmount(), Pair::new), combinedValues -> {
+                boolean isReceiveBtc = combinedValues.getFirst();
+                boolean isRangeAmount = combinedValues.getSecond();
 
-                        HBox amountHBox = toReceive.getSecond();
-                        amountHBox.getChildren().clear();
+                HBox amountHBox = toReceive.getSecond();
+                amountHBox.getChildren().clear();
 
-                        if (isReceiveBtc) {
-                            if (isRangeAmount) {
-                                amountHBox.getChildren().addAll(
-                                        toReceiveBitcoinMinAmountDisplay,
-                                        dashLabel,
-                                        toReceiveBitcoinMaxAmountDisplay,
-                                        toReceive.getFirst().getThird()
-                                );
-                            } else {
-                                amountHBox.getChildren().add(toReceiveBitcoinAmountDisplay);
-                            }
-                            amountHBox.setAlignment(Pos.CENTER_LEFT);
-                            VBox.setMargin(toReceive.getSecond(), new Insets(-11, 0, 0, 0));
-                        } else {
-                            amountHBox.getChildren().addAll(
-                                    toReceive.getFirst().getSecond(),
-                                    toReceive.getFirst().getThird()
-                            );
-                            amountHBox.setAlignment(Pos.BASELINE_LEFT);
-                            VBox.setMargin(toReceive.getSecond(), new Insets(0, 0, 0, 0));
-                        }
+                if (isReceiveBtc) {
+                    if (isRangeAmount) {
+                        amountHBox.getChildren().addAll(toReceiveBitcoinMinAmountDisplay, dashLabel, toReceiveBitcoinMaxOrFixedAmountDisplay, toReceive.getFirst().getThird());
+                    } else {
+                        amountHBox.getChildren().addAll(toReceiveBitcoinMaxOrFixedAmountDisplay, toReceive.getFirst().getThird());
                     }
-            );
+                    amountHBox.setAlignment(Pos.CENTER_LEFT);
+                    VBox.setMargin(toReceive.getSecond(), new Insets(-11, 0, 0, 0));
+                } else {
+                    amountHBox.getChildren().addAll(toReceive.getFirst().getSecond(), toReceive.getFirst().getThird());
+                    amountHBox.setAlignment(Pos.BASELINE_LEFT);
+                    VBox.setMargin(toReceive.getSecond(), new Insets(0, 0, 0, 0));
+                }
+            });
 
 
             isRangeAmountPin = EasyBind.subscribe(model.getIsRangeAmount(), isRangeAmount -> {
@@ -313,16 +260,9 @@ public class ReviewDataDisplay {
                 if (isRangeAmount) {
                     VBox.setMargin(toReceiveVBox, new Insets(-10, 0, 0, 0));
                     rangeAmountVBox.getChildren().addAll(toSendVBox, toReceiveVBox);
-                    root.getChildren().addAll(
-                            direction.getThird(), Spacer.fillHBox(),
-                            rangeAmountVBox, Spacer.fillHBox(),
-                            paymentMethod.getThird());
+                    root.getChildren().addAll(direction.getThird(), Spacer.fillHBox(), rangeAmountVBox, Spacer.fillHBox(), paymentMethod.getThird());
                 } else {
-                    root.getChildren().addAll(
-                            direction.getThird(), Spacer.fillHBox(),
-                            toSendVBox, Spacer.fillHBox(),
-                            toReceiveVBox, Spacer.fillHBox(),
-                            paymentMethod.getThird());
+                    root.getChildren().addAll(direction.getThird(), Spacer.fillHBox(), toSendVBox, Spacer.fillHBox(), toReceiveVBox, Spacer.fillHBox(), paymentMethod.getThird());
                 }
             });
         }
@@ -339,17 +279,14 @@ public class ReviewDataDisplay {
             paymentMethod.getFirst().textProperty().unbind();
             paymentMethod.getSecond().textProperty().unbind();
 
-            toSendBitcoinAmountDisplay.getBtcAmount().unbind();
-            toReceiveBitcoinAmountDisplay.getBtcAmount().unbind();
-
             isRangeAmountPin.unsubscribe();
             isSendBtcPin.unsubscribe();
             isReceiveBtcPin.unsubscribe();
 
             toSendBitcoinMinAmountDisplay.getBtcAmount().unbind();
-            toSendBitcoinMaxAmountDisplay.getBtcAmount().unbind();
+            toSendBitcoinMaxOrFixedAmountDisplay.getBtcAmount().unbind();
             toReceiveBitcoinMinAmountDisplay.getBtcAmount().unbind();
-            toReceiveBitcoinMaxAmountDisplay.getBtcAmount().unbind();
+            toReceiveBitcoinMaxOrFixedAmountDisplay.getBtcAmount().unbind();
         }
 
         private void configureBitcoinAmountDisplay(BitcoinAmountDisplay bitcoinAmountDisplay) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
@@ -302,10 +302,10 @@ public class TakeOfferReviewController implements Controller {
         reviewDataDisplay.setDirection(Res.get("bisqEasy.tradeWizard.review.direction",
                 Res.get(takersDirection.isSell() ? "offer.sell" : "offer.buy").toUpperCase()));
         reviewDataDisplay.setToSendAmountDescription(toSendAmountDescription.toUpperCase());
-        reviewDataDisplay.setToSendAmount(toSendAmount);
+        reviewDataDisplay.setToSendMaxOrFixedAmount(toSendAmount);
         reviewDataDisplay.setToSendCode(toSendCode);
         reviewDataDisplay.setToReceiveAmountDescription(toReceiveAmountDescription.toUpperCase());
-        reviewDataDisplay.setToReceiveAmount(toReceiveAmount);
+        reviewDataDisplay.setToReceiveMaxOrFixedAmount(toReceiveAmount);
         reviewDataDisplay.setToReceiveCode(toReceiveCode);
         reviewDataDisplay.setFiatPaymentMethodDescription(Res.get("bisqEasy.tradeWizard.review.paymentMethodDescription.fiat").toUpperCase());
         reviewDataDisplay.setBitcoinPaymentMethod(model.getBitcoinPaymentMethod());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -281,12 +281,9 @@ public class TradeWizardReviewController implements Controller {
         applyPriceDetails(model.getPriceSpec(), market);
 
         model.setRangeAmount(amountSpec instanceof RangeAmountSpec);
-        Monetary currentToSendMinAmount = null;
-        Monetary currentToSendMaxAmount = null;
-        Monetary currentToReceiveMinAmount = null;
-        Monetary currentToReceiveMaxAmount = null;
-
-        String toSendAmountDescription, toSendAmount, toSendCode, toReceiveAmountDescription, toReceiveAmount, toReceiveCode;
+        String currentToSendMinAmount = null, currentToReceiveMinAmount = null,
+                currentToReceiveMaxOrFixedAmount, currentToSendMaxOrFixedAmount,
+                toSendAmountDescription, toSendCode, toReceiveAmountDescription, toReceiveCode;
         if (model.isRangeAmount()) {
             Monetary minBaseSideAmount = OfferAmountUtil.findBaseSideMinAmount(marketPriceService, amountSpec, priceSpec, market).orElseThrow();
             model.setMinBaseSideAmount(minBaseSideAmount);
@@ -303,24 +300,20 @@ public class TradeWizardReviewController implements Controller {
             String formattedMaxQuoteAmount = AmountFormatter.formatQuoteAmount(maxQuoteSideAmount);
             String formattedMaxBaseAmount = AmountFormatter.formatBaseAmount(maxBaseSideAmount);
             if (isCreateOfferMode && direction.isSell()) {
-                currentToSendMinAmount = minBaseSideAmount;
-                currentToSendMaxAmount = maxBaseSideAmount;
-                currentToReceiveMinAmount = minQuoteSideAmount;
-                currentToReceiveMaxAmount = maxQuoteSideAmount;
+                currentToSendMinAmount = formattedMinBaseAmount;
+                currentToSendMaxOrFixedAmount = formattedMaxBaseAmount;
+                currentToReceiveMinAmount = formattedMinQuoteAmount;
+                currentToReceiveMaxOrFixedAmount = formattedMaxQuoteAmount;
 
-                toSendAmount = formattedMinBaseAmount + " " + DASH_SYMBOL + " " + formattedMaxBaseAmount;
                 toSendCode = maxBaseSideAmount.getCode();
-                toReceiveAmount = formattedMinQuoteAmount + " " + DASH_SYMBOL + " " + formattedMaxQuoteAmount;
                 toReceiveCode = maxQuoteSideAmount.getCode();
             } else {
-                currentToSendMinAmount = minQuoteSideAmount;
-                currentToSendMaxAmount = maxQuoteSideAmount;
-                currentToReceiveMinAmount = minBaseSideAmount;
-                currentToReceiveMaxAmount = maxBaseSideAmount;
+                currentToSendMinAmount = formattedMinQuoteAmount;
+                currentToSendMaxOrFixedAmount = formattedMaxQuoteAmount;
+                currentToReceiveMinAmount = formattedMinBaseAmount;
+                currentToReceiveMaxOrFixedAmount = formattedMaxBaseAmount;
 
-                toSendAmount = formattedMinQuoteAmount + " " + DASH_SYMBOL + " " + formattedMaxQuoteAmount;
                 toSendCode = maxQuoteSideAmount.getCode();
-                toReceiveAmount = formattedMinBaseAmount + " " + DASH_SYMBOL + " " + formattedMaxBaseAmount;
                 toReceiveCode = maxBaseSideAmount.getCode();
             }
         } else {
@@ -333,14 +326,14 @@ public class TradeWizardReviewController implements Controller {
             String formattedQuoteAmount = AmountFormatter.formatQuoteAmount(fixQuoteSideAmount);
 
             if (isCreateOfferMode && direction.isSell()) {
-                toSendAmount = formattedBaseAmount;
+                currentToSendMaxOrFixedAmount = formattedBaseAmount;
                 toSendCode = fixBaseSideAmount.getCode();
-                toReceiveAmount = formattedQuoteAmount;
+                currentToReceiveMaxOrFixedAmount = formattedQuoteAmount;
                 toReceiveCode = fixQuoteSideAmount.getCode();
             } else {
-                toSendAmount = formattedQuoteAmount;
+                currentToSendMaxOrFixedAmount = formattedQuoteAmount;
                 toSendCode = fixQuoteSideAmount.getCode();
-                toReceiveAmount = formattedBaseAmount;
+                currentToReceiveMaxOrFixedAmount = formattedBaseAmount;
                 toReceiveCode = fixBaseSideAmount.getCode();
             }
         }
@@ -398,16 +391,14 @@ public class TradeWizardReviewController implements Controller {
         applyHeaderFiatPaymentMethod();
 
         reviewDataDisplay.setToSendMinAmount(currentToSendMinAmount);
-        reviewDataDisplay.setToSendMaxAmount(currentToSendMaxAmount);
+        reviewDataDisplay.setToSendMaxOrFixedAmount(currentToSendMaxOrFixedAmount);
         reviewDataDisplay.setToReceiveMinAmount(currentToReceiveMinAmount);
-        reviewDataDisplay.setToReceiveMaxAmount(currentToReceiveMaxAmount);
+        reviewDataDisplay.setToReceiveMaxOrFixedAmount(currentToReceiveMaxOrFixedAmount);
         reviewDataDisplay.setRangeAmount(model.isRangeAmount());
         reviewDataDisplay.setDirection(Res.get("bisqEasy.tradeWizard.review.direction", Res.get(direction.isSell() ? "offer.sell" : "offer.buy").toUpperCase()));
         reviewDataDisplay.setToSendAmountDescription(toSendAmountDescription.toUpperCase());
-        reviewDataDisplay.setToSendAmount(toSendAmount);
         reviewDataDisplay.setToSendCode(toSendCode);
         reviewDataDisplay.setToReceiveAmountDescription(toReceiveAmountDescription.toUpperCase());
-        reviewDataDisplay.setToReceiveAmount(toReceiveAmount);
         reviewDataDisplay.setToReceiveCode(toReceiveCode);
         reviewDataDisplay.setBitcoinPaymentMethodDescription(model.getBitcoinPaymentMethodDescription().toUpperCase());
         reviewDataDisplay.setFiatPaymentMethodDescription(model.getFiatPaymentMethodDescription().toUpperCase());


### PR DESCRIPTION
issue #3530 

after fix:
![image](https://github.com/user-attachments/assets/00b39814-c4a8-46d0-86be-27caf6603a04)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to display a range (minimum and maximum) of BTC amounts for both "to send" and "to receive" fields in the review screen.
  - The UI now conditionally shows either a single amount or a range of amounts, depending on the trade details.

- **Style**
  - Improved layout and alignment to accommodate the new range display for BTC amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->