### PR TITLE
Add more jvm argumnets for key restore

### DIFF
--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -42,8 +42,12 @@ application {
 
     security = {
         keyBundle = {
+            keyStoreSecretUid = ""
+            defaultPrivateKey = ""
             defaultTorPrivateKey = ""
             defaultI2pIdentityBase64 = ""
+            writeKeyStoreSecretUidToFile = false
+            writeDefaultPrivateKeyToFile = false
             writeDefaultTorPrivateKeyToFile = false
             writeDefaultI2pIdentityBase64ToFile = false
         }

--- a/apps/http-api-app/src/main/resources/http_api_app.conf
+++ b/apps/http-api-app/src/main/resources/http_api_app.conf
@@ -42,8 +42,12 @@ application {
 
     security = {
         keyBundle = {
+            keyStoreSecretUid = ""
+            defaultPrivateKey = ""
             defaultTorPrivateKey = ""
             defaultI2pIdentityBase64 = ""
+            writeKeyStoreSecretUidToFile = false
+            writeDefaultPrivateKeyToFile = false
             writeDefaultTorPrivateKeyToFile = false
             writeDefaultI2pIdentityBase64ToFile = false
         }

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -42,8 +42,12 @@ application {
 
     security = {
         keyBundle = {
+            keyStoreSecretUid = ""
+            defaultPrivateKey = ""
             defaultTorPrivateKey = ""
             defaultI2pIdentityBase64 = ""
+            writeKeyStoreSecretUidToFile = false
+            writeDefaultPrivateKeyToFile = false
             writeDefaultTorPrivateKeyToFile = false
             writeDefaultI2pIdentityBase64ToFile = false
         }

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -42,8 +42,12 @@ application {
 
     security = {
         keyBundle = {
+            keyStoreSecretUid = ""
+            defaultPrivateKey = ""
             defaultTorPrivateKey = ""
             defaultI2pIdentityBase64 = ""
+            writeKeyStoreSecretUidToFile = false
+            writeDefaultPrivateKeyToFile = false
             writeDefaultTorPrivateKeyToFile = false
             writeDefaultI2pIdentityBase64ToFile = false
         }

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -42,8 +42,12 @@ application {
 
     security = {
         keyBundle = {
+            keyStoreSecretUid = ""
+            defaultPrivateKey = ""
             defaultTorPrivateKey = ""
             defaultI2pIdentityBase64 = ""
+            writeKeyStoreSecretUidToFile = false
+            writeDefaultPrivateKeyToFile = false
             writeDefaultTorPrivateKeyToFile = false
             writeDefaultI2pIdentityBase64ToFile = false
         }

--- a/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
@@ -37,11 +37,11 @@ public class I2PKeyUtils {
         Path destination_b32Path = I2PKeyGeneration.getDestinationFilePath(storageDir, tag, "destination_b32");
         Path identityBase64Path = I2PKeyGeneration.getDestinationFilePath(storageDir, tag, "identity_b64");
         try {
-            log.info("Storing the I2P private key into {}", i2pPrivateKeyDir);
             FileUtils.makeDirs(i2pPrivateKeyDir);
             FileUtils.writeToFile(i2pKeyPair.getDestinationBase64(), destination_b64Path.toFile());
             FileUtils.writeToFile(i2pKeyPair.getDestinationBase32(), destination_b32Path.toFile());
             FileUtils.writeToFile(Base64.encode(i2pKeyPair.getIdentityBytes()), identityBase64Path.toFile());
+            log.info("Persisted the I2P private key and destinations into {}", i2pPrivateKeyDir);
         } catch (Exception e) {
             log.error("Could not persist I2P destination files", e);
         }

--- a/security/src/main/java/bisq/security/keys/KeyBundleStore.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundleStore.java
@@ -25,6 +25,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -39,13 +40,17 @@ public final class KeyBundleStore implements PersistableStore<KeyBundleStore> {
     // Secret uid used for deriving keyIds
     // As the keyID is public in the mailbox message we do not want to leak any information of the user identity
     // to the network.
-    // Once we have persisted the stores we use the secretUid from the persisted data
+    // Once we have persisted the stores we use the secretUid from the persisted data if not overridden by jvm data
     @Getter(AccessLevel.PACKAGE)
-    private String secretUid = StringUtils.createUid();
+    @Setter(AccessLevel.PACKAGE)
+    private String secretUid;
     private final Map<String, KeyBundle> keyBundleById = new ConcurrentHashMap<>();
 
-    private KeyBundleStore(String secretUid,
-                           Map<String, KeyBundle> keyBundleById) {
+    KeyBundleStore(Optional<String> keyStoreSecretUid) {
+        this(keyStoreSecretUid.orElseGet(StringUtils::createUid), new HashMap<>());
+    }
+
+    private KeyBundleStore(String secretUid, Map<String, KeyBundle> keyBundleById) {
         this.secretUid = secretUid;
         this.keyBundleById.putAll(keyBundleById);
     }

--- a/security/src/main/java/bisq/security/keys/KeyPairUtils.java
+++ b/security/src/main/java/bisq/security/keys/KeyPairUtils.java
@@ -1,0 +1,82 @@
+package bisq.security.keys;
+
+import bisq.common.encoding.Hex;
+import bisq.common.file.FileUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.math.ec.ECPoint;
+
+import java.math.BigInteger;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
+
+@Slf4j
+public class KeyPairUtils {
+    static {
+        if (java.security.Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    public static void writePrivateKey(KeyPair keyPair, Path storageDir, String tag) {
+        Path targetPath = storageDir.resolve(tag);
+        try {
+            FileUtils.makeDirs(targetPath);
+
+            ECPrivateKey ecPrivate = (ECPrivateKey) keyPair.getPrivate();
+            byte[] priv32 = toUnsignedFixedLength(ecPrivate.getS(), 32);
+
+            FileUtils.writeToFile(Hex.encode(priv32), targetPath.resolve("private_key_hex").toFile());
+            log.info("Persisted hex encoded 32-byte secp256k1 private key for tag {} at {}", tag, targetPath);
+        } catch (Exception e) {
+            log.error("Could not persist private key", e);
+        }
+    }
+
+    private static byte[] toUnsignedFixedLength(BigInteger d, int length) {
+        byte[] b = d.toByteArray(); // big-endian; may include leading 0x00
+        if (b.length == length) return b;
+        if (b.length == length + 1 && b[0] == 0x00) return java.util.Arrays.copyOfRange(b, 1, b.length);
+        if (b.length < length) {
+            byte[] out = new byte[length];
+            System.arraycopy(b, 0, out, length - b.length, b.length);
+            return out;
+        }
+        throw new IllegalArgumentException("Invalid secp256k1 scalar length");
+    }
+
+    public static KeyPair fromPrivateKey(String privateKeyHex) {
+        try {
+            byte[] privBytes = Hex.decode(privateKeyHex);
+            if (privBytes.length != 32) {
+                throw new IllegalArgumentException("Private key must be 32 bytes");
+            }
+            BigInteger privateKeyInt = new BigInteger(1, privBytes);
+            ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec("secp256k1");
+            if (privateKeyInt.signum() <= 0 || privateKeyInt.compareTo(parameterSpec.getN()) >= 0) {
+                throw new IllegalArgumentException("Invalid secp256k1 private key");
+            }
+            ECPrivateKeySpec privateKeySpec = new ECPrivateKeySpec(privateKeyInt, parameterSpec);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC", "BC");
+            PrivateKey privateKey = keyFactory.generatePrivate(privateKeySpec);
+
+            // Derive public point = G * privateKey
+            ECPoint q = parameterSpec.getG().multiply(privateKeyInt).normalize();
+            ECPublicKeySpec publicKeySpec = new ECPublicKeySpec(q, parameterSpec);
+            PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+            return new KeyPair(publicKey, privateKey);
+        } catch (Exception e) {
+            log.error("Could not create keypair from private key", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/security/src/main/java/bisq/security/keys/TorKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyUtils.java
@@ -22,7 +22,6 @@ public class TorKeyUtils {
         Path targetPath = Paths.get(storageDir.toString(), tag);
         File torPrivateKeyDir = targetPath.toFile();
         try {
-            log.info("Store the torPrivateKey into {}", torPrivateKeyDir);
             FileUtils.makeDirs(torPrivateKeyDir);
             String dir = torPrivateKeyDir.getAbsolutePath();
 


### PR DESCRIPTION
When oracle nodes are published only from the tor private key and not from a full db backup, we get a port, private key and new UID for the db secret to mask the keyID. To make restore from backup data easier we add more fields and allow to write those data to disk.

Currently there are multiple oracle nodes in the network with the same onion address which differ from the port, pubKey and keyId. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new security.keyBundle configuration options across desktop, HTTP API, node monitor, oracle node, and seed node apps: keyStoreSecretUid, defaultPrivateKey, and flags to optionally write both to disk.
  - Allows supplying or persisting a default private key and a secret UID; app warns when config values override persisted keys.

- **Chores**
  - Reduced/logging clarified around Tor/I2P key persistence for less noisy logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->