### PR TITLE
fix(tor): remove control port file if it exists

### DIFF
--- a/common/src/main/java/bisq/common/file/FileUtils.java
+++ b/common/src/main/java/bisq/common/file/FileUtils.java
@@ -131,10 +131,12 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Deletes a file if it exists. On some operating systems it may not be possible
+     * to remove a file when it is open and in use by this Java virtual machine or other programs
+     */
     public static void deleteFile(File file) throws IOException {
-        if (file.exists()) {
-            Files.delete(file.toPath());
-        }
+        Files.deleteIfExists(file.toPath());
     }
 
     public static void makeDirIfNotExists(String dirName) throws IOException {


### PR DESCRIPTION
fixes #3631

from the errors mentioned in the issue it seems likely that a previously existing control port file is causing wrong port to be used. 
this fix aims to fix it by deleting the file before launching tor and after reading the file, hopefully mitigating the issue.

I updated `FileUtils#deleteFile` to use `deleteIfExists`, as it seemed cleaner and ignores the `NoSuchFileException` internally. previously there was a very small chance of throwing between check and delete in case the file gets deleted before `Files.delete` is called.