### PR TITLE
API for Ignore user (for xClients)

### DIFF
--- a/http-api/src/main/java/bisq/http_api/HttpApiService.java
+++ b/http-api/src/main/java/bisq/http_api/HttpApiService.java
@@ -33,6 +33,7 @@ import bisq.http_api.rest_api.domain.reputation.ReputationRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
+import bisq.http_api.rest_api.domain.user_profile.UserProfileRestApi;
 import bisq.http_api.web_socket.WebSocketRestApiResourceConfig;
 import bisq.http_api.web_socket.WebSocketService;
 import bisq.http_api.web_socket.domain.OpenTradeItemsService;
@@ -87,6 +88,7 @@ public class HttpApiService implements Service {
             MarketPriceRestApi marketPriceRestApi = new MarketPriceRestApi(bondedRolesService.getMarketPriceService());
             SettingsRestApi settingsRestApi = new SettingsRestApi(settingsService);
             PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
+            UserProfileRestApi userProfileRestApi = new UserProfileRestApi(userService.getUserProfileService());
             ExplorerRestApi explorerRestApi = new ExplorerRestApi(bondedRolesService.getExplorerService());
             ReputationRestApi reputationRestApi = new ReputationRestApi(reputationService, userService);
             if (restApiConfigEnabled) {
@@ -99,7 +101,8 @@ public class HttpApiService implements Service {
                         settingsRestApi,
                         explorerRestApi,
                         paymentAccountsRestApi,
-                        reputationRestApi);
+                        reputationRestApi,
+                        userProfileRestApi);
                 this.restApiService = Optional.of(new RestApiService(restApiConfig, restApiResourceConfig));
             } else {
                 this.restApiService = Optional.empty();
@@ -115,7 +118,8 @@ public class HttpApiService implements Service {
                         settingsRestApi,
                         explorerRestApi,
                         paymentAccountsRestApi,
-                        reputationRestApi);
+                        reputationRestApi,
+                        userProfileRestApi);
                 this.webSocketService = Optional.of(new WebSocketService(webSocketConfig,
                         webSocketConfig.getRestApiBaseAddress(),
                         webSocketResourceConfig,

--- a/http-api/src/main/java/bisq/http_api/rest_api/RestApiResourceConfig.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/RestApiResourceConfig.java
@@ -9,6 +9,7 @@ import bisq.http_api.rest_api.domain.reputation.ReputationRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
+import bisq.http_api.rest_api.domain.user_profile.UserProfileRestApi;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
@@ -25,7 +26,8 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
                                  SettingsRestApi settingsRestApi,
                                  ExplorerRestApi explorerRestApi,
                                  PaymentAccountsRestApi paymentAccountsRestApi,
-                                 ReputationRestApi reputationRestApi) {
+                                 ReputationRestApi reputationRestApi,
+                                 UserProfileRestApi userProfileRestApi) {
         super(swaggerBaseUrl);
 
         //todo apply filtering with whiteListEndPoints/whiteListEndPoints
@@ -42,6 +44,7 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
         register(ExplorerRestApi.class);
         register(PaymentAccountsRestApi.class);
         register(ReputationRestApi.class);
+        register(UserProfileRestApi.class);
 
         register(new AbstractBinder() {
             @Override
@@ -55,6 +58,7 @@ public class RestApiResourceConfig extends BaseRestApiResourceConfig {
                 bind(explorerRestApi).to(ExplorerRestApi.class);
                 bind(paymentAccountsRestApi).to(PaymentAccountsRestApi.class);
                 bind(reputationRestApi).to(ReputationRestApi.class);
+                bind(userProfileRestApi).to(UserProfileRestApi.class);
             }
         });
     }

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/user_identity/UserIdentityRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/user_identity/UserIdentityRestApi.java
@@ -31,6 +31,7 @@ import bisq.user.identity.NymIdGenerator;
 import bisq.user.identity.UserIdentity;
 import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -47,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.security.KeyPair;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -62,7 +64,10 @@ public class UserIdentityRestApi extends RestApiBase {
     private final SecurityService securityService;
     private final UserIdentityService userIdentityService;
 
-    public UserIdentityRestApi(SecurityService securityService, UserIdentityService userIdentityService) {
+    public UserIdentityRestApi(
+            SecurityService securityService,
+            UserIdentityService userIdentityService
+    ) {
         this.securityService = securityService;
         this.userIdentityService = userIdentityService;
     }
@@ -229,4 +234,5 @@ public class UserIdentityRestApi extends RestApiBase {
         UserProfileDto userProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(selectedUserIdentity.getUserProfile());
         return buildOkResponse(userProfileDto);
     }
+
 }

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/user_profile/UserProfileRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/user_profile/UserProfileRestApi.java
@@ -1,0 +1,167 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.http_api.rest_api.domain.user_profile;
+
+import bisq.dto.DtoMappings;
+import bisq.dto.user.profile.UserProfileDto;
+import bisq.http_api.rest_api.domain.RestApiBase;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Path("/user-profiles")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "User Profile API", description = "API for managing user profiles")
+public class UserProfileRestApi extends RestApiBase {
+    private final UserProfileService userProfileService;
+
+    public UserProfileRestApi(UserProfileService userProfileService) {
+        this.userProfileService = userProfileService;
+    }
+
+    @POST
+    @Path("/ignore/{profileId}")
+    @Operation(
+            summary = "Ignore User Profile",
+            description = "Add a user profile to the ignored list",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "User profile ignored successfully"),
+                    @ApiResponse(responseCode = "400", description = "Invalid input data"),
+                    @ApiResponse(responseCode = "404", description = "User profile not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response ignoreUserProfile(@PathParam("profileId") String profileId) {
+        try {
+            Optional<UserProfile> userProfile = userProfileService.findUserProfile(profileId);
+            if (userProfile.isEmpty()) {
+                return buildNotFoundResponse("User profile not found with ID: " + profileId);
+            }
+            userProfileService.ignoreUserProfile(userProfile.get());
+            return Response.noContent().build();
+        } catch (Exception e) {
+            log.error("Error ignoring user profile", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @DELETE
+    @Path("/ignore/{profileId}")
+    @Operation(
+            summary = "Undo Ignore User Profile",
+            description = "Remove a user profile from the ignored list",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "User profile un-ignored successfully"),
+                    @ApiResponse(responseCode = "400", description = "Invalid input data"),
+                    @ApiResponse(responseCode = "404", description = "User profile not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response undoIgnoreUserProfile(@PathParam("profileId") String profileId) {
+        try {
+            Optional<UserProfile> userProfile = userProfileService.findUserProfile(profileId);
+            
+            if (userProfile.isEmpty()) {
+                return buildNotFoundResponse("User profile not found with ID: " + profileId);
+            }
+            
+            userProfileService.undoIgnoreUserProfile(userProfile.get());
+            return Response.noContent().build();
+        } catch (Exception e) {
+            log.error("Error un-ignoring user profile", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/ignored")
+    @Operation(
+            summary = "Get Ignored User Profile IDs",
+            description = "Retrieve a list of all ignored user profile IDs",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Ignored user profile IDs retrieved successfully",
+                            content = @Content(schema = @Schema(type = "array", implementation = String.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getIgnoredUserProfileIds() {
+        try {
+            List<String> ignoredIds = new ArrayList<>(userProfileService.getIgnoredUserProfileIds());
+            return buildOkResponse(ignoredIds);
+        } catch (Exception e) {
+            log.error("Error retrieving ignored user profile IDs", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("")
+    @Operation(
+            summary = "Get Multiple User Profiles by IDs",
+            description = "Fetches a list of user profiles given a comma-separated list of profile IDs.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "User profiles retrieved successfully",
+                            content = @Content(schema = @Schema(type = "array", implementation = UserProfileDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid input"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getUserProfilesByIds(@QueryParam("ids") String profileIds) {
+        try {
+            if (profileIds == null || profileIds.isBlank()) {
+                return buildResponse(Response.Status.BAD_REQUEST, "Profile IDs must be provided.");
+            }
+
+            List<String> ids = List.of(profileIds.split(","))
+                    .stream()
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .toList();
+
+            List<UserProfileDto> profiles = ids.stream()
+                    .map(userProfileService::findUserProfile)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(DtoMappings.UserProfileMapping::fromBisq2Model)
+                    .toList();
+
+            return buildOkResponse(profiles);
+        } catch (Exception e) {
+            log.error("Error retrieving user profiles by IDs", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+} 

--- a/http-api/src/main/java/bisq/http_api/web_socket/WebSocketRestApiResourceConfig.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/WebSocketRestApiResourceConfig.java
@@ -10,6 +10,7 @@ import bisq.http_api.rest_api.domain.reputation.ReputationRestApi;
 import bisq.http_api.rest_api.domain.settings.SettingsRestApi;
 import bisq.http_api.rest_api.domain.trades.TradeRestApi;
 import bisq.http_api.rest_api.domain.user_identity.UserIdentityRestApi;
+import bisq.http_api.rest_api.domain.user_profile.UserProfileRestApi;
 import jakarta.ws.rs.ApplicationPath;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,7 +26,8 @@ public class WebSocketRestApiResourceConfig extends RestApiResourceConfig {
                                           SettingsRestApi settingsRestApi,
                                           ExplorerRestApi explorerRestApi,
                                           PaymentAccountsRestApi paymentAccountsRestApi,
-                                          ReputationRestApi reputationRestApi) {
-        super(swaggerBaseUrl, offerbookRestApi, tradeRestApi, tradeChatRestApi, userIdentityRestApi, marketPriceRestApi, settingsRestApi, explorerRestApi, paymentAccountsRestApi, reputationRestApi);
+                                          ReputationRestApi reputationRestApi,
+                                          UserProfileRestApi userProfileRestApi) {
+        super(swaggerBaseUrl, offerbookRestApi, tradeRestApi, tradeChatRestApi, userIdentityRestApi, marketPriceRestApi, settingsRestApi, explorerRestApi, paymentAccountsRestApi, reputationRestApi, userProfileRestApi);
     }
 }

--- a/http-api/src/main/java/bisq/http_api/web_socket/rest_api_proxy/RequestValidation.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/rest_api_proxy/RequestValidation.java
@@ -40,6 +40,6 @@ public class RequestValidation {
         // todo add more validation, whitelist of endpoints and
         // Only allow alphanumeric characters and some special characters like /, -, _
         // Do not allow '../' to avoid path traversal attacks
-        return path != null && path.matches("^[a-zA-Z0-9/_-]+$");
+        return path != null && path.matches("^[a-zA-Z0-9/_\\-?=,&]*$");
     }
 }


### PR DESCRIPTION
Changes:

1. UserProfileRestApi
 - Ignore user - POST /user-profiles/ignore
 - Undo ignore user - DELETE /user-profiles/ignore/{profileId}
 - Get ignored users list - GET /user-profiles/ignored

2. UserIdentityRestApi
 - Get Multiple User Profiles by IDs - GET /user-identities/list?ids=[comma separated profile ids]

3. RequestValidation :: isValidPath
 - Updated regex from
`^[a-zA-Z0-9/_-]+$`
to
`^[a-zA-Z0-9/_\\-?=,&]*$`
to allow query params in the URL

Needed for https://github.com/bisq-network/bisq-mobile/pull/501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new API endpoints for managing user profiles, including ignoring/unignoring profiles, retrieving ignored profile IDs, and fetching multiple profiles by ID.

* **Bug Fixes**
  * Improved path validation to support additional characters in API requests, allowing for more flexible query parameters.

* **Documentation**
  * Enhanced OpenAPI documentation for the new user profile endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->