### PR TITLE
Add my offer actions in MuSig offerlist

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/BisqEasyOfferbookView.java
@@ -537,7 +537,7 @@ public final class BisqEasyOfferbookView extends ChatView<BisqEasyOfferbookView,
     }
 
     private Button createAndGetCreateOfferButton() {
-        Button createOfferButton = new Button(Res.get("offer.createOffer"));
+        Button createOfferButton = new Button(Res.get("offer.create"));
         createOfferButton.getStyleClass().addAll("create-offer-button", "normal-text");
         return createOfferButton;
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyOfferMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyOfferMessageBox.java
@@ -89,7 +89,7 @@ public final class MyOfferMessageBox extends BubbleMessageBox {
 
         removeOffer = new BisqMenuItem("delete-t-grey", "delete-t-red");
         removeOffer.useIconOnly();
-        removeOffer.setTooltip(Res.get("offer.deleteOffer"));
+        removeOffer.setTooltip(Res.get("offer.delete"));
         HBox.setMargin(removeOffer, ACTION_ITEMS_MARGIN);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookView.java
@@ -595,7 +595,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
                 myOfferActionsMenuBox.setAlignment(Pos.CENTER);
 
                 removeOfferMenuItem.useIconOnly();
-                removeOfferMenuItem.setTooltip(Res.get("offer.deleteOffer"));
+                removeOfferMenuItem.setTooltip(Res.get("offer.delete"));
 
                 copyOfferMenuItem.useIconOnly();
                 copyOfferMenuItem.setTooltip(Res.get("offer.copy"));
@@ -766,7 +766,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
     }
 
     private Button createAndGetCreateOfferButton() {
-        Button createOfferButton = new Button(Res.get("offer.createOffer"));
+        Button createOfferButton = new Button(Res.get("offer.create"));
         createOfferButton.getStyleClass().addAll("create-offer-button", "normal-text");
         return createOfferButton;
     }

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -63,10 +63,10 @@ data.add=Add
 data.remove=Remove
 data.redacted=Data has been removed for privacy and security reasons
 
-offer.createOffer=Create offer
+offer.create=Create offer
 offer.takeOffer.buy.button=Buy Bitcoin
 offer.takeOffer.sell.button=Sell Bitcoin
-offer.deleteOffer=Delete offer
+offer.delete=Delete offer
 offer.buy=buy
 offer.sell=sell
 offer.buying=buying


### PR DESCRIPTION
* Add edit, copy and remove offer action menu items to MuSig offers.
* Small refactor improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the offer list UI for your own offers with a hover-activated menu, allowing quick access to edit, copy, and remove actions.
  * Added tooltips and distinct icons for offer action buttons.

* **Style**
  * Updated button and tooltip labels for creating and deleting offers to use more concise wording.

* **Documentation**
  * Improved localization with new and updated strings for offer actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->