### PR TITLE
for-mobile-based-on-2.1.7-profile-age

### DIFF
--- a/http-api/src/main/java/bisq/http_api/HttpApiService.java
+++ b/http-api/src/main/java/bisq/http_api/HttpApiService.java
@@ -29,6 +29,7 @@ import bisq.http_api.rest_api.domain.explorer.ExplorerRestApi;
 import bisq.http_api.rest_api.domain.market_price.MarketPriceRestApi;
 import bisq.http_api.rest_api.domain.offers.OfferbookRestApi;
 import bisq.http_api.rest_api.domain.payment_accounts.PaymentAccountsRestApi;
+import bisq.http_api.rest_api.domain.reputation.ReputationRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
@@ -87,6 +88,7 @@ public class HttpApiService implements Service {
             SettingsRestApi settingsRestApi = new SettingsRestApi(settingsService);
             PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
             ExplorerRestApi explorerRestApi = new ExplorerRestApi(bondedRolesService.getExplorerService());
+            ReputationRestApi reputationRestApi = new ReputationRestApi(reputationService, userService);
             if (restApiConfigEnabled) {
                 var restApiResourceConfig = new RestApiResourceConfig(restApiConfig.getRestApiBaseUrl(),
                         offerbookRestApi,
@@ -96,7 +98,8 @@ public class HttpApiService implements Service {
                         marketPriceRestApi,
                         settingsRestApi,
                         explorerRestApi,
-                        paymentAccountsRestApi);
+                        paymentAccountsRestApi,
+                        reputationRestApi);
                 this.restApiService = Optional.of(new RestApiService(restApiConfig, restApiResourceConfig));
             } else {
                 this.restApiService = Optional.empty();
@@ -111,7 +114,8 @@ public class HttpApiService implements Service {
                         marketPriceRestApi,
                         settingsRestApi,
                         explorerRestApi,
-                        paymentAccountsRestApi);
+                        paymentAccountsRestApi,
+                        reputationRestApi);
                 this.webSocketService = Optional.of(new WebSocketService(webSocketConfig,
                         webSocketConfig.getRestApiBaseAddress(),
                         webSocketResourceConfig,

--- a/http-api/src/main/java/bisq/http_api/rest_api/RestApiResourceConfig.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/RestApiResourceConfig.java
@@ -5,6 +5,7 @@ import bisq.http_api.rest_api.domain.explorer.ExplorerRestApi;
 import bisq.http_api.rest_api.domain.market_price.MarketPriceRestApi;
 import bisq.http_api.rest_api.domain.offers.OfferbookRestApi;
 import bisq.http_api.rest_api.domain.payment_accounts.PaymentAccountsRestApi;
+import bisq.http_api.rest_api.domain.reputation.ReputationRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
@@ -23,7 +24,8 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
                                  MarketPriceRestApi marketPriceRestApi,
                                  SettingsRestApi settingsRestApi,
                                  ExplorerRestApi explorerRestApi,
-                                 PaymentAccountsRestApi paymentAccountsRestApi) {
+                                 PaymentAccountsRestApi paymentAccountsRestApi,
+                                 ReputationRestApi reputationRestApi) {
         super(swaggerBaseUrl);
 
         //todo apply filtering with whiteListEndPoints/whiteListEndPoints
@@ -39,6 +41,7 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
         register(SettingsRestApi.class);
         register(ExplorerRestApi.class);
         register(PaymentAccountsRestApi.class);
+        register(ReputationRestApi.class);
 
         register(new AbstractBinder() {
             @Override
@@ -51,6 +54,7 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
                 bind(settingsRestApi).to(SettingsRestApi.class);
                 bind(explorerRestApi).to(ExplorerRestApi.class);
                 bind(paymentAccountsRestApi).to(PaymentAccountsRestApi.class);
+                bind(reputationRestApi).to(ReputationRestApi.class);
             }
         });
     }

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/reputation/ReputationRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/reputation/ReputationRestApi.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.http_api.rest_api.domain.reputation;
+
+import bisq.dto.DtoMappings;
+import bisq.dto.user.reputation.ReputationScoreDto;
+import bisq.http_api.rest_api.domain.RestApiBase;
+import bisq.user.UserService;
+import bisq.user.profile.UserProfile;
+import bisq.user.reputation.ReputationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Slf4j
+@Path("/reputation")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Reputation API")
+public class ReputationRestApi extends RestApiBase {
+    private final ReputationService reputationService;
+    private final UserService userService;
+
+    public ReputationRestApi(ReputationService reputationService, UserService userService) {
+        this.reputationService = reputationService;
+        this.userService = userService;
+    }
+
+    @GET
+    @Path("/score/{userProfileId}")
+    @Operation(
+            summary = "Get Reputation Score",
+            description = "Retrieves the reputation score for a specific user profile.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Reputation score retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = ReputationScoreDto.class))),
+                    @ApiResponse(responseCode = "404", description = "User profile not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getReputationScore(
+            @Parameter(description = "User profile ID", required = true)
+            @PathParam("userProfileId") String userProfileId) {
+        try {
+            Optional<UserProfile> userProfile = userService.getUserProfileService().findUserProfile(userProfileId);
+            if (userProfile.isEmpty()) {
+                return buildNotFoundResponse("User profile not found for ID: " + userProfileId);
+            }
+
+            var reputationScore = reputationService.getReputationScore(userProfileId);
+            ReputationScoreDto reputationScoreDto = DtoMappings.ReputationScoreMapping.fromBisq2Model(reputationScore);
+            return buildOkResponse(reputationScoreDto);
+        } catch (Exception e) {
+            log.error("Error getting reputation score for userProfileId: " + userProfileId, e);
+            return buildErrorResponse("Error getting reputation score: " + e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/profile-age/{userProfileId}")
+    @Operation(
+            summary = "Get Profile Age",
+            description = "Retrieves the profile creation timestamp for a specific user profile from the ProfileAgeService.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Profile age retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = Long.class, 
+                                    description = "Profile creation timestamp in milliseconds, or null if not available"))),
+                    @ApiResponse(responseCode = "404", description = "User profile not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getProfileAge(
+            @Parameter(description = "User profile ID", required = true)
+            @PathParam("userProfileId") String userProfileId) {
+        try {
+            Optional<UserProfile> userProfile = userService.getUserProfileService().findUserProfile(userProfileId);
+            if (userProfile.isEmpty()) {
+                return buildNotFoundResponse("User profile not found for ID: " + userProfileId);
+            }
+
+            Optional<Long> profileAge = reputationService.getProfileAgeService().getProfileAge(userProfile.get());
+            if (profileAge.isPresent()) {
+                return buildOkResponse(profileAge.get());
+            } else {
+                // Return explicit null as JSON string to avoid empty response body
+                return Response.status(Response.Status.OK)
+                        .entity("null")
+                        .type("application/json")
+                        .build();
+            }
+        } catch (Exception e) {
+            log.error("Error getting profile age for userProfileId: " + userProfileId, e);
+            return buildErrorResponse("Error getting profile age: " + e.getMessage());
+        }
+    }
+}

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/reputation/ReputationRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/reputation/ReputationRestApi.java
@@ -105,15 +105,7 @@ public class ReputationRestApi extends RestApiBase {
             }
 
             Optional<Long> profileAge = reputationService.getProfileAgeService().getProfileAge(userProfile.get());
-            if (profileAge.isPresent()) {
-                return buildOkResponse(profileAge.get());
-            } else {
-                // Return explicit null as JSON string to avoid empty response body
-                return Response.status(Response.Status.OK)
-                        .entity("null")
-                        .type("application/json")
-                        .build();
-            }
+            return buildOkResponse(profileAge.orElse(null));
         } catch (Exception e) {
             log.error("Error getting profile age for userProfileId: " + userProfileId, e);
             return buildErrorResponse("Error getting profile age: " + e.getMessage());

--- a/http-api/src/main/java/bisq/http_api/web_socket/WebSocketRestApiResourceConfig.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/WebSocketRestApiResourceConfig.java
@@ -6,6 +6,7 @@ import bisq.http_api.rest_api.domain.explorer.ExplorerRestApi;
 import bisq.http_api.rest_api.domain.market_price.MarketPriceRestApi;
 import bisq.http_api.rest_api.domain.offers.OfferbookRestApi;
 import bisq.http_api.rest_api.domain.payment_accounts.PaymentAccountsRestApi;
+import bisq.http_api.rest_api.domain.reputation.ReputationRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
@@ -23,7 +24,8 @@ public class WebSocketRestApiResourceConfig extends RestApiResourceConfig {
                                           MarketPriceRestApi marketPriceRestApi,
                                           SettingsRestApi settingsRestApi,
                                           ExplorerRestApi explorerRestApi,
-                                          PaymentAccountsRestApi paymentAccountsRestApi) {
-        super(swaggerBaseUrl, offerbookRestApi, tradeRestApi, tradeChatRestApi, userIdentityRestApi, marketPriceRestApi, settingsRestApi, explorerRestApi, paymentAccountsRestApi);
+                                          PaymentAccountsRestApi paymentAccountsRestApi,
+                                          ReputationRestApi reputationRestApi) {
+        super(swaggerBaseUrl, offerbookRestApi, tradeRestApi, tradeChatRestApi, userIdentityRestApi, marketPriceRestApi, settingsRestApi, explorerRestApi, paymentAccountsRestApi, reputationRestApi);
     }
 }


### PR DESCRIPTION
 - For bisq-mobile https://github.com/bisq-network/bisq-mobile/issues/215
 - implemented api to retrieve profile age for bisq mobile clients to consume
 - also added this api `curl http://localhost:8090/api/v1/reputation/score/410decbc92bbc2358120e379dce5c241301a2095` (last get param is the user id) to get the reputation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced new REST API endpoints for accessing user reputation data, including reputation score and profile age, under the `/reputation` path.
  * Endpoints provide clear responses for valid, missing, or erroneous user profiles.
  * Integrated reputation-related endpoints into both REST and WebSocket API services for expanded access.

* **Documentation**
  * Added Swagger/OpenAPI documentation for the new reputation endpoints to improve API discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->