### PR TITLE
Use Locale.ROOT for toUpperCase/toLowerCase

### DIFF
--- a/common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java
+++ b/common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java
@@ -154,6 +154,6 @@ public class FiatCurrencyRepository {
 
 
     public static String getSymbol(String code) {
-        return Currency.getInstance(code.toUpperCase()).getSymbol();
+        return Currency.getInstance(code.toUpperCase(Locale.ROOT)).getSymbol();
     }
 }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -93,7 +94,7 @@ public class StringUtils {
         if (string == null || searchString == null) {
             return false;
         }
-        return string.toLowerCase().contains(searchString.toLowerCase());
+        return string.toLowerCase(Locale.ROOT).contains(searchString.toLowerCase(Locale.ROOT));
     }
 
     /*
@@ -174,7 +175,7 @@ public class StringUtils {
     }
 
     public static String kebapCaseToCamelCase(String value) {
-        return CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, value.toLowerCase());
+        return CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, value.toLowerCase(Locale.ROOT));
     }
 
     public static String camelCaseToSnakeCase(String value) {
@@ -186,7 +187,7 @@ public class StringUtils {
     }
 
     public static String snakeCaseToKebapCase(String value) {
-        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_HYPHEN, value.toLowerCase());
+        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_HYPHEN, value.toLowerCase(Locale.ROOT));
     }
 
     public static List<Pair<String, List<String>>> getTextStylePairs(String input) {

--- a/common/src/main/java/bisq/common/util/TextFormatterUtils.java
+++ b/common/src/main/java/bisq/common/util/TextFormatterUtils.java
@@ -17,6 +17,7 @@
 
 package bisq.common.util;
 
+import java.util.Locale;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -60,7 +61,7 @@ public class TextFormatterUtils {
         return StringUtils.toOptional(iban)
                 .filter(StringUtils::isNotEmpty)
                 .map(value -> {
-                    String cleanIban = value.replaceAll("\\s", "").toUpperCase();
+                    String cleanIban = value.replaceAll("\\s", "").toUpperCase(Locale.ROOT);
                     StringBuilder formatted = new StringBuilder();
                     for (int i = 0; i < cleanIban.length(); i++) {
                         if (i > 0 && i % 4 == 0) {

--- a/common/src/main/java/bisq/common/validation/SepaPaymentAccountValidation.java
+++ b/common/src/main/java/bisq/common/validation/SepaPaymentAccountValidation.java
@@ -109,7 +109,7 @@ public class SepaPaymentAccountValidation {
         checkArgument(StringUtils.isNotEmpty(countryCode), "Country code must not be empty for IBAN consistency check");
         checkArgument(iban.length() >= 2, "IBAN too short for country code extraction.");
 
-        String cleanIban = iban.replaceAll("\\s", "").toUpperCase();
+        String cleanIban = iban.replaceAll("\\s", "").toUpperCase(Locale.ROOT);
         String ibanCountryCode = cleanIban.substring(0, 2);
 
         checkArgument(countryCode.equals(ibanCountryCode),


### PR DESCRIPTION
fixes: #3820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent currency code lookup and symbol display across locales.
  * Made IBAN formatting and SEPA account validation locale-independent to avoid incorrect rejections/formatting on certain device languages.
  * Standardized case-insensitive text checks and case conversions to behave consistently regardless of system locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->