### PR TITLE
Ensure that the removal from the map happens before the requestFuture completes

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/common/RequestFuture.java
+++ b/network/network/src/main/java/bisq/network/p2p/common/RequestFuture.java
@@ -28,20 +28,38 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 @Getter
 @Slf4j
 public class RequestFuture<T extends Request, R extends Response> extends CompletableFuture<R> {
     private final Node node;
     private final Connection connection;
-    private final String requestId;
-    private final long requestTs;
+    private final T request;
+    // We use that to execute code in the caller prior to the main future gets completed, to ensure that
+    // cleanup code is executed before any client can react to completion.
+    private final CompletableFuture<Void> priorityFuture = new CompletableFuture<>();
+    private long requestTs;
 
-    public RequestFuture(Node node, Connection connection, T request) {
+    public RequestFuture(Node node,
+                         Connection connection,
+                         T request,
+                         long timeout) {
         this.node = node;
         this.connection = connection;
-        requestId = request.getRequestId();
+        this.request = request;
+        orTimeout(timeout, TimeUnit.MILLISECONDS);
+    }
 
+    @Override
+    public boolean completeExceptionally(Throwable throwable) {
+        if (!priorityFuture.isDone()) {
+            priorityFuture.completeExceptionally(throwable);
+        }
+        return super.completeExceptionally(throwable);
+    }
+
+    CompletableFuture<Void> sendRequest() {
         log.info("Send {} to {}", StringUtils.truncate(request), connection.getPeerAddress());
         requestTs = System.currentTimeMillis();
         node.sendAsync(request, connection)
@@ -54,22 +72,39 @@ public class RequestFuture<T extends Request, R extends Response> extends Comple
                                 StringUtils.truncate(request),
                                 connection.getPeerAddress(),
                                 ExceptionUtil.getRootCauseMessage(throwable));
-                        completeExceptionally(throwable);
+                        if (!priorityFuture.isDone()) {
+                            priorityFuture.completeExceptionally(throwable);
+                        }
+                        if (isDone()) {
+                            log.warn("We got a failed sendAsync but the response handler had already completed our future. This should never happen");
+                        } else {
+                            completeExceptionally(throwable);
+                        }
                     }
                 });
+        return priorityFuture;
     }
 
     void handleResponse(R response) {
-        if (response.getRequestId().equals(requestId)) {
-            String passed = MathUtils.roundDouble((System.currentTimeMillis() - requestTs) / 1000d, 2) + " sec.";
-            log.info("Received {} after {} from {}",
-                    StringUtils.truncate(response),
-                    passed,
-                    connection.getPeerAddress());
-            complete(response);
-        } else {
+        String requestId = request.getRequestId();
+        if (!response.getRequestId().equals(requestId)) {
             log.warn("Received response from {} with invalid requestId {}. RequestId was {}. Connection={}. response={}",
                     connection.getPeerAddress(), response.getRequestId(), requestId, connection.getId(), StringUtils.truncate(response));
+            return;
+        }
+
+        String passed = MathUtils.roundDouble((System.currentTimeMillis() - requestTs) / 1000d, 2) + " sec.";
+        log.info("Received {} after {} from {}",
+                StringUtils.truncate(response, 100),
+                passed,
+                connection.getPeerAddress());
+        if (!priorityFuture.isDone()) {
+            priorityFuture.complete(null);
+        }
+        if (isDone()) {
+            log.info("Discarded response for requestId {} (already completed by error or timeout)", request.getRequestId());
+        } else {
+            complete(response);
         }
     }
 }


### PR DESCRIPTION
Ensure that the removal from the map happens before the requestFuture completes.

It might be that client handlers look up that map and the various whenComplete handlers have no defined order of execution. This can lead to the case that the client whenComplete is called before our class internal whenComplete is called where we remove the entry from the map.

This case happened in the InventoryService.

By adding the internal priorityFuture, we ensure that the removal from the map happens always before the requestFuture completes.

We also moved the timout handling into the RequestFuture to control the order of the priorityFuture completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Stricter matching of responses to their originating requests to prevent handling incorrect or stale responses.
  - Consistent cleanup and completion on errors and timeouts, reducing stuck or duplicate operations.

- Refactor
  - Introduced coordinated pre-completion cleanup to improve reliability under concurrency.
  - Added timeout-aware request handling to standardize failure behavior.
  - Improved lifecycle management of pending requests to ensure timely removal and clearer completion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->