### PR TITLE
Pass data from handshake to connection to ensure no reuse of pow is possible

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/node/InboundConnection.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/InboundConnection.java
@@ -31,7 +31,8 @@ public class InboundConnection extends Connection {
     @Getter
     private final ServerSocketResult serverSocketResult;
 
-    InboundConnection(Socket socket,
+    InboundConnection(String connectionId,
+                      Socket socket,
                       ServerSocketResult serverSocketResult,
                       Capability peersCapability,
                       NetworkLoadSnapshot peersNetworkLoadSnapshot,
@@ -39,7 +40,8 @@ public class InboundConnection extends Connection {
                       ConnectionThrottle connectionThrottle,
                       Handler handler,
                       BiConsumer<Connection, Exception> errorHandler) {
-        super(socket,
+        super(connectionId,
+                socket,
                 peersCapability,
                 peersNetworkLoadSnapshot,
                 connectionMetrics,

--- a/network/network/src/main/java/bisq/network/p2p/node/Node.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Node.java
@@ -287,7 +287,8 @@ public class Node implements Connection.Handler {
 
             NetworkLoadSnapshot peersNetworkLoadSnapshot = new NetworkLoadSnapshot(result.getPeersNetworkLoad());
             ConnectionThrottle connectionThrottle = new ConnectionThrottle(peersNetworkLoadSnapshot, networkLoadSnapshot, config);
-            InboundConnection connection = new InboundConnection(socket,
+            InboundConnection connection = new InboundConnection(result.getConnectionId(),
+                    socket,
                     serverSocketResult,
                     result.getPeersCapability(),
                     peersNetworkLoadSnapshot,
@@ -344,7 +345,7 @@ public class Node implements Connection.Handler {
             AuthorizationToken token = authorizationService.createToken(envelopePayloadMessage,
                     connection.getPeersNetworkLoadSnapshot().getCurrentNetworkLoad(),
                     connection.getPeerAddress().getFullAddress(),
-                    connection.getSentMessageCounter().incrementAndGet(),
+                    connection.getSentMessageCounter().getAndIncrement(),
                     connection.getPeersCapability().getFeatures());
             maybeSimulateDelay();
             return connection.send(envelopePayloadMessage, token);
@@ -506,7 +507,8 @@ public class Node implements Connection.Handler {
         try {
             NetworkLoadSnapshot peersNetworkLoadSnapshot = new NetworkLoadSnapshot(result.getPeersNetworkLoad());
             ConnectionThrottle connectionThrottle = new ConnectionThrottle(peersNetworkLoadSnapshot, networkLoadSnapshot, config);
-            connection = new OutboundConnection(socket,
+            connection = new OutboundConnection(result.getConnectionId(),
+                    socket,
                     address,
                     result.getPeersCapability(),
                     peersNetworkLoadSnapshot,

--- a/network/network/src/main/java/bisq/network/p2p/node/OutboundConnection.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/OutboundConnection.java
@@ -32,7 +32,8 @@ public class OutboundConnection extends Connection {
     @Getter
     private final Address address;
 
-    OutboundConnection(Socket socket,
+    OutboundConnection(String connectionId,
+                       Socket socket,
                        Address address,
                        Capability peersCapability,
                        NetworkLoadSnapshot peersNetworkLoadSnapshot,
@@ -40,7 +41,8 @@ public class OutboundConnection extends Connection {
                        ConnectionThrottle connectionThrottle,
                        Handler handler,
                        BiConsumer<Connection, Exception> errorHandler) {
-        super(socket,
+        super(connectionId,
+                socket,
                 peersCapability,
                 peersNetworkLoadSnapshot,
                 connectionMetrics,


### PR DESCRIPTION
Pass connectionId which was created in the handshake to the connection, so that validation code in AuthorizationTokenService works.

Set initial value of sentMessageCounter to 1 in connection as we have the first message sent in the handshake.

We use the messageCounter to avoid that pow could be reused we keep track of all messageCounter values per connection ID and fail if we detect a reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds unique per-connection identifiers carried from handshake through connection lifecycle for improved traceability.

- Refactor
  - Connection construction now requires an explicit connection identifier.
  - Internal message-counter access tightened and previously exposed accessors removed.

- Behavior Change
  - Message-counter initialization and increment semantics adjusted, affecting the sequence values used for token/authorization generation.

- Tests
  - Updated to align with the new identifier flow and counter access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->