### PR TITLE
Add missing config entry

### DIFF
--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -158,7 +158,7 @@ application {
             maxPeersForRequest = 4
             maxPendingRequests = 5
             maxPendingRequestsAtPeriodicRequests = 2
-            minCompletedRequests = 2
+            minCompletedRequests = 3
             myPreferredFilterTypes=["HASH_SET"]
         }
 

--- a/apps/http-api-app/src/main/resources/http_api_app.conf
+++ b/apps/http-api-app/src/main/resources/http_api_app.conf
@@ -157,7 +157,7 @@ application {
             maxPeersForRequest = 4
             maxPendingRequests = 5
             maxPendingRequestsAtPeriodicRequests = 2
-            minCompletedRequests = 2
+            minCompletedRequests = 3
             myPreferredFilterTypes=["HASH_SET"]
         }
 

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -157,7 +157,7 @@ application {
             maxPeersForRequest = 4
             maxPendingRequests = 5
             maxPendingRequestsAtPeriodicRequests = 2
-            minCompletedRequests = 2
+            minCompletedRequests = 3
             myPreferredFilterTypes=["HASH_SET"]
         }
 

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -166,7 +166,7 @@ application {
             maxPeersForRequest = 4
             maxPendingRequests = 5
             maxPendingRequestsAtPeriodicRequests = 2
-            minCompletedRequests = 2
+            minCompletedRequests = 3
             myPreferredFilterTypes=["HASH_SET"]
         }
 

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -146,6 +146,7 @@ application {
             maxPeersForRequest = 8
             maxPendingRequests = 7
             maxPendingRequestsAtPeriodicRequests = 4
+            minCompletedRequests = 3
             myPreferredFilterTypes=["HASH_SET"]
         }
 

--- a/network/i2p/src/main/java/bisq/network/i2p/I2PSocketManagerByNodeId.java
+++ b/network/i2p/src/main/java/bisq/network/i2p/I2PSocketManagerByNodeId.java
@@ -82,7 +82,7 @@ public class I2PSocketManagerByNodeId {
     }
 
     synchronized I2PSocketManager createNewSocketManager(I2PKeyPair i2PKeyPair, String nodeId) {
-        log.info("createNewSocketManager {}", nodeId);
+        log.debug("createNewSocketManager {}", nodeId);
         checkArgument(!socketManagerByNodeId.containsKey(nodeId),
                 "createNewSocketManager for nodeID %s must be called only once. ", nodeId);
 
@@ -103,7 +103,7 @@ public class I2PSocketManagerByNodeId {
     }
 
     I2PSocketManager getSocketManager(String nodeId) {
-        log.info("getSocketManager {}", nodeId);
+        log.debug("getSocketManager {}", nodeId);
         return checkNotNull(socketManagerByNodeId.get(nodeId),
                 "socketManager must not be null as the client socket cannot be called before we have created the server socket. nodeId=" + nodeId);
     }

--- a/network/network/src/main/java/bisq/network/p2p/common/RequestResponseHandler.java
+++ b/network/network/src/main/java/bisq/network/p2p/common/RequestResponseHandler.java
@@ -26,7 +26,6 @@ import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -72,8 +71,12 @@ public abstract class RequestResponseHandler<T extends Request, R extends Respon
     // ResponseHandler implementation
     /* --------------------------------------------------------------------- */
 
-    protected Map<String, RequestFuture<T, R>> getRequestFuturesByConnectionId() {
-        return responseHandlerDelegate.getRequestFuturesByConnectionId();
+    public boolean hasPendingRequest(String connectionId) {
+        return responseHandlerDelegate.hasPendingRequest(connectionId);
+    }
+
+    public int getNumPendingRequests() {
+        return responseHandlerDelegate.getNumPendingRequests();
     }
 
     protected CompletableFuture<R> request(Connection connection, T request) {

--- a/network/network/src/main/java/bisq/network/p2p/common/ResponseHandler.java
+++ b/network/network/src/main/java/bisq/network/p2p/common/ResponseHandler.java
@@ -26,7 +26,6 @@ import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -57,8 +56,12 @@ public abstract class ResponseHandler<T extends Request, R extends Response> ext
     // ResponseHandler implementation
     /* --------------------------------------------------------------------- */
 
-    protected Map<String, RequestFuture<T, R>> getRequestFuturesByConnectionId() {
-        return responseHandlerDelegate.getRequestFuturesByConnectionId();
+    public boolean hasPendingRequest(String connectionId) {
+        return responseHandlerDelegate.hasPendingRequest(connectionId);
+    }
+
+    public int getNumPendingRequests() {
+        return responseHandlerDelegate.getNumPendingRequests();
     }
 
     protected CompletableFuture<R> request(Connection connection, T request) {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/Inventory.java
@@ -26,7 +26,11 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -48,7 +52,9 @@ public final class Inventory implements NetworkProto {
         this(entries, maxSizeReached, Optional.empty());
     }
 
-    private Inventory(Collection<? extends DataRequest> entries, boolean maxSizeReached, Optional<Integer> cachedSerializedSize) {
+    private Inventory(Collection<? extends DataRequest> entries,
+                      boolean maxSizeReached,
+                      Optional<Integer> cachedSerializedSize) {
         this.entries = new ArrayList<>(entries);
         this.maxSizeReached = maxSizeReached;
         this.cachedSerializedSize = cachedSerializedSize;
@@ -91,7 +97,9 @@ public final class Inventory implements NetworkProto {
         return new Inventory(entries, proto.getMaxSizeReached(), Optional.of(proto.getSerializedSize()));
     }
 
-    public boolean allDataReceived() {
-        return !maxSizeReached;
+    // It can be a node has not sent any data but maxSizeReached is false.
+    // finalDataDelivered provides the state that some data was delivered and the peer signalled to not have more data
+    public boolean finalDataDelivered() {
+        return !maxSizeReached && !entries.isEmpty();
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryPrinter.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryPrinter.java
@@ -83,9 +83,10 @@ public class InventoryPrinter {
         if (report.isEmpty()) {
             report = "No items received";
         }
+        int numEntries = inventory.getEntries().size();
         String maxSizeReached = inventory.isMaxSizeReached()
                 ? "Still missing data. Response got truncated because max size was reached"
-                : "All data received from peer";
+                : numEntries == 0 ? "No data received from peer." : "All data received from peer. Num entries: " + numEntries;
         String size = ByteUnit.BYTE.toKB((double) inventory.getCachedSerializedSize().orElse(0)) + " KB";
         String passed = MathUtils.roundDouble((System.currentTimeMillis() - requestTs) / 1000d, 2) + " sec.";
         log.info("\n##########################################################################################\n" +

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestModel.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestModel.java
@@ -18,20 +18,23 @@
 package bisq.network.p2p.services.data.inventory;
 
 import bisq.common.observable.Observable;
-import bisq.network.p2p.common.RequestFuture;
+import bisq.network.p2p.common.RequestResponseHandler;
 import lombok.Getter;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Getter
 public class InventoryRequestModel {
-    private final Observable<Integer> numPendingRequests = new Observable<>(0);
-    private final Observable<Boolean> allDataReceived = new Observable<>(false);
+    private final Observable<Integer> numPendingRequestsObservable = new Observable<>(0);
+    private final Observable<Boolean> initialInventoryRequestsCompleted = new Observable<>(false);
+    private final Observable<Integer> numInventoryRequestsCompletedObservable = new Observable<>(0);
+    private final AtomicInteger numInventoryRequestsCompleted = new AtomicInteger(0);
     private final Map<String, Long> requestTimestampByConnectionId = new ConcurrentHashMap<>();
-    private final Map<String, RequestFuture<InventoryRequest, InventoryResponse>> requestFuturesByConnectionId;
+    private final RequestResponseHandler<InventoryRequest, InventoryResponse> requestResponseHandler;
 
-    public InventoryRequestModel(Map<String, RequestFuture<InventoryRequest, InventoryResponse>> requestFuturesByConnectionId) {
-        this.requestFuturesByConnectionId = requestFuturesByConnectionId;
+    public InventoryRequestModel(RequestResponseHandler<InventoryRequest, InventoryResponse> requestResponseHandler) {
+        this.requestResponseHandler = requestResponseHandler;
     }
 }


### PR DESCRIPTION
Add missing config entry for seed nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an explicit “initial inventory requests completed” state that drives UI indicators and tooltips.
  - Introduced a configurable threshold for completion; default increased to require 3 completed requests.

- Refactor
  - Reworked inventory progress handling and observables to align with the new initial-completion state.
  - Updated periodic request timing and candidate selection logic for more consistent syncing.

- Chores
  - Updated configuration across desktop, HTTP API, node monitor, oracle node, and seed node to use the new threshold.

- Style
  - Reduced I2P network log verbosity for a quieter runtime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->