### PR TITLE
Allow to select amount using base currency in muSig take offer

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/amount/MuSigTakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/amount/MuSigTakeOfferAmountController.java
@@ -102,6 +102,8 @@ public class MuSigTakeOfferAmountController implements Controller {
 
     @Override
     public void onActivate() {
+        amountSelectionController.setAllowInvertingBaseAndQuoteCurrencies(true);
+        amountSelectionController.setBaseAsInputCurrency(true);
         applyQuoteSideMinMaxRange();
         baseSideAmountPin = EasyBind.subscribe(amountSelectionController.getMaxOrFixedBaseSideAmount(),
                 amount -> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled the option to invert base and quote currencies when taking an offer.
  - Set the base currency as the default input currency during the offer-taking process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->