### PR TITLE
Increase memory to 3GB, as windows CI builds fail

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx5120M
 version=2.1.7
 tor.version=13.5.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the maximum memory allocation for Gradle builds to improve build stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->