### PR TITLE
support_2.1.7_dependant_bisq_mobile_cleanet_lan_emulator

### DIFF
--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -129,7 +129,7 @@ application {
         }
     }
     
-    network = {
+    network {
         version = 1
 
         supportedTransportTypes = ["TOR"]
@@ -218,6 +218,7 @@ application {
                 sendMessageThrottleTime = 200
                 receiveMessageThrottleTime = 200
                 connectTimeoutMs = 3000
+                clearNetAddressType = "LOCAL_HOST"
             }
             tor {
                 bootstrapTimeout = 240

--- a/apps/http-api-app/src/main/resources/http_api_app.conf
+++ b/apps/http-api-app/src/main/resources/http_api_app.conf
@@ -128,7 +128,7 @@ application {
         }
     }
 
-    network = {
+    network {
         version = 1
 
         supportedTransportTypes = ["TOR"]
@@ -217,6 +217,7 @@ application {
                 sendMessageThrottleTime = 200
                 receiveMessageThrottleTime = 200
                 connectTimeoutMs = 3000
+                clearNetAddressType = "LOCAL_HOST"
             }
             tor {
                 bootstrapTimeout = 240

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -128,7 +128,7 @@ application {
         }
     }
 
-    network = {
+    network {
         version = 1
 
         supportedTransportTypes = ["TOR"]
@@ -217,6 +217,7 @@ application {
                 sendMessageThrottleTime = 200
                 receiveMessageThrottleTime = 200
                 connectTimeoutMs = 3000
+                clearNetAddressType = "LOCAL_HOST"
             }
             tor {
                 bootstrapTimeout = 240

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -132,7 +132,7 @@ application {
         }
     }
     
-    network = {
+    network {
         version = 1
 
         supportedTransportTypes = ["TOR"]
@@ -221,6 +221,7 @@ application {
                 sendMessageThrottleTime = 200
                 receiveMessageThrottleTime = 200
                 connectTimeoutMs = 3000
+                clearNetAddressType = "LOCAL_HOST"
             }
             tor {
                 bootstrapTimeout = 240

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -116,7 +116,7 @@ application {
         }
     }
       
-    network = {
+    network {
         version = 1
 
         supportedTransportTypes = ["TOR"]
@@ -206,6 +206,7 @@ application {
                 sendMessageThrottleTime = 200
                 receiveMessageThrottleTime = 200
                 connectTimeoutMs = 3000
+                clearNetAddressType = "LOCAL_HOST"
             }
             tor {
                 bootstrapTimeout = 240

--- a/common/src/main/java/bisq/common/facades/FacadeProvider.java
+++ b/common/src/main/java/bisq/common/facades/FacadeProvider.java
@@ -17,8 +17,8 @@
 
 package bisq.common.facades;
 
-import bisq.common.network.DefaultLocalhostFacade;
-import bisq.common.network.LocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
+import bisq.common.network.clear_net_address_types.ClearNetAddressTypeFacade;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class FacadeProvider {
     private static JdkFacade jdkFacade;
     private static GuavaFacade guavaFacade;
-    private static LocalhostFacade localhostFacade = new DefaultLocalhostFacade();
+    private static ClearNetAddressTypeFacade clearNetAddressTypeFacade = new LocalHostAddressTypeFacade();
 
     public static void setJdkFacade(JdkFacade jdkFacade) {
         FacadeProvider.jdkFacade = jdkFacade;
@@ -49,12 +49,12 @@ public class FacadeProvider {
         return guavaFacade;
     }
 
-    public static LocalhostFacade getLocalhostFacade() {
-        return localhostFacade;
+    public static ClearNetAddressTypeFacade getClearNetAddressTypeFacade() {
+        return clearNetAddressTypeFacade;
     }
 
-    public static void setLocalhostFacade(LocalhostFacade localhostFacade) {
-        FacadeProvider.localhostFacade = localhostFacade;
+    public static void setClearNetAddressTypeFacade(ClearNetAddressTypeFacade clearNetAddressTypeFacade) {
+        FacadeProvider.clearNetAddressTypeFacade = clearNetAddressTypeFacade;
     }
 
 }

--- a/common/src/main/java/bisq/common/network/clear_net_address_types/AndroidEmulatorAddressTypeFacade.java
+++ b/common/src/main/java/bisq/common/network/clear_net_address_types/AndroidEmulatorAddressTypeFacade.java
@@ -15,19 +15,22 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.common.network;
+package bisq.common.network.clear_net_address_types;
 
+import bisq.common.network.Address;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class AndroidEmulatorLocalhostFacade implements LocalhostFacade {
-    public Address toMyLocalhost(int port) {
+public class AndroidEmulatorAddressTypeFacade implements ClearNetAddressTypeFacade {
+    @Override
+    public Address toMyLocalAddress(int port) {
         log.info("The android app is running in the emulator. We convert our localhost " +
                 "address to `10.0.2.15`");
         return new Address("10.0.2.15", port);
     }
 
-    public Address toPeersLocalhost(Address address) {
+    @Override
+    public Address toPeersLocalAddress(Address address) {
         if (address.isLocalhost()) {
             log.info("The android app is running in the emulator. We convert the target localhost " +
                     "address `127.0.0.1` to `10.0.2.2`");

--- a/common/src/main/java/bisq/common/network/clear_net_address_types/ClearNetAddressType.java
+++ b/common/src/main/java/bisq/common/network/clear_net_address_types/ClearNetAddressType.java
@@ -15,17 +15,10 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.common.network;
+package bisq.common.network.clear_net_address_types;
 
-import com.google.common.annotations.VisibleForTesting;
-
-public class DefaultLocalhostFacade implements LocalhostFacade {
-    @VisibleForTesting
-    public static Address toLocalHostAddress(int port) {
-        return new Address("127.0.0.1", port);
-    }
-
-    public Address toMyLocalhost(int port) {
-        return toLocalHostAddress(port);
-    }
+public enum ClearNetAddressType {
+    LOCAL_HOST,
+    ANDROID_EMULATOR,
+    LAN
 }

--- a/common/src/main/java/bisq/common/network/clear_net_address_types/ClearNetAddressTypeFacade.java
+++ b/common/src/main/java/bisq/common/network/clear_net_address_types/ClearNetAddressTypeFacade.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.network.clear_net_address_types;
+
+import bisq.common.network.Address;
+
+/**
+ * For Android running in emulator we need to convert the localhost addresses to the IP addresses used by the emulator.
+ * To support that we use a facade which by default use the loop-back address 127.0.0.1.
+ */
+public interface ClearNetAddressTypeFacade {
+    Address toMyLocalAddress(int port);
+
+    default Address toPeersLocalAddress(Address address) {
+        return address;
+    }
+}

--- a/common/src/main/java/bisq/common/network/clear_net_address_types/LANAddressTypeFacade.java
+++ b/common/src/main/java/bisq/common/network/clear_net_address_types/LANAddressTypeFacade.java
@@ -1,0 +1,45 @@
+package bisq.common.network.clear_net_address_types;
+
+import bisq.common.network.Address;
+import bisq.common.util.NetworkUtils;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.NetworkInterface;
+import java.util.Optional;
+
+@Slf4j
+public class LANAddressTypeFacade implements ClearNetAddressTypeFacade {
+    private volatile Optional<NetworkInterface> preferredNetworkInterface;
+
+    public LANAddressTypeFacade() {
+        this.preferredNetworkInterface = Optional.empty();
+    }
+
+    public LANAddressTypeFacade(NetworkInterface preferredNetworkInterface) {
+        this.preferredNetworkInterface = Optional.of(preferredNetworkInterface);
+    }
+
+    /**
+     * If preferredNetworkInterface is set and an IPv4 LAN address is found for that network interface we return that.
+     * If no preferredNetworkInterface is set, we return the IPv4 LAN address of the first network interface.
+     */
+    @Override
+    public synchronized Address toMyLocalAddress(int port) {
+        Optional<String> optionalHost = NetworkUtils.findLANHostAddress(preferredNetworkInterface);
+        if (optionalHost.isEmpty()) {
+            log.warn("We did not find any LAN IP address. We use 127.0.0.1 as fallback.");
+            return new Address("127.0.0.1", port);
+        }
+        String host = optionalHost.get();
+        if (preferredNetworkInterface.isPresent()) {
+            log.info("My LAN IP address matching my preferred network interface is: {}", host);
+        } else {
+            log.info("The LAN IP address from my first network interface is: {}", host);
+        }
+        return new Address(host, port);
+    }
+
+    public synchronized void setPreferredNetworkInterface(Optional<NetworkInterface> preferredNetworkInterface) {
+        this.preferredNetworkInterface = preferredNetworkInterface;
+    }
+}

--- a/common/src/main/java/bisq/common/network/clear_net_address_types/LocalHostAddressTypeFacade.java
+++ b/common/src/main/java/bisq/common/network/clear_net_address_types/LocalHostAddressTypeFacade.java
@@ -15,16 +15,19 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.common.network;
+package bisq.common.network.clear_net_address_types;
 
-/**
- * For Android running in emulator we need to convert the localhost addresses to the IP addresses used by the emulator.
- * To support that we use a facade which by default use the loop-back address 127.0.0.1.
- */
-public interface LocalhostFacade {
-    Address toMyLocalhost(int port);
+import bisq.common.network.Address;
+import com.google.common.annotations.VisibleForTesting;
 
-    default Address toPeersLocalhost(Address address) {
-        return address;
+public class LocalHostAddressTypeFacade implements ClearNetAddressTypeFacade {
+    @VisibleForTesting
+    public static Address toLocalHostAddress(int port) {
+        return new Address("127.0.0.1", port);
+    }
+
+    @Override
+    public Address toMyLocalAddress(int port) {
+        return toLocalHostAddress(port);
     }
 }

--- a/common/src/main/java/bisq/common/util/NetworkUtils.java
+++ b/common/src/main/java/bisq/common/util/NetworkUtils.java
@@ -17,11 +17,20 @@
 
 package bisq.common.util;
 
+import bisq.common.data.Pair;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -64,5 +73,69 @@ public class NetworkUtils {
             // Could not connect
             return false;
         }
+    }
+
+    public static List<NetworkInterface> findNetworkInterfaces() {
+        return getNetworkInterfaceHostAddressPairs().stream()
+                .map(Pair::getFirst)
+                .distinct()
+                .toList();
+    }
+
+    public static List<Pair<NetworkInterface, String>> getNetworkInterfaceHostAddressPairs() {
+        List<Pair<NetworkInterface, String>> networkInterfaceHostAddressPairs = new ArrayList<>();
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = interfaces.nextElement();
+
+                // Ignore down, loopback, virtual and point to point interfaces
+                if (!networkInterface.isUp() ||
+                        networkInterface.isLoopback() ||
+                        networkInterface.isVirtual() ||
+                        networkInterface.isPointToPoint()) {
+                    continue;
+                }
+
+                Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress inetAddress = addresses.nextElement();
+                    // isSiteLocalAddress ensures that we return only LAN addresses (10.x.x.x, 192.168.x.x, 172.16.x.x–172.31.x.x)
+                    if (inetAddress instanceof Inet4Address && inetAddress.isSiteLocalAddress()) {
+                        // return Optional.of(inetAddress.getHostAddress());
+                        networkInterfaceHostAddressPairs.add(new Pair<>(networkInterface, inetAddress.getHostAddress()));
+                    }
+                }
+            }
+        } catch (SocketException socketException) {
+            log.error("Could not access network interfaces", socketException);
+        }
+
+        if (networkInterfaceHostAddressPairs.isEmpty()) {
+            // Not expected but possible (machine is not connected to any Ethernet, Wi-Fi, or VPN,
+            // sandboxes or restricted environments like Android emulator, Docker,...)
+            log.warn("No IPv4 LAN addresses found");
+        }
+
+        return networkInterfaceHostAddressPairs;
+    }
+
+    public static Optional<String> findLANHostAddress(Optional<NetworkInterface> preferredNetworkInterface) {
+        List<Pair<NetworkInterface, String>> networkInterfaceHostAddressPairs = getNetworkInterfaceHostAddressPairs();
+        if (preferredNetworkInterface.isPresent()) {
+            Optional<String> preferred = networkInterfaceHostAddressPairs.stream()
+                    .filter(pair ->
+                            pair.getFirst().equals(preferredNetworkInterface.get()))
+                    .map(Pair::getSecond)
+                    .findFirst();
+            if (preferred.isPresent()) {
+                return preferred;
+            } else {
+                log.warn("No networkInterface found which matches the preferredNetworkInterface. We return all LAN addresses.");
+            }
+        }
+        return networkInterfaceHostAddressPairs.stream()
+                .map(Pair::getSecond)
+                .findFirst();
     }
 }

--- a/identity/src/test/java/bisq/identity/IdentityServiceTest.java
+++ b/identity/src/test/java/bisq/identity/IdentityServiceTest.java
@@ -17,7 +17,7 @@
 
 package bisq.identity;
 
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.network.NetworkService;
 import bisq.common.network.AddressByTransportTypeMap;
 import bisq.common.network.TransportType;
@@ -160,7 +160,7 @@ public class IdentityServiceTest {
     @Test
     void findInvalidIdentityByNetworkId() {
         AddressByTransportTypeMap addressByTransportTypeMap = new AddressByTransportTypeMap(
-                Map.of(TransportType.CLEAR, DefaultLocalhostFacade.toLocalHostAddress(1234)));
+                Map.of(TransportType.CLEAR, LocalHostAddressTypeFacade.toLocalHostAddress(1234)));
 
         String keyId = keyBundleService.getKeyIdFromTag("myTag2");
         KeyPair keyPair = keyBundleService.getOrCreateKeyBundle(keyId).getKeyPair();
@@ -192,7 +192,7 @@ public class IdentityServiceTest {
     @Test
     void findInvalidRetiredIdentity() {
         AddressByTransportTypeMap addressByTransportTypeMap = new AddressByTransportTypeMap(
-                Map.of(TransportType.CLEAR, DefaultLocalhostFacade.toLocalHostAddress(1234)));
+                Map.of(TransportType.CLEAR, LocalHostAddressTypeFacade.toLocalHostAddress(1234)));
         String keyId = keyBundleService.getKeyIdFromTag("myTag3");
         KeyPair keyPair = keyBundleService.getOrCreateKeyBundle(keyId).getKeyPair();
         var pubKey = new PubKey(keyPair.getPublic(), keyId);

--- a/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
+++ b/network/network/src/integrationTest/java/bisq/network/p2p/NetworkEnvelopeSocketChannelTests.java
@@ -19,7 +19,7 @@ package bisq.network.p2p;
 
 import bisq.common.application.ApplicationVersion;
 import bisq.common.file.FileUtils;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.common.util.NetworkUtils;
 import bisq.common.network.Address;
 import bisq.common.network.TransportType;
@@ -189,11 +189,11 @@ public class NetworkEnvelopeSocketChannelTests {
         List<TransportType> supportedTransportTypes = new ArrayList<>(1);
         supportedTransportTypes.add(TransportType.CLEAR);
 
-        Capability peerCapability = createCapability(DefaultLocalhostFacade.toLocalHostAddress(2345), supportedTransportTypes);
+        Capability peerCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationService authorizationService = createAuthorizationService();
 
-        Capability responderCapability = createCapability(DefaultLocalhostFacade.toLocalHostAddress(1234), supportedTransportTypes);
+        Capability responderCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(1234), supportedTransportTypes);
 
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),

--- a/network/network/src/integrationTest/java/bisq/network/p2p/OutboundConnectionsMultiplexerTest.java
+++ b/network/network/src/integrationTest/java/bisq/network/p2p/OutboundConnectionsMultiplexerTest.java
@@ -19,7 +19,7 @@ package bisq.network.p2p;
 
 import bisq.common.application.ApplicationVersion;
 import bisq.common.file.FileUtils;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.common.util.NetworkUtils;
 import bisq.common.network.Address;
 import bisq.common.network.TransportType;
@@ -60,7 +60,7 @@ public class OutboundConnectionsMultiplexerTest {
         ArrayList<TransportType> supportedTransportTypes = new ArrayList<>();
         supportedTransportTypes.add(TransportType.CLEAR);
 
-        Address serverAddress = DefaultLocalhostFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
+        Address serverAddress = LocalHostAddressTypeFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
         Capability serverCapability = createCapability(serverAddress, supportedTransportTypes);
         ServerChannel serverChannel = new ServerChannel(
                 serverCapability,
@@ -84,7 +84,7 @@ public class OutboundConnectionsMultiplexerTest {
                 }
 
                 AuthorizationService authorizationService = createAuthorizationService();
-                Address outboundAddress = DefaultLocalhostFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
+                Address outboundAddress = LocalHostAddressTypeFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
                 Capability outboundCapability = createCapability(outboundAddress, supportedTransportTypes);
                 Selector selector = SelectorProvider.provider().openSelector();
 

--- a/network/network/src/main/java/bisq/network/NetworkIdService.java
+++ b/network/network/src/main/java/bisq/network/NetworkIdService.java
@@ -168,7 +168,7 @@ public class NetworkIdService implements PersistenceClient<NetworkIdStore>, Serv
         return switch (transportType) {
             case TOR -> new Address(keyBundle.getTorKeyPair().getOnionAddress(), port);
             case I2P -> throw new RuntimeException("I2P not unsupported yet");
-            case CLEAR -> FacadeProvider.getLocalhostFacade().toMyLocalhost(port);
+            case CLEAR -> FacadeProvider.getClearNetAddressTypeFacade().toMyLocalAddress(port);
         };
     }
 

--- a/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
@@ -20,7 +20,7 @@ package bisq.network.p2p;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.file.FileUtils;
 import bisq.common.network.Address;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.common.network.TransportType;
 import bisq.network.p2p.message.NetworkEnvelope;
 import bisq.network.p2p.node.Capability;
@@ -58,7 +58,7 @@ public class ConnectionHandshakeResponderTest {
 
     public ConnectionHandshakeResponderTest() throws IOException {
         supportedTransportTypes.add(TransportType.CLEAR);
-        this.responderCapability = createCapability(DefaultLocalhostFacade.toLocalHostAddress(1234), supportedTransportTypes);
+        this.responderCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(1234), supportedTransportTypes);
         this.authorizationService = createAuthorizationService();
         this.handshakeResponder = new ConnectionHandshakeResponder(
                 banList,
@@ -99,7 +99,7 @@ public class ConnectionHandshakeResponderTest {
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
-                DefaultLocalhostFacade.toLocalHostAddress(1234).toString(),
+                LocalHostAddressTypeFacade.toLocalHostAddress(1234).toString(),
                 0, new ArrayList<>());
         NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(NetworkEnvelope.networkVersion + 1000, token, request);
         List<NetworkEnvelope> allEnvelopesToReceive = List.of(requestNetworkEnvelope);
@@ -114,7 +114,7 @@ public class ConnectionHandshakeResponderTest {
         AuthorizationToken token = authorizationService.createToken(
                 response,
                 new NetworkLoad(),
-                DefaultLocalhostFacade.toLocalHostAddress(1234).toString(),
+                LocalHostAddressTypeFacade.toLocalHostAddress(1234).toString(),
                 0, new ArrayList<>());
         NetworkEnvelope responseEnvelope = new NetworkEnvelope(token, response);
         List<NetworkEnvelope> allEnvelopesToReceive = List.of(responseEnvelope);
@@ -132,13 +132,13 @@ public class ConnectionHandshakeResponderTest {
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
-                DefaultLocalhostFacade.toLocalHostAddress(1234).toString(),
+                LocalHostAddressTypeFacade.toLocalHostAddress(1234).toString(),
                 0, new ArrayList<>());
         NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(token, request);
         List<NetworkEnvelope> allEnvelopesToReceive = List.of(requestNetworkEnvelope);
         when(networkEnvelopeSocketChannel.receiveNetworkEnvelopes()).thenReturn(allEnvelopesToReceive);
 
-        when(banList.isBanned(DefaultLocalhostFacade.toLocalHostAddress(1234))).thenReturn(true);
+        when(banList.isBanned(LocalHostAddressTypeFacade.toLocalHostAddress(1234))).thenReturn(true);
 
         ConnectionException exception = assertThrows(ConnectionException.class, handshakeResponder::verifyAndBuildRespond);
         assertEquals(exception.getReason(), ConnectionException.Reason.ADDRESS_BANNED);
@@ -149,7 +149,7 @@ public class ConnectionHandshakeResponderTest {
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
-                DefaultLocalhostFacade.toLocalHostAddress(1234).toString(),
+                LocalHostAddressTypeFacade.toLocalHostAddress(1234).toString(),
                 5, new ArrayList<>());
         NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(token, request);
         List<NetworkEnvelope> allEnvelopesToReceive = List.of(requestNetworkEnvelope);
@@ -164,7 +164,7 @@ public class ConnectionHandshakeResponderTest {
 
     @Test
     void correctPoW() throws IOException {
-        Capability peerCapability = createCapability(DefaultLocalhostFacade.toLocalHostAddress(2345), supportedTransportTypes);
+        Capability peerCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
@@ -182,7 +182,7 @@ public class ConnectionHandshakeResponderTest {
     }
 
     private NetworkEnvelope createValidRequest() {
-        Capability peerCapability = createCapability(DefaultLocalhostFacade.toLocalHostAddress(2345), supportedTransportTypes);
+        Capability peerCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),

--- a/network/network/src/test/java/bisq/network/p2p/InboundConnectionsManagerTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/InboundConnectionsManagerTests.java
@@ -19,7 +19,7 @@ package bisq.network.p2p;
 
 import bisq.common.application.ApplicationVersion;
 import bisq.common.file.FileUtils;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.common.util.NetworkUtils;
 import bisq.common.network.Address;
 import bisq.common.network.TransportType;
@@ -71,7 +71,7 @@ public class InboundConnectionsManagerTests {
         ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
         serverSocketChannel.configureBlocking(false);
 
-        Address myAddress = DefaultLocalhostFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
+        Address myAddress = LocalHostAddressTypeFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
         InetSocketAddress socketAddress = new InetSocketAddress(
                 InetAddress.getLocalHost(),
                 myAddress.getPort()
@@ -129,7 +129,7 @@ public class InboundConnectionsManagerTests {
             socketChannel.connect(socketAddress);
 
             InetSocketAddress localSocketAddress = (InetSocketAddress) socketChannel.getLocalAddress();
-            Address peerAddress = DefaultLocalhostFacade.toLocalHostAddress(localSocketAddress.getPort());
+            Address peerAddress = LocalHostAddressTypeFacade.toLocalHostAddress(localSocketAddress.getPort());
 
             bisq.network.protobuf.NetworkEnvelope poWRequest = createPoWRequest(myAddress, peerAddress);
             byte[] requestInBytes = poWRequest.toByteArray();
@@ -160,7 +160,7 @@ public class InboundConnectionsManagerTests {
         ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
         serverSocketChannel.configureBlocking(false);
 
-        Address myAddress = DefaultLocalhostFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
+        Address myAddress = LocalHostAddressTypeFacade.toLocalHostAddress(NetworkUtils.findFreeSystemPort());
         InetSocketAddress socketAddress = new InetSocketAddress(
                 InetAddress.getLocalHost(),
                 myAddress.getPort()
@@ -218,7 +218,7 @@ public class InboundConnectionsManagerTests {
             socketChannel.connect(socketAddress);
 
             InetSocketAddress localSocketAddress = (InetSocketAddress) socketChannel.getLocalAddress();
-            Address peerAddress = DefaultLocalhostFacade.toLocalHostAddress(localSocketAddress.getPort());
+            Address peerAddress = LocalHostAddressTypeFacade.toLocalHostAddress(localSocketAddress.getPort());
 
             bisq.network.protobuf.NetworkEnvelope invalidPoWRequest = createPoWRequest(peerAddress, myAddress);
 

--- a/network/network/src/test/java/bisq/network/p2p/ProtoBufMessageLengthTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/ProtoBufMessageLengthTests.java
@@ -20,7 +20,7 @@ package bisq.network.p2p;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.file.FileUtils;
 import bisq.common.network.Address;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.common.network.TransportType;
 import bisq.network.p2p.message.NetworkEnvelope;
 import bisq.network.p2p.node.Capability;
@@ -112,11 +112,11 @@ public class ProtoBufMessageLengthTests {
     }
 
     private bisq.network.protobuf.NetworkEnvelope createValidRequest() {
-        Capability peerCapability = createCapability(DefaultLocalhostFacade.toLocalHostAddress(2345), supportedTransportTypes);
+        Capability peerCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);
         AuthorizationToken token = authorizationService.createToken(request,
                 new NetworkLoad(),
-                DefaultLocalhostFacade.toLocalHostAddress(1234).getFullAddress(),
+                LocalHostAddressTypeFacade.toLocalHostAddress(1234).getFullAddress(),
                 0, new ArrayList<>());
         return new NetworkEnvelope(token, request).completeProto();
     }

--- a/network/network/src/test/java/bisq/network/p2p/node/handshake/OnionAddressValidationSignTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/node/handshake/OnionAddressValidationSignTests.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.node.handshake;
 
 import bisq.common.network.Address;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.security.keys.TorKeyGeneration;
 import bisq.security.keys.TorKeyPair;
 import org.junit.jupiter.api.Test;
@@ -34,15 +34,15 @@ public class OnionAddressValidationSignTests {
 
     @Test
     void testSignNonOnionAddresses() {
-        Address myAddress = DefaultLocalhostFacade.toLocalHostAddress(1234);
-        Address peerAddress = DefaultLocalhostFacade.toLocalHostAddress(4321);
+        Address myAddress = LocalHostAddressTypeFacade.toLocalHostAddress(1234);
+        Address peerAddress = LocalHostAddressTypeFacade.toLocalHostAddress(4321);
         Optional<byte[]> signature = OnionAddressValidation.sign(myAddress, peerAddress, signatureDate, myTorKeyPair.getPrivateKey());
         assertThat(signature).isEmpty();
     }
 
     @Test
     void testSignMyNonOnionAddress() {
-        Address myAddress = DefaultLocalhostFacade.toLocalHostAddress(1234);
+        Address myAddress = LocalHostAddressTypeFacade.toLocalHostAddress(1234);
         Address peerAddress = new Address(peerTorKeyPair.getOnionAddress(), 8888);
         Optional<byte[]> signature = OnionAddressValidation.sign(myAddress, peerAddress, signatureDate, myTorKeyPair.getPrivateKey());
         assertThat(signature).isEmpty();
@@ -51,7 +51,7 @@ public class OnionAddressValidationSignTests {
     @Test
     void testSignPeerNonOnionAddress() {
         Address myAddress = new Address(myTorKeyPair.getOnionAddress(), 8888);
-        Address peerAddress = DefaultLocalhostFacade.toLocalHostAddress(4321);
+        Address peerAddress = LocalHostAddressTypeFacade.toLocalHostAddress(4321);
         Optional<byte[]> signature = OnionAddressValidation.sign(myAddress, peerAddress, signatureDate, myTorKeyPair.getPrivateKey());
         assertThat(signature).isEmpty();
     }

--- a/network/network/src/test/java/bisq/network/p2p/node/handshake/OnionAddressValidationVerifyTests.java
+++ b/network/network/src/test/java/bisq/network/p2p/node/handshake/OnionAddressValidationVerifyTests.java
@@ -18,7 +18,7 @@
 package bisq.network.p2p.node.handshake;
 
 import bisq.common.network.Address;
-import bisq.common.network.DefaultLocalhostFacade;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.security.keys.TorKeyGeneration;
 import bisq.security.keys.TorKeyPair;
 import org.junit.jupiter.api.Test;
@@ -34,15 +34,15 @@ public class OnionAddressValidationVerifyTests {
 
     @Test
     void testVerifyNonOnionAddresses() {
-        Address myAddress = DefaultLocalhostFacade.toLocalHostAddress(1234);
-        Address peerAddress = DefaultLocalhostFacade.toLocalHostAddress(4321);
+        Address myAddress = LocalHostAddressTypeFacade.toLocalHostAddress(1234);
+        Address peerAddress = LocalHostAddressTypeFacade.toLocalHostAddress(4321);
         boolean isValid = OnionAddressValidation.verify(myAddress, peerAddress, signatureDate, Optional.empty());
         assertThat(isValid).isTrue();
     }
 
     @Test
     void testVerifyMyNonOnionAddress() {
-        Address myAddress = DefaultLocalhostFacade.toLocalHostAddress(1234);
+        Address myAddress = LocalHostAddressTypeFacade.toLocalHostAddress(1234);
         Address peerAddress = new Address(peerTorKeyPair.getOnionAddress(), 8888);
         boolean isValid = OnionAddressValidation.verify(myAddress, peerAddress, signatureDate, Optional.empty());
         assertThat(isValid).isTrue();
@@ -51,7 +51,7 @@ public class OnionAddressValidationVerifyTests {
     @Test
     void testVerifyPeerNonOnionAddress() {
         Address myAddress = new Address(myTorKeyPair.getOnionAddress(), 8888);
-        Address peerAddress = DefaultLocalhostFacade.toLocalHostAddress(4321);
+        Address peerAddress = LocalHostAddressTypeFacade.toLocalHostAddress(4321);
         boolean isValid = OnionAddressValidation.verify(myAddress, peerAddress, signatureDate, Optional.empty());
         assertThat(isValid).isTrue();
     }


### PR DESCRIPTION
**IMPORTANT: Please read**

DO NOT MERGE THIS PR to main as is. This is a request to park this changes to a bisq2 new branch off `v2.1.7` tag to support bisq-mobile developers.

## Details

Support for ongoing bisq-mobile development over CLEARNET for day to day local dev.

 - branch of tag `v2.1.7`
 - cherry-pick android/lan support for bisq mobile node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple clear net address types (LOCAL_HOST, ANDROID_EMULATOR, LAN), allowing dynamic selection based on configuration.
  * Introduced new configuration property to specify clear net address type for network connections.

* **Refactor**
  * Renamed and reorganized classes and interfaces related to network address handling for improved clarity and extensibility.
  * Updated configuration file syntax for network settings across multiple applications.

* **Bug Fixes**
  * Improved detection and selection of local network addresses, with fallback mechanisms for unavailable interfaces.

* **Tests**
  * Updated tests to use the new network address facade and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->