### PR TITLE
Improve handling of typssafe config

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -138,7 +138,8 @@ public abstract class ApplicationService implements Service {
         programArgConfig = TypesafeConfigUtils.parseArgsToConfig(args);
         jvmConfig = TypesafeConfigUtils.resolveFilteredJvmOptions();
         resourceConfig = ConfigFactory.parseResources(configFileName + ".conf").resolve();
-        resourceConfig.checkValid(ConfigFactory.defaultReference(), "application");
+        // We do not check validity yet, as we do not have a reference config. Typesafe use then the existing config
+        // which is the preliminary config from program args and jvm args but that is not a useful reference.
 
         // Precedence Order: Program Arguments > JVM options > Resource config
         rootConfig = programArgConfig

--- a/application/src/main/java/bisq/application/TypesafeConfigUtils.java
+++ b/application/src/main/java/bisq/application/TypesafeConfigUtils.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.application;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class TypesafeConfigUtils {
+    public static Config resolveFilteredJvmOptions() {
+        Map<String, String> filteredJvmProps = new HashMap<>();
+        System.getProperties().forEach((key, value) -> {
+            if (key instanceof String keyAsString && keyAsString.startsWith("application.")) {
+                filteredJvmProps.put(keyAsString, String.valueOf(value));
+            }
+        });
+        return ConfigFactory.parseMap(filteredJvmProps);
+    }
+
+    public static Config parseArgsToConfig(String[] args) {
+        Map<String, Object> map = Arrays.stream(args)
+                .filter(arg -> arg.startsWith("--application.") && arg.contains("="))
+                .map(arg -> arg.substring(2).split("=", 2))
+                .collect(Collectors.toMap(arr -> arr[0], arr -> arr[1], (a, b) -> b)); // last one wins if duplicates
+        map.putAll(mapCustomArgsToTypesafeEntries(args));
+        return ConfigFactory.parseMap(map);
+    }
+
+    private static Map<String, Object> mapCustomArgsToTypesafeEntries(String[] args) {
+        Map<String, Object> map = new HashMap<>();
+        for (int i = 0; i < args.length; i++) {
+            int valueIndex = i + 1;
+            switch (args[i]) {
+                case "--app-name":
+                    if (valueIndex < args.length) {
+                        map.put("application.appName", args[valueIndex]);
+                        i++; // skip the value
+                    }
+                    break;
+                case "--data-dir":
+                    if (valueIndex < args.length) {
+                        map.put("application.dataDir", args[valueIndex]);
+                        i++;
+                    }
+                    break;
+            }
+        }
+        return map;
+    }
+
+    public static Optional<Config> resolveCustomConfig(Path appDataDir) {
+        // J8 compatible to avoid issues on mobile Samsung devices
+        String configName = ApplicationService.CUSTOM_CONFIG_FILE_NAME;
+        File customConfigFile = Paths.get(appDataDir.toString(), configName).toFile();
+        if (customConfigFile.exists()) {
+            try {
+                com.typesafe.config.Config config = ConfigFactory.parseFile(customConfigFile);
+                config.checkValid(ConfigFactory.defaultReference(), "application");
+                log.info("Using custom config file: {}", customConfigFile.getAbsolutePath());
+                return Optional.of(config);
+            } catch (Exception e) {
+                log.error("Could not load custom config file {}", customConfigFile.getAbsolutePath(), e);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/application/src/test/java/bisq/application/TypesafeConfigUtilsTest.java
+++ b/application/src/test/java/bisq/application/TypesafeConfigUtilsTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.application;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static bisq.application.TypesafeConfigUtils.coerce;
+import static bisq.application.TypesafeConfigUtils.mapCustomArgsToTypesafeEntries;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class TypesafeConfigUtilsTest {
+
+    @Test
+    void testMapCustomArgsAppNameWithEqualsSyntax() {
+        String[] args = {"--app-name=bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("bisq", result.get("application.appName"));
+        assertFalse(result.containsKey("application.baseDir"));
+    }
+
+    @Test
+    void testMapCustomArgsAppNameWithSeparateArgSyntax() {
+        String[] args = {"--app-name", "bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("bisq", result.get("application.appName"));
+    }
+
+    @Test
+    void testMapCustomArgsDataDirWithEqualsSyntax() {
+        String[] args = {"--data-dir=/tmp/bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("/tmp/bisq", result.get("application.baseDir"));
+    }
+
+    @Test
+    void testMapCustomArgsDataDirWithSeparateArgSyntax() {
+        String[] args = {"--data-dir", "/tmp/bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("/tmp/bisq", result.get("application.baseDir"));
+    }
+
+    @Test
+    void testMapCustomArgsMultipleArgsTogether() {
+        String[] args = {"--app-name=bisq", "--data-dir", "/opt/bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("bisq", result.get("application.appName"));
+        assertEquals("/opt/bisq", result.get("application.baseDir"));
+    }
+
+    @Test
+    void testMapCustomArgsMultipleArgsTogether2() {
+        String[] args = {"--app-name=bisq", "--data-dir=/tmp/bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("bisq", result.get("application.appName"));
+        assertEquals("/tmp/bisq", result.get("application.baseDir"));
+    }
+
+    @Test
+    void testMapCustomArgsIgnoreUnknownArgs() {
+        String[] args = {"--foo=bar", "--app-name", "bisq"};
+        Map<String, Object> result = mapCustomArgsToTypesafeEntries(args);
+
+        assertEquals("bisq", result.get("application.appName"));
+        assertFalse(result.containsKey("application.baseDir"));
+        assertEquals(1, result.size()); // Only appName should be present
+    }
+
+
+
+    @Test
+    void testCoerceBooleanTrue() {
+        assertEquals(Boolean.TRUE, coerce("true"));
+        assertEquals(Boolean.TRUE, coerce("TrUe"));
+        assertEquals(Boolean.TRUE, coerce("TRUE"));
+    }
+
+    @Test
+    void testCoerceBooleanFalse() {
+        assertEquals(Boolean.FALSE, coerce("false"));
+        assertEquals(Boolean.FALSE, coerce("FaLsE"));
+    }
+
+    @Test
+    void testCoerceInteger() {
+        Object coerce = coerce("123");
+        int expected = 123;
+        assertEquals(expected, coerce);
+        assertEquals(-456, coerce("-456"));
+    }
+
+    @Test
+    void testCoerceLong() {
+        long big = (long) Integer.MAX_VALUE + 1;
+        assertEquals(big, coerce(String.valueOf(big)));
+        int small = (int) Integer.MIN_VALUE - 1;
+        assertEquals(small, coerce(String.valueOf(small)));
+    }
+
+    @Test
+    void testCoerceDouble() {
+        assertEquals(3.14, coerce("3.14"));
+        assertEquals(-0.001, coerce("-0.001"));
+        assertEquals(1.23e4, coerce("1.23e4"));
+        assertEquals(-5.67E-8, coerce("-5.67E-8"));
+    }
+
+    @Test
+    void testCoerceFallbackString() {
+        assertEquals("hello", coerce("hello"));
+        assertEquals("123abc", coerce("123abc"));
+        assertEquals("1.2.3", coerce("1.2.3"));
+    }
+
+    @Test
+    void testCoerceTrimmedString() {
+        assertEquals(42, coerce(" 42 "));
+        assertEquals(Boolean.TRUE, coerce(" true "));
+        assertEquals("  some text  ", coerce("  some text  ")); // spaces preserved if not numeric/boolean
+    }
+}

--- a/application/src/test/java/bisq/application/TypesafeConfigUtilsTest.java
+++ b/application/src/test/java/bisq/application/TypesafeConfigUtilsTest.java
@@ -90,7 +90,6 @@ class TypesafeConfigUtilsTest {
     }
 
 
-
     @Test
     void testCoerceBooleanTrue() {
         assertEquals(Boolean.TRUE, coerce("true"));
@@ -114,10 +113,12 @@ class TypesafeConfigUtilsTest {
 
     @Test
     void testCoerceLong() {
-        long big = (long) Integer.MAX_VALUE + 1;
-        assertEquals(big, coerce(String.valueOf(big)));
-        int small = (int) Integer.MIN_VALUE - 1;
-        assertEquals(small, coerce(String.valueOf(small)));
+        long longValue1 = (long) Integer.MAX_VALUE + 1;
+        assertEquals(longValue1, coerce(String.valueOf(longValue1)));
+        long longValue2 = (long) Integer.MIN_VALUE - 1; // overflow
+        assertEquals(longValue2, coerce(String.valueOf(longValue2)));
+        int intValue = Integer.MIN_VALUE + 1;
+        assertEquals(intValue, coerce(String.valueOf(intValue)));
     }
 
     @Test


### PR DESCRIPTION
Add support for program arguments following the typesafe path names.
Add precedence Order for various config sources: Program Arguments > JVM options > Custom config > Resource config

This PR is a preparation for a follow up PR for I2P settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for a user-provided configuration file (bisq.conf) and stronger CLI/JVM config mapping.
  - Application name and base/data directory can be set from CLI or JVM options.

- Improvements
  - Layered configuration precedence (CLI > JVM > custom file > defaults).
  - More reliable startup: consistent logging, clearer data directory handling, and improved instance-lock behavior.
  - Robust parsing of key ID lists.

- Tests
  - Added unit tests for CLI-to-config parsing and value coercion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->