### PR TITLE
using BisqHyperlink replace original outer links(e.g. 'Lear more')

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BisqHyperlink.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BisqHyperlink.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.components.controls;
+
+import bisq.common.util.StringUtils;
+import javafx.scene.control.Hyperlink;
+
+public class BisqHyperlink extends Hyperlink {
+
+    public BisqHyperlink(String link, String tooltip) {
+        super(link);
+        if (StringUtils.isNotEmpty(tooltip)) {
+            setTooltip(new BisqTooltip(tooltip));
+        }
+    }
+
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/academy/AcademyBaseView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/academy/AcademyBaseView.java
@@ -22,7 +22,7 @@ import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Model;
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.scene.control.Hyperlink;
@@ -46,10 +46,9 @@ public abstract class AcademyBaseView<M extends Model, C extends Controller> ext
         headline.setGraphicTextGap(10);
         headline.setWrapText(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip(getUrl()));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), getUrl());
         learnMore.getStyleClass().addAll("font-size-12", "text-fill-green");
-        VBox.setMargin(learnMore, new Insets(25, 0, 0,0));
+        VBox.setMargin(learnMore, new Insets(25, 0, 0, 0));
 
         VBox.setMargin(headline, new Insets(0, 0, 0, 0));
         contentBox = new VBox();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_guide/process/BisqEasyGuideProcessView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_guide/process/BisqEasyGuideProcessView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.content.bisq_easy.trade_guide.process;
 
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.OrderedList;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
@@ -57,8 +57,7 @@ public class BisqEasyGuideProcessView extends View<VBox, BisqEasyGuideProcessMod
 
         HBox buttons = new HBox(20, backButton, nextButton);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Bisq_Easy"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Bisq_Easy");
 
         VBox.setMargin(headline, new Insets(10, 0, -5, 0));
         VBox.setMargin(learnMore, new Insets(0, 0, 10, 0));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_guide/rules/BisqEasyGuideRulesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_guide/rules/BisqEasyGuideRulesView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.content.bisq_easy.trade_guide.rules;
 
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.UnorderedList;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
@@ -51,8 +51,7 @@ public class BisqEasyGuideRulesView extends View<VBox, BisqEasyGuideRulesModel, 
 
         UnorderedList content = new UnorderedList(Res.get("bisqEasy.tradeGuide.rules.content"), "bisq-easy-trade-guide-content");
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Bisq_Easy"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Bisq_Easy");
 
         backButton = new Button(Res.get("action.back"));
         closeButton = new Button(Res.get("action.close"));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_guide/security/BisqEasyGuideSecurityView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_guide/security/BisqEasyGuideSecurityView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.content.bisq_easy.trade_guide.security;
 
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.UnorderedList;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
@@ -54,8 +54,7 @@ public class BisqEasyGuideSecurityView extends View<VBox, BisqEasyGuideSecurityM
 
         HBox buttons = new HBox(20, backButton, nextButton);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Bisq_Easy"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Bisq_Easy");
 
         VBox.setMargin(headline, new Insets(10, 0, -5, 0));
         VBox.setMargin(learnMore, new Insets(0, 0, 10, 0));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/download/WalletGuideDownloadView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/download/WalletGuideDownloadView.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.bisq_easy.wallet_guide.download;
 
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -59,8 +59,7 @@ public class WalletGuideDownloadView extends View<HBox, WalletGuideDownloadModel
 
         HBox buttons = new HBox(20, backButton, nextButton);
 
-        download = new Hyperlink(Res.get("bisqEasy.walletGuide.download.link"));
-        download.setTooltip(new BisqTooltip("https://bluewallet.io"));
+        download = new BisqHyperlink(Res.get("bisqEasy.walletGuide.download.link"), "https://bluewallet.io");
 
         VBox.setMargin(headline, new Insets(0, 0, -5, 0));
         VBox.setMargin(download, new Insets(0, 0, 10, 0));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/wallet_guide/receive/WalletGuideReceiveView.java
@@ -20,7 +20,7 @@ package bisq.desktop.main.content.bisq_easy.wallet_guide.receive;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Carousel;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -55,10 +55,8 @@ public class WalletGuideReceiveView extends View<HBox, WalletGuideReceiveModel, 
         text.getStyleClass().add("bisq-easy-trade-guide-content");
         TextFlow content = new TextFlow(text);
 
-        link1 = new Hyperlink(Res.get("bisqEasy.walletGuide.receive.link1"));
-        link2 = new Hyperlink(Res.get("bisqEasy.walletGuide.receive.link2"));
-        link1.setTooltip(new BisqTooltip("https://www.youtube.com/watch?v=NqY3wBhloH4"));
-        link2.setTooltip(new BisqTooltip("https://www.youtube.com/watch?v=imMX7i4qpmg"));
+        link1 = new BisqHyperlink(Res.get("bisqEasy.walletGuide.receive.link1"), "https://www.youtube.com/watch?v=NqY3wBhloH4");
+        link2 = new BisqHyperlink(Res.get("bisqEasy.walletGuide.receive.link2"), "https://www.youtube.com/watch?v=imMX7i4qpmg");
         backButton = new Button(Res.get("action.back"));
         closeButton = new Button(Res.get("action.close"));
         closeButton.setDefaultButton(true);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/tabs/registration/BondedRolesRegistrationView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/tabs/registration/BondedRolesRegistrationView.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.network.bonded_roles.tabs.registration;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.OrderedList;
@@ -110,8 +111,7 @@ public abstract class BondedRolesRegistrationView<M extends BondedRolesRegistrat
         requestCancellationButton = new Button(Res.get("user.bondedRoles.cancellation.requestCancellation"));
         requestCancellationButton.setPrefWidth(180);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Bisq_2_Roles"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Bisq_2_Roles");
 
         buttons = new HBox(20, requestRegistrationButton, requestCancellationButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/BuildReputationView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/BuildReputationView.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation;
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -99,8 +99,7 @@ public class BuildReputationView extends View<VBox, BuildReputationModel, BuildR
         HBox signedAccountAndAgeBox = new HBox(20, signedAccountBox, accountAgeBox);
 
         Label learnMoreLabel = new Label(Res.get("reputation.buildReputation.learnMore"));
-        learnMoreLink = new Hyperlink(Res.get("reputation.buildReputation.learnMore.link"));
-        learnMoreLink.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMoreLink = new BisqHyperlink(Res.get("reputation.buildReputation.learnMore.link"), "https://bisq.wiki/Reputation");
         learnMoreLabel.getStyleClass().addAll("reputation-learn-more");
         learnMoreLink.getStyleClass().addAll("reputation-learn-more-link");
         HBox learnMoreHBox = new HBox(2, learnMoreLabel, learnMoreLink);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab1/AccountAgeTab1View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab1/AccountAgeTab1View.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation.accountAge.tab1;
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -56,8 +56,7 @@ public class AccountAgeTab1View extends View<VBox, AccountAgeTab1Model, AccountA
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab2/AccountAgeTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab2/AccountAgeTab2View.java
@@ -20,7 +20,7 @@ package bisq.desktop.main.content.reputation.build_reputation.accountAge.tab2;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
 import bisq.user.reputation.AccountAgeService;
@@ -59,8 +59,7 @@ public class AccountAgeTab2View extends View<VBox, AccountAgeTab2Model, AccountA
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab3/AccountAgeTab3View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab3/AccountAgeTab3View.java
@@ -21,7 +21,7 @@ import bisq.desktop.common.Layout;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
@@ -61,8 +61,7 @@ public class AccountAgeTab3View extends View<VBox, AccountAgeTab3Model, AccountA
         closeButton = new Button(Res.get("action.close"));
         closeButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, closeButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab1/BondedReputationTab1View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab1/BondedReputationTab1View.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation.bond.tab1;
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -56,8 +56,7 @@ public class BondedReputationTab1View extends View<VBox, BondedReputationTab1Mod
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab2/BondedReputationTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab2/BondedReputationTab2View.java
@@ -20,7 +20,7 @@ package bisq.desktop.main.content.reputation.build_reputation.bond.tab2;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
 import bisq.user.reputation.BondedReputationService;
@@ -38,7 +38,9 @@ public class BondedReputationTab2View extends View<VBox, BondedReputationTab2Mod
     private final Button backButton, nextButton;
     private final Hyperlink learnMore;
 
-    public BondedReputationTab2View(BondedReputationTab2Model model, BondedReputationTab2Controller controller, VBox simulation) {
+    public BondedReputationTab2View(BondedReputationTab2Model model,
+                                    BondedReputationTab2Controller controller,
+                                    VBox simulation) {
         super(new VBox(), model, controller);
 
         Label headline = new Label(Res.get("reputation.bond.score.headline"));
@@ -61,8 +63,7 @@ public class BondedReputationTab2View extends View<VBox, BondedReputationTab2Mod
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab3/BondedReputationTab3View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab3/BondedReputationTab3View.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation.bond.tab3;
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.OrderedList;
 import bisq.i18n.Res;
@@ -60,8 +60,7 @@ public class BondedReputationTab3View extends View<VBox, BondedReputationTab3Mod
 
         closeButton = new Button(Res.get("action.close"));
         closeButton.setDefaultButton(true);
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
         backButton = new Button(Res.get("action.back"));
 
         HBox buttons = new HBox(20, backButton, closeButton, Spacer.fillHBox(), learnMore);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab1/BurnBsqTab1View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab1/BurnBsqTab1View.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation.burn.tab1;
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -56,8 +56,7 @@ public class BurnBsqTab1View extends View<VBox, BurnBsqTab1Model, BurnBsqTab1Con
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab2/BurnBsqTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab2/BurnBsqTab2View.java
@@ -20,7 +20,7 @@ package bisq.desktop.main.content.reputation.build_reputation.burn.tab2;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
 import bisq.user.reputation.ProofOfBurnService;
@@ -61,8 +61,7 @@ public class BurnBsqTab2View extends View<VBox, BurnBsqTab2Model, BurnBsqTab2Con
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab3/BurnBsqTab3View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab3/BurnBsqTab3View.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation.burn.tab3;
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.OrderedList;
 import bisq.i18n.Res;
@@ -63,8 +63,7 @@ public class BurnBsqTab3View extends View<VBox, BurnBsqTab3Model, BurnBsqTab3Con
         closeButton = new Button(Res.get("action.close"));
         closeButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, closeButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab1/SignedWitnessTab1View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab1/SignedWitnessTab1View.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.reputation.build_reputation.signedAccount.tab1
 
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -56,8 +56,7 @@ public class SignedWitnessTab1View extends View<VBox, SignedWitnessTab1Model, Si
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessTab2View.java
@@ -20,7 +20,7 @@ package bisq.desktop.main.content.reputation.build_reputation.signedAccount.tab2
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
 import bisq.user.reputation.SignedWitnessService;
@@ -38,7 +38,9 @@ public class SignedWitnessTab2View extends View<VBox, SignedWitnessTab2Model, Si
     private final Button backButton, nextButton;
     private final Hyperlink learnMore;
 
-    public SignedWitnessTab2View(SignedWitnessTab2Model model, SignedWitnessTab2Controller controller, VBox simulation) {
+    public SignedWitnessTab2View(SignedWitnessTab2Model model,
+                                 SignedWitnessTab2Controller controller,
+                                 VBox simulation) {
         super(new VBox(), model, controller);
 
         Label headline = new Label(Res.get("reputation.signedWitness.score.headline"));
@@ -59,8 +61,7 @@ public class SignedWitnessTab2View extends View<VBox, SignedWitnessTab2Model, Si
         nextButton = new Button(Res.get("action.next"));
         nextButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, nextButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab3/SignedWitnessTab3View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab3/SignedWitnessTab3View.java
@@ -21,7 +21,7 @@ import bisq.desktop.common.Layout;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.i18n.Res;
@@ -61,8 +61,7 @@ public class SignedWitnessTab3View extends View<VBox, SignedWitnessTab3Model, Si
         closeButton = new Button(Res.get("action.close"));
         closeButton.setDefaultButton(true);
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Reputation"));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), "https://bisq.wiki/Reputation");
 
         HBox buttons = new HBox(20, backButton, closeButton, Spacer.fillHBox(), learnMore);
         buttons.setAlignment(Pos.BOTTOM_RIGHT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesView.java
@@ -18,7 +18,7 @@
 package bisq.desktop.main.content.support.resources;
 
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.validator.DirectoryPathValidator;
 import bisq.desktop.components.controls.validator.ValidatorBase;
@@ -29,7 +29,6 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
-import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import lombok.extern.slf4j.Slf4j;
@@ -74,15 +73,15 @@ public class ResourcesView extends View<VBox, ResourcesModel, ResourcesControlle
 
 
         Label resourcesHeadline = SettingsViewUtils.getHeadline(Res.get("support.resources.resources.headline"));
-        webpage = new Hyperlink(Res.get("support.resources.resources.webpage"));
-        dao = new Hyperlink(Res.get("support.resources.resources.dao"));
-        sourceCode = new Hyperlink(Res.get("support.resources.resources.sourceCode"));
-        community = new Hyperlink(Res.get("support.resources.resources.community"));
-        contribute = new Hyperlink(Res.get("support.resources.resources.contribute"));
+        webpage = new BisqHyperlink(Res.get("support.resources.resources.webpage"), "https://bisq.network/");
+        dao = new BisqHyperlink(Res.get("support.resources.resources.dao"), "https://bisq.network/dao");
+        sourceCode = new BisqHyperlink(Res.get("support.resources.resources.sourceCode"), "https://github.com/bisq-network/bisq2");
+        community = new BisqHyperlink(Res.get("support.resources.resources.community"), "https://matrix.to/#/%23bisq:bitcoin.kyoto");
+        contribute = new BisqHyperlink(Res.get("support.resources.resources.contribute"), "https://bisq.wiki/Contributor_checklist");
 
         Label legalHeadline = SettingsViewUtils.getHeadline(Res.get("support.resources.legal.headline"));
         tac = new Hyperlink(Res.get("support.resources.legal.tac"));
-        license = new Hyperlink(Res.get("support.resources.legal.license"));
+        license = new BisqHyperlink(Res.get("support.resources.legal.license"), "https://github.com/bisq-network/bisq2/blob/main/LICENSE");
         VBox legalBox = new VBox(5, tac, license);
 
         VBox resourcesBox = new VBox(5, webpage, dao, sourceCode, community, contribute);
@@ -104,14 +103,6 @@ public class ResourcesView extends View<VBox, ResourcesModel, ResourcesControlle
         contentBox.getStyleClass().add("bisq-common-bg");
         root.getChildren().add(contentBox);
         root.setPadding(new Insets(0, 40, 20, 40));
-
-        // Display the urls while mouse hovering for all external links
-        webpage.setTooltip(new Tooltip("https://bisq.network/"));
-        dao.setTooltip(new BisqTooltip("https://bisq.network/dao"));
-        sourceCode.setTooltip(new BisqTooltip("https://github.com/bisq-network/bisq2"));
-        community.setTooltip(new BisqTooltip("https://matrix.to/#/%23bisq:bitcoin.kyoto"));
-        contribute.setTooltip(new BisqTooltip("https://bisq.wiki/Contributor_checklist"));
-        license.setTooltip(new BisqTooltip("https://github.com/bisq-network/bisq2/blob/main/LICENSE"));
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/trade_apps/roadmap/ProtocolRoadmapView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/trade_apps/roadmap/ProtocolRoadmapView.java
@@ -19,13 +19,12 @@ package bisq.desktop.main.content.trade_apps.roadmap;
 
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.UnorderedList;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
-import javafx.scene.control.Tooltip;
 import javafx.scene.layout.VBox;
 import lombok.extern.slf4j.Slf4j;
 
@@ -64,8 +63,7 @@ public class ProtocolRoadmapView extends View<VBox, ProtocolRoadmapModel, Protoc
         UnorderedList pro = new UnorderedList(Res.get("tradeApps." + name + ".pro"), "trade-protocols-roadmap-text", "\\+ ", "+ ");
         UnorderedList con = new UnorderedList(Res.get("tradeApps." + name + ".con"), "trade-protocols-roadmap-text", "- ", "- ");
 
-        learnMore = new Hyperlink(Res.get("action.learnMore"));
-        learnMore.setTooltip(new BisqTooltip(model.getUrl()));
+        learnMore = new BisqHyperlink(Res.get("action.learnMore"), model.getUrl());
         learnMore.getStyleClass().addAll("font-size-12", "text-fill-green");
 
         VBox.setMargin(overviewHeadline, new Insets(25, 0, 0, 0));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileView.java
@@ -22,6 +22,7 @@ import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.AutoCompleteComboBox;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
@@ -47,7 +48,8 @@ import org.fxmisc.easybind.Subscription;
 
 import javax.annotation.Nullable;
 
-import static bisq.user.profile.UserProfile.*;
+import static bisq.user.profile.UserProfile.MAX_LENGTH_STATEMENT;
+import static bisq.user.profile.UserProfile.MAX_LENGTH_TERMS;
 
 @Slf4j
 public class UserProfileView extends View<HBox, UserProfileModel, UserProfileController> {
@@ -95,8 +97,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
         createNewProfileButton = new Button(Res.get("user.userProfile.createNewProfile"));
         createNewProfileButton.getStyleClass().addAll("outlined-button");
 
-        learnMore = new Hyperlink(Res.get("user.userProfile.learnMore"));
-        learnMore.setTooltip(new BisqTooltip("https://bisq.wiki/Identity"));
+        learnMore = new BisqHyperlink(Res.get("user.userProfile.learnMore"), "https://bisq.wiki/Identity");
 
         VBox buttons = new VBox(5, createNewProfileButton, learnMore);
         buttons.setAlignment(Pos.TOP_RIGHT);
@@ -255,7 +256,7 @@ public class UserProfileView extends View<HBox, UserProfileModel, UserProfileCon
     }
 
     private void onDeleteButtonPressed() {
-        if(!comboBox.getIsValidSelection().get()) {
+        if (!comboBox.getIsValidSelection().get()) {
             new Popup().invalid(Res.get("user.userProfile.popup.noSelectedProfile")).show();
             return;
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/update/UpdaterView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/update/UpdaterView.java
@@ -20,7 +20,7 @@ package bisq.desktop.overlay.update;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.containers.Spacer;
-import bisq.desktop.components.controls.BisqTooltip;
+import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.Switch;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.BisqTableView;
@@ -35,7 +35,15 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
@@ -80,8 +88,7 @@ public class UpdaterView extends View<VBox, UpdaterModel, UpdaterController> {
         furtherInfo = new Label();
         furtherInfo.getStyleClass().add("updater-text");
 
-        downloadUrl = new Hyperlink();
-        downloadUrl.setTooltip(new BisqTooltip(model.getDownloadUrl().get()));
+        downloadUrl = new BisqHyperlink("", model.getDownloadUrl().get());
         downloadUrl.getStyleClass().add("updater-text");
 
         downloadButton = new Button(Res.get("updater.download"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified hyperlink component that displays both link text and associated URLs in various sections of the application.

- **Refactor**
  - Replaced standard hyperlinks and manual tooltip assignments with the new unified hyperlink component throughout the user interface for a more consistent and streamlined experience.
  - Minor formatting improvements in some UI components for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->