### PR TITLE
Add mu_sig to translation pipeline [PIPELINE-BLOCK]

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -126,3 +126,12 @@ minimum_perc           = 0
 resource_name          = support.properties
 replace_edited_strings = false
 keep_translations      = false
+
+[o:bisq:p:bisq-2:r:mu_sigproperties]
+file_filter            = i18n/src/main/resources/mu_sig_<lang>.properties
+source_file            = i18n/src/main/resources/mu_sig.properties
+type                   = UNICODEPROPERTIES
+minimum_perc           = 0
+resource_name          = mu_sig.properties
+replace_edited_strings = false
+keep_translations      = false

--- a/i18n/src/main/resources/bisq_easy_es.properties
+++ b/i18n/src/main/resources/bisq_easy_es.properties
@@ -655,6 +655,8 @@ bisqEasy.tradeState.info.phase3b.balance.help.explorerLookup=Buscando transacci�
 bisqEasy.tradeState.info.phase3b.balance.help.notConfirmed=Transacción vista en el mempool pero aún no confirmada
 bisqEasy.tradeState.info.phase3b.balance.help.confirmed=Transacción confirmada
 bisqEasy.tradeState.info.phase3b.txId.failed=La búsqueda de la transacción en ''{0}'' falló con {1}: ''{2}''
+bisqEasy.tradeState.info.phase3b.button.skip=Omitir espera por confirmación de bloque
+
 bisqEasy.tradeState.info.phase3b.balance.invalid.noOutputsForAddress=No se han encontrado salidas que coincidan en la transacción
 bisqEasy.tradeState.info.phase3b.balance.invalid.multipleOutputsForAddress=Múltiples salidas de la transacción coinciden
 bisqEasy.tradeState.info.phase3b.balance.invalid.amountNotMatching=La cantidad saliente de la transacción no es igual a la cantidad de la compra-venta

--- a/i18n/src/main/resources/bisq_easy_it.properties
+++ b/i18n/src/main/resources/bisq_easy_it.properties
@@ -655,11 +655,11 @@ bisqEasy.tradeState.info.phase3b.balance.help.explorerLookup=Ricerca della trans
 bisqEasy.tradeState.info.phase3b.balance.help.notConfirmed=Transazione presente nel mempool ma non ancora confermata
 bisqEasy.tradeState.info.phase3b.balance.help.confirmed=La transazione è confermata
 bisqEasy.tradeState.info.phase3b.txId.failed=La ricerca della transazione su ''{0}'' non è riuscita con {1}: ''{2}''
+bisqEasy.tradeState.info.phase3b.button.skip=Salta l'attesa della conferma del blocco
+
 bisqEasy.tradeState.info.phase3b.balance.invalid.noOutputsForAddress=Nessun output corrispondente trovato nella transazione
 bisqEasy.tradeState.info.phase3b.balance.invalid.multipleOutputsForAddress=Più output corrispondenti trovati nella transazione
 bisqEasy.tradeState.info.phase3b.balance.invalid.amountNotMatching=L'importo dell'output dalla transazione non corrisponde all'importo dello scambio
-
-bisqEasy.tradeState.info.phase3b.button.skip=Salta l'attesa della conferma del blocco
 
 bisqEasy.tradeState.info.phase3b.button.next=Avanti
 bisqEasy.tradeState.info.phase3b.button.next.amountNotMatching=L'importo dell'output per l'indirizzo ''{0}'' nella transazione ''{1}'' è ''{2}'', che non corrisponde all'importo dello scambio di ''{3}''.\n\nSei riuscito a risolvere questo problema con il tuo partner di scambio?\nSe non lo hai fatto, puoi considerare di richiedere una mediazione per aiutarti a risolvere la questione.
@@ -696,6 +696,10 @@ bisqEasy.tradeState.paymentProof.LN=Preimmagine
 bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.headline.MAIN_CHAIN=Inserisci il tuo indirizzo Bitcoin
 # suppress inspection "UnusedProperty"
 bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.description.MAIN_CHAIN=Indirizzo Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.prompt.MAIN_CHAIN=Inserisci il tuo indirizzo Bitcoin
+# suppress inspection "UnusedProperty"
+bisqEasy.tradeState.info.buyer.phase1a.tradeLogMessage.MAIN_CHAIN={0} ha inviato l'indirizzo Bitcoin ''{1}''
 # suppress inspection "UnusedProperty"
 bisqEasy.tradeState.info.buyer.phase1a.bitcoinPayment.headline.LN=Inserisci la tua fattura Lightning
 # suppress inspection "UnusedProperty"

--- a/i18n/src/main/resources/default_af_ZA.properties
+++ b/i18n/src/main/resources/default_af_ZA.properties
@@ -61,6 +61,7 @@ data.true=Waar
 data.false=Vals
 data.add=Voeg
 data.remove=Verwyder
+data.redacted=Data is verwyder vir privaatheid en sekuriteit redes
 
 offer.createOffer=Skep aanbod
 offer.takeOffer.buy.button=Koop Bitcoin
@@ -90,6 +91,7 @@ temporal.year.1={0} jaar
 temporal.year.*={0} jare
 temporal.at=by
 temporal.today=Vandag
+temporal.online=Aanlyn
 
 
 
@@ -138,4 +140,3 @@ component.standardTable.filter.showAll=Wys alles
 component.standardTable.filter.tooltip=Filtreer volgens {0}
 component.standardTable.numEntries=Aantal inskrywings: {0}
 component.standardTable.csv.plainValue={0}
-

--- a/i18n/src/main/resources/default_cs.properties
+++ b/i18n/src/main/resources/default_cs.properties
@@ -140,4 +140,3 @@ component.standardTable.filter.showAll=Zobrazit vše
 component.standardTable.filter.tooltip=Filtrovat podle {0}
 component.standardTable.numEntries=Počet položek: {0}
 component.standardTable.csv.plainValue={0} (běžná hodnota)
-

--- a/i18n/src/main/resources/default_de.properties
+++ b/i18n/src/main/resources/default_de.properties
@@ -61,6 +61,7 @@ data.true=Wahr
 data.false=Falsch
 data.add=Hinzufügen
 data.remove=Entfernen
+data.redacted=Daten wurden aus Datenschutz- und Sicherheitsgründen entfernt
 
 offer.createOffer=Neues Angebot erstellen
 offer.takeOffer.buy.button=Bitcoin kaufen
@@ -90,6 +91,7 @@ temporal.year.1={0} Jahr
 temporal.year.*={0} Jahre
 temporal.at=bei
 temporal.today=Heute
+temporal.online=Online
 
 
 
@@ -138,4 +140,3 @@ component.standardTable.filter.showAll=Alles anzeigen
 component.standardTable.filter.tooltip=Nach {0} filtern
 component.standardTable.numEntries=Anzahl der Einträge: {0}
 component.standardTable.csv.plainValue={0} (einfacher Wert)
-

--- a/i18n/src/main/resources/default_es.properties
+++ b/i18n/src/main/resources/default_es.properties
@@ -61,6 +61,7 @@ data.true=Verdadero
 data.false=Falso
 data.add=Añadir
 data.remove=Eliminar
+data.redacted=Los datos han sido eliminados por razones de privacidad y seguridad
 
 offer.createOffer=Crear oferta
 offer.takeOffer.buy.button=Comprar Bitcoin
@@ -90,6 +91,7 @@ temporal.year.1={0} año
 temporal.year.*={0} años
 temporal.at=en
 temporal.today=Hoy
+temporal.online=En línea
 
 
 
@@ -138,4 +140,3 @@ component.standardTable.filter.showAll=Mostrar todo
 component.standardTable.filter.tooltip=Filtrar por {0}
 component.standardTable.numEntries=Número de entradas: {0}
 component.standardTable.csv.plainValue={0} (valor simple)
-

--- a/i18n/src/main/resources/default_it.properties
+++ b/i18n/src/main/resources/default_it.properties
@@ -61,6 +61,7 @@ data.true=Vero
 data.false=Falso
 data.add=Aggiungi
 data.remove=Rimuovi
+data.redacted=I dati sono stati rimossi per motivi di privacy e sicurezza
 
 offer.createOffer=Crea offerta
 offer.takeOffer.buy.button=Compra Bitcoin
@@ -90,6 +91,7 @@ temporal.year.1={0} anno
 temporal.year.*={0} anni
 temporal.at=a
 temporal.today=Oggi
+temporal.online=Online
 
 
 
@@ -138,4 +140,3 @@ component.standardTable.filter.showAll=Mostra tutto
 component.standardTable.filter.tooltip=Filtra per {0}
 component.standardTable.numEntries=Numero di voci: {0}
 component.standardTable.csv.plainValue={0} (valore semplice)
-

--- a/i18n/src/main/resources/default_pcm.properties
+++ b/i18n/src/main/resources/default_pcm.properties
@@ -37,7 +37,7 @@ confirmation.no=No
 confirmation.ok=OK
 
 action.next=Nekst
-action.back=Back
+action.back=Bak
 action.cancel=Kansel
 action.close=Klose
 action.save=Save
@@ -60,10 +60,11 @@ data.na=N/A
 data.true=Tru
 data.false=Fals
 data.add=Add
-data.remove=Remove
+data.remove=Remov
+data.redacted=Data don comot for privacy and security reasons
 
 offer.createOffer=Kreate offer
-offer.takeOffer.buy.button=Buy Bitcoin
+offer.takeOffer.buy.button=Bai Bitcoin
 offer.takeOffer.sell.button=Sali Bitcoin
 offer.deleteOffer=Klose my offer
 offer.buy=bai
@@ -90,6 +91,7 @@ temporal.year.1={0} yara
 temporal.year.*={0} yara
 temporal.at=for
 temporal.today=Todey
+temporal.online=Online
 
 
 
@@ -138,4 +140,3 @@ component.standardTable.filter.showAll=Show all
 component.standardTable.filter.tooltip=Filta by {0}
 component.standardTable.numEntries=Namba of entries: {0}
 component.standardTable.csv.plainValue={0} (plin valyu)
-

--- a/i18n/src/main/resources/default_pt_BR.properties
+++ b/i18n/src/main/resources/default_pt_BR.properties
@@ -61,6 +61,7 @@ data.true=Verdadeiro
 data.false=Falso
 data.add=Adicionar
 data.remove=Remover
+data.redacted=Os dados foram removidos por motivos de privacidade e segurança
 
 offer.createOffer=Criar oferta
 offer.takeOffer.buy.button=Comprar Bitcoin
@@ -90,6 +91,7 @@ temporal.year.1={0} ano
 temporal.year.*={0} anos
 temporal.at=às
 temporal.today=Hoje
+temporal.online=Online
 
 
 
@@ -138,4 +140,3 @@ component.standardTable.filter.showAll=Mostrar todos
 component.standardTable.filter.tooltip=Filtrar por {0}
 component.standardTable.numEntries=Número de entradas: {0}
 component.standardTable.csv.plainValue={0} (valor simples)
-

--- a/i18n/src/main/resources/mu_sig_af_ZA.properties
+++ b/i18n/src/main/resources/mu_sig_af_ZA.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Aanbodboek
+muSig.openTrades=My oop transaksies
+muSig.history=Gesiedenis
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Kies Mark
+
+
+muSig.offerbook.table.header.intent=Ek wil
+muSig.offerbook.table.header.amountToReceive={0} om te ontvang
+muSig.offerbook.table.header.amountToPay={0} om te betaal
+muSig.offerbook.table.header.amountToSend={0} om te stuur
+muSig.offerbook.table.header.price=Prys in {0}
+muSig.offerbook.table.header.paymentMethod=Betalingmetode
+muSig.offerbook.table.header.maker.seller=Koop van
+muSig.offerbook.table.header.maker.buyer=Verkoop aan
+muSig.offerbook.table.header.deposit=Sekuriteitsdeposito
+
+muSig.offerbook.table.cell.intent.buy=Koop Bitcoin
+muSig.offerbook.table.cell.intent.sell=Verkoop Bitcoin
+muSig.offerbook.table.cell.intent.remove=Verwyder
+
+
+
+muSig.offerbook.createOffer.buy=Skep aanbod om BTC te koop
+muSig.offerbook.createOffer.sell=Skep aanbod om BTC te verkoop
+
+muSig.offerbook.removeOffer.confirmation=Is jy seker jy wil hierdie aanbod verwyder?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=Jy kan daardie aanbod nie verwyder nie omdat jy die koerslimiet oorgesteek het.\nProbeer asseblief om 'n ander aanbod te gebruik.
+
+muSig.offerbook.marketHeader.title=Mark vir handel met {0}
+muSig.offerbook.table.header.peerProfile=Peer-profiel
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Alle aanbiedinge
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Koop
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Verkoop
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Watter betalingmetodes wil jy gebruik?
+muSig.createOffer.rateLimitsExceeded.publish.warning=Jy kan daardie aanbod nie publiseer nie omdat jy die koerslimiet oorskry het.\nProbeer asseblief om 'n ander aanbod te gebruik.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=Die aanbod het nie binne {0} sekondes geslaag nie.\nKontroleer asseblief jou netwerkverbinding en probeer dalk om die toepassing te herbegin.
+muSig.takeOffer.banned.maker.warning=Jy kan daardie aanbod nie aanvaar nie.\nDie maker van hierdie aanbod is verbied.\nProbeer asseblief om 'n ander aanbod te gebruik.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=Jy kan daardie aanbod nie aanvaar nie.\nDie maker van hierdie aanbod het die koerslimiet oorskry.\nProbeer asseblief om 'n ander aanbod te gebruik.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=Jy kan daardie aanbod nie aanvaar nie.\nJy het jou tariefgrens oorgesteek. Neem 'n bietjie 'n blaaskans totdat jou tariefgrens weer vrygestel word.\nBesonderhede: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} het {1} se aanbod met ID {2} geneem
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Deposito-transaksie
+muSig.tradeState.phase2=Begin Fiat-betaling
+muSig.tradeState.phase3=Wag vir Fiat betalingsontvangs
+muSig.tradeState.phase4=Handel voltooi
+
+
+muSig.tradeState.info.phase1a.headline=Stel deposito transaksie op
+muSig.tradeState.info.phase1a.info=Die MuSig deposito transaksie word saam met jou peer geskep.
+
+muSig.tradeState.info.phase1b.headline=Wag vir blockchain bevestiging
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=Die MuSig deposito transaksie moet ten minste 1 bevestiging hê voordat jy kan begin om die {0} bedrag te stuur.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=Die MuSig deposito-transaksie moet ten minste 1 bevestiging hê voordat die koper kan begin om die {0} bedrag te stuur.
+muSig.tradeState.info.phase1b.txId=Transaksie-ID
+muSig.tradeState.info.phase1b.txId.tooltip=Open transaksie in blok verkenner
+muSig.tradeState.info.phase1b.txId.prompt=Wag vir blockchain data...
+
+muSig.tradeState.info.buyer.phase3.headline=Wag vir die verkoper om die ontvangs van betaling te bevestig
+muSig.tradeState.info.buyer.phase3.info=Sodra die verkoper jou betaling van {0} ontvang het, sal hulle die vereiste data stuur om jou fondse te ontgrendel.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Wag vir die koper se sleutel om die handel te sluit
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=Die koper sal jou die sleutel stuur wat benodig word om die handel te sluit.\n\nAs die sleutel nie binne die verwagte tydraam gestuur word nie, sluit ons die handel met geweld deur die swap transaksie te gebruik.
+
+
+
+muSig.tradeCompleted.title=Geluk met die voltooiing van jou Bisq Musig handel!
+muSig.tradeCompleted.info=Ons hoop jou ervaring was glad en aangenaam. Ons sal graag jou gedagtes wil hoor!\nOm jou indrukke in die besprekingsgesels te deel help die Bisq-span om Bisq Musig te verbeter.
+

--- a/i18n/src/main/resources/mu_sig_cs.properties
+++ b/i18n/src/main/resources/mu_sig_cs.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Nabídková kniha
+muSig.openTrades=Moje otevřené obchody
+muSig.history=Historie
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Vyberte trh
+
+
+muSig.offerbook.table.header.intent=Chci
+muSig.offerbook.table.header.amountToReceive={0} k přijetí
+muSig.offerbook.table.header.amountToPay={0} k zaplacení
+muSig.offerbook.table.header.amountToSend={0} k odeslání
+muSig.offerbook.table.header.price=Cena v {0}
+muSig.offerbook.table.header.paymentMethod=Způsob platby
+muSig.offerbook.table.header.maker.seller=Koupit od
+muSig.offerbook.table.header.maker.buyer=Prodat
+muSig.offerbook.table.header.deposit=Záloha na zabezpečení
+
+muSig.offerbook.table.cell.intent.buy=Koupit Bitcoin
+muSig.offerbook.table.cell.intent.sell=Prodat Bitcoin
+muSig.offerbook.table.cell.intent.remove=Odebrat
+
+
+
+muSig.offerbook.createOffer.buy=Vytvořit nabídku na koupi BTC
+muSig.offerbook.createOffer.sell=Vytvořit nabídku na prodej BTC
+
+muSig.offerbook.removeOffer.confirmation=Opravdu chcete tuto nabídku smazat?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=Nemůžete tuto nabídku smazat, protože jste překročili limit rychlosti.\nZkuste prosím použít jinou nabídku.
+
+muSig.offerbook.marketHeader.title=Trh pro obchodování s {0}
+muSig.offerbook.table.header.peerProfile=Profil protějšku
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Všechny nabídky
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Koupit
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Prodat
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Jaké způsoby platby chcete použít?
+muSig.createOffer.rateLimitsExceeded.publish.warning=Nemůžete tuto nabídku publikovat, protože jste překročili limit pro publikaci.\nZkuste prosím použít jinou nabídku.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=Nabídku se nepodařilo přijmout za {0} sekund.\nZkontrolujte prosím své připojení k síti a zkuste aplikaci restartovat.
+muSig.takeOffer.banned.maker.warning=Nemůžete tuto nabídku přijmout.\nTvůrce této nabídky je zakázán.\nZkuste prosím použít jinou nabídku.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=Nemůžete přijmout tuto nabídku.\nTvůrce této nabídky překročil limit rychlosti.\nZkuste prosím použít jinou nabídku.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=Nemůžete přijmout tuto nabídku.\nPřekročili jste svůj limit. Chvíli si odpočiňte, dokud se váš limit znovu neuvolní.\nPodrobnosti: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} přijal nabídku {1} s ID {2}
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Vkladová transakce
+muSig.tradeState.phase2=Začít platbu fiat
+muSig.tradeState.phase3=Čekání na potvrzení přijetí platby v fiat
+muSig.tradeState.phase4=Obchod dokončen
+
+
+muSig.tradeState.info.phase1a.headline=Nastavení transakce vkladu
+muSig.tradeState.info.phase1a.info=Transakce vkladu MuSig je vytvářena spolupracující s vaším protějškem.
+
+muSig.tradeState.info.phase1b.headline=Čekání na potvrzení v blockchainu
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=Transakce vkladu MuSig musí mít alespoň 1 potvrzení, než budete moci začít odesílat částku {0}.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=Transakce vkladu MuSig musí mít alespoň 1 potvrzení, než může kupující začít odesílat částku {0}.
+muSig.tradeState.info.phase1b.txId=ID transakce
+muSig.tradeState.info.phase1b.txId.tooltip=Otevřít transakci v prohlížeči bloků
+muSig.tradeState.info.phase1b.txId.prompt=Čekání na data blockchainu...
+
+muSig.tradeState.info.buyer.phase3.headline=Čekání na potvrzení přijetí platby prodejcem
+muSig.tradeState.info.buyer.phase3.info=Jakmile prodejce obdrží vaši platbu ve výši {0}, odešle požadovaná data pro odemčení vašich prostředků.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Čekání na klíč kupujícího pro uzavření obchodu
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=Kupující vám zašle klíč potřebný k uzavření obchodu.\n\nPokud klíč nebude zaslán v očekávaném časovém rámci, obchod uzavřeme násilně pomocí swapové transakce.
+
+
+
+muSig.tradeCompleted.title=Gratulujeme k dokončení vašeho obchodu Bisq Musig!
+muSig.tradeCompleted.info=Doufáme, že vaše zkušenost byla plynulá a příjemná. Rádi bychom slyšeli vaše názory!\nSdílení vašich dojmů v diskusním chatu pomáhá týmu Bisq zlepšovat Bisq Musig.
+

--- a/i18n/src/main/resources/mu_sig_de.properties
+++ b/i18n/src/main/resources/mu_sig_de.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Angebotsbuch
+muSig.openTrades=Meine offenen Transaktionen
+muSig.history=Verlauf
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Markt auswählen
+
+
+muSig.offerbook.table.header.intent=Ich möchte
+muSig.offerbook.table.header.amountToReceive={0} zu empfangen
+muSig.offerbook.table.header.amountToPay={0} zu zahlen
+muSig.offerbook.table.header.amountToSend={0} zu senden
+muSig.offerbook.table.header.price=Preis in {0}
+muSig.offerbook.table.header.paymentMethod=Zahlungsmethode
+muSig.offerbook.table.header.maker.seller=Kaufen von
+muSig.offerbook.table.header.maker.buyer=Verkaufen an
+muSig.offerbook.table.header.deposit=Sicherheitsleistung
+
+muSig.offerbook.table.cell.intent.buy=Bitcoin kaufen
+muSig.offerbook.table.cell.intent.sell=Bitcoin verkaufen
+muSig.offerbook.table.cell.intent.remove=Entfernen
+
+
+
+muSig.offerbook.createOffer.buy=Angebot zum Kauf von BTC erstellen
+muSig.offerbook.createOffer.sell=Angebot zum Verkauf von BTC erstellen
+
+muSig.offerbook.removeOffer.confirmation=Sind Sie sicher, dass Sie dieses Angebot löschen möchten?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=Sie können dieses Angebot nicht entfernen, da Sie das Limit überschritten haben.\nBitte versuchen Sie, ein anderes Angebot zu verwenden.
+
+muSig.offerbook.marketHeader.title=Markt für den Handel mit {0}
+muSig.offerbook.table.header.peerProfile=Peer-Profil
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Alle Angebote
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Bitcoin kaufen
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Verkaufen
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Welche Zahlungsmethoden möchten Sie verwenden?
+muSig.createOffer.rateLimitsExceeded.publish.warning=Sie können dieses Angebot nicht veröffentlichen, da Sie das Limit überschritten haben.\nBitte versuchen Sie, ein anderes Angebot zu verwenden.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=Das Angebot konnte in {0} Sekunden nicht angenommen werden.\nBitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie möglicherweise, die App neu zu starten.
+muSig.takeOffer.banned.maker.warning=Sie können dieses Angebot nicht annehmen.\nDer Anbieter dieses Angebots ist gesperrt.\nBitte versuchen Sie, ein anderes Angebot zu nutzen.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=Sie können dieses Angebot nicht annehmen.\nDer Anbieter dieses Angebots hat das Kontingent überschritten.\nBitte versuchen Sie, ein anderes Angebot zu verwenden.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=Sie können dieses Angebot nicht annehmen.\nSie haben Ihr Kontingent überschritten. Machen Sie eine kurze Pause, bis Ihr Kontingent wieder freigegeben wird.\nDetails: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} hat das Angebot von {1} mit der ID {2} angenommen
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Einzahlungs-Transaktion
+muSig.tradeState.phase2=Starten Sie die Fiat-Zahlung
+muSig.tradeState.phase3=Warten auf den Zahlungseingang in Fiat
+muSig.tradeState.phase4=Handel abgeschlossen
+
+
+muSig.tradeState.info.phase1a.headline=Einzahlungs-Transaktion einrichten
+muSig.tradeState.info.phase1a.info=Die MuSig-Einzahlungstransaktion wird kooperativ mit Ihrem Peer erstellt.
+
+muSig.tradeState.info.phase1b.headline=Warten auf Blockchain-Bestätigung
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=Die MuSig-Einzahlungstransaktion muss mindestens 1 Bestätigung haben, bevor Sie den Betrag von {0} senden können.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=Die MuSig-Einzahlungstransaktion muss mindestens 1 Bestätigung haben, bevor der Käufer beginnen kann, den {0} Betrag zu senden.
+muSig.tradeState.info.phase1b.txId=Transaktions-ID
+muSig.tradeState.info.phase1b.txId.tooltip=Transaktion im Block Explorer öffnen
+muSig.tradeState.info.phase1b.txId.prompt=Warten auf Blockchain-Daten...
+
+muSig.tradeState.info.buyer.phase3.headline=Warten auf die Bestätigung des Verkäufers über den Zahlungseingang
+muSig.tradeState.info.buyer.phase3.info=Sobald der Verkäufer Ihre Zahlung von {0} erhalten hat, wird er die erforderlichen Daten zum Entsperren Ihrer Mittel senden.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Warten auf den Schlüssel des Käufers, um den Handel abzuschließen
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=Der Käufer wird Ihnen den Schlüssel senden, der erforderlich ist, um den Handel abzuschließen.\n\nFalls der Schlüssel nicht innerhalb des erwarteten Zeitrahmens gesendet wird, schließen wir den Handel zwangsweise, indem wir die Swap-Transaktion verwenden.
+
+
+
+muSig.tradeCompleted.title=Herzlichen Glückwunsch zum Abschluss Ihres Bisq Musig Handels!
+muSig.tradeCompleted.info=Wir hoffen, dass Ihre Erfahrung reibungslos und angenehm war. Wir würden gerne Ihre Gedanken hören!\nDas Teilen Ihrer Eindrücke im Diskussions-Chat hilft dem Bisq-Team, Bisq Musig zu verbessern.
+

--- a/i18n/src/main/resources/mu_sig_es.properties
+++ b/i18n/src/main/resources/mu_sig_es.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Libro de ofertas
+muSig.openTrades=Mis compra-ventas en curso
+muSig.history=Historial
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Seleccionar mercado
+
+
+muSig.offerbook.table.header.intent=Quiero
+muSig.offerbook.table.header.amountToReceive={0} a recibir
+muSig.offerbook.table.header.amountToPay={0} a pagar
+muSig.offerbook.table.header.amountToSend={0} a enviar
+muSig.offerbook.table.header.price=Precio en {0}
+muSig.offerbook.table.header.paymentMethod=Método de pago
+muSig.offerbook.table.header.maker.seller=Comprar de
+muSig.offerbook.table.header.maker.buyer=Vender a
+muSig.offerbook.table.header.deposit=Depósito de seguridad
+
+muSig.offerbook.table.cell.intent.buy=Comprar Bitcoin
+muSig.offerbook.table.cell.intent.sell=Vender Bitcoin
+muSig.offerbook.table.cell.intent.remove=Eliminar
+
+
+
+muSig.offerbook.createOffer.buy=Crear oferta para comprar BTC
+muSig.offerbook.createOffer.sell=Crear oferta para vender BTC
+
+muSig.offerbook.removeOffer.confirmation=¿Estás seguro de querer borrar esta oferta?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=No puedes eliminar esa oferta porque has superado el límite de tasa.\nPor favor, intenta usar una oferta diferente.
+
+muSig.offerbook.marketHeader.title=Mercado para comerciar con {0}
+muSig.offerbook.table.header.peerProfile=Perfil del usuario
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Todas las ofertas
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Comprar
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Vender
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=¿Qué métodos de pago deseas utilizar?
+muSig.createOffer.rateLimitsExceeded.publish.warning=No puedes publicar esa oferta porque has superado el límite de tasa.\nPor favor, intenta usar una oferta diferente.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=No se pudo aceptar la oferta en {0} segundos.\nPor favor, verifica tu conectividad de red y tal vez intenta reiniciar la aplicación.
+muSig.takeOffer.banned.maker.warning=No puedes aceptar esa oferta.\nEl creador de esta oferta está prohibido.\nPor favor, intenta usar una oferta diferente.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=No puedes aceptar esa oferta.\nEl creador de esta oferta ha excedido el límite de tasa.\nPor favor, intenta usar una oferta diferente.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=No puedes aceptar esa oferta.\nHas superado tu límite de tasa. Tómate un pequeño descanso hasta que tu límite de tasa se restablezca.\nDetalles: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} ha aceptado la oferta de {1} con ID {2}
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Transacción de Depósito
+muSig.tradeState.phase2=Iniciar pago en fiat
+muSig.tradeState.phase3=Esperando la recepción del pago en Fiat
+muSig.tradeState.phase4=Intercambio completado
+
+
+muSig.tradeState.info.phase1a.headline=Configurar transacción de depósito
+muSig.tradeState.info.phase1a.info=La transacción de depósito de MuSig se está creando de manera cooperativa con tu par.
+
+muSig.tradeState.info.phase1b.headline=Esperando confirmación en la cadena de bloques
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=La transacción de depósito de MuSig debe tener al menos 1 confirmación antes de que puedas comenzar a enviar la cantidad de {0}.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=La transacción de depósito de MuSig debe tener al menos 1 confirmación antes de que el comprador pueda comenzar a enviar la cantidad de {0}.
+muSig.tradeState.info.phase1b.txId=ID de la transacción
+muSig.tradeState.info.phase1b.txId.tooltip=Abrir transacción en el explorador de bloques
+muSig.tradeState.info.phase1b.txId.prompt=Esperando datos de la cadena de bloques...
+
+muSig.tradeState.info.buyer.phase3.headline=Esperar a que el vendedor confirme la recepción del pago
+muSig.tradeState.info.buyer.phase3.info=Una vez que el vendedor haya recibido tu pago de {0}, enviará los datos necesarios para desbloquear tus fondos.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Espera la clave del comprador para cerrar el comercio
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=El comprador te enviará la clave necesaria para cerrar el comercio.\n\nEn caso de que la clave no se envíe en el tiempo esperado, cerraremos el comercio de forma forzada utilizando la transacción de intercambio.
+
+
+
+muSig.tradeCompleted.title=¡Felicidades por completar tu comercio de Bisq Musig!
+muSig.tradeCompleted.info=Esperamos que tu experiencia haya sido fluida y agradable. ¡Nos encantaría conocer tus opiniones!\nCompartir tus impresiones en el chat de discusión ayuda al equipo de Bisq a mejorar Bisq Easy.
+

--- a/i18n/src/main/resources/mu_sig_it.properties
+++ b/i18n/src/main/resources/mu_sig_it.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Registro delle offerte
+muSig.openTrades=Le mie transazioni aperte
+muSig.history=Cronologia
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Seleziona Mercato
+
+
+muSig.offerbook.table.header.intent=Desidero
+muSig.offerbook.table.header.amountToReceive={0} da ricevere
+muSig.offerbook.table.header.amountToPay={0} da pagare
+muSig.offerbook.table.header.amountToSend={0} da inviare
+muSig.offerbook.table.header.price=Prezzo in {0}
+muSig.offerbook.table.header.paymentMethod=Metodo di pagamento
+muSig.offerbook.table.header.maker.seller=Compra da
+muSig.offerbook.table.header.maker.buyer=Vendi a
+muSig.offerbook.table.header.deposit=Deposito di sicurezza
+
+muSig.offerbook.table.cell.intent.buy=Compra Bitcoin
+muSig.offerbook.table.cell.intent.sell=Vendi Bitcoin
+muSig.offerbook.table.cell.intent.remove=Rimuovi
+
+
+
+muSig.offerbook.createOffer.buy=Crea offerta per comprare BTC
+muSig.offerbook.createOffer.sell=Crea offerta per vendere BTC
+
+muSig.offerbook.removeOffer.confirmation=Sei sicuro di voler eliminare questa offerta?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=Non puoi rimuovere quell'offerta perché hai superato il limite di frequenza.\nPer favore, prova a utilizzare un'offerta diversa.
+
+muSig.offerbook.marketHeader.title=Mercato per il commercio con {0}
+muSig.offerbook.table.header.peerProfile=Profilo Peer
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Tutte le offerte
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Compra
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Vendi
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Quali metodi di pagamento desideri utilizzare?
+muSig.createOffer.rateLimitsExceeded.publish.warning=Non puoi pubblicare quell'offerta perché hai superato il limite di pubblicazione.\nPer favore, prova a utilizzare un'offerta diversa.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=L'offerta non è riuscita in {0} secondi.\nControlla la tua connessione di rete e prova a riavviare l'app.
+muSig.takeOffer.banned.maker.warning=Non puoi accettare quell'offerta.\nIl creatore di questa offerta è bannato.\nPer favore, prova a utilizzare un'offerta diversa.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=Non puoi accettare quell'offerta.\nIl creatore di questa offerta ha superato il limite di frequenza.\nPer favore, prova a utilizzare un'offerta diversa.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=Non puoi accettare quell'offerta.\nHai superato il tuo limite di velocità. Fai una pausa fino a quando il tuo limite di velocità non sarà nuovamente disponibile.\nDettagli: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} ha accettato l'offerta di {1} con ID {2}
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Transazione di deposito
+muSig.tradeState.phase2=Inizia pagamento Fiat
+muSig.tradeState.phase3=Attendi la ricezione del pagamento in fiat
+muSig.tradeState.phase4=Compravendita completata
+
+
+muSig.tradeState.info.phase1a.headline=Imposta la transazione di deposito
+muSig.tradeState.info.phase1a.info=La transazione di deposito MuSig viene creata cooperativamente con il tuo peer.
+
+muSig.tradeState.info.phase1b.headline=In attesa di conferma blockchain
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=La transazione di deposito MuSig deve avere almeno 1 conferma prima di poter iniziare a inviare l'importo di {0}.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=La transazione di deposito MuSig deve avere almeno 1 conferma prima che l'acquirente possa iniziare a inviare l'importo di {0}.
+muSig.tradeState.info.phase1b.txId=ID della transazione
+muSig.tradeState.info.phase1b.txId.tooltip=Apri transazione nel block explorer
+muSig.tradeState.info.phase1b.txId.prompt=In attesa di dati blockchain...
+
+muSig.tradeState.info.buyer.phase3.headline=Attendi che il venditore confermi la ricezione del pagamento
+muSig.tradeState.info.buyer.phase3.info=Una volta che il venditore ha ricevuto il tuo pagamento di {0}, invierà i dati necessari per sbloccare i tuoi fondi.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Attendi la chiave dell'acquirente per chiudere il commercio
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=L'acquirente ti invierà la chiave necessaria per chiudere il commercio.\n\nNel caso in cui la chiave non venga inviata entro il tempo previsto, chiudiamo il commercio forzatamente utilizzando la transazione di scambio.
+
+
+
+muSig.tradeCompleted.title=Congratulazioni per aver completato il tuo commercio Bisq Musig!
+muSig.tradeCompleted.info=Speriamo che la tua esperienza sia stata fluida e piacevole. Ci piacerebbe conoscere le tue opinioni!\nCondividere le tue impressioni nella chat delle discussioni aiuta il team di Bisq a migliorare Bisq Easy.
+

--- a/i18n/src/main/resources/mu_sig_it.properties
+++ b/i18n/src/main/resources/mu_sig_it.properties
@@ -97,5 +97,5 @@ muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=L'acquirente ti invi
 
 
 muSig.tradeCompleted.title=Congratulazioni per aver completato il tuo commercio Bisq Musig!
-muSig.tradeCompleted.info=Speriamo che la tua esperienza sia stata fluida e piacevole. Ci piacerebbe conoscere le tue opinioni!\nCondividere le tue impressioni nella chat delle discussioni aiuta il team di Bisq a migliorare Bisq Easy.
+muSig.tradeCompleted.info=Speriamo che la tua esperienza sia stata fluida e piacevole. Ci piacerebbe conoscere le tue opinioni!\nCondividere le tue impressioni nella chat delle discussioni aiuta il team di Bisq a migliorare Bisq Musig.
 

--- a/i18n/src/main/resources/mu_sig_pcm.properties
+++ b/i18n/src/main/resources/mu_sig_pcm.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Ofa List
+muSig.openTrades=My open trads
+muSig.history=History
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Select Markit chanel
+
+
+muSig.offerbook.table.header.intent=I wan
+muSig.offerbook.table.header.amountToReceive={0} to receiv
+muSig.offerbook.table.header.amountToPay={0} to pay
+muSig.offerbook.table.header.amountToSend={0} to send
+muSig.offerbook.table.header.price=Price for {0}
+muSig.offerbook.table.header.paymentMethod=Akaunt for Payment
+muSig.offerbook.table.header.maker.seller=Buy From
+muSig.offerbook.table.header.maker.buyer=Sell to:
+muSig.offerbook.table.header.deposit=Sekuriti deposit
+
+muSig.offerbook.table.cell.intent.buy=Buy Bitcoin
+muSig.offerbook.table.cell.intent.sell=Sali Bitcoin
+muSig.offerbook.table.cell.intent.remove=Remove
+
+
+
+muSig.offerbook.createOffer.buy=Create ofa to buy BTC
+muSig.offerbook.createOffer.sell=Create ofa to sali BTC
+
+muSig.offerbook.removeOffer.confirmation=You dey sure say you wan delete this offer?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=You no fit delete that offer because you don pass the rate limit.\nAbeg try use another offer.
+
+muSig.offerbook.marketHeader.title=Markit for trayd with {0}
+muSig.offerbook.table.header.peerProfile=Profil for Peer
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=All ofa
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Buy
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Sali
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Which payment methods you wan use?
+muSig.createOffer.rateLimitsExceeded.publish.warning=You no fit publish that offer because you don pass the rate limit.\nAbeg try use another offer.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=Take offer no succeed for {0} seconds.\nAbeg check your network connectivity and maybe try restart the app.
+muSig.takeOffer.banned.maker.warning=You no fit take that offer.\nDi maker of dis offer don banned.\nAbeg try use anoda offer.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=You no fit take that offer.\nDi maker of dis offer don pass di rate limit.\nAbeg try use anoda offer.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=You no fit take that offer.\nYou don pass your rate limit. Take small break until your rate limit go release again.\nDetails: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} don take {1} offer wey get ID {2}
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Deposit Transakshon
+muSig.tradeState.phase2=Start Fiat payment
+muSig.tradeState.phase3=Dey wait for Fiat payment receiv
+muSig.tradeState.phase4=Trade don complete
+
+
+muSig.tradeState.info.phase1a.headline=Set deposit transakshon
+muSig.tradeState.info.phase1a.info=MuSig deposit transakshon dey create cooperatively with your peer.
+
+muSig.tradeState.info.phase1b.headline=Dey wait for blockchain Confirmeshon
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=MuSig deposit transakshon gatz to get at least 1 Confirmeshon before you fit start to Send the {0} amount.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=MuSig deposit transakshon gatz at least 1 Confirmeshon before di buyer fit start to Send di {0} amount.
+muSig.tradeState.info.phase1b.txId=ID Transakshon
+muSig.tradeState.info.phase1b.txId.tooltip=Open transaction for block explorer
+muSig.tradeState.info.phase1b.txId.prompt=Dey wait for blockchain data...
+
+muSig.tradeState.info.buyer.phase3.headline=Wait for the seller to confirm say e receive payment
+muSig.tradeState.info.buyer.phase3.info=Once di seller don receiv your payment of {0}, dem go send di required data to unlock your funds.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Dey wait for buyer key to close the trad
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=Di buyer go send you di key wey you go need to close di trad.\n\nIf dem no send di key for di time wey we expect, we go close di trad forcefully by using di swap transakshon.
+
+
+
+muSig.tradeCompleted.title=Congratulashon for don complete your Bisq Easy Musig trayd!
+muSig.tradeCompleted.info=We dey hope say your experience dey smooth and enjoyable. We go like hear your thoughts!\nSharing your impressions for the diskoshon chat go help Bisq team improve Bisq Musig.
+

--- a/i18n/src/main/resources/mu_sig_pt_BR.properties
+++ b/i18n/src/main/resources/mu_sig_pt_BR.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Livro de ofertas
+muSig.openTrades=Minhas negociações abertas
+muSig.history=Histórico
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Selecionar Mercado
+
+
+muSig.offerbook.table.header.intent=Eu quero
+muSig.offerbook.table.header.amountToReceive={0} a receber
+muSig.offerbook.table.header.amountToPay={0} a pagar
+muSig.offerbook.table.header.amountToSend={0} para enviar
+muSig.offerbook.table.header.price=Preço em {0}
+muSig.offerbook.table.header.paymentMethod=Método de pagamento
+muSig.offerbook.table.header.maker.seller=Comprar de
+muSig.offerbook.table.header.maker.buyer=Vender para
+muSig.offerbook.table.header.deposit=Depósito de segurança
+
+muSig.offerbook.table.cell.intent.buy=Comprar Bitcoin
+muSig.offerbook.table.cell.intent.sell=Vender Bitcoin
+muSig.offerbook.table.cell.intent.remove=Remover
+
+
+
+muSig.offerbook.createOffer.buy=Criar oferta para comprar BTC
+muSig.offerbook.createOffer.sell=Criar oferta para vender BTC
+
+muSig.offerbook.removeOffer.confirmation=Tem certeza de que deseja excluir esta oferta?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=Você não pode remover essa oferta porque você ultrapassou o limite de taxa.\nPor favor, tente usar uma oferta diferente.
+
+muSig.offerbook.marketHeader.title=Mercado para negociação com {0}
+muSig.offerbook.table.header.peerProfile=Perfil do Par
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Todas as ofertas
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Comprar
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Vender
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Quais métodos de pagamento você deseja usar?
+muSig.createOffer.rateLimitsExceeded.publish.warning=Você não pode publicar essa oferta porque você excedeu o limite de taxa.\nPor favor, tente usar uma oferta diferente.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=A oferta não foi aceita em {0} segundos.\nVerifique sua conectividade de rede e talvez tente reiniciar o aplicativo.
+muSig.takeOffer.banned.maker.warning=Você não pode aceitar essa oferta.\nO criador desta oferta está banido.\nPor favor, tente usar uma oferta diferente.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=Você não pode aceitar essa oferta.\nO criador desta oferta excedeu o limite de taxa.\nPor favor, tente usar uma oferta diferente.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=Você não pode aceitar essa oferta.\nVocê excedeu seu limite de taxa. Faça uma pausa até que seu limite de taxa seja liberado novamente.\nDetalhes: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} aceitou a oferta de {1} com ID {2}
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Transação de Depósito
+muSig.tradeState.phase2=Iniciar pagamento em Fiat
+muSig.tradeState.phase3=Aguardando recebimento do pagamento em Fiat
+muSig.tradeState.phase4=Negociação concluída
+
+
+muSig.tradeState.info.phase1a.headline=Configurar transação de depósito
+muSig.tradeState.info.phase1a.info=A transação de depósito MuSig está sendo criada cooperativamente com seu par.
+
+muSig.tradeState.info.phase1b.headline=Aguardando confirmação na blockchain
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=A transação de depósito MuSig deve ter pelo menos 1 confirmação antes que você possa começar a enviar o valor de {0}.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=A transação de depósito MuSig deve ter pelo menos 1 confirmação antes que o comprador possa começar a enviar o valor de {0}.
+muSig.tradeState.info.phase1b.txId=ID da transação
+muSig.tradeState.info.phase1b.txId.tooltip=Abrir transação no explorador de blocos
+muSig.tradeState.info.phase1b.txId.prompt=Aguardando dados da blockchain...
+
+muSig.tradeState.info.buyer.phase3.headline=Aguardar o vendedor confirmar o recebimento do pagamento
+muSig.tradeState.info.buyer.phase3.info=Assim que o vendedor receber seu pagamento de {0}, ele enviará os dados necessários para desbloquear seus fundos.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Aguarde a chave do comprador para fechar a negociação
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=O comprador lhe enviará a chave necessária para fechar a negociação.\n\nCaso a chave não seja enviada no prazo esperado, fecharemos a negociação forçosamente utilizando a transação de swap.
+
+
+
+muSig.tradeCompleted.title=Parabéns por concluir sua negociação Bisq Musig!
+muSig.tradeCompleted.info=Esperamos que sua experiência tenha sido tranquila e agradável. Adoraríamos ouvir seus pensamentos!\nCompartilhar suas impressões no chat de discussões ajuda a equipe do Bisq a melhorar o Bisq Musig.
+

--- a/i18n/src/main/resources/mu_sig_ru.properties
+++ b/i18n/src/main/resources/mu_sig_ru.properties
@@ -1,0 +1,101 @@
+######################################################
+# Musig
+######################################################
+
+muSig.offerbook=Книга предложений
+muSig.openTrades=Мои открытые сделки
+muSig.history=История
+
+
+######################################################
+# Offerbook
+######################################################
+
+muSig.offerbook.market.select=Выберите рынок
+
+
+muSig.offerbook.table.header.intent=Я хочу
+muSig.offerbook.table.header.amountToReceive={0} для получения
+muSig.offerbook.table.header.amountToPay={0} к оплате
+muSig.offerbook.table.header.amountToSend={0} для отправки
+muSig.offerbook.table.header.price=Цена в {0}
+muSig.offerbook.table.header.paymentMethod=Способ оплаты
+muSig.offerbook.table.header.maker.seller=Купить у
+muSig.offerbook.table.header.maker.buyer=Продать
+muSig.offerbook.table.header.deposit=Залог безопасности
+
+muSig.offerbook.table.cell.intent.buy=Купить биткойн
+muSig.offerbook.table.cell.intent.sell=Продать биткойн
+muSig.offerbook.table.cell.intent.remove=Удалить
+
+
+
+muSig.offerbook.createOffer.buy=Создать предложение на покупку BTC
+muSig.offerbook.createOffer.sell=Создать предложение на продажу BTC
+
+muSig.offerbook.removeOffer.confirmation=Вы уверены, что хотите удалить это предложение?
+muSig.offerbook.rateLimitsExceeded.removeOffer.warning=Вы не можете удалить это предложение, потому что вы превысили лимит запросов.\nПожалуйста, попробуйте использовать другое предложение.
+
+muSig.offerbook.marketHeader.title=Рынок для торговли с {0}
+muSig.offerbook.table.header.peerProfile=Профиль сверстника
+
+muSig.offerbook.offerlistSubheader.offersToggleGroup.allOffers=Все предложения
+muSig.offerbook.offerlistSubheader.offersToggleGroup.buy=Купить
+muSig.offerbook.offerlistSubheader.offersToggleGroup.sell=Продать
+
+
+######################################################
+# Create offer
+######################################################
+
+muSig.createOffer.paymentMethods.headline=Какие способы оплаты вы хотите использовать?
+muSig.createOffer.rateLimitsExceeded.publish.warning=Вы не можете опубликовать это предложение, потому что вы превысили лимит на публикацию.\nПожалуйста, попробуйте использовать другое предложение.
+
+
+######################################################
+# Take offer
+######################################################
+
+muSig.takeOffer.timeout.warning=Предложение не было принято за {0} секунд.\nПожалуйста, проверьте подключение к сети и попробуйте перезапустить приложение.
+muSig.takeOffer.banned.maker.warning=Вы не можете принять это предложение.\nСоздатель этого предложения заблокирован.\nПожалуйста, попробуйте использовать другое предложение.
+muSig.takeOffer.rateLimitsExceeded.maker.warning=Вы не можете принять это предложение.\nСоздатель этого предложения превысил лимит на количество предложений.\nПожалуйста, попробуйте использовать другое предложение.
+muSig.takeOffer.rateLimitsExceeded.taker.warning=Вы не можете принять это предложение.\nВы превысили свой лимит. Сделайте небольшую паузу, пока ваш лимит не будет восстановлен.\nПодробности: {0}
+
+
+######################################################
+# Trade protocol
+######################################################
+
+muSig.protocol.logMessage.takeOffer={0} принял предложение {1} с ID {2}
+
+
+# Trade State: Phase (left side)
+muSig.tradeState.phase1=Депозитная транзакция
+muSig.tradeState.phase2=Начать платеж в фиатной валюте
+muSig.tradeState.phase3=Ожидание получения фиатного платежа
+muSig.tradeState.phase4=Торговля завершена
+
+
+muSig.tradeState.info.phase1a.headline=Настройка транзакции депозита
+muSig.tradeState.info.phase1a.info=Транзакция депозита MuSig создается совместно с вашим сверстником.
+
+muSig.tradeState.info.phase1b.headline=Ожидание подтверждения блокчейна
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.buyer=Транзакция депозита MuSig должна иметь как минимум 1 подтверждение, прежде чем вы сможете начать отправлять сумму {0}.
+# suppress inspection "UnusedProperty"
+muSig.tradeState.info.phase1b.info.seller=Транзакция депозита MuSig должна иметь как минимум 1 подтверждение, прежде чем покупатель сможет начать отправлять сумму {0}.
+muSig.tradeState.info.phase1b.txId=Идентификатор транзакции
+muSig.tradeState.info.phase1b.txId.tooltip=Откройте транзакцию в проводнике блоков
+muSig.tradeState.info.phase1b.txId.prompt=Ожидание данных блокчейна...
+
+muSig.tradeState.info.buyer.phase3.headline=Дождитесь подтверждения продавцом получения платежа
+muSig.tradeState.info.buyer.phase3.info=Как только продавец получит ваш платеж в размере {0}, он отправит необходимые данные для разблокировки ваших средств.
+
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.headline=Ожидание ключа покупателя для завершения торговли
+muSig.tradeState.info.seller.phase3b.waitForTradeClose.info=Покупатель отправит вам ключ, необходимый для завершения сделки.\n\nЕсли ключ не будет отправлен в ожидаемые сроки, мы принудительно закроем сделку, используя транзакцию свопа.
+
+
+
+muSig.tradeCompleted.title=Поздравляем с завершением вашей торговли Bisq Musig!
+muSig.tradeCompleted.info=Мы надеемся, что ваш опыт был гладким и приятным. Нам бы хотелось услышать ваше мнение!\nПоделитесь своими впечатлениями в чате обсуждений, это поможет команде Bisq улучшить Bisq Легко.
+


### PR DESCRIPTION
and other minor translations including updated documentation for translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full localization support for the MuSig feature in Afrikaans, Czech, German, Spanish, Italian, Nigerian Pidgin, Brazilian Portuguese, and Russian.
  - Introduced new translation strings for data redaction and online status in Afrikaans, German, Spanish, Italian, Nigerian Pidgin, and Brazilian Portuguese.
  - Added new UI prompts and log messages for Bitcoin payment phases in Italian and Spanish.
  - Added a new Spanish localization string for skipping block confirmation wait in the trade state UI.

- **Bug Fixes**
  - Removed a duplicate entry and improved key ordering in the Italian localization file.
  - Cleaned up trailing whitespace in the Czech localization file.

- **Documentation**
  - Rewrote and expanded the translation management guide, providing clear, step-by-step instructions for using Transifex and managing localization files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->