### PR TITLE
Improve and refactor multiple accounts selection in Musig create offer wizard

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/payment/MuSigCreateOfferPaymentModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/payment/MuSigCreateOfferPaymentModel.java
@@ -56,6 +56,7 @@ public class MuSigCreateOfferPaymentModel implements Model {
     private final ObjectProperty<PaymentMethod<?>> paymentMethodWithMultipleAccounts = new SimpleObjectProperty<>();
     private final BooleanProperty shouldShowNoAccountOverlay = new SimpleBooleanProperty();
     private final StringProperty noAccountOverlayHeadlineText = new SimpleStringProperty();
+    private final BooleanProperty shouldShowMultipleAccountsOverlay = new SimpleBooleanProperty();
     private final StringProperty multipleAccountsOverlayHeadlineText = new SimpleStringProperty();
 
     private final ObservableList<Account<? extends PaymentMethod<?>, ?>> accountsForPaymentMethod = FXCollections.observableArrayList();
@@ -76,6 +77,7 @@ public class MuSigCreateOfferPaymentModel implements Model {
         paymentMethodWithMultipleAccounts.set(null);
         shouldShowNoAccountOverlay.set(false);
         noAccountOverlayHeadlineText.set("");
+        shouldShowMultipleAccountsOverlay.set(false);
         multipleAccountsOverlayHeadlineText.set("");
         accountsForPaymentMethod.clear();
         sortedAccountsForPaymentMethod.clear();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Multiple Accounts” overlay when selecting payment methods in the MuSig offer flow.
  - Dynamic overlay headline reflecting the selected payment method.
  - Account selection updates the chip label and proceeds seamlessly.

- Bug Fixes
  - Overlay consistently hides after toggling payment methods or confirming account selection.
  - Escape key reliably closes the overlay.

- Refactor
  - Consolidated multiple-accounts UI into a single wizard overlay for a smoother, more consistent experience.
  - Simplified layout and removed unused animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->