### PR TITLE
fix: fail future if already scheduled delay

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeService.java
@@ -278,6 +278,8 @@ public class PeerExchangeService implements Node.Listener {
                     .host(this)
                     .runnableName("retryPeerExchange")
                     .after(delay);
+        } else {
+            future.completeExceptionally(new RuntimeException("retryPeerExchange has already been called"));
         }
         return future;
     }


### PR DESCRIPTION
a very small fix
it seemed to me the best course of action was to finish it exceptionally,
as the future result is not used and the `retryPeerExchange` will be called again by itself if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for retry operations, providing clear feedback if a retry is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->