### PR TITLE
Enhance amount slider thumbs with hover and pressed states

### DIFF
--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -1119,6 +1119,14 @@
     -fx-translate-y: -8;
 }
 
+.slider.max-or-fixed-amount-slider .thumb:hover,
+.slider.max-or-fixed-amount-slider .thumb:pressed {
+    -fx-background-color: -bisq-green-hover;
+    -fx-cursor: hand;
+    -fx-scale-x: 1.3;
+    -fx-scale-y: 1.3;
+}
+
 .slider.max-or-fixed-amount-slider .track,
 .slider.price-slider-buyer .track,
 .slider.price-slider-seller .track {
@@ -1132,6 +1140,14 @@
     -fx-background-insets: 2.5;
     -fx-shape: "M 0 4 h 7 l -3.5 -4 z";
     -fx-translate-y: -9;
+}
+
+.slider.min-amount-slider .thumb:hover,
+.slider.min-amount-slider .thumb:pressed {
+    -fx-background-color: -bisq-green-hover;
+    -fx-cursor: hand;
+    -fx-scale-x: 1.3;
+    -fx-scale-y: 1.3;
 }
 
 .slider.min-amount-slider .track {


### PR DESCRIPTION
This PR improves the user experience by adding distinct hover and pressed visual feedback to the amount selection slider thumbs.
Previously, the slider thumbs lacked clear interaction cues. This update makes them more noticeable and interactive when hovered over or dragged.

How it looks like:
![image](https://github.com/user-attachments/assets/8fb784a3-fa51-4f3a-a2b2-850d9dba4e93)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced slider thumbs with new hover and pressed state styles, including color change, pointer cursor, and scaling effect for improved interactive feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->