### PR TITLE
Use orElseGet instead of orElse in Optional where appropriate

### DIFF
--- a/account/src/main/java/bisq/account/payment_method/crypto/CryptoPaymentMethod.java
+++ b/account/src/main/java/bisq/account/payment_method/crypto/CryptoPaymentMethod.java
@@ -48,7 +48,7 @@ public final class CryptoPaymentMethod extends PaymentMethod<CryptoPaymentRail> 
         this.code = code;
         Optional<CryptoAsset> optionalCryptoAsset = CryptoAssetRepository.find(code);
         isFeatured = optionalCryptoAsset.isPresent();
-        cryptoAsset = optionalCryptoAsset.orElse(new CryptoAsset(code));
+        cryptoAsset = optionalCryptoAsset.orElseGet(() -> new CryptoAsset(code));
 
         verify();
     }
@@ -58,7 +58,7 @@ public final class CryptoPaymentMethod extends PaymentMethod<CryptoPaymentRail> 
         this.code = code;
         Optional<CryptoAsset> optionalCryptoAsset = CryptoAssetRepository.find(code);
         isFeatured = optionalCryptoAsset.isPresent();
-        cryptoAsset = optionalCryptoAsset.orElse(new CryptoAsset(code));
+        cryptoAsset = optionalCryptoAsset.orElseGet(() -> new CryptoAsset(code));
 
         verify();
     }
@@ -68,7 +68,7 @@ public final class CryptoPaymentMethod extends PaymentMethod<CryptoPaymentRail> 
         this.code = code;
         Optional<CryptoAsset> optionalCryptoAsset = CryptoAssetRepository.find(code);
         isFeatured = optionalCryptoAsset.isPresent();
-        cryptoAsset = optionalCryptoAsset.orElse(new CryptoAsset(code));
+        cryptoAsset = optionalCryptoAsset.orElseGet(() -> new CryptoAsset(code));
 
         verify();
     }

--- a/apps/desktop/bi2p/src/main/java/bisq/bi2p/Bi2pApp.java
+++ b/apps/desktop/bi2p/src/main/java/bisq/bi2p/Bi2pApp.java
@@ -77,7 +77,7 @@ public class Bi2pApp extends Application {
     public void init() {
         Parameters parameters = getParameters();
         i2pRouterDir = Optional.ofNullable(parameters.getNamed().get("i2pRouterDir"))
-                .orElse(PlatformUtils.getUserDataDir().resolve("Bisq2_I2P_router").toString());
+                .orElseGet(() -> PlatformUtils.getUserDataDir().resolve("Bisq2_I2P_router").toString());
         setupRes(parameters);
 
         preventStandbyModeService = new PreventStandbyModeService(i2pRouterDir, preventStandbyMode);

--- a/apps/desktop/bi2p/src/main/java/bisq/bi2p/common/standby/PreventStandbyModeService.java
+++ b/apps/desktop/bi2p/src/main/java/bisq/bi2p/common/standby/PreventStandbyModeService.java
@@ -39,7 +39,7 @@ public class PreventStandbyModeService {
     public PreventStandbyModeService(String baseDir, ReadOnlyObservable<Boolean> prevent) {
         this.prevent = prevent;
         this.preventStandbyMode = OS.isLinux()
-                ? Inhibitor.findExecutableInhibitor().orElse(new SoundPlayer(baseDir))
+                ? Inhibitor.findExecutableInhibitor().orElseGet(() -> new SoundPlayer(baseDir))
                 : new SoundPlayer(baseDir);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/DesktopController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/DesktopController.java
@@ -150,13 +150,13 @@ public class DesktopController extends NavigationController {
         Cookie cookie = serviceProvider.getSettingsService().getCookie();
         Rectangle2D screenBounds = Screen.getPrimary().getBounds();
         model.setStageWidth(cookie.asDouble(CookieKey.STAGE_W)
-                .orElse(Math.max(DesktopModel.MIN_WIDTH, Math.min(DesktopModel.PREF_WIDTH, screenBounds.getWidth()))));
+                .orElseGet(() -> Math.max(DesktopModel.MIN_WIDTH, Math.min(DesktopModel.PREF_WIDTH, screenBounds.getWidth()))));
         model.setStageHeight(cookie.asDouble(CookieKey.STAGE_H)
-                .orElse(Math.max(DesktopModel.MIN_HEIGHT, Math.min(DesktopModel.PREF_HEIGHT, screenBounds.getHeight()))));
+                .orElseGet(() -> Math.max(DesktopModel.MIN_HEIGHT, Math.min(DesktopModel.PREF_HEIGHT, screenBounds.getHeight()))));
         model.setStageX(cookie.asDouble(CookieKey.STAGE_X)
-                .orElse((screenBounds.getWidth() - model.getStageWidth()) / 2));
+                .orElseGet(() -> (screenBounds.getWidth() - model.getStageWidth()) / 2));
         model.setStageY(cookie.asDouble(CookieKey.STAGE_Y)
-                .orElse((screenBounds.getHeight() - model.getStageHeight()) / 2));
+                .orElseGet(() -> (screenBounds.getHeight() - model.getStageHeight()) / 2));
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/standby/PreventStandbyModeService.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/standby/PreventStandbyModeService.java
@@ -39,7 +39,7 @@ public class PreventStandbyModeService {
 
     public PreventStandbyModeService(ServiceProvider serviceProvider) {
         settingsService = serviceProvider.getSettingsService();
-        preventStandbyMode = OS.isLinux() ? Inhibitor.findExecutableInhibitor().orElse(new SoundPlayer(serviceProvider)) : new SoundPlayer(serviceProvider);
+        preventStandbyMode = OS.isLinux() ? Inhibitor.findExecutableInhibitor().orElseGet(() -> new SoundPlayer(serviceProvider)) : new SoundPlayer(serviceProvider);
     }
 
     public void initialize() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/FileChooserUtil.java
@@ -76,8 +76,8 @@ public class FileChooserUtil {
     private static Optional<File> chooseDirectory(Scene scene, Optional<String> initialDirectory, String title) {
         DirectoryChooser directoryChooser = new DirectoryChooser();
         String directory = initialDirectory
-                .orElse(SettingsService.getInstance().getCookie().asString(CookieKey.FILE_CHOOSER_DIR)
-                        .orElse(PlatformUtils.getDownloadOfHomeDir()));
+                .orElseGet(() -> SettingsService.getInstance().getCookie().asString(CookieKey.FILE_CHOOSER_DIR)
+                        .orElseGet(PlatformUtils::getDownloadOfHomeDir));
         File initDir = new File(directory);
         if (initDir.isDirectory()) {
             directoryChooser.setInitialDirectory(initDir);
@@ -92,7 +92,7 @@ public class FileChooserUtil {
         FileChooser fileChooser = new FileChooser();
         initialFileName.ifPresent(fileChooser::setInitialFileName);
         String initialDirectory = SettingsService.getInstance().getCookie().asString(CookieKey.FILE_CHOOSER_DIR)
-                .orElse(PlatformUtils.getDownloadOfHomeDir());
+                .orElseGet(PlatformUtils::getDownloadOfHomeDir);
         File initDir = new File(initialDirectory);
         if (initDir.isDirectory()) {
             fileChooser.setInitialDirectory(initDir);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/RichTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/RichTableView.java
@@ -154,7 +154,7 @@ public class RichTableView<T> extends VBox {
         this.filterItems = filterItems;
         this.toggleGroup = toggleGroup;
         this.searchTextHandler = searchTextHandler;
-        this.entriesUnit = entriesUnit.orElse(Res.get("component.standardTable.entriesUnit.generic"));
+        this.entriesUnit = entriesUnit.orElseGet(() -> Res.get("component.standardTable.entriesUnit.generic"));
         if (filterItems.isPresent()) {
             checkArgument(toggleGroup.isPresent(), "filterItems and toggleGroup must be both present or empty");
         }
@@ -227,8 +227,8 @@ public class RichTableView<T> extends VBox {
         filterItems.ifPresent(filterItems -> filterItems.forEach(RichTableView.FilterMenuItem::initialize));
         searchTextHandler.ifPresent(stringConsumer -> searchTextPin = EasyBind.subscribe(searchBox.textProperty(), stringConsumer));
         exportButton.setOnAction(ev -> {
-            List<String> headers = csvHeaders.orElse(buildCsvHeaders());
-            List<List<String>> data = csvData.orElse(buildCsvData());
+            List<String> headers = csvHeaders.orElseGet(() -> buildCsvHeaders());
+            List<List<String>> data = csvData.orElseGet(() -> buildCsvData());
             String csv = Csv.toCsv(headers, data);
             String initialFileName = headline.orElse("Bisq-table-data") + ".csv";
             FileChooserUtil.saveFile(tableView.getScene(), initialFileName)

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/info/RoleInfo.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/info/RoleInfo.java
@@ -97,7 +97,7 @@ public class RoleInfo {
                         model.setBondedRoleType(authorizedBondedRole.getBondedRoleType().getDisplayString());
                         model.setBondUserName(authorizedBondedRole.getBondUserName());
                         model.setSignature(authorizedBondedRole.getSignatureBase64());
-                        model.setAuthorizingOracleNodeProfileId(authorizedBondedRole.getAuthorizingOracleNode().map(AuthorizedOracleNode::getProfileId).orElse(Res.get("data.na")));
+                        model.setAuthorizingOracleNodeProfileId(authorizedBondedRole.getAuthorizingOracleNode().map(AuthorizedOracleNode::getProfileId).orElseGet(() -> Res.get("data.na")));
                         model.setStaticPublicKeysProvided(BooleanFormatter.toYesNo(authorizedBondedRole.isStaticPublicKeysProvided()));
                         model.setAuthorizedPublicKeys(Joiner.on(", ").join(authorizedBondedRole.getAuthorizedPublicKeys()));
                     });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediationCaseListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediationCaseListItem.java
@@ -175,7 +175,7 @@ public class MediationCaseListItem implements ActivatableTableItem, DateTableIte
             profileAge = optionalProfileAge.orElse(0L);
             profileAgeString = optionalProfileAge
                     .map(TimeFormatter::formatAgeInDaysAndYears)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/BannedUserProfileTable.java
@@ -275,7 +275,7 @@ public class BannedUserProfileTable {
                     super.updateItem(item, empty);
 
                     if (item != null && !empty) {
-                        String banReasonText = StringUtils.toOptional(item.getBanReason()).orElse(Res.get("data.na"));
+                        String banReasonText = StringUtils.toOptional(item.getBanReason()).orElseGet(() -> Res.get("data.na"));
                         banReason.setText(StringUtils.truncate(banReasonText, 30));
                         banReason.setMaxHeight(30);
                         tooltip.setText(banReasonText);
@@ -372,7 +372,7 @@ public class BannedUserProfileTable {
                 banReason = moderatorDataOpt
                         .map(BannedUserModeratorData::getBanReason)
                         .flatMap(StringUtils::toOptional)
-                        .orElse(Res.get("data.na"));
+                        .orElseGet(() -> Res.get("data.na"));
 
                 reporterUserProfileId = moderatorDataOpt
                         .map(BannedUserModeratorData::getReporterUserProfileId)
@@ -384,7 +384,7 @@ public class BannedUserProfileTable {
 
                 reporterUserName = reporterUserProfile
                         .map(UserProfile::getUserName)
-                        .orElse(Res.get("data.na"));
+                        .orElseGet(() -> Res.get("data.na"));
             }
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/moderator/ReportToModeratorTable.java
@@ -415,7 +415,7 @@ public class ReportToModeratorTable {
                 UserProfileService userProfileService = serviceProvider.getUserService().getUserProfileService();
                 String reporterUserProfileId = reportToModeratorMessage.getReporterUserProfileId();
                 reporterUserProfile = userProfileService.findUserProfile(reporterUserProfileId);
-                reporterUserName = reporterUserProfile.map(UserProfile::getUserName).orElse(Res.get("data.na"));
+                reporterUserName = reporterUserProfile.map(UserProfile::getUserName).orElseGet(() -> Res.get("data.na"));
 
                 accusedUserProfile = reportToModeratorMessage.getAccusedUserProfile();
                 accusedUserName = accusedUserProfile.getUserName();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/security_manager/SecurityManagerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/security_manager/SecurityManagerController.java
@@ -225,7 +225,7 @@ public class SecurityManagerController implements Controller {
         String profileId = authorizedBondedRole.getProfileId();
         String nickNameOrBondName = userProfileService.findUserProfile(profileId)
                 .map(UserProfile::getNickName)
-                .orElse(authorizedBondedRole.getBondUserName());
+                .orElseGet(() -> authorizedBondedRole.getBondUserName());
         Optional<String> addresses = authorizedBondedRole.getAddressByTransportTypeMap()
                 .map(e -> e.values().stream()
                         .map(Address::getFullAddress)
@@ -239,7 +239,7 @@ public class SecurityManagerController implements Controller {
         String profileId = authorizedBondedRole.getProfileId();
         String nickNameOrBondName = userProfileService.findUserProfile(profileId)
                 .map(UserProfile::getNickName)
-                .orElse(authorizedBondedRole.getBondUserName());
+                .orElseGet(() -> authorizedBondedRole.getBondUserName());
         return Res.get("authorizedRole.securityManager.alert.table.bannedRole.value", roleType, nickNameOrBondName, profileId);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offer_details/BisqEasyOfferDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offer_details/BisqEasyOfferDetailsController.java
@@ -111,7 +111,7 @@ public class BisqEasyOfferDetailsController implements InitWithDataController<Bi
                             .orElse("");
                     return Res.get("bisqEasy.offerDetails.priceValue", price, percentFromMarketPrice);
                 })
-                .orElse(Res.get("data.na")));
+                .orElseGet(() -> Res.get("data.na")));
         model.getPriceDescription().set(Res.get("bisqEasy.offerDetails.price", bisqEasyOffer.getMarket().getMarketCodes()));
         model.getPaymentMethods().set(PaymentMethodSpecFormatter.fromPaymentMethodSpecs(bisqEasyOffer.getQuoteSidePaymentMethodSpecs()));
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
@@ -33,8 +33,8 @@ public class OpenTradesUtils {
             long quoteSideAmount = contract.getQuoteSideAmount();
             String formattedBaseAmount = AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(baseSideAmount));
             String formattedQuoteAmount = AmountFormatter.formatQuoteAmountWithCode(Fiat.from(quoteSideAmount, quoteCurrencyCode));
-            String paymentProof = Optional.ofNullable(trade.getPaymentProof().get()).orElse(Res.get("data.na"));
-            String bitcoinPaymentData = trade.getBitcoinPaymentData().get();
+            String paymentProof = Optional.ofNullable(trade.getPaymentProof().get()).orElseGet(() -> Res.get("data.na"));
+            String bitcoinPaymentData = Optional.ofNullable(trade.getBitcoinPaymentData().get()).orElseGet(() -> Res.get("data.na"));
             String bitcoinMethod = contract.getBaseSidePaymentMethodSpec().getDisplayString();
             String fiatMethod = contract.getQuoteSidePaymentMethodSpec().getDisplayString();
             String paymentMethod = bitcoinMethod + " / " + fiatMethod;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
@@ -333,7 +333,7 @@ public class TakeOfferReviewController implements Controller {
         Optional<MarketPrice> marketPrice = marketPriceService.findMarketPrice(market);
         marketPrice.ifPresent(price -> model.setMarketPrice(price.getPriceQuote().getValue()));
         Optional<PriceQuote> marketPriceQuote = marketPrice.map(MarketPrice::getPriceQuote);
-        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElse(Res.get("data.na"));
+        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElseGet(() -> Res.get("data.na"));
         Optional<Double> percentFromMarketPrice = PriceUtil.findPercentFromMarketPrice(marketPriceService, priceSpec, market);
         double percent = percentFromMarketPrice.orElse(0d);
         if ((priceSpec instanceof FloatPriceSpec || priceSpec instanceof MarketPriceSpec) && percent == 0) {
@@ -341,7 +341,7 @@ public class TakeOfferReviewController implements Controller {
         } else {
             String aboveOrBelow = percent > 0 ? Res.get("offer.price.above") : Res.get("offer.price.below");
             String percentAsString = percentFromMarketPrice.map(Math::abs).map(PercentageFormatter::formatToPercentWithSymbol)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
             if (priceSpec instanceof FloatPriceSpec) {
                 model.setPriceDetails(Res.get("bisqEasy.tradeWizard.review.priceDetails.float",
                         percentAsString, aboveOrBelow, marketPriceAsString));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount_and_price/amount/TradeWizardAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount_and_price/amount/TradeWizardAmountController.java
@@ -624,7 +624,7 @@ public class TradeWizardAmountController implements Controller {
                     .max()
                     .orElse(0L);
             Monetary highestPossibleAmountFromSellers = BisqEasyTradeAmountLimits.getReputationBasedQuoteSideAmount(marketPriceService, market, highestScore)
-                    .orElse(Fiat.from(0, market.getQuoteCurrencyCode()));
+                    .orElseGet(() -> Fiat.from(0, market.getQuoteCurrencyCode()));
             if (isCreateOfferMode) {
                 amountSelectionController.setRightMarkerQuoteSideValue(highestPossibleAmountFromSellers);
             }
@@ -656,7 +656,7 @@ public class TradeWizardAmountController implements Controller {
         long myReputationScore = reputationService.getReputationScore(myProfileId).getTotalScore();
         model.setMyReputationScore(myReputationScore);
         model.setReputationBasedMaxAmount(BisqEasyTradeAmountLimits.getReputationBasedQuoteSideAmount(marketPriceService, model.getMarket(), myReputationScore)
-                .orElse(Fiat.fromValue(0, model.getMarket().getQuoteCurrencyCode()))
+                .orElseGet(() -> Fiat.fromValue(0, model.getMarket().getQuoteCurrencyCode()))
         );
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -628,7 +628,7 @@ public class TradeWizardReviewController implements Controller {
         Optional<MarketPrice> marketPrice = marketPriceService.findMarketPrice(market);
         marketPrice.ifPresent(price -> model.setMarketPrice(price.getPriceQuote().getValue()));
         Optional<PriceQuote> marketPriceQuote = marketPriceService.findMarketPrice(market).map(MarketPrice::getPriceQuote);
-        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElse(Res.get("data.na"));
+        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElseGet(() -> Res.get("data.na"));
         Optional<Double> percentFromMarketPrice = PriceUtil.findPercentFromMarketPrice(marketPriceService, priceSpec, market);
         double percent = percentFromMarketPrice.orElse(0d);
         if ((priceSpec instanceof FloatPriceSpec || priceSpec instanceof MarketPriceSpec) && percent == 0) {
@@ -636,7 +636,7 @@ public class TradeWizardReviewController implements Controller {
         } else {
             String aboveOrBelow = percent > 0 ? Res.get("offer.price.above") : Res.get("offer.price.below");
             String percentAsString = percentFromMarketPrice.map(Math::abs).map(PercentageFormatter::formatToPercentWithSymbol)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
             if (priceSpec instanceof FloatPriceSpec) {
                 model.setPriceDetails(Res.get("bisqEasy.tradeWizard.review.priceDetails.float",
                         percentAsString, aboveOrBelow, marketPriceAsString));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -588,7 +588,7 @@ public class ChatMessagesListController implements Controller {
     public String getUserName(String userProfileId) {
         return userProfileService.findUserProfile(userProfileId)
                 .map(UserProfile::getUserName)
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     public void onResendMessage(String messageId) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
@@ -297,7 +297,7 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             profileAge = optionalProfileAge.orElse(0L);
             profileAgeString = optionalProfileAge
                     .map(TimeFormatter::formatAgeInDaysAndYears)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
         }
 
         public void setNumNotifications(long numNotifications) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/contacts_list/ContactsListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/contacts_list/ContactsListView.java
@@ -306,15 +306,15 @@ public class ContactsListView extends View<VBox, ContactsListModel, ContactsList
 
             userName = userProfile.getUserName();
             contactReasonString = contactListEntry.getContactReason().getDisplayString();
-            tag = contactListEntry.getTag().orElse(Res.get("data.na"));
+            tag = contactListEntry.getTag().orElseGet(() -> Res.get("data.na"));
             //todo use custom trust display
-            trustScore = contactListEntry.getTrustScore().map(String::valueOf).orElse(Res.get("data.na"));
-            notes = contactListEntry.getNotes().orElse(Res.get("data.na"));
+            trustScore = contactListEntry.getTrustScore().map(String::valueOf).orElseGet(() -> Res.get("data.na"));
+            notes = contactListEntry.getNotes().orElseGet(() -> Res.get("data.na"));
             Optional<Long> optionalProfileAge = reputationService.getProfileAgeService().getProfileAge(userProfile);
             profileAge = optionalProfileAge.orElse(0L);
             profileAgeString = optionalProfileAge
                     .map(TimeFormatter::formatAgeInDaysAndYears)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
 
             applyReputationScore(userProfile.getId());
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/MuSigOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/MuSigOfferListItem.java
@@ -163,7 +163,7 @@ public class MuSigOfferListItem {
 
         maker = userProfileService.findUserProfile(offer.getMakersUserProfileId())
                 .map(UserProfile::getUserName)
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
 
         //  Monetary quoteSideMinAmount = OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, offer).orElseThrow();
         // String formattedRangeQuoteAmount = OfferAmountFormatter.formatQuoteAmount(marketPriceService, offer, false);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/amount_and_price/amount/MuSigCreateOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/amount_and_price/amount/MuSigCreateOfferAmountController.java
@@ -528,7 +528,7 @@ public class MuSigCreateOfferAmountController implements Controller {
                     .max()
                     .orElse(0L);
             Monetary highestPossibleAmountFromSellers = MuSigTradeAmountLimits.getReputationBasedQuoteSideAmount(marketPriceService, market, highestScore)
-                    .orElse(Monetary.from(0, market.getQuoteCurrencyCode()));
+                    .orElseGet(() -> Monetary.from(0, market.getQuoteCurrencyCode()));
             amountSelectionController.setRightMarkerQuoteSideValue(highestPossibleAmountFromSellers);
             if (amountSelectionController.getMaxOrFixedQuoteSideAmount().get() == null) {
                 amountSelectionController.setMaxOrFixedQuoteSideAmount(defaultAmount);
@@ -552,7 +552,7 @@ public class MuSigCreateOfferAmountController implements Controller {
         long myReputationScore = reputationService.getReputationScore(myProfileId).getTotalScore();
         model.setMyReputationScore(myReputationScore);
         model.setReputationBasedMaxAmount(MuSigTradeAmountLimits.getReputationBasedQuoteSideAmount(marketPriceService, model.getMarket(), myReputationScore)
-                .orElse(Fiat.fromValue(0, model.getMarket().getQuoteCurrencyCode()))
+                .orElseGet(() -> Fiat.fromValue(0, model.getMarket().getQuoteCurrencyCode()))
         );
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewController.java
@@ -363,7 +363,7 @@ public class MuSigCreateOfferReviewController implements Controller {
         Optional<MarketPrice> marketPrice = marketPriceService.findMarketPrice(market);
         marketPrice.ifPresent(price -> model.setMarketPrice(price.getPriceQuote().getValue()));
         Optional<PriceQuote> marketPriceQuote = marketPriceService.findMarketPrice(market).map(MarketPrice::getPriceQuote);
-        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElse(Res.get("data.na"));
+        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElseGet(() -> Res.get("data.na"));
         Optional<Double> percentFromMarketPrice = PriceUtil.findPercentFromMarketPrice(marketPriceService, priceSpec, market);
         double percent = percentFromMarketPrice.orElse(0d);
         if ((priceSpec instanceof FloatPriceSpec || priceSpec instanceof MarketPriceSpec) && percent == 0) {
@@ -371,7 +371,7 @@ public class MuSigCreateOfferReviewController implements Controller {
         } else {
             String aboveOrBelow = percent > 0 ? Res.get("offer.price.above") : Res.get("offer.price.below");
             String percentAsString = percentFromMarketPrice.map(Math::abs).map(PercentageFormatter::formatToPercentWithSymbol)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
             if (priceSpec instanceof FloatPriceSpec) {
                 model.setPriceDetails(Res.get("bisqEasy.tradeWizard.review.priceDetails.float",
                         percentAsString, aboveOrBelow, marketPriceAsString));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigOpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigOpenTradesUtils.java
@@ -33,7 +33,7 @@ public class MuSigOpenTradesUtils {
             long quoteSideAmount = contract.getQuoteSideAmount();
             String formattedBaseAmount = AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(baseSideAmount));
             String formattedQuoteAmount = AmountFormatter.formatQuoteAmountWithCode(Fiat.from(quoteSideAmount, quoteCurrencyCode));
-            String paymentProof = Optional.ofNullable(trade.getDepositTxId()).orElse(Res.get("data.na"));
+            String paymentProof = Optional.ofNullable(trade.getDepositTxId()).orElseGet(() -> Res.get("data.na"));
             String bitcoinMethod = contract.getBaseSidePaymentMethodSpec().getDisplayString();
             String fiatMethod = contract.getQuoteSidePaymentMethodSpec().getDisplayString();
             String paymentMethod = bitcoinMethod + " / " + fiatMethod;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/review/MuSigTakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/review/MuSigTakeOfferReviewController.java
@@ -220,7 +220,7 @@ public class MuSigTakeOfferReviewController implements Controller {
                 if (muSigOffer.getMakersUserProfileId().equals(e.getUserProfileId())) {
                     new Popup().warning(Res.get("muSig.takeOffer.rateLimitsExceeded.maker.warning")).show();
                 } else {
-                    String exceedsLimitInfo = bannedUserService.getExceedsLimitInfo(e.getUserProfileId()).orElse(Res.get("data.na"));
+                    String exceedsLimitInfo = bannedUserService.getExceedsLimitInfo(e.getUserProfileId()).orElseGet(() -> Res.get("data.na"));
                     new Popup().warning(Res.get("muSig.takeOffer.rateLimitsExceeded.taker.warning", exceedsLimitInfo)).show();
                 }
                 onCancelHandler.run();
@@ -317,7 +317,7 @@ public class MuSigTakeOfferReviewController implements Controller {
         Optional<MarketPrice> marketPrice = marketPriceService.findMarketPrice(market);
         marketPrice.ifPresent(price -> model.setMarketPrice(price.getPriceQuote().getValue()));
         Optional<PriceQuote> marketPriceQuote = marketPrice.map(MarketPrice::getPriceQuote);
-        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElse(Res.get("data.na"));
+        String marketPriceAsString = marketPriceQuote.map(PriceFormatter::formatWithCode).orElseGet(() -> Res.get("data.na"));
         Optional<Double> percentFromMarketPrice = PriceUtil.findPercentFromMarketPrice(marketPriceService, priceSpec, market);
         double percent = percentFromMarketPrice.orElse(0d);
         if ((priceSpec instanceof FloatPriceSpec || priceSpec instanceof MarketPriceSpec) && percent == 0) {
@@ -325,7 +325,7 @@ public class MuSigTakeOfferReviewController implements Controller {
         } else {
             String aboveOrBelow = percent > 0 ? Res.get("offer.price.above") : Res.get("offer.price.below");
             String percentAsString = percentFromMarketPrice.map(Math::abs).map(PercentageFormatter::formatToPercentWithSymbol)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
             if (priceSpec instanceof FloatPriceSpec) {
                 model.setPriceDetails(Res.get("bisqEasy.tradeWizard.review.priceDetails.float",
                         percentAsString, aboveOrBelow, marketPriceAsString));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/BondedRolesListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/BondedRolesListItem.java
@@ -69,8 +69,8 @@ public class BondedRolesListItem {
         isBanned = bondedRole.isBanned() ? Res.get("confirmation.yes") : "";
         UserProfileService userProfileService = userService.getUserProfileService();
         userProfile = userProfileService.findUserProfile(authorizedBondedRoleData.getProfileId());
-        userProfileId = userProfile.map(UserProfile::getId).orElse(Res.get("data.na"));
-        userName = userProfile.map(UserProfile::getUserName).orElse(Res.get("data.na"));
+        userProfileId = userProfile.map(UserProfile::getId).orElseGet(() -> Res.get("data.na"));
+        userName = userProfile.map(UserProfile::getUserName).orElseGet(() -> Res.get("data.na"));
         bondUserName = authorizedBondedRoleData.getBondUserName();
         signature = authorizedBondedRoleData.getSignatureBase64();
         bondedRoleType = authorizedBondedRoleData.getBondedRoleType();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/NodeListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/NodeListItem.java
@@ -66,7 +66,7 @@ public class NodeListItem implements ActivatableTableItem {
         nodeTagTooltip = Res.get("network.header.nodeTag.tooltip", identityTag);
         nodeTag = identityTag.contains("-") ? identityTag.split("-")[0] : identityTag;
 
-        address = node.findMyAddress().map(Address::getFullAddress).orElse(Res.get("data.na"));
+        address = node.findMyAddress().map(Address::getFullAddress).orElseGet(() -> Res.get("data.na"));
 
         numConnections.set(String.valueOf(node.getAllConnections().count()));
         listener = new Node.Listener() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/SystemLoad.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/SystemLoad.java
@@ -88,11 +88,11 @@ public class SystemLoad {
             model.setNetworkLoad(networkLoadService.map(NetworkLoadService::updateNetworkLoad)
                     .map(NetworkLoad::getLoad)
                     .map(PercentageFormatter::formatToPercentWithSymbol)
-                    .orElse(Res.get("data.na")));
+                    .orElseGet(() -> Res.get("data.na")));
 
             model.setDbSize(storageService.map(StorageService::getNetworkDatabaseSize)
                     .map(DataSizeFormatter::formatMB)
-                    .orElse(Res.get("data.na")));
+                    .orElseGet(() -> Res.get("data.na")));
 
             metrics.ifPresent(metrics -> {
                 model.setAccumulatedPoWDuration(TimeFormatter.formatDuration(metrics.getAccumulatedPoWDuration()));

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/peers/all_peers/AllNetworkPeersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/peers/all_peers/AllNetworkPeersView.java
@@ -345,7 +345,7 @@ public class AllNetworkPeersView extends View<VBox, AllNetworkPeersModel, AllNet
             profileAge = optionalProfileAge.orElse(0L);
             profileAgeString = optionalProfileAge
                     .map(TimeFormatter::formatAgeInDaysAndYears)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
 
             // applyReputationScore gets called from selectedToggleChanged
             selectedTogglePin = EasyBind.subscribe(toggleGroup.selectedToggleProperty(), this::selectedToggleChanged);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/ranking/ReputationRankingView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/ranking/ReputationRankingView.java
@@ -350,7 +350,7 @@ public class ReputationRankingView extends View<VBox, ReputationRankingModel, Re
             profileAge = optionalProfileAge.orElse(0L);
             profileAgeString = optionalProfileAge
                     .map(TimeFormatter::formatAgeInDaysAndYears)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
 
             // applyReputationScore gets called from selectedToggleChanged
             selectedTogglePin = EasyBind.subscribe(toggleGroup.selectedToggleProperty(), this::selectedToggleChanged);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/details/ProfileCardDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/details/ProfileCardDetailsController.java
@@ -51,7 +51,7 @@ public class ProfileCardDetailsController implements Controller {
         model.setTransportAddress(userProfile.getAddressByTransportDisplayString());
         model.setProfileAge(reputationService.getProfileAgeService().getProfileAge(userProfile)
                 .map(TimeFormatter::formatAgeInDaysAndYears)
-                .orElse(Res.get("data.na")));
+                .orElseGet(() -> Res.get("data.na")));
         model.setStatement(StringUtils.toOptional(userProfile.getStatement()));
         String version = userProfile.getApplicationVersion();
         model.setVersion(version.isEmpty() ? Res.get("data.na") : version);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/messages/ChannelMessageItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/messages/ChannelMessageItem.java
@@ -52,7 +52,7 @@ public class ChannelMessageItem implements Comparable<ChannelMessageItem> {
         this.citationAuthorName = citationAuthorName;
 
         String editPostFix = publicChatMessage.isWasEdited() ? EDITED_POST_FIX : "";
-        message = publicChatMessage.getText().orElse(Res.get("data.na")) + editPostFix;
+        message = publicChatMessage.getText().orElseGet(() -> Res.get("data.na")) + editPostFix;
         dateTime = DateFormatter.formatDateTime(new Date(publicChatMessage.getDate()),
                 DateFormat.MEDIUM, DateFormat.SHORT, true, " " + Res.get("temporal.at") + " ");
         citation = publicChatMessage.getCitation();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/messages/ChannelMessagesDisplayList.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/messages/ChannelMessagesDisplayList.java
@@ -188,7 +188,7 @@ public class ChannelMessagesDisplayList<M extends PublicChatMessage> {
         private String getUserName(String userProfileId) {
             return userProfileService.findUserProfile(userProfileId)
                     .map(UserProfile::getUserName)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
         }
 
         private void onGoToMessage(PublicChatMessage publicChatMessage) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewController.java
@@ -79,7 +79,7 @@ public class ProfileCardOverviewController implements Controller {
 
         model.setProfileAge(reputationService.getProfileAgeService().getProfileAge(userProfile)
                 .map(TimeFormatter::formatAgeInDaysAndYears)
-                .orElse(Res.get("data.na")));
+                .orElseGet(() -> Res.get("data.na")));
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/user_profile/UserProfileController.java
@@ -94,7 +94,7 @@ public class UserProfileController implements Controller {
 
                         model.getProfileAge().set(profileAgeService.getProfileAge(userIdentity.getUserProfile())
                                 .map(TimeFormatter::formatAgeInDaysAndYears)
-                                .orElse(Res.get("data.na")));
+                                .orElseGet(() -> Res.get("data.na")));
 
                         if (livenessUpdateScheduler != null) {
                             livenessUpdateScheduler.stop();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/top/MarketPriceComponent.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/top/MarketPriceComponent.java
@@ -339,7 +339,7 @@ public class MarketPriceComponent {
             return marketPriceService.getMarketPriceRequestService()
                     .flatMap(MarketPriceRequestService::getMostRecentProvider)
                     .map(MarketPriceRequestService.Provider::getBaseUrl)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
         }
 
         public String getMarketPriceProvidingOracle() {
@@ -348,7 +348,7 @@ public class MarketPriceComponent {
                     .map(NetworkId::getAddressByTransportTypeMap)
                     .flatMap(map -> map.values().stream().findAny())
                     .map(Address::getFullAddress)
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
         }
 
         public String getSource() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/splash/BootstrapElement.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/splash/BootstrapElement.java
@@ -155,7 +155,7 @@ public class BootstrapElement {
                                 model.getIconId().set("rocket");
                                 pins.add(transportService.getInitializeServerSocketTimestampByNetworkId().addObserver((networkId, timestamp) -> {
                                     UIThread.run(() -> {
-                                        String tag = identityService.findAnyIdentityByNetworkId(networkId).map(Identity::getTag).orElse(Res.get("data.na"));
+                                        String tag = identityService.findAnyIdentityByNetworkId(networkId).map(Identity::getTag).orElseGet(() -> Res.get("data.na"));
                                         if (identityTag.isPresent() && identityTag.get().equals(tag)) {
                                             model.getVisible().set(true);
                                             model.getInfo().set(Res.get(transportSpecificInitializingKey, resolveUsername(tag)));
@@ -168,7 +168,7 @@ public class BootstrapElement {
                                 }));
                                 pins.add(transportService.getInitializedServerSocketTimestampByNetworkId().addObserver((networkId, timestamp) -> {
                                     UIThread.run(() -> {
-                                        String tag = identityService.findAnyIdentityByNetworkId(networkId).map(Identity::getTag).orElse(Res.get("data.na"));
+                                        String tag = identityService.findAnyIdentityByNetworkId(networkId).map(Identity::getTag).orElseGet(() -> Res.get("data.na"));
                                         if (identityTag.isPresent() && identityTag.get().equals(tag)) {
                                             model.getInitialized().set(true);
                                             model.getInfo().set(Res.get(transportSpecificInitializedKey, resolveUsername(tag)));

--- a/apps/desktop/webcam-app/src/main/java/bisq/webcam/service/WebcamException.java
+++ b/apps/desktop/webcam-app/src/main/java/bisq/webcam/service/WebcamException.java
@@ -51,7 +51,7 @@ public class WebcamException extends RuntimeException {
         while (cause instanceof WebcamException && cause.getCause() != null) {
             cause = cause.getCause();
         }
-        String details = Optional.ofNullable(cause).map(Throwable::getMessage).orElse(getMessage());
+        String details = Optional.ofNullable(cause).map(Throwable::getMessage).orElseGet(() -> getMessage());
         return Res.get("webcam.errorCode." + errorCode.name(), details);
     }
 }

--- a/apps/node-monitor-web-app/src/main/java/bisq/node_monitor/NodeMonitorService.java
+++ b/apps/node-monitor-web-app/src/main/java/bisq/node_monitor/NodeMonitorService.java
@@ -89,7 +89,7 @@ public class NodeMonitorService implements Service {
                                 userService.getUserProfileService()
                                         .findUserProfile(bondedRole.getAuthorizedBondedRole().getProfileId())
                                         .map(UserProfile::getNickName)
-                                        .orElse(bondedRole.getAuthorizedBondedRole().getBondUserName())
+                                        .orElseGet(() -> bondedRole.getAuthorizedBondedRole().getBondUserName())
                         ))))
                 .collect(Collectors.toList());
     }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProviderInfo.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceProviderInfo.java
@@ -31,7 +31,7 @@ public class MarketPriceProviderInfo {
 
 
     public MarketPriceProviderInfo(MarketPriceProvider marketPriceProvider) {
-        this(marketPriceProvider, marketPriceProvider.getDisplayName().orElse(Res.get("data.na")));
+        this(marketPriceProvider, marketPriceProvider.getDisplayName().orElseGet(() -> Res.get("data.na")));
     }
 
     public MarketPriceProviderInfo(MarketPriceProvider marketPriceProvider, String displayName) {

--- a/chat/src/main/java/bisq/chat/ChatMessage.java
+++ b/chat/src/main/java/bisq/chat/ChatMessage.java
@@ -153,7 +153,7 @@ public abstract class ChatMessage implements NetworkProto, Comparable<ChatMessag
     /* --------------------------------------------------------------------- */
 
     public String getTextOrNA() {
-        return text.orElse(Res.get("data.na"));
+        return text.orElseGet(() -> Res.get("data.na"));
     }
 
     public boolean wasMentioned(UserIdentity userIdentity) {

--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
@@ -159,7 +159,7 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
                     addMessage(takeOfferMessage, channel);
                     return networkService.confidentialSend(takeOfferMessage, maker.getNetworkId(), myUserIdentity.getNetworkIdWithKeyPair());
                 })
-                .orElse(CompletableFuture.failedFuture(new RuntimeException("makerUserProfile not found from message.authorUserProfileId")));
+                .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("makerUserProfile not found from message.authorUserProfileId")));
     }
 
     public CompletableFuture<SendMessageResult> sendTradeLogMessage(String text,

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -522,7 +522,7 @@ public class ChatNotificationService implements PersistenceClient<ChatNotificati
         } else {
             // For Public messages we show title: `{username} ({channel domain} - {channel title})`
             // For Private messages we show title: `{username} ({channel domain} - Private message)`
-            String userName = senderUserProfile.map(UserProfile::getUserName).orElse(Res.get("data.na"));
+            String userName = senderUserProfile.map(UserProfile::getUserName).orElseGet(() -> Res.get("data.na"));
             String channelInfo = ChatUtil.getChannelNavigationPath(chatChannel);
             title = StringUtils.truncate(userName, 20) + " (" + channelInfo + ")";
             String text = chatMessage.getTextOrNA();

--- a/common/src/main/java/bisq/common/asset/CryptoAssetRepository.java
+++ b/common/src/main/java/bisq/common/asset/CryptoAssetRepository.java
@@ -69,7 +69,7 @@ public class CryptoAssetRepository {
     }
 
     public static CryptoAsset findOrCreateCustom(String code) {
-        return find(code).orElse(new CryptoAsset(code));
+        return find(code).orElseGet(() -> new CryptoAsset(code));
     }
 
     public static List<CryptoAsset> getCryptoAssets() {

--- a/common/src/main/java/bisq/common/locale/CountryRepository.java
+++ b/common/src/main/java/bisq/common/locale/CountryRepository.java
@@ -40,7 +40,7 @@ public class CountryRepository {
     }
 
     public static void applyDefaultLocale(Locale defaultLocale) {
-        CountryRepository.defaultCountry = findCountry(defaultLocale).orElse(findCountry(Locale.US).orElseThrow());
+        CountryRepository.defaultCountry = findCountry(defaultLocale).orElseGet(() -> findCountry(Locale.US).orElseThrow());
     }
 
     public static Optional<Country> findCountry(Locale locale) {

--- a/network/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/network/src/main/java/bisq/network/NetworkService.java
@@ -438,7 +438,7 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
 
     public ObservableHashMap<String, Observable<MessageDeliveryStatus>> getMessageDeliveryStatusByMessageId() {
         return messageDeliveryStatusService.map(MessageDeliveryStatusService::getMessageDeliveryStatusByMessageId)
-                .orElse(new ObservableHashMap<>());
+                .orElseGet(ObservableHashMap::new);
     }
 
     public Set<NetworkLoadService> getNetworkLoadServices() {
@@ -501,7 +501,7 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
     /* --------------------------------------------------------------------- */
 
     public Set<ResendMessageData> getPendingResendMessageDataSet() {
-        return resendMessageService.map(ResendMessageService::getPendingResendMessageDataSet).orElse(new HashSet<>());
+        return resendMessageService.map(ResendMessageService::getPendingResendMessageDataSet).orElseGet(HashSet::new);
     }
 
     public Set<ConfidentialMessageService> getConfidentialMessageServices() {

--- a/network/network/src/main/java/bisq/network/p2p/node/Node.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Node.java
@@ -751,7 +751,7 @@ public class Node implements Connection.Handler {
     @Override
     public String toString() {
         return findMyAddress().map(address -> "Node with address " + address)
-                .orElse("Node with networkId " + networkId.getInfo());
+                .orElseGet(() -> "Node with networkId " + networkId.getInfo());
     }
 
     public String getNodeInfo() {

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
@@ -138,7 +138,7 @@ public class AuthorizationService {
         return myPreferredAuthorizationTokenTypes.stream()
                 .filter(peersAuthorizationTokenTypes::contains)
                 .findFirst()
-                .orElse(peersAuthorizationTokenTypes.get(0));
+                .orElseGet(peersAuthorizationTokenTypes::getFirst);
     }
 
     private static List<AuthorizationTokenType> toAuthorizationTypes(Collection<Feature> features) {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/AuthenticatedDataStorageService.java
@@ -408,7 +408,7 @@ public class AuthenticatedDataStorageService extends DataStorageService<Authenti
                     .map(RemoveAuthenticatedDataRequest::getClassName)
                     .collect(Collectors.toList());
             var className = Stream.concat(added.stream(), removed.stream())
-                    .findAny().orElse(persistence.getFileName().replace("Store", "")); // Remove trailing Store postfix
+                    .findAny().orElseGet(() -> persistence.getFileName().replace("Store", "")); // Remove trailing Store postfix
             log.info("Method: {}; map entry: {}; num AddRequests: {}; num RemoveRequests={}; map size:{}, data size: {}",
                     methodName, className, added.size(), removed.size(), dataStore.getMap().size(), DataSizeFormatter.format(dataSize));
         }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxDataStorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxDataStorageService.java
@@ -267,7 +267,7 @@ public class MailboxDataStorageService extends DataStorageService<MailboxRequest
                     .map(RemoveMailboxRequest::getClassName)
                     .toList();
             var className = Stream.concat(added.stream(), removed.stream())
-                    .findAny().orElse(persistence.getFileName().replace("Store", ""));
+                    .findAny().orElseGet(() -> persistence.getFileName().replace("Store", ""));
             log.info("Method: {}; map entry: {}; num AddRequests: {}; num RemoveRequests={}; map size:{}, data size: {}",
                     methodName, className, added.size(), removed.size(), dataStore.getMap().size(), DataSizeFormatter.format(dataSize));
         }

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountFormatter.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountFormatter.java
@@ -83,7 +83,7 @@ public class OfferAmountFormatter {
                                                    boolean useLowPrecision) {
         return OfferAmountUtil.findBaseSideFixedAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, useLowPrecision))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Min
@@ -104,7 +104,7 @@ public class OfferAmountFormatter {
                                                  boolean withCode) {
         return OfferAmountUtil.findBaseSideMinAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, true))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Max
@@ -125,7 +125,7 @@ public class OfferAmountFormatter {
                                                  boolean withCode) {
         return OfferAmountUtil.findBaseSideMaxAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, true))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Max or fixed
@@ -144,7 +144,7 @@ public class OfferAmountFormatter {
                                                         boolean useLowPrecision) {
         return OfferAmountUtil.findBaseSideMaxOrFixedAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, useLowPrecision))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Range (Min - Max)
@@ -217,7 +217,7 @@ public class OfferAmountFormatter {
                                                     boolean withCode) {
         return OfferAmountUtil.findQuoteSideFixedAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, true))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Min
@@ -238,7 +238,7 @@ public class OfferAmountFormatter {
                                                   boolean withCode) {
         return OfferAmountUtil.findQuoteSideMinAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, true))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Min or fixed
@@ -259,7 +259,7 @@ public class OfferAmountFormatter {
                                                          boolean withCode) {
         return OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, true))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Max
@@ -280,7 +280,7 @@ public class OfferAmountFormatter {
                                                   boolean withCode) {
         return OfferAmountUtil.findQuoteSideMaxAmount(marketPriceService, amountSpec, priceSpec, market)
                 .map(monetary -> getFormatFunction(withCode).apply(monetary, true))
-                .orElse(Res.get("data.na"));
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     // Max or fixed
@@ -295,7 +295,7 @@ public class OfferAmountFormatter {
                                                          PriceSpec priceSpec,
                                                          Market market,
                                                          boolean withCode) {
-        return OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, amountSpec, priceSpec, market).map(monetary -> getFormatFunction(withCode).apply(monetary, true)).orElse(Res.get("data.na"));
+        return OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, amountSpec, priceSpec, market).map(monetary -> getFormatFunction(withCode).apply(monetary, true)).orElseGet(() -> Res.get("data.na"));
     }
 
     // Range (Min - Max)

--- a/offer/src/main/java/bisq/offer/mu_sig/MuSigOfferService.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MuSigOfferService.java
@@ -78,7 +78,7 @@ public class MuSigOfferService implements Service {
     public CompletableFuture<BroadcastResult> publishAndAddOffer(String offerId) {
         return findOffer(offerId)
                 .map(this::publishAndAddOffer)
-                .orElse(CompletableFuture.failedFuture(new RuntimeException("Offer with not found. OfferID=" + offerId)));
+                .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("Offer not found. OfferID=" + offerId)));
     }
 
     public CompletableFuture<BroadcastResult> publishAndAddOffer(MuSigOffer offer) {
@@ -101,7 +101,7 @@ public class MuSigOfferService implements Service {
     public CompletableFuture<BroadcastResult> removeOffer(String offerId) {
         return findOffer(offerId)
                 .map(this::removeOffer)
-                .orElse(CompletableFuture.failedFuture(new RuntimeException("Offer with not found. OfferID=" + offerId)));
+                .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("Offer not found. OfferID=" + offerId)));
     }
 
     public CompletableFuture<BroadcastResult> removeOffer(MuSigOffer offer) {

--- a/offer/src/main/java/bisq/offer/mu_sig/MuSigOfferbookService.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MuSigOfferbookService.java
@@ -95,14 +95,14 @@ public class MuSigOfferbookService implements Service, DataService.Listener {
         return identityService.findActiveIdentity(muSigOffer.getMakerNetworkId())
                 .map(identity -> networkService.publishAuthenticatedData(new MuSigOfferMessage(muSigOffer),
                         identity.getNetworkIdWithKeyPair().getKeyPair()))
-                .orElse(CompletableFuture.failedFuture(new RuntimeException("No identity found for networkNodeId used in the muSigOffer")));
+                .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("No identity found for networkNodeId used in the muSigOffer")));
     }
 
     public CompletableFuture<BroadcastResult> removeFromNetwork(MuSigOffer muSigOffer) {
         return findIdentity(muSigOffer)
                 .map(identity -> networkService.removeAuthenticatedData(new MuSigOfferMessage(muSigOffer),
                         identity.getNetworkIdWithKeyPair().getKeyPair()))
-                .orElse(CompletableFuture.failedFuture(new RuntimeException("No identity found for networkNodeId used in the muSigOffer")));
+                .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("No identity found for networkNodeId used in the muSigOffer")));
     }
 
     public CompletableFuture<List<BroadcastResult>> refreshMyOffers() {
@@ -111,7 +111,7 @@ public class MuSigOfferbookService implements Service, DataService.Listener {
                 identityService.findActiveIdentity(muSigOffer.getMakerNetworkId())
                         .map(identity -> networkService.refreshAuthenticatedData(new MuSigOfferMessage(muSigOffer),
                                 identity.getNetworkIdWithKeyPair().getKeyPair()))
-                        .orElse(CompletableFuture.failedFuture(new RuntimeException("No identity found for networkNodeId used in the muSigOffer")))));
+                        .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("No identity found for networkNodeId used in the muSigOffer")))));
     }
 
     public synchronized Optional<MuSigOffer> findOffer(String offerId) {

--- a/offer/src/main/java/bisq/offer/price/OfferPriceFormatter.java
+++ b/offer/src/main/java/bisq/offer/price/OfferPriceFormatter.java
@@ -31,7 +31,7 @@ public class OfferPriceFormatter {
     }
 
     public static String formatQuote(MarketPriceService marketPriceService, Offer<?, ?> offer, boolean showCode) {
-        return PriceUtil.findQuote(marketPriceService, offer).map(getFormatFunction(showCode)).orElse(Res.get("data.na"));
+        return PriceUtil.findQuote(marketPriceService, offer).map(getFormatFunction(showCode)).orElseGet(() -> Res.get("data.na"));
     }
 
     private static Function<PriceQuote, String> getFormatFunction(boolean showCode) {

--- a/offer/src/main/java/bisq/offer/price/spec/PriceSpecFormatter.java
+++ b/offer/src/main/java/bisq/offer/price/spec/PriceSpecFormatter.java
@@ -82,7 +82,7 @@ public class PriceSpecFormatter {
             String currentPrice = marketPrice.map(MarketPrice::getPriceQuote)
                     .map(priceQuote -> PriceUtil.fromMarketPriceMarkup(priceQuote, percentage))
                     .map(priceQuote -> PriceFormatter.format(priceQuote, true))
-                    .orElse(Res.get("data.na"));
+                    .orElseGet(() -> Res.get("data.na"));
 
             String percent = PercentageFormatter.formatToPercentWithSymbol(Math.abs(percentage));
             return currentPrice + " (" + Res.get(percentage >= 0

--- a/support/src/main/java/bisq/support/moderator/ModeratorService.java
+++ b/support/src/main/java/bisq/support/moderator/ModeratorService.java
@@ -204,7 +204,7 @@ public class ModeratorService implements PersistenceClient<ModeratorStore>, Serv
                         return CompletableFuture.completedFuture(new SendMessageResult());
                     }
                 })
-                .orElse(CompletableFuture.failedFuture(new RuntimeException("No channel found")));
+                .orElseGet(() -> CompletableFuture.failedFuture(new RuntimeException("No channel found")));
     }
 
     public ObservableSet<ReportToModeratorMessage> getReportToModeratorMessages() {

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
@@ -470,7 +470,7 @@ public class BisqEasyTradeService implements PersistenceClient<BisqEasyTradeStor
                         return false;
                     }
                     boolean doRedaction = trade.getTradeCompletedDate().map(date -> date < redactDate)
-                            .orElse(trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
+                            .orElseGet(() -> trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
                     if (doRedaction) {
                         trade.getPaymentAccountData().set(Res.get("data.redacted"));
                     }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -595,7 +595,7 @@ public final class MuSigTradeService implements PersistenceClient<MuSigTradeStor
         long numChanges = getTrades().stream()
                 .filter(trade -> {
                     boolean doRedaction = trade.getTradeCompletedDate().map(date -> date < redactDate)
-                            .orElse(trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
+                            .orElseGet(() -> trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
                     //todo
                     return doRedaction;
                 })

--- a/user/src/main/java/bisq/user/cathash/CatHashService.java
+++ b/user/src/main/java/bisq/user/cathash/CatHashService.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -183,7 +184,7 @@ public abstract class CatHashService<T> {
                             .map(profiles -> profiles.stream()
                                     .map(userProfile -> userProfile.getId() + ".raw")
                                     .collect(Collectors.toSet()))
-                            .orElse(new HashSet<>());
+                            .orElseGet(Collections::emptySet);
                     Set<String> toRemove = new HashSet<>(fromDisk);
                     toRemove.removeAll(fromData);
 

--- a/user/src/main/java/bisq/user/reputation/ProfileAgeService.java
+++ b/user/src/main/java/bisq/user/reputation/ProfileAgeService.java
@@ -246,6 +246,6 @@ public class ProfileAgeService extends SourceReputationService<AuthorizedTimesta
                         .map(authorizedData -> (AuthorizedTimestampData) authorizedData.getAuthorizedDistributedData())
                         .map(AuthorizedTimestampData::getProfileId)
                         .collect(Collectors.toSet()))
-                .orElse(Collections.emptySet());
+                .orElseGet(Collections::emptySet);
     }
 }

--- a/user/src/main/java/bisq/user/reputation/ReputationService.java
+++ b/user/src/main/java/bisq/user/reputation/ReputationService.java
@@ -122,11 +122,11 @@ public class ReputationService implements Service {
     /* --------------------------------------------------------------------- */
 
     public ReputationScore getReputationScore(String userProfileId) {
-        return findReputationScore(userProfileId).orElse(new ReputationScore(0, 0, scoreByUserProfileId.size()));
+        return findReputationScore(userProfileId).orElseGet(() -> new ReputationScore(0, 0, scoreByUserProfileId.size()));
     }
 
     public ReputationScore getReputationScore(UserProfile userProfile) {
-        return findReputationScore(userProfile).orElse(new ReputationScore(0, 0, scoreByUserProfileId.size()));
+        return findReputationScore(userProfile).orElseGet(() -> new ReputationScore(0, 0, scoreByUserProfileId.size()));
     }
 
     public Optional<ReputationScore> findReputationScore(UserProfile userProfile) {


### PR DESCRIPTION
This PR refactors Optional usage by replacing `orElse` with `orElseGet` where appropriate.

Related issue: #3843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Performance Improvements
  - Deferred many default/fallback computations across the app so costly values are computed only when needed, reducing unnecessary work.

- UX Enhancements
  - Minor error message wording adjusted ("Offer not found. OfferID=..."); visible behavior unchanged.

- Refactor
  - Widespread conversion to lazy initialization for fallbacks and defaults, preserving behavior while improving efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->