### PR TITLE
Restrict file permissions on Bisq data dir

### DIFF
--- a/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
+++ b/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
@@ -80,7 +80,7 @@ public class ZipFileExtractor implements AutoCloseable {
 
     private void writeStreamToFile(byte[] buffer, InputStream inputStream, String fileName) {
         File destFile = new File(destDir, fileName);
-        try (FileOutputStream outputStream = new FileOutputStream(destFile)) {
+        try (FileOutputStream outputStream = FileUtils.newFileOutputStreamWithPermissions(destFile.getAbsolutePath())) {
             int length;
             while ((length = inputStream.read(buffer)) > 0) {
                 outputStream.write(buffer, 0, length);

--- a/common/src/main/java/bisq/common/logging/LogSetup.java
+++ b/common/src/main/java/bisq/common/logging/LogSetup.java
@@ -45,7 +45,7 @@ public class LogSetup {
 
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
-        RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
+        RollingFileAppender<ILoggingEvent> appender = new RestrictedRollingFileAppender();
         appender.setContext(loggerContext);
         appender.setFile(fileName + ".log");
 

--- a/common/src/main/java/bisq/common/logging/RestrictedRollingFileAppender.java
+++ b/common/src/main/java/bisq/common/logging/RestrictedRollingFileAppender.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+
+public class RestrictedRollingFileAppender extends RollingFileAppender<ILoggingEvent> {
+    @Override
+    public void openFile(String fileName) throws IOException {
+        super.openFile(fileName);
+        try {
+            Files.setPosixFilePermissions(Paths.get(fileName),
+                    EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException e) {
+            // For non-posix file systems, we ignore this exception
+        }
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -144,6 +144,11 @@ public class TorService implements Service {
         Path controlDirPath = torDataDirPath.resolve(BaseTorrcGenerator.CONTROL_DIR_NAME);
         Path controlPortFilePath = controlDirPath.resolve("control");
         try {
+            FileUtils.makeDirs(controlDirPath.toAbsolutePath());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create control file dir for tor", e);
+        }
+        try {
             FileUtils.deleteFileAndWait(controlPortFilePath.toFile(), 5000);
         } catch (Exception e) {
             throw new RuntimeException("Failed to delete tor control port file", e);

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreFileManager.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreFileManager.java
@@ -17,6 +17,7 @@
 
 package bisq.persistence;
 
+import bisq.common.file.FileUtils;
 import bisq.persistence.backup.BackupService;
 import bisq.persistence.backup.MaxBackupSize;
 import lombok.Getter;
@@ -53,8 +54,9 @@ public class PersistableStoreFileManager {
     public void createParentDirectoriesIfNotExisting() {
         File parentDir = parentDirectoryPath.toFile();
         if (!parentDir.exists()) {
-            boolean isSuccess = parentDir.mkdirs();
-            if (!isSuccess) {
+            try {
+                FileUtils.makeDirs(parentDir);
+            } catch (IOException e) {
                 throw new CouldNotCreateParentDirs("Couldn't create " + parentDir);
             }
         }

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
@@ -113,7 +113,7 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
     }
 
     private void writeStoreToFile(T persistableStore, File file) {
-        try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+        try (FileOutputStream fileOutputStream = FileUtils.newFileOutputStreamWithPermissions(file.getAbsolutePath())) {
             // We use an Any container (byte blob) as we do not have the dependencies to the
             // external PersistableStore implementations (at deserialization we would have an issue otherwise as
             // it requires static access).

--- a/security/src/test/java/bisq/security/PgPUtilsTest.java
+++ b/security/src/test/java/bisq/security/PgPUtilsTest.java
@@ -26,12 +26,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SignatureException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @Slf4j
 public class PgPUtilsTest {
@@ -88,8 +93,8 @@ public class PgPUtilsTest {
     private PGPPublicKeyRing getPGPPublicKeyRing(String fileName) throws IOException, PGPException {
         File file = Paths.get("temp", fileName).toFile();
         try {
-            try (InputStream resource = FileUtils.getResourceAsStream(fileName)) {
-                OutputStream out = new FileOutputStream(file);
+            try (InputStream resource = FileUtils.getResourceAsStream(fileName);
+                 OutputStream out = FileUtils.newFileOutputStreamWithPermissions(file.getAbsolutePath())) {
                 FileUtils.copy(resource, out);
             }
             return PgPUtils.readPgpPublicKeyRing(file);
@@ -101,8 +106,9 @@ public class PgPUtilsTest {
     private PGPSignature getPGPSignature(String fileName) throws IOException, SignatureException {
         File file = Paths.get("temp", fileName).toFile();
         try {
-            try (InputStream resource = FileUtils.getResourceAsStream(fileName)) {
-                OutputStream out = new FileOutputStream(file);
+            try (InputStream resource = FileUtils.getResourceAsStream(fileName);
+                 OutputStream out = FileUtils.newFileOutputStreamWithPermissions(file.getAbsolutePath())
+            ) {
                 FileUtils.copy(resource, out);
             }
             return PgPUtils.readPgpSignature(file);
@@ -114,8 +120,9 @@ public class PgPUtilsTest {
     private File getDataAsFile(String fileName) throws IOException {
         File file = Paths.get("temp", fileName).toFile();
         try {
-            try (InputStream resource = FileUtils.getResourceAsStream(fileName)) {
-                OutputStream out = new FileOutputStream(file);
+            try (InputStream resource = FileUtils.getResourceAsStream(fileName);
+                 OutputStream out = FileUtils.newFileOutputStreamWithPermissions(file.getAbsolutePath());
+            ) {
                 FileUtils.copy(resource, out);
             }
             return file;


### PR DESCRIPTION
Restrict file permissions on all content in the Bisq data directory to read/write of the current user.
Result:
`❯ tree -p Bisq2
[drwx------]  Bisq2
├── [drwx------]  backups
│   ├── [drwx------]  private
│   │   ├── [drwx------]  identity
│   │   │   └── [-rw-------]  identity_store.protobuf_2025-09-03_0950
│   │   ├── [drwx------]  key_bundle
│   │   │   └── [-rw-------]  key_bundle_store.protobuf_2025-09-03_0950
│   │   ├── [drwx------]  network_id
│   │   │   └── [-rw-------]  network_id_store.protobuf_2025-09-03_0950
│   │   └── [drwx------]  user_identity
│   │       ├── [-rw-------]  user_identity_store.protobuf_2025-09-03_0950
│   │       └── [-rw-------]  user_identity_store.protobuf_2025-09-03_0951
│   └── [drwx------]  settings
│       ├── [drwx------]  chat_notifications
│       │   └── [-rw-------]  chat_notifications_store.protobuf_2025-09-03_0950
│       ├── [drwx------]  market_price
│       │   └── [-rw-------]  market_price_store.protobuf_2025-09-03_0950
│       ├── [drwx------]  settings
│       │   ├── [-rw-------]  settings_store.protobuf_2025-09-03_0950
│       │   └── [-rw-------]  settings_store.protobuf_2025-09-03_0951
│       ├── [drwx------]  tor_peer_group
│       │   ├── [-rw-------]  tor_peer_group_store.protobuf_2025-09-03_0950
│       │   └── [-rw-------]  tor_peer_group_store.protobuf_2025-09-03_0951
│       └── [drwx------]  user_profile
│           └── [-rw-------]  user_profile_store.protobuf_2025-09-03_0950
├── [-rw-------]  bisq.log
├── [drwx------]  db
│   ├── [drwx------]  cache
│   │   ├── [-rw-------]  banned_user_store.protobuf
│   │   ├── [-rw-------]  bisq_easy_offerbook_channel_store.protobuf
│   │   ├── [drwx------]  cat_hash_icons
│   │   │   └── [drwx------]  v0
│   │   │       ├── [-rw-------]  2357c93fc43e234ad8c8f732587d356bff1dcdb4.raw
│   │   │       ├── [-rw-------]  33e3bb5add0de4f6114e170b4dd9539ddacaecab.raw
│   │   │       ├── [-rw-------]  5b21a17f99a152a3e29d3e4d71f39b104fdc0871.raw
│   │   │       ├── [-rw-------]  a376997d1c0130a5197f3016009cbf28c43f0ea1.raw
│   │   │       └── [-rw-------]  b81cba31872b7476e92cb42b93e1e1322f941249.raw
│   │   ├── [-rw-------]  network_service_store.protobuf
│   │   ├── [-rw-------]  public_discussion_chat_channel_store.protobuf
│   │   └── [-rw-------]  public_support_chat_channel_store.protobuf
│   ├── [drwx------]  network_db
│   │   ├── [drwx------]  authenticated
│   │   │   ├── [-rw-------]  authorized_account_age_data_store.protobuf
│   │   │   ├── [-rw-------]  authorized_alert_data_store.protobuf
│   │   │   ├── [-rw-------]  authorized_bonded_reputation_data_store.protobuf
│   │   │   ├── [-rw-------]  authorized_bonded_role_store.protobuf
│   │   │   ├── [-rw-------]  authorized_burningman_list_by_block_store.protobuf
│   │   │   ├── [-rw-------]  authorized_market_price_data_store.protobuf
│   │   │   ├── [-rw-------]  authorized_oracle_node_store.protobuf
│   │   │   ├── [-rw-------]  authorized_proof_of_burn_data_store.protobuf
│   │   │   ├── [-rw-------]  authorized_signed_witness_data_store.protobuf
│   │   │   ├── [-rw-------]  authorized_timestamp_data_store.protobuf
│   │   │   ├── [-rw-------]  banned_user_profile_data_store.protobuf
│   │   │   ├── [-rw-------]  bisq_easy_offerbook_message_reaction_store.protobuf
│   │   │   ├── [-rw-------]  bisq_easy_offerbook_message_store.protobuf
│   │   │   ├── [-rw-------]  common_public_chat_message_reaction_store.protobuf
│   │   │   ├── [-rw-------]  common_public_chat_message_store.protobuf
│   │   │   ├── [-rw-------]  release_notification_store.protobuf
│   │   │   └── [-rw-------]  user_profile_store.protobuf
│   │   └── [drwx------]  mailbox
│   │       ├── [-rw-------]  ack_message_store.protobuf
│   │       ├── [-rw-------]  authorize_account_age_request_store.protobuf
│   │       ├── [-rw-------]  authorize_signed_witness_request_store.protobuf
│   │       ├── [-rw-------]  authorize_timestamp_request_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_account_data_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_btc_address_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_cancel_trade_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_confirm_btc_sent_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_confirm_fiat_receipt_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_confirm_fiat_sent_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_open_trade_message_reaction_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_open_trade_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_reject_trade_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_report_error_message_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_take_offer_request_store.protobuf
│   │       ├── [-rw-------]  bisq_easy_take_offer_response_store.protobuf
│   │       ├── [-rw-------]  mediation_request_store.protobuf
│   │       ├── [-rw-------]  mediators_response_store.protobuf
│   │       ├── [-rw-------]  report_to_moderator_message_store.protobuf
│   │       ├── [-rw-------]  two_party_private_chat_message_reaction_store.protobuf
│   │       └── [-rw-------]  two_party_private_chat_message_store.protobuf
│   ├── [drwx------]  private
│   │   ├── [-rw-------]  identity_store.protobuf
│   │   ├── [-rw-------]  key_bundle_store.protobuf
│   │   ├── [-rw-------]  network_id_store.protobuf
│   │   └── [-rw-------]  user_identity_store.protobuf
│   └── [drwx------]  settings
│       ├── [-rw-------]  account_age_store.protobuf
│       ├── [-rw-------]  bisq_easy_offerbook_channel_selection_store.protobuf
│       ├── [-rw-------]  chat_notifications_store.protobuf
│       ├── [-rw-------]  discussion_channel_selection_store.protobuf
│       ├── [-rw-------]  market_price_store.protobuf
│       ├── [-rw-------]  settings_store.protobuf
│       ├── [-rw-------]  signed_witness_store.protobuf
│       ├── [-rw-------]  support_channel_selection_store.protobuf
│       ├── [-rw-------]  tor_peer_group_store.protobuf
│       └── [-rw-------]  user_profile_store.protobuf
└── [drwx------]  tor
    ├── [-rw-------]  cached-certs
    ├── [-rw-------]  cached-microdesc-consensus
    ├── [-rw-------]  cached-microdescs.new
    ├── [drwx------]  control
    │   └── [-rw-------]  control
    ├── [-rw-r-----]  debug.log
    ├── [-rw-------]  external_tor.config
    ├── [drwx------]  keys
    ├── [-rw-------]  lock
    ├── [-rw-------]  state
    └── [-rw-------]  torrc

25 directories, 84 files
`

Fixes: #3781


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enforced owner-only permissions for newly created files and application log files on POSIX-capable systems.

- **Bug Fixes**
  - POSIX-aware directory creation with safe cross-platform fallback and clearer error handling.
  - Consistent secure file-writing across archives, stores, readers/writers, and initialization flows; proactive creation of control directories to prevent startup failures.

- **Tests**
  - Updated tests to use secure file creation and ensure temporary files are cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->