### PR TITLE
Fix text not wrapped at create user profile

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
@@ -62,7 +62,6 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         subtitleLabel.setTextAlignment(TextAlignment.CENTER);
         subtitleLabel.setMaxWidth(400);
         subtitleLabel.setMinHeight(Region.USE_PREF_SIZE); // does not wrap without that...
-        subtitleLabel.setWrapText(true);
         subtitleLabel.getStyleClass().addAll("bisq-text-3", "wrap-text");
 
         nickname = new MaterialTextField(Res.get("onboarding.createProfile.nickName"), Res.get("onboarding.createProfile.nickName.prompt"));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/onboarding/create_profile/CreateProfileView.java
@@ -29,6 +29,7 @@ import javafx.scene.Cursor;
 import javafx.scene.control.*;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
@@ -60,7 +61,8 @@ public class CreateProfileView extends View<VBox, CreateProfileModel, CreateProf
         Label subtitleLabel = new Label(Res.get("onboarding.createProfile.subTitle"));
         subtitleLabel.setTextAlignment(TextAlignment.CENTER);
         subtitleLabel.setMaxWidth(400);
-        subtitleLabel.setMinHeight(40); // does not wrap without that...
+        subtitleLabel.setMinHeight(Region.USE_PREF_SIZE); // does not wrap without that...
+        subtitleLabel.setWrapText(true);
         subtitleLabel.getStyleClass().addAll("bisq-text-3", "wrap-text");
 
         nickname = new MaterialTextField(Res.get("onboarding.createProfile.nickName"), Res.get("onboarding.createProfile.nickName.prompt"));


### PR DESCRIPTION
**Background:** 
- When clicking "Create new profile" in User Options, the title section does not wrap automatically, causing the UI to display incomplete information.
- Related issue: https://github.com/bisq-network/bisq2/issues/3605
- Reproduce this UI issue locally
<img width="1840" height="1104" alt="image" src="https://github.com/user-attachments/assets/a7cb84c9-ca66-49b5-88ba-f9f4b12d8aaa" />


**Changes:**
- We have already set wrap-text in the style, but it didn’t take effect because minHeight was fixed at 40. This likely caused the wrap to fail, as the label height wasn’t correctly calculated during UI rendering. Therefore, we set minHeight to Region.USE_PREF_SIZE to calculate the label height dynamically.

**How to verify:**
- I have reproduced the issue locally and verified that it is resolved after the code changes.
- 
<img width="1878" height="1134" alt="image" src="https://github.com/user-attachments/assets/7b599dea-af7a-45c9-ba66-c55c86dee41a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved the onboarding “Create Profile” screen subtitle for better readability and responsiveness. The subtitle now wraps across multiple lines and adjusts its height dynamically, preventing truncation or clipping on smaller windows and with longer or localized text. Enhances layout consistency and user experience across different display sizes and languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->