### PR TITLE
feat: Add version info to Support/Resources screen

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesView.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.support.resources;
 
+import bisq.common.application.ApplicationVersion;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.BisqHyperlink;
 import bisq.desktop.components.controls.MaterialTextField;
@@ -71,6 +72,14 @@ public class ResourcesView extends View<VBox, ResourcesModel, ResourcesControlle
 
         VBox localDataBox = new VBox(5, openDataDirButton, openLogFileButton, openTorLogFileButton);
 
+        Label localVersionHeadline = SettingsViewUtils.getHeadline(Res.get("support.resources.localVersion.headline"));
+
+        Label details = new Label(Res.get("support.resources.localVersion.details",
+            ApplicationVersion.getVersion().getVersionAsString(),
+            ApplicationVersion.getBuildCommitShortHash(),
+            ApplicationVersion.getTorVersionString()));
+        VBox localVersionBox = new VBox(5, details);
+
 
         Label resourcesHeadline = SettingsViewUtils.getHeadline(Res.get("support.resources.resources.headline"));
         webpage = new BisqHyperlink(Res.get("support.resources.resources.webpage"), "https://bisq.network/");
@@ -92,10 +101,12 @@ public class ResourcesView extends View<VBox, ResourcesModel, ResourcesControlle
         VBox.setMargin(guidesBox, value);
         VBox.setMargin(legalBox, value);
         VBox.setMargin(resourcesBox, value);
+        VBox.setMargin(localVersionBox, value);
         VBox contentBox = new VBox(50);
         contentBox.getChildren().addAll(
                 guidesHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), guidesBox,
                 localDataHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), localDataBox,
+                localVersionHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), localVersionBox,
                 backupHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), backupBox,
                 resourcesHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), resourcesBox,
                 legalHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), legalBox

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/support/resources/ResourcesView.java
@@ -74,12 +74,17 @@ public class ResourcesView extends View<VBox, ResourcesModel, ResourcesControlle
 
         Label localVersionHeadline = SettingsViewUtils.getHeadline(Res.get("support.resources.localVersion.headline"));
 
-        Label details = new Label(Res.get("support.resources.localVersion.details",
-            ApplicationVersion.getVersion().getVersionAsString(),
-            ApplicationVersion.getBuildCommitShortHash(),
-            ApplicationVersion.getTorVersionString()));
-        VBox localVersionBox = new VBox(5, details);
+        String versionString = ApplicationVersion.getVersion() != null ?
+                ApplicationVersion.getVersion().getVersionAsString() : Res.get("na");
+        String commitHash = ApplicationVersion.getBuildCommitShortHash() != null ?
+                ApplicationVersion.getBuildCommitShortHash() : Res.get("na");
+        String torVersion = ApplicationVersion.getTorVersionString() != null ?
+                ApplicationVersion.getTorVersionString() : Res.get("na");
 
+        Label details = new Label(Res.get("support.resources.localVersion.details",
+                versionString, commitHash, torVersion));
+        details.getStyleClass().add("user-content-note");
+        VBox localVersionBox = new VBox(5, details);
 
         Label resourcesHeadline = SettingsViewUtils.getHeadline(Res.get("support.resources.resources.headline"));
         webpage = new BisqHyperlink(Res.get("support.resources.resources.webpage"), "https://bisq.network/");
@@ -106,8 +111,8 @@ public class ResourcesView extends View<VBox, ResourcesModel, ResourcesControlle
         contentBox.getChildren().addAll(
                 guidesHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), guidesBox,
                 localDataHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), localDataBox,
-                localVersionHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), localVersionBox,
                 backupHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), backupBox,
+                localVersionHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), localVersionBox,
                 resourcesHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), resourcesBox,
                 legalHeadline, SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()), legalBox
         );

--- a/i18n/src/main/resources/support.properties
+++ b/i18n/src/main/resources/support.properties
@@ -39,6 +39,11 @@ support.resources.legal.headline=Legal
 support.resources.legal.tac=Open user agreement
 support.resources.legal.license=Software license (AGPLv3)
 
+support.resources.localVersion.headline=Local version info
+support.resources.localVersion.details=Bisq version: v{0}\n\
+  Commit hash: {1}\n\
+  Tor version: v{2}
+
 support.resources.resources.headline=Web resources
 support.resources.resources.webpage=Bisq webpage
 support.resources.resources.dao=About the Bisq DAO


### PR DESCRIPTION
Resolves #3603 

Local version info was hidden and hard to find.  This makes it easier to find by adding it to the Support -> Resources tab.  

Changes:
- The Bisq version, commit hash, and tor version are now displayed in the Support -> Resources tab under the local data section.  

- The new headline is consistent with other headlines on the Resources screen

- The content is styled as static text so it stands out from the surrounding hyperlinks

- Added internationalization (i18n) keys to support.properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new section in the support resources view displaying local application version details, including Bisq version, commit hash, and Tor version.

* **Documentation**
  * Updated support resources with new labels and formatted descriptions for the local version information section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->