### PR TITLE
Sync RPC client code with Musig security enhancements

### DIFF
--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
@@ -33,7 +33,8 @@ public final class PartialSignaturesMessage implements Proto {
                 peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
                 peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
                 peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
-                peersPartialSignatures.getSwapTxInputPartialSignature()
+                peersPartialSignatures.getSwapTxInputPartialSignature(),
+                peersPartialSignatures.getSwapTxInputSighash()
         );
     }
 
@@ -41,15 +42,18 @@ public final class PartialSignaturesMessage implements Proto {
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
     private final Optional<byte[]> swapTxInputPartialSignature;
+    private final Optional<byte[]> swapTxInputSighash;
 
     public PartialSignaturesMessage(byte[] peersWarningTxBuyerInputPartialSignature,
                                     byte[] peersWarningTxSellerInputPartialSignature,
                                     byte[] peersRedirectTxInputPartialSignature,
-                                    Optional<byte[]> swapTxInputPartialSignature) {
+                                    Optional<byte[]> swapTxInputPartialSignature,
+                                    Optional<byte[]> swapTxInputSighash) {
         this.peersWarningTxBuyerInputPartialSignature = peersWarningTxBuyerInputPartialSignature;
         this.peersWarningTxSellerInputPartialSignature = peersWarningTxSellerInputPartialSignature;
         this.peersRedirectTxInputPartialSignature = peersRedirectTxInputPartialSignature;
         this.swapTxInputPartialSignature = swapTxInputPartialSignature;
+        this.swapTxInputSighash = swapTxInputSighash;
     }
 
     @Override
@@ -59,6 +63,7 @@ public final class PartialSignaturesMessage implements Proto {
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
                 .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature));
         swapTxInputPartialSignature.ifPresent(e -> builder.setSwapTxInputPartialSignature(ByteString.copyFrom(e)));
+        swapTxInputSighash.ifPresent(e -> builder.setSwapTxInputSighash(ByteString.copyFrom(e)));
         return builder;
     }
 
@@ -73,6 +78,9 @@ public final class PartialSignaturesMessage implements Proto {
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
                 proto.hasSwapTxInputPartialSignature()
                         ? Optional.of(proto.getSwapTxInputPartialSignature().toByteArray())
+                        : Optional.empty(),
+                proto.hasSwapTxInputSighash()
+                        ? Optional.of(proto.getSwapTxInputSighash().toByteArray())
                         : Optional.empty());
     }
 
@@ -84,7 +92,8 @@ public final class PartialSignaturesMessage implements Proto {
         return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
                 Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
                 Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
-                OptionalUtils.optionalByteArrayEquals(swapTxInputPartialSignature, that.swapTxInputPartialSignature);
+                OptionalUtils.optionalByteArrayEquals(swapTxInputPartialSignature, that.swapTxInputPartialSignature) &&
+                OptionalUtils.optionalByteArrayEquals(swapTxInputSighash, that.swapTxInputSighash);
     }
 
     @Override
@@ -93,6 +102,7 @@ public final class PartialSignaturesMessage implements Proto {
         result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
         result = 31 * result + swapTxInputPartialSignature.map(Arrays::hashCode).orElse(0);
+        result = 31 * result + swapTxInputSighash.map(Arrays::hashCode).orElse(0);
         return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesRequest.java
@@ -30,13 +30,16 @@ public final class PartialSignaturesRequest implements Proto {
     private final String tradeId;
     private final NonceSharesMessage peersNonceShares;
     private final List<ReceiverAddressAndAmount> receivers;
+    private final boolean buyerReadyToRelease;
 
     public PartialSignaturesRequest(String tradeId,
                                     NonceSharesMessage peersNonceShares,
-                                    List<ReceiverAddressAndAmount> receivers) {
+                                    List<ReceiverAddressAndAmount> receivers,
+                                    boolean buyerReadyToRelease) {
         this.tradeId = tradeId;
         this.peersNonceShares = peersNonceShares;
         this.receivers = receivers;
+        this.buyerReadyToRelease = buyerReadyToRelease;
     }
 
     @Override
@@ -46,7 +49,8 @@ public final class PartialSignaturesRequest implements Proto {
                 .setPeersNonceShares(peersNonceShares.toProto(serializeForHash))
                 .addAllReceivers(receivers.stream()
                         .map(e -> e.toProto(serializeForHash))
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()))
+                .setBuyerReadyToRelease(buyerReadyToRelease);
     }
 
     @Override
@@ -59,6 +63,7 @@ public final class PartialSignaturesRequest implements Proto {
                 NonceSharesMessage.fromProto(proto.getPeersNonceShares()),
                 proto.getReceiversList().stream()
                         .map(ReceiverAddressAndAmount::fromProto)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()),
+                proto.getBuyerReadyToRelease());
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/SwapTxSignatureRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/SwapTxSignatureRequest.java
@@ -28,17 +28,22 @@ import java.util.Objects;
 public final class SwapTxSignatureRequest implements Proto {
     private final String tradeId;
     private final byte[] swapTxInputPeersPartialSignature;
+    private final boolean sellerReadyToRelease;
 
-    public SwapTxSignatureRequest(String tradeId, byte[] swapTxInputPeersPartialSignature) {
+    public SwapTxSignatureRequest(String tradeId,
+                                  byte[] swapTxInputPeersPartialSignature,
+                                  boolean sellerReadyToRelease) {
         this.tradeId = tradeId;
         this.swapTxInputPeersPartialSignature = swapTxInputPeersPartialSignature;
+        this.sellerReadyToRelease = sellerReadyToRelease;
     }
 
     @Override
     public bisq.trade.protobuf.SwapTxSignatureRequest.Builder getBuilder(boolean serializeForHash) {
         return bisq.trade.protobuf.SwapTxSignatureRequest.newBuilder()
                 .setTradeId(tradeId)
-                .setSwapTxInputPeersPartialSignature(ByteString.copyFrom(swapTxInputPeersPartialSignature));
+                .setSwapTxInputPeersPartialSignature(ByteString.copyFrom(swapTxInputPeersPartialSignature))
+                .setSellerReadyToRelease(sellerReadyToRelease);
     }
 
     @Override
@@ -47,7 +52,9 @@ public final class SwapTxSignatureRequest implements Proto {
     }
 
     public static SwapTxSignatureRequest fromProto(bisq.trade.protobuf.SwapTxSignatureRequest proto) {
-        return new SwapTxSignatureRequest(proto.getTradeId(), proto.getSwapTxInputPeersPartialSignature().toByteArray());
+        return new SwapTxSignatureRequest(proto.getTradeId(),
+                proto.getSwapTxInputPeersPartialSignature().toByteArray(),
+                proto.getSellerReadyToRelease());
     }
 
     @Override
@@ -55,13 +62,15 @@ public final class SwapTxSignatureRequest implements Proto {
         if (!(o instanceof SwapTxSignatureRequest that)) return false;
 
         return Objects.equals(tradeId, that.tradeId) &&
-                Arrays.equals(swapTxInputPeersPartialSignature, that.swapTxInputPeersPartialSignature);
+                Arrays.equals(swapTxInputPeersPartialSignature, that.swapTxInputPeersPartialSignature) &&
+                sellerReadyToRelease == that.sellerReadyToRelease;
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hashCode(tradeId);
         result = 31 * result + Arrays.hashCode(swapTxInputPeersPartialSignature);
+        result = 31 * result + Boolean.hashCode(sellerReadyToRelease);
         return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller/PaymentInitiatedMessage_E_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/seller/PaymentInitiatedMessage_E_Handler.java
@@ -50,6 +50,7 @@ public final class PaymentInitiatedMessage_E_Handler extends MuSigTradeMessageHa
         SwapTxSignatureRequest swapTxSignatureRequest = SwapTxSignatureRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setSwapTxInputPeersPartialSignature(ByteString.copyFrom(peersSwapTxInputPartialSignature))
+                .setSellerReadyToRelease(true) // TODO: Clear this flag to verify only, and make the same RPC call at trade end with the flag set.
                 .build();
         bisq.trade.protobuf.SwapTxSignatureResponse swapTxSignatureResponse = blockingStub.signSwapTx(swapTxSignatureRequest);
         mySwapTxSignatureResponse = SwapTxSignatureResponse.fromProto(swapTxSignatureResponse);

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/PartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/PartialSignatures.java
@@ -39,7 +39,8 @@ public final class PartialSignatures implements NetworkProto {
                 partialSignaturesMessage.getPeersWarningTxBuyerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersWarningTxSellerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersRedirectTxInputPartialSignature().clone(),
-                swapTxInputPartialSignature
+                swapTxInputPartialSignature,
+                partialSignaturesMessage.getSwapTxInputSighash().map(byte[]::clone)
         );
     }
 
@@ -51,7 +52,8 @@ public final class PartialSignatures implements NetworkProto {
                 redactedPartialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
                 redactedPartialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
                 redactedPartialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
-                Optional.of(swapTxInputPartialSignature.clone())
+                Optional.of(swapTxInputPartialSignature.clone()),
+                redactedPartialSignatures.getSwapTxInputSighash().map(byte[]::clone)
         );
     }
 
@@ -59,15 +61,18 @@ public final class PartialSignatures implements NetworkProto {
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
     private final Optional<byte[]> swapTxInputPartialSignature;
+    private final Optional<byte[]> swapTxInputSighash;
 
     private PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
                               byte[] peersWarningTxSellerInputPartialSignature,
                               byte[] peersRedirectTxInputPartialSignature,
-                              Optional<byte[]> swapTxInputPartialSignature) {
+                              Optional<byte[]> swapTxInputPartialSignature,
+                              Optional<byte[]> swapTxInputSighash) {
         this.peersWarningTxBuyerInputPartialSignature = peersWarningTxBuyerInputPartialSignature;
         this.peersWarningTxSellerInputPartialSignature = peersWarningTxSellerInputPartialSignature;
         this.peersRedirectTxInputPartialSignature = peersRedirectTxInputPartialSignature;
         this.swapTxInputPartialSignature = swapTxInputPartialSignature;
+        this.swapTxInputSighash = swapTxInputSighash;
 
         verify();
     }
@@ -84,6 +89,7 @@ public final class PartialSignatures implements NetworkProto {
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
                 .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature));
         swapTxInputPartialSignature.ifPresent(e -> builder.setSwapTxInputPartialSignature(ByteString.copyFrom(e)));
+        swapTxInputSighash.ifPresent(e -> builder.setSwapTxInputSighash(ByteString.copyFrom(e)));
         return builder;
     }
 
@@ -98,6 +104,9 @@ public final class PartialSignatures implements NetworkProto {
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
                 proto.hasSwapTxInputPartialSignature()
                         ? Optional.of(proto.getSwapTxInputPartialSignature().toByteArray())
+                        : Optional.empty(),
+                proto.hasSwapTxInputSighash()
+                        ? Optional.of(proto.getSwapTxInputSighash().toByteArray())
                         : Optional.empty());
     }
 
@@ -108,7 +117,8 @@ public final class PartialSignatures implements NetworkProto {
         return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
                 Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
                 Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
-                OptionalUtils.optionalByteArrayEquals(swapTxInputPartialSignature, that.swapTxInputPartialSignature);
+                OptionalUtils.optionalByteArrayEquals(swapTxInputPartialSignature, that.swapTxInputPartialSignature) &&
+                OptionalUtils.optionalByteArrayEquals(swapTxInputSighash, that.swapTxInputSighash);
     }
 
     @Override
@@ -117,6 +127,7 @@ public final class PartialSignatures implements NetworkProto {
         result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
         result = 31 * result + swapTxInputPartialSignature.map(Arrays::hashCode).orElse(0);
+        result = 31 * result + swapTxInputSighash.map(Arrays::hashCode).orElse(0);
         return result;
     }
 }

--- a/trade/src/main/proto/rpc.proto
+++ b/trade/src/main/proto/rpc.proto
@@ -95,6 +95,7 @@ message PartialSignaturesRequest {
   string tradeId = 1;
   NonceSharesMessage peersNonceShares = 2;
   repeated ReceiverAddressAndAmount receivers = 3;
+  bool buyerReadyToRelease = 4;
 }
 
 message PartialSignaturesMessage {
@@ -102,6 +103,7 @@ message PartialSignaturesMessage {
   bytes peersWarningTxSellerInputPartialSignature = 2;
   bytes peersRedirectTxInputPartialSignature = 3;
   optional bytes swapTxInputPartialSignature = 4;
+  optional bytes swapTxInputSighash = 5;
 }
 
 message DepositTxSignatureRequest {
@@ -132,6 +134,7 @@ message TxConfirmationStatus {
 message SwapTxSignatureRequest {
   string tradeId = 1;
   bytes swapTxInputPeersPartialSignature = 2;
+  bool sellerReadyToRelease = 3;
 }
 
 message SwapTxSignatureResponse {

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -175,6 +175,7 @@ message PartialSignatures {
   bytes peersWarningTxSellerInputPartialSignature = 2;
   bytes peersRedirectTxInputPartialSignature = 3;
   optional bytes swapTxInputPartialSignature = 4;
+  optional bytes swapTxInputSighash = 5;
 }
 
 message SwapTxSignature {


### PR DESCRIPTION
Bring the MuSig2 protocol code into sync with pending (breaking) API changes on the Rust side, which attempt to enhance the trade protocol security, made in the PR https://github.com/bisq-network/bisq-musig/pull/75.

This requires an extra `swapTxInputSighash` (optional) byte array to be passed from the seller to the buyer at the trade start, in Messages C + D. (Message C for the seller-as-taker and Message D for the seller-as-maker.)

The changes also make the Bisq2 client call the gRPC methods `GetPartialSignatures` and `SignSwapTx` twice, once with a redacted response and once with the relevant secret to reveal to the peer (further on in the trade when it's safe to reveal it), to avoid any cryptographic secrets from having to be held on the Java side (even momentarily, as none of the server responses should be sensitive if the API is used correctly).

_These changes should probably only be merged at the same time as https://github.com/bisq-network/bisq-musig/pull/75, as they won't work otherwise._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for buyer and seller readiness flags during the signature exchange process, improving trade state signaling.
  * Introduced handling and transmission of an additional optional signature hash (swapTxInputSighash) in trade messages.

* **Enhancements**
  * Improved message structures to include new fields for readiness and signature data, enabling more precise communication between trading parties.
  * Updated trade workflows to utilize the new readiness flags and signature hash fields for smoother transaction progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->