### PR TITLE
Remove reputation restriction when creating MuSig sell offer

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/MuSigCreateOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/MuSigCreateOfferController.java
@@ -85,7 +85,6 @@ public class MuSigCreateOfferController extends NavigationController implements 
 
         muSigCreateOfferDirectionAndMarketController = new MuSigCreateOfferDirectionAndMarketController(serviceProvider,
                 this::onNext,
-                this::setMainButtonsVisibleState,
                 this::closeAndNavigateTo);
         muSigCreateOfferAmountAndPriceController = new MuSigCreateOfferAmountAndPriceController(serviceProvider,
                 view.getRoot(),
@@ -231,9 +230,6 @@ public class MuSigCreateOfferController extends NavigationController implements 
     }
 
     private boolean validate(boolean calledFromNext) {
-        if (model.getSelectedChildTarget().get() == NavigationTarget.MU_SIG_CREATE_OFFER_DIRECTION_AND_MARKET) {
-            return muSigCreateOfferDirectionAndMarketController.validate();
-        }
         if (model.getSelectedChildTarget().get() == NavigationTarget.MU_SIG_CREATE_OFFER_AMOUNT_AND_PRICE) {
             return muSigCreateOfferAmountAndPriceController.validate();
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/direction_and_market/MuSigCreateOfferDirectionAndMarketModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/direction_and_market/MuSigCreateOfferDirectionAndMarketModel.java
@@ -31,16 +31,10 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public class MuSigCreateOfferDirectionAndMarketModel implements Model {
-    // TODO to be removed
-    @Setter
-    private boolean isAllowedToCreateSellOffer = true;
-
     private final ObjectProperty<Direction> direction = new SimpleObjectProperty<>(Direction.BUY);
-    private final BooleanProperty showReputationInfo = new SimpleBooleanProperty();
     private final BooleanProperty buyButtonDisabled = new SimpleBooleanProperty();
     private final ObjectProperty<MuSigCreateOfferDirectionAndMarketView.ListItem> selectedMarketListItem = new SimpleObjectProperty<>();
     private final StringProperty searchText = new SimpleStringProperty();
@@ -50,9 +44,7 @@ public class MuSigCreateOfferDirectionAndMarketModel implements Model {
     private final SortedList<MuSigCreateOfferDirectionAndMarketView.ListItem> sortedList = new SortedList<>(filteredList);
 
     void reset() {
-        isAllowedToCreateSellOffer = true;
         direction.set(Direction.BUY);
-        showReputationInfo.set(false);
         buyButtonDisabled.set(false);
         selectedMarketListItem.set(null);
         searchText.set(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed all reputation information overlays and related UI elements from the offer creation flow.
  - Streamlined the process for selecting offer direction by eliminating reputation checks and overlays.
- **Bug Fixes**
  - Simplified validation logic during offer creation, reducing unnecessary checks and improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->