### PR TITLE
Increase TTL for AuthorizedAlertData

### DIFF
--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -71,7 +71,7 @@ application {
             fallbackProviders = [
                         {
                            url = "http://172.86.75.7:8080"
-                           operator = "wiz",
+                           operator = "runbtc",
                         },
                         {
                             url = "http://emzypricpidesmyqg2hc6dkwitqzaxrqnpkdg3ae2wef5znncu2ambqd.onion"

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
@@ -51,6 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -268,13 +269,13 @@ public class BisqEasyService implements Service {
 
     @VisibleForTesting
     static boolean isAccountDataBanned(Set<String> bannedAccountDataSet, String sellersAccountData) {
+        String sellersLowerCaseAccountData = sellersAccountData.toLowerCase(Locale.ROOT);
         // Format is account data of a user separated with |, and then comma separated attributes like name and account number
         return bannedAccountDataSet.stream()
                 .flatMap(data -> Stream.of(data.split("\\|")))
                 .flatMap(account -> Stream.of(account.split(",")))
-                .anyMatch(attribute -> {
-                    String trimmed = attribute.trim();
-                    return !trimmed.isEmpty() && sellersAccountData.contains(trimmed);
-                });
+                .map(attribute -> attribute.trim().toLowerCase(Locale.ROOT))
+                .filter(attribute -> !attribute.isEmpty())
+                .anyMatch(sellersLowerCaseAccountData::contains);
     }
 }

--- a/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyServiceTest.java
+++ b/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyServiceTest.java
@@ -22,7 +22,8 @@ import org.junit.jupiter.api.Test;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class BisqEasyServiceTest {
@@ -31,44 +32,72 @@ public class BisqEasyServiceTest {
         Set<String> bannedAccountDataSet = new HashSet<>();
         String sellersAccountData;
 
-        sellersAccountData="";
+        sellersAccountData = "";
         assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of(" | , ");
-        sellersAccountData="Name: Peter Tosh\nIBAN:123456789";
+        sellersAccountData = "Name: Peter Tosh\nIBAN:123456789";
         assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
-        sellersAccountData="abc";
+        sellersAccountData = "abc";
         assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
-        sellersAccountData="Name: Peter Tosh\nIBAN:123456789, BIC:3333";
+        sellersAccountData = "Name: Peter Tosh\nIBAN:123456789, BIC:3333";
         assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
-        sellersAccountData="Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
+        sellersAccountData = "Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
         assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of("Peter Tosh,123456789");
-        sellersAccountData="Name: Peter Tosh\nIBAN:123456789, BIC:3333";
+        sellersAccountData = "Name: Peter Tosh\nIBAN:123456789, BIC:3333";
         assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of("Peter Tosh,123456789");
-        sellersAccountData="Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
+        sellersAccountData = "Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
         assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of("Paula Jam, 3333");
-        sellersAccountData="Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
+        sellersAccountData = "Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
         assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of("Paula Jam  ,  3333");
-        sellersAccountData="Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
+        sellersAccountData = "Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
         assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of("Tim Burns,98989|123456789|");
-        sellersAccountData="Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
+        sellersAccountData = "Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
         assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
 
         bannedAccountDataSet = Set.of("Tim Burns,98989| Tosh |");
-        sellersAccountData="Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
+        sellersAccountData = "Name: Peter Tosh, Paula Jam\nIBAN:123456789 | BIC:3333";
         assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Burns,070.5981.333-22");
+        sellersAccountData = "Peter Tosh; 070.5981.333-22";
+        assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Burns,070.5981,333-22");
+        sellersAccountData = "Peter Tosh; 070.5981,333-22";
+        assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Burns,070.5981.333-21");
+        sellersAccountData = "Peter Tosh; 070.5981.333-22";
+        assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Burns,070.5981.333-22");
+        sellersAccountData = "Peter Tosh; 070.5981,333-22";
+        assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Burns,070.5981,333-22"); // 070.5981,333-22 are 2 tokens
+        sellersAccountData = "Peter Tosh; 070.5981.333-22";
+        assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Bo");
+        sellersAccountData = "Tim Bon"; // Tim Bon contains Tim Bo, thus interpreted as banned
+        assertTrue(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
+
+        bannedAccountDataSet = Set.of("Tim Bon");
+        sellersAccountData = "Tim Bo";
+        assertFalse(BisqEasyService.isAccountDataBanned(bannedAccountDataSet, sellersAccountData));
     }
 }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
@@ -49,7 +49,7 @@ public final class AuthorizedAlertData implements AuthorizedDistributedData {
     public final static int MAX_BANNED_ACCOUNT_DATA_LENGTH = 10_000;
 
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
+    private transient final MetaData metaData = new MetaData(TTL_100_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
     @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved account banning with case-insensitive, token-based matching for more reliable detection across punctuation and spacing variations.
- Chores
  - Updated desktop configuration to use a new market price fallback provider operator.
  - Extended authorized alert metadata retention from 30 to 100 days, keeping alerts available longer.
- Tests
  - Expanded test coverage for account banning, adding cases for diverse tokenization patterns and edge scenarios to ensure robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->