### PR TITLE
Fix bug when changing markets in MuSig create offer

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/AmountSelectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/amount_selection/AmountSelectionController.java
@@ -210,6 +210,12 @@ public class AmountSelectionController implements Controller {
         minQuoteSideAmountInput.setSelectedMarket(market);
         invertedMinQuoteSideAmountDisplay.setSelectedMarket(market);
         price.setMarket(market);
+
+        // Reset all amounts to avoid currency mismatch when market changes
+        model.getMaxOrFixedQuoteSideAmount().set(null);
+        model.getMinQuoteSideAmount().set(null);
+        model.getMaxOrFixedBaseSideAmount().set(null);
+        model.getMinBaseSideAmount().set(null);
     }
 
     public void setDescription(String description) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Amount fields now reset when switching markets, preventing leftover values from a previous market.
  - Reduces risk of currency mismatches and invalid inputs after changing market selection.
  - Ensures more accurate quotes and order setup by clearing incompatible amounts automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->