### PR TITLE
Add markets column to my offers table

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
@@ -82,9 +82,19 @@ public class MarketImageComposition {
             }
         }
 
+        StackPane pane = getMarketPairIcons(baseCurrencyCode, quoteCurrencyCode);
+
+        if (dedicatedCache.isPresent()) {
+            dedicatedCache.get().put(key, pane);
+        } else {
+            MARKET_IMAGE_CACHE.put(key, pane);
+        }
+        return pane;
+    }
+
+    public static StackPane getMarketPairIcons(String baseCurrencyCode, String quoteCurrencyCode) {
         StackPane pane = new StackPane();
         pane.setPrefWidth(61);
-
         Stream<String> stream = Stream.of(baseCurrencyCode, quoteCurrencyCode);
         stream.forEach(code -> {
             if (quoteCurrencyCode.equals(code)) {
@@ -107,12 +117,6 @@ public class MarketImageComposition {
                 pane.getChildren().add(node);
             }
         });
-
-        if (dedicatedCache.isPresent()) {
-            dedicatedCache.get().put(key, pane);
-        } else {
-            MARKET_IMAGE_CACHE.put(key, pane);
-        }
         return pane;
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/my_offers/MuSigMyOffersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/my_offers/MuSigMyOffersView.java
@@ -22,6 +22,7 @@ import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.RichTableView;
+import bisq.desktop.main.content.components.MarketImageComposition;
 import bisq.desktop.main.content.mu_sig.MuSigOfferListItem;
 import bisq.desktop.main.content.mu_sig.MuSigOfferUtil;
 import bisq.i18n.Res;
@@ -34,6 +35,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 
@@ -72,12 +74,22 @@ public class MuSigMyOffersView extends View<VBox, MuSigMyOffersModel, MuSigMyOff
         muSigMyOffersListView.getColumns().add(muSigMyOffersListView.getTableView().getSelectionMarkerColumn());
 
         muSigMyOffersListView.getColumns().add(new BisqTableColumn.Builder<MuSigOfferListItem>()
+                .title(Res.get("muSig.myOffers.table.header.market"))
+                .left()
+                .comparator(Comparator.comparing(MuSigOfferListItem::getMarket))
+                .setCellFactory(getMarketCellFactory())
+                .fixWidth(81)
+                .build());
+
+        muSigMyOffersListView.getColumns().add(new BisqTableColumn.Builder<MuSigOfferListItem>()
                 .title(Res.get("muSig.myOffers.table.header.myProfile"))
                 .left()
                 .comparator(Comparator.comparingLong(MuSigOfferListItem::getTotalScore).reversed())
                 .setCellFactory(MuSigOfferUtil.getUserProfileCellFactory())
                 .minWidth(100)
                 .build());
+
+        // OfferId
 
         // Date
 //        muSigMyOffersListView.getSortOrder().add(dateColumn);
@@ -234,6 +246,25 @@ public class MuSigMyOffersView extends View<VBox, MuSigMyOffersModel, MuSigMyOff
             private void resetVisibilities() {
                 myOfferActionsMenuBox.setVisible(false);
                 myOfferActionsMenuBox.setManaged(false);
+            }
+        };
+    }
+
+    public static Callback<TableColumn<MuSigOfferListItem, MuSigOfferListItem>,
+            TableCell<MuSigOfferListItem, MuSigOfferListItem>> getMarketCellFactory() {
+        return column -> new TableCell<>() {
+
+            @Override
+            protected void updateItem(MuSigOfferListItem item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (item != null && !empty) {
+                    StackPane tradePairImage = MarketImageComposition.getMarketPairIcons(item.getMarket().getBaseCurrencyCode(),
+                            item.getMarket().getQuoteCurrencyCode());
+                    setGraphic(tradePairImage);
+                } else {
+                    setGraphic(null);
+                }
             }
         };
     }

--- a/apps/desktop/desktop/src/main/resources/css/mu_sig.css
+++ b/apps/desktop/desktop/src/main/resources/css/mu_sig.css
@@ -147,3 +147,18 @@
     -fx-min-height: 30;
     -fx-pref-height: 30;
 }
+
+
+/*******************************************************************************
+ *                                                                             *
+ * My offers                                                                   *
+ *                                                                             *
+ ******************************************************************************/
+
+.mu-sig-my-offers-table .table-row-cell:hover .quote-currency-market-logo {
+    -fx-fill: -bisq-dark-grey-50 !important;
+}
+
+.mu-sig-my-offers-table .table-row-cell:selected .quote-currency-market-logo {
+    -fx-fill: -bisq-dark-grey-40 !important;
+}

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -145,6 +145,7 @@ muSig.tradeCompleted.info=We hope your experience was smooth and enjoyable. Weâ€
 
 muSig.myOffers.headline=My offers
 
+muSig.myOffers.table.header.market=Market
 muSig.myOffers.table.header.myProfile=My profile
 muSig.myOffers.table.header.baseAmount=Trade amount
 muSig.myOffers.table.header.quoteAmount=Amount value


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Market" column to the "My Offers" table, displaying graphical icons for the base and quote currencies of each offer.

* **Style**
  * Enhanced visual feedback for currency market logos in the "My Offers" table, including new hover and selection effects.

* **Documentation**
  * Added a new localization entry for the "Market" column header in the "My Offers" table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->