### PR TITLE
Sync `rpc.proto` with bisq-musig & add receiver amounts calculation

### DIFF
--- a/trade/src/main/java/bisq/trade/mu_sig/DelayedPayoutTxReceiverService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/DelayedPayoutTxReceiverService.java
@@ -17,13 +17,109 @@
 
 package bisq.trade.mu_sig;
 
+import bisq.burningman.BurningmanData;
 import bisq.burningman.BurningmanService;
 import bisq.common.application.Service;
+import bisq.trade.protobuf.ReceiverAddressAndAmount;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 public class DelayedPayoutTxReceiverService implements Service {
+    // Outputs paying less than this absolute satoshi amount are excluded:
+    private static final long MIN_OUTPUT_AMOUNT = 1000;
+    // Twice the cost (32 bytes) of a P2SH output -- outputs paying less than this weight-equivalent are excluded:
+    private static final long MIN_OUTPUT_EQUIVALENT_WEIGHT = 256;
+
+    private static final Pattern P2SH_PATTERN = Pattern.compile("^[23][1-9A-HJ-NP-Za-km-z]{33,34}$");
+    private static final Pattern P2PKH_PATTERN = Pattern.compile("^[1mn][1-9A-HJ-NP-Za-km-z]{25,33}$");
+    private static final Pattern BECH32_PATTERN = Pattern.compile("^(?i)(?:bc|tb|bcrt)1([02-9ac-hj-np-z]{11,71})$");
+
     private final BurningmanService burningmanService;
 
     public DelayedPayoutTxReceiverService(BurningmanService burningmanService) {
         this.burningmanService = burningmanService;
+    }
+
+    public static List<ReceiverAddressAndAmount> computeReceivers(List<BurningmanData> burningmanDataList,
+                                                                  long availableAmountMsat,
+                                                                  long feeRateSatPerKwu) {
+        // Sort the receivers by order of decreasing share size.
+        var sortedBM = new ArrayList<>(burningmanDataList);
+        sortedBM.sort(Comparator.comparingDouble(BurningmanData::getCappedBurnAmountShare).reversed());
+
+        // Compute the total to receive after subtracting the tx fee, and which receivers can be economically included.
+        long minOutputAmount = minOutputAmount(feeRateSatPerKwu);
+        long totalToReceiveMsat = availableAmountMsat;
+        double totalShare = 0.0;
+        int numReceivers = 0;
+        for (var bm : sortedBM) {
+            double newTotalShare = totalShare + bm.getCappedBurnAmountShare();
+            long newTotalToReceiveMsat = totalToReceiveMsat - outputCostMsat(bm.getReceiverAddress(), numReceivers, feeRateSatPerKwu);
+            long newTotalToReceive = newTotalToReceiveMsat / 1000;
+            long outputAmount = (long) (newTotalToReceive * (bm.getCappedBurnAmountShare() / newTotalShare));
+            if (outputAmount < minOutputAmount) {
+                // No further receivers with this share size or smaller can be added economically.
+                break;
+            }
+            totalShare = newTotalShare;
+            totalToReceiveMsat = newTotalToReceiveMsat;
+            numReceivers++;
+        }
+        if (numReceivers == 0) {
+            throw new IllegalArgumentException("Could not economically include any receivers: " +
+                    "availableAmountMsat=" + availableAmountMsat + ", feeRateSatPerKwu=" + feeRateSatPerKwu);
+        }
+
+        // Convert the included shares into absolute satoshi amounts, subject to rounding errors.
+        double finalTotalShare = totalShare;
+        long totalToReceive = totalToReceiveMsat / 1000;
+        long[] outputAmounts = sortedBM.stream()
+                .limit(numReceivers)
+                .mapToLong(bm -> (long) (totalToReceive * bm.getCappedBurnAmountShare() / finalTotalShare))
+                .toArray();
+
+        // Correct any slight total overpayment/underpayment to the receivers (likely just a few satoshis), by
+        // subtracting/adding a uniform (or as close to uniform as possible) amount from/to each output, favoring the
+        // bigger receivers and making sure that no receiver amount dips below the fee dependent 'minOutputAmount'.
+        long underpayment = totalToReceive - Arrays.stream(outputAmounts).sum();
+        for (int i = numReceivers; i-- > 0; ) {
+            long correction = Math.max(Math.floorDiv(underpayment, i + 1), minOutputAmount - outputAmounts[i]);
+            outputAmounts[i] += correction;
+            underpayment -= correction;
+        }
+        return IntStream.range(0, numReceivers)
+                .mapToObj(i -> ReceiverAddressAndAmount.newBuilder()
+                        .setAddress(sortedBM.get(i).getReceiverAddress())
+                        .setAmount(outputAmounts[i])
+                        .build())
+                .toList();
+    }
+
+    private static long minOutputAmount(long feeRateSatPerKwu) {
+        return Math.max(MIN_OUTPUT_AMOUNT, MIN_OUTPUT_EQUIVALENT_WEIGHT * feeRateSatPerKwu / 1000);
+    }
+
+    private static long outputCostMsat(String address, int index, long feeRateSatPerKwu) {
+        int weight = 4 * (scriptPubKeyLength(address) + (index == 251 ? 11 : 9));
+        return weight * feeRateSatPerKwu;
+    }
+
+    private static int scriptPubKeyLength(String address) {
+        var matcher = BECH32_PATTERN.matcher(address);
+        if (matcher.matches()) {
+            return matcher.group(1).length() * 5 / 8 - 2;
+        }
+        if (P2SH_PATTERN.matcher(address).matches()) {
+            return 23;
+        }
+        if (P2PKH_PATTERN.matcher(address).matches()) {
+            return 25;
+        }
+        throw new IllegalArgumentException("Unrecognized address type: " + address);
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigFeeRateProvider.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigFeeRateProvider.java
@@ -20,7 +20,7 @@ package bisq.trade.mu_sig;
 import static com.google.common.base.Preconditions.checkArgument;
 
 // TODO Add fee estimation input to determine fee rate
-public class MusSigFeeRateProvider {
+public class MuSigFeeRateProvider {
     public static final long DEFAULT_OPTIMAL_SAT_PER_V_BYTE = 10;
 
     private static long optimalSatPerVByte = DEFAULT_OPTIMAL_SAT_PER_V_BYTE;
@@ -28,14 +28,14 @@ public class MusSigFeeRateProvider {
     public static void setOptimalSatPerVByte(long optimalSatPerVByte) {
         checkArgument(optimalSatPerVByte >= 1);
         checkArgument(optimalSatPerVByte <= 1000); // Just some sanity check. Maybe we let user set max fee rate in settings.
-        MusSigFeeRateProvider.optimalSatPerVByte = optimalSatPerVByte;
+        MuSigFeeRateProvider.optimalSatPerVByte = optimalSatPerVByte;
     }
 
     public static long getDepositTxFeeRate() {
-        return 5000 * optimalSatPerVByte;
+        return 300 * optimalSatPerVByte; // convert to sat per kwu, plus 20% extra
     }
 
     public static long getPreparedTxFeeRate() {
-        return 4000 * optimalSatPerVByte;
+        return 250 * optimalSatPerVByte; // convert to sat per kwu
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -57,7 +57,6 @@ import bisq.trade.mu_sig.events.buyer.PaymentInitiatedEvent;
 import bisq.trade.mu_sig.events.seller.PaymentReceiptConfirmedEvent;
 import bisq.trade.mu_sig.events.taker.MuSigTakeOfferEvent;
 import bisq.trade.mu_sig.grpc.MusigGrpcClient;
-import bisq.trade.mu_sig.messages.grpc.DepositPsbt;
 import bisq.trade.mu_sig.messages.grpc.TxConfirmationStatus;
 import bisq.trade.mu_sig.messages.network.MuSigTradeMessage;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
@@ -411,10 +410,8 @@ public final class MuSigTradeService implements PersistenceClient<MuSigTradeStor
 
         // todo we dont want to create a thread for each trade... but lets see how real impl. will look like
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
-            DepositPsbt depositPsbt = trade.getMyself().getMyDepositPsbt().orElseThrow();
             SubscribeTxConfirmationStatusRequest request = SubscribeTxConfirmationStatusRequest.newBuilder()
                     .setTradeId(tradeId)
-                    .setDepositPsbt(depositPsbt.toProto(true))
                     .build();
             getMusigAsyncStub().subscribeTxConfirmationStatus(request, new StreamObserver<>() {
                 @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
@@ -33,6 +33,7 @@ public final class NonceSharesMessage implements Proto {
                 nonceShares.getRedirectTxFeeBumpAddress(),
                 nonceShares.getClaimTxPayoutAddress(),
                 nonceShares.getHalfDepositPsbt(),
+                0, // only received from the server, not exchanged between peers, so set to default
                 nonceShares.getSwapTxInputNonceShare(),
                 nonceShares.getBuyersWarningTxBuyerInputNonceShare(),
                 nonceShares.getBuyersWarningTxSellerInputNonceShare(),
@@ -49,6 +50,7 @@ public final class NonceSharesMessage implements Proto {
     private final String redirectTxFeeBumpAddress;
     private final String claimTxPayoutAddress;
     private final byte[] halfDepositPsbt;
+    private final long redirectionAmountMsat;
     private final byte[] swapTxInputNonceShare;
     private final byte[] buyersWarningTxBuyerInputNonceShare;
     private final byte[] buyersWarningTxSellerInputNonceShare;
@@ -63,6 +65,7 @@ public final class NonceSharesMessage implements Proto {
                                String redirectTxFeeBumpAddress,
                                String claimTxPayoutAddress,
                                byte[] halfDepositPsbt,
+                               long redirectionAmountMsat,
                                byte[] swapTxInputNonceShare,
                                byte[] buyersWarningTxBuyerInputNonceShare,
                                byte[] buyersWarningTxSellerInputNonceShare,
@@ -76,6 +79,7 @@ public final class NonceSharesMessage implements Proto {
         this.redirectTxFeeBumpAddress = redirectTxFeeBumpAddress;
         this.claimTxPayoutAddress = claimTxPayoutAddress;
         this.halfDepositPsbt = halfDepositPsbt;
+        this.redirectionAmountMsat = redirectionAmountMsat;
         this.swapTxInputNonceShare = swapTxInputNonceShare;
         this.buyersWarningTxBuyerInputNonceShare = buyersWarningTxBuyerInputNonceShare;
         this.buyersWarningTxSellerInputNonceShare = buyersWarningTxSellerInputNonceShare;
@@ -93,6 +97,7 @@ public final class NonceSharesMessage implements Proto {
                 .setWarningTxFeeBumpAddress(warningTxFeeBumpAddress)
                 .setRedirectTxFeeBumpAddress(redirectTxFeeBumpAddress)
                 .setClaimTxPayoutAddress(claimTxPayoutAddress)
+                .setRedirectionAmountMsat(redirectionAmountMsat)
                 .setHalfDepositPsbt(ByteString.copyFrom(halfDepositPsbt))
                 .setSwapTxInputNonceShare(ByteString.copyFrom(swapTxInputNonceShare))
                 .setBuyersWarningTxBuyerInputNonceShare(ByteString.copyFrom(buyersWarningTxBuyerInputNonceShare))
@@ -115,6 +120,7 @@ public final class NonceSharesMessage implements Proto {
                 proto.getRedirectTxFeeBumpAddress(),
                 proto.getClaimTxPayoutAddress(),
                 proto.getHalfDepositPsbt().toByteArray(),
+                proto.getRedirectionAmountMsat(),
                 proto.getSwapTxInputNonceShare().toByteArray(),
                 proto.getBuyersWarningTxBuyerInputNonceShare().toByteArray(),
                 proto.getBuyersWarningTxSellerInputNonceShare().toByteArray(),
@@ -134,6 +140,7 @@ public final class NonceSharesMessage implements Proto {
                 Objects.equals(redirectTxFeeBumpAddress, that.redirectTxFeeBumpAddress) &&
                 Objects.equals(claimTxPayoutAddress, that.claimTxPayoutAddress) &&
                 Arrays.equals(halfDepositPsbt, that.halfDepositPsbt) &&
+                redirectionAmountMsat == that.redirectionAmountMsat &&
                 Arrays.equals(swapTxInputNonceShare, that.swapTxInputNonceShare) &&
                 Arrays.equals(buyersWarningTxBuyerInputNonceShare, that.buyersWarningTxBuyerInputNonceShare) &&
                 Arrays.equals(buyersWarningTxSellerInputNonceShare, that.buyersWarningTxSellerInputNonceShare) &&
@@ -151,6 +158,7 @@ public final class NonceSharesMessage implements Proto {
         result = 31 * result + Objects.hashCode(redirectTxFeeBumpAddress);
         result = 31 * result + Objects.hashCode(claimTxPayoutAddress);
         result = 31 * result + Arrays.hashCode(halfDepositPsbt);
+        result = 31 * result + Long.hashCode(redirectionAmountMsat);
         result = 31 * result + Arrays.hashCode(swapTxInputNonceShare);
         result = 31 * result + Arrays.hashCode(buyersWarningTxBuyerInputNonceShare);
         result = 31 * result + Arrays.hashCode(buyersWarningTxSellerInputNonceShare);

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/NonceSharesMessage.java
@@ -31,6 +31,7 @@ public final class NonceSharesMessage implements Proto {
         return new NonceSharesMessage(
                 nonceShares.getWarningTxFeeBumpAddress(),
                 nonceShares.getRedirectTxFeeBumpAddress(),
+                nonceShares.getClaimTxPayoutAddress(),
                 nonceShares.getHalfDepositPsbt(),
                 nonceShares.getSwapTxInputNonceShare(),
                 nonceShares.getBuyersWarningTxBuyerInputNonceShare(),
@@ -38,12 +39,15 @@ public final class NonceSharesMessage implements Proto {
                 nonceShares.getSellersWarningTxBuyerInputNonceShare(),
                 nonceShares.getSellersWarningTxSellerInputNonceShare(),
                 nonceShares.getBuyersRedirectTxInputNonceShare(),
-                nonceShares.getSellersRedirectTxInputNonceShare()
+                nonceShares.getSellersRedirectTxInputNonceShare(),
+                nonceShares.getBuyersClaimTxInputNonceShare(),
+                nonceShares.getSellersClaimTxInputNonceShare()
         );
     }
 
     private final String warningTxFeeBumpAddress;
     private final String redirectTxFeeBumpAddress;
+    private final String claimTxPayoutAddress;
     private final byte[] halfDepositPsbt;
     private final byte[] swapTxInputNonceShare;
     private final byte[] buyersWarningTxBuyerInputNonceShare;
@@ -52,9 +56,12 @@ public final class NonceSharesMessage implements Proto {
     private final byte[] sellersWarningTxSellerInputNonceShare;
     private final byte[] buyersRedirectTxInputNonceShare;
     private final byte[] sellersRedirectTxInputNonceShare;
+    private final byte[] buyersClaimTxInputNonceShare;
+    private final byte[] sellersClaimTxInputNonceShare;
 
     private NonceSharesMessage(String warningTxFeeBumpAddress,
                                String redirectTxFeeBumpAddress,
+                               String claimTxPayoutAddress,
                                byte[] halfDepositPsbt,
                                byte[] swapTxInputNonceShare,
                                byte[] buyersWarningTxBuyerInputNonceShare,
@@ -62,9 +69,12 @@ public final class NonceSharesMessage implements Proto {
                                byte[] sellersWarningTxBuyerInputNonceShare,
                                byte[] sellersWarningTxSellerInputNonceShare,
                                byte[] buyersRedirectTxInputNonceShare,
-                               byte[] sellersRedirectTxInputNonceShare) {
+                               byte[] sellersRedirectTxInputNonceShare,
+                               byte[] buyersClaimTxInputNonceShare,
+                               byte[] sellersClaimTxInputNonceShare) {
         this.warningTxFeeBumpAddress = warningTxFeeBumpAddress;
         this.redirectTxFeeBumpAddress = redirectTxFeeBumpAddress;
+        this.claimTxPayoutAddress = claimTxPayoutAddress;
         this.halfDepositPsbt = halfDepositPsbt;
         this.swapTxInputNonceShare = swapTxInputNonceShare;
         this.buyersWarningTxBuyerInputNonceShare = buyersWarningTxBuyerInputNonceShare;
@@ -73,6 +83,8 @@ public final class NonceSharesMessage implements Proto {
         this.sellersWarningTxSellerInputNonceShare = sellersWarningTxSellerInputNonceShare;
         this.buyersRedirectTxInputNonceShare = buyersRedirectTxInputNonceShare;
         this.sellersRedirectTxInputNonceShare = sellersRedirectTxInputNonceShare;
+        this.buyersClaimTxInputNonceShare = buyersClaimTxInputNonceShare;
+        this.sellersClaimTxInputNonceShare = sellersClaimTxInputNonceShare;
     }
 
     @Override
@@ -80,6 +92,7 @@ public final class NonceSharesMessage implements Proto {
         return bisq.trade.protobuf.NonceSharesMessage.newBuilder()
                 .setWarningTxFeeBumpAddress(warningTxFeeBumpAddress)
                 .setRedirectTxFeeBumpAddress(redirectTxFeeBumpAddress)
+                .setClaimTxPayoutAddress(claimTxPayoutAddress)
                 .setHalfDepositPsbt(ByteString.copyFrom(halfDepositPsbt))
                 .setSwapTxInputNonceShare(ByteString.copyFrom(swapTxInputNonceShare))
                 .setBuyersWarningTxBuyerInputNonceShare(ByteString.copyFrom(buyersWarningTxBuyerInputNonceShare))
@@ -87,7 +100,9 @@ public final class NonceSharesMessage implements Proto {
                 .setSellersWarningTxBuyerInputNonceShare(ByteString.copyFrom(sellersWarningTxBuyerInputNonceShare))
                 .setSellersWarningTxSellerInputNonceShare(ByteString.copyFrom(sellersWarningTxSellerInputNonceShare))
                 .setBuyersRedirectTxInputNonceShare(ByteString.copyFrom(buyersRedirectTxInputNonceShare))
-                .setSellersRedirectTxInputNonceShare(ByteString.copyFrom(sellersRedirectTxInputNonceShare));
+                .setSellersRedirectTxInputNonceShare(ByteString.copyFrom(sellersRedirectTxInputNonceShare))
+                .setBuyersClaimTxInputNonceShare(ByteString.copyFrom(buyersClaimTxInputNonceShare))
+                .setSellersClaimTxInputNonceShare(ByteString.copyFrom(sellersClaimTxInputNonceShare));
     }
 
     @Override
@@ -98,6 +113,7 @@ public final class NonceSharesMessage implements Proto {
     public static NonceSharesMessage fromProto(bisq.trade.protobuf.NonceSharesMessage proto) {
         return new NonceSharesMessage(proto.getWarningTxFeeBumpAddress(),
                 proto.getRedirectTxFeeBumpAddress(),
+                proto.getClaimTxPayoutAddress(),
                 proto.getHalfDepositPsbt().toByteArray(),
                 proto.getSwapTxInputNonceShare().toByteArray(),
                 proto.getBuyersWarningTxBuyerInputNonceShare().toByteArray(),
@@ -105,7 +121,9 @@ public final class NonceSharesMessage implements Proto {
                 proto.getSellersWarningTxBuyerInputNonceShare().toByteArray(),
                 proto.getSellersWarningTxSellerInputNonceShare().toByteArray(),
                 proto.getBuyersRedirectTxInputNonceShare().toByteArray(),
-                proto.getSellersRedirectTxInputNonceShare().toByteArray());
+                proto.getSellersRedirectTxInputNonceShare().toByteArray(),
+                proto.getBuyersClaimTxInputNonceShare().toByteArray(),
+                proto.getSellersClaimTxInputNonceShare().toByteArray());
     }
 
     @Override
@@ -114,6 +132,7 @@ public final class NonceSharesMessage implements Proto {
 
         return Objects.equals(warningTxFeeBumpAddress, that.warningTxFeeBumpAddress) &&
                 Objects.equals(redirectTxFeeBumpAddress, that.redirectTxFeeBumpAddress) &&
+                Objects.equals(claimTxPayoutAddress, that.claimTxPayoutAddress) &&
                 Arrays.equals(halfDepositPsbt, that.halfDepositPsbt) &&
                 Arrays.equals(swapTxInputNonceShare, that.swapTxInputNonceShare) &&
                 Arrays.equals(buyersWarningTxBuyerInputNonceShare, that.buyersWarningTxBuyerInputNonceShare) &&
@@ -121,13 +140,16 @@ public final class NonceSharesMessage implements Proto {
                 Arrays.equals(sellersWarningTxBuyerInputNonceShare, that.sellersWarningTxBuyerInputNonceShare) &&
                 Arrays.equals(sellersWarningTxSellerInputNonceShare, that.sellersWarningTxSellerInputNonceShare) &&
                 Arrays.equals(buyersRedirectTxInputNonceShare, that.buyersRedirectTxInputNonceShare) &&
-                Arrays.equals(sellersRedirectTxInputNonceShare, that.sellersRedirectTxInputNonceShare);
+                Arrays.equals(sellersRedirectTxInputNonceShare, that.sellersRedirectTxInputNonceShare) &&
+                Arrays.equals(buyersClaimTxInputNonceShare, that.buyersClaimTxInputNonceShare) &&
+                Arrays.equals(sellersClaimTxInputNonceShare, that.sellersClaimTxInputNonceShare);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hashCode(warningTxFeeBumpAddress);
         result = 31 * result + Objects.hashCode(redirectTxFeeBumpAddress);
+        result = 31 * result + Objects.hashCode(claimTxPayoutAddress);
         result = 31 * result + Arrays.hashCode(halfDepositPsbt);
         result = 31 * result + Arrays.hashCode(swapTxInputNonceShare);
         result = 31 * result + Arrays.hashCode(buyersWarningTxBuyerInputNonceShare);
@@ -136,6 +158,8 @@ public final class NonceSharesMessage implements Proto {
         result = 31 * result + Arrays.hashCode(sellersWarningTxSellerInputNonceShare);
         result = 31 * result + Arrays.hashCode(buyersRedirectTxInputNonceShare);
         result = 31 * result + Arrays.hashCode(sellersRedirectTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersClaimTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersClaimTxInputNonceShare);
         return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesMessage.java
@@ -33,6 +33,7 @@ public final class PartialSignaturesMessage implements Proto {
                 peersPartialSignatures.getPeersWarningTxBuyerInputPartialSignature(),
                 peersPartialSignatures.getPeersWarningTxSellerInputPartialSignature(),
                 peersPartialSignatures.getPeersRedirectTxInputPartialSignature(),
+                peersPartialSignatures.getPeersClaimTxInputPartialSignature(),
                 peersPartialSignatures.getSwapTxInputPartialSignature(),
                 peersPartialSignatures.getSwapTxInputSighash()
         );
@@ -41,17 +42,20 @@ public final class PartialSignaturesMessage implements Proto {
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
+    private final byte[] peersClaimTxInputPartialSignature;
     private final Optional<byte[]> swapTxInputPartialSignature;
     private final Optional<byte[]> swapTxInputSighash;
 
     public PartialSignaturesMessage(byte[] peersWarningTxBuyerInputPartialSignature,
                                     byte[] peersWarningTxSellerInputPartialSignature,
                                     byte[] peersRedirectTxInputPartialSignature,
+                                    byte[] peersClaimTxInputPartialSignature,
                                     Optional<byte[]> swapTxInputPartialSignature,
                                     Optional<byte[]> swapTxInputSighash) {
         this.peersWarningTxBuyerInputPartialSignature = peersWarningTxBuyerInputPartialSignature;
         this.peersWarningTxSellerInputPartialSignature = peersWarningTxSellerInputPartialSignature;
         this.peersRedirectTxInputPartialSignature = peersRedirectTxInputPartialSignature;
+        this.peersClaimTxInputPartialSignature = peersClaimTxInputPartialSignature;
         this.swapTxInputPartialSignature = swapTxInputPartialSignature;
         this.swapTxInputSighash = swapTxInputSighash;
     }
@@ -61,7 +65,8 @@ public final class PartialSignaturesMessage implements Proto {
         bisq.trade.protobuf.PartialSignaturesMessage.Builder builder = bisq.trade.protobuf.PartialSignaturesMessage.newBuilder()
                 .setPeersWarningTxBuyerInputPartialSignature(ByteString.copyFrom(peersWarningTxBuyerInputPartialSignature))
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
-                .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature));
+                .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature))
+                .setPeersClaimTxInputPartialSignature(ByteString.copyFrom(peersClaimTxInputPartialSignature));
         swapTxInputPartialSignature.ifPresent(e -> builder.setSwapTxInputPartialSignature(ByteString.copyFrom(e)));
         swapTxInputSighash.ifPresent(e -> builder.setSwapTxInputSighash(ByteString.copyFrom(e)));
         return builder;
@@ -76,6 +81,7 @@ public final class PartialSignaturesMessage implements Proto {
         return new PartialSignaturesMessage(proto.getPeersWarningTxBuyerInputPartialSignature().toByteArray(),
                 proto.getPeersWarningTxSellerInputPartialSignature().toByteArray(),
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
+                proto.getPeersClaimTxInputPartialSignature().toByteArray(),
                 proto.hasSwapTxInputPartialSignature()
                         ? Optional.of(proto.getSwapTxInputPartialSignature().toByteArray())
                         : Optional.empty(),
@@ -92,6 +98,7 @@ public final class PartialSignaturesMessage implements Proto {
         return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
                 Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
                 Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
+                Arrays.equals(peersClaimTxInputPartialSignature, that.peersClaimTxInputPartialSignature) &&
                 OptionalUtils.optionalByteArrayEquals(swapTxInputPartialSignature, that.swapTxInputPartialSignature) &&
                 OptionalUtils.optionalByteArrayEquals(swapTxInputSighash, that.swapTxInputSighash);
     }
@@ -101,6 +108,7 @@ public final class PartialSignaturesMessage implements Proto {
         int result = Arrays.hashCode(peersWarningTxBuyerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(peersClaimTxInputPartialSignature);
         result = 31 * result + swapTxInputPartialSignature.map(Arrays::hashCode).orElse(0);
         result = 31 * result + swapTxInputSighash.map(Arrays::hashCode).orElse(0);
         return result;

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PartialSignaturesRequest.java
@@ -29,16 +29,16 @@ import java.util.stream.Collectors;
 public final class PartialSignaturesRequest implements Proto {
     private final String tradeId;
     private final NonceSharesMessage peersNonceShares;
-    private final List<ReceiverAddressAndAmount> receivers;
+    private final List<ReceiverAddressAndAmount> redirectionReceivers;
     private final boolean buyerReadyToRelease;
 
     public PartialSignaturesRequest(String tradeId,
                                     NonceSharesMessage peersNonceShares,
-                                    List<ReceiverAddressAndAmount> receivers,
+                                    List<ReceiverAddressAndAmount> redirectionReceivers,
                                     boolean buyerReadyToRelease) {
         this.tradeId = tradeId;
         this.peersNonceShares = peersNonceShares;
-        this.receivers = receivers;
+        this.redirectionReceivers = redirectionReceivers;
         this.buyerReadyToRelease = buyerReadyToRelease;
     }
 
@@ -47,7 +47,7 @@ public final class PartialSignaturesRequest implements Proto {
         return bisq.trade.protobuf.PartialSignaturesRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setPeersNonceShares(peersNonceShares.toProto(serializeForHash))
-                .addAllReceivers(receivers.stream()
+                .addAllRedirectionReceivers(redirectionReceivers.stream()
                         .map(e -> e.toProto(serializeForHash))
                         .collect(Collectors.toList()))
                 .setBuyerReadyToRelease(buyerReadyToRelease);
@@ -61,7 +61,7 @@ public final class PartialSignaturesRequest implements Proto {
     public static PartialSignaturesRequest fromProto(bisq.trade.protobuf.PartialSignaturesRequest proto) {
         return new PartialSignaturesRequest(proto.getTradeId(),
                 NonceSharesMessage.fromProto(proto.getPeersNonceShares()),
-                proto.getReceiversList().stream()
+                proto.getRedirectionReceiversList().stream()
                         .map(ReceiverAddressAndAmount::fromProto)
                         .collect(Collectors.toList()),
                 proto.getBuyerReadyToRelease());

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PublishDepositTxRequest.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/grpc/PublishDepositTxRequest.java
@@ -25,19 +25,19 @@ import lombok.Getter;
 @EqualsAndHashCode
 public final class PublishDepositTxRequest implements Proto {
     private final String tradeId;
-    private final DepositPsbt depositPsbt;
+    private final DepositPsbt peersDepositPsbt;
 
     public PublishDepositTxRequest(String tradeId,
-                                   DepositPsbt depositPsbt) {
+                                   DepositPsbt peersDepositPsbt) {
         this.tradeId = tradeId;
-        this.depositPsbt = depositPsbt;
+        this.peersDepositPsbt = peersDepositPsbt;
     }
 
     @Override
     public bisq.trade.protobuf.PublishDepositTxRequest.Builder getBuilder(boolean serializeForHash) {
         return bisq.trade.protobuf.PublishDepositTxRequest.newBuilder()
                 .setTradeId(tradeId)
-                .setDepositPsbt(depositPsbt.toProto(serializeForHash));
+                .setPeersDepositPsbt(peersDepositPsbt.toProto(serializeForHash));
     }
 
     @Override
@@ -47,6 +47,6 @@ public final class PublishDepositTxRequest implements Proto {
 
     public static PublishDepositTxRequest fromProto(bisq.trade.protobuf.PublishDepositTxRequest proto) {
         return new PublishDepositTxRequest(proto.getTradeId(),
-                DepositPsbt.fromProto(proto.getDepositPsbt()));
+                DepositPsbt.fromProto(proto.getPeersDepositPsbt()));
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/NonceSharesRequestUtil.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/NonceSharesRequestUtil.java
@@ -18,8 +18,8 @@
 package bisq.trade.mu_sig.messages.network.handler;
 
 import bisq.common.market.Market;
+import bisq.trade.mu_sig.MuSigFeeRateProvider;
 import bisq.trade.mu_sig.MuSigTrade;
-import bisq.trade.mu_sig.MusSigFeeRateProvider;
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
 
 public class NonceSharesRequestUtil {
@@ -35,11 +35,11 @@ public class NonceSharesRequestUtil {
     }
 
     public static long getDepositTxFeeRate() {
-        return MusSigFeeRateProvider.getDepositTxFeeRate();
+        return MuSigFeeRateProvider.getDepositTxFeeRate();
     }
 
     public static long getPreparedTxFeeRate() {
-        return MusSigFeeRateProvider.getPreparedTxFeeRate();
+        return MuSigFeeRateProvider.getPreparedTxFeeRate();
     }
 
     public static long getBuyerSecurityDeposit() {

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/NonceSharesRequestUtil.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/NonceSharesRequestUtil.java
@@ -20,6 +20,7 @@ package bisq.trade.mu_sig.messages.network.handler;
 import bisq.common.market.Market;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MusSigFeeRateProvider;
+import bisq.trade.protobuf.ReceiverAddressAndAmount;
 
 public class NonceSharesRequestUtil {
     public static long getTradeAmount(MuSigTrade trade) {
@@ -49,5 +50,22 @@ public class NonceSharesRequestUtil {
     public static long getSellersSecurityDeposit() {
         // TODO get from CollateralOptions
         return 30_000;
+    }
+
+    public static ReceiverAddressAndAmount getTradeFeeReceiver() {
+        // NOTE: As implemented right now on the Rust side, the seller pays the entire trade fee (including the small
+        //  amount needed to cover the increase in the mining fee from the optional trade fee output). In order to split
+        //  the trade fee differently, the specified _buyer_ security deposit (but not the specified seller security
+        //  deposit, which may be different) can be adjusted upwards by X sats, and the trade amount can be adjusted
+        //  downwards by X sats. This has the effect of transferring an extra X sats from the buyer to the seller at the
+        //  start of the trade. Thus, the Rust server would be using adjusted trade params (amount + security deposits)
+        //  that are slightly different to those presented to the user on the Java side.
+
+        // TODO: Determine the correct amount and pick address non-uniformly at random from oracle-provided BM list.
+        //noinspection SpellCheckingInspection
+        return ReceiverAddressAndAmount.newBuilder()
+                .setAddress("bcrt1qwk6p86mzqmstcsg99qlu2mhsp3766u68jktv6k")
+                .setAmount(5_000)
+                .build();
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/PartialSignaturesRequestUtil.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/PartialSignaturesRequestUtil.java
@@ -17,30 +17,27 @@
 
 package bisq.trade.mu_sig.messages.network.handler;
 
+import bisq.burningman.BurningmanData;
+import bisq.trade.mu_sig.DelayedPayoutTxReceiverService;
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
 import com.google.common.collect.ImmutableMap;
-import lombok.extern.slf4j.Slf4j;
 
-import java.util.stream.Collectors;
-
-@Slf4j
 public class PartialSignaturesRequestUtil {
     // TODO We need to publish from the oracle data from bisq 1 to bisq 2 network so that the BM
     // addresses and receiver shares are accessible.
     // As this data is p2p network data we need some tolerance handling in case the traders have a different view of the
     // p2p network data.
     public static Iterable<ReceiverAddressAndAmount> getBurningMenDPTReceivers(long redirectionAmountMsat) {
-        // TODO: To prevent server-side errors/warnings, the receiver costs (amount + tx fee cost of each output) should
-        //  sum exactly to the redirectionAmountMsat quantity computed by the server.
-        log.warn("Ignoring redirectionAmountMsat {} received from the MuSig server.", redirectionAmountMsat);
         //noinspection SpellCheckingInspection
-        return ImmutableMap.of(
-                        "bcrt1phc8m8vansnl4utths947mjquprw20puwrrdfrwx8akeeu2tqwklsnxsvf0", 200_000,
-                        "bcrt1qwk6p86mzqmstcsg99qlu2mhsp3766u68jktv6k", 80_000,
-                        "2N2x2bA28AsLZZEHss4SjFoyToQV5YYZsJM", 12_345
+        var burningmanShares = ImmutableMap.of(
+                        "bcrt1phc8m8vansnl4utths947mjquprw20puwrrdfrwx8akeeu2tqwklsnxsvf0", 0.6,
+                        "bcrt1qwk6p86mzqmstcsg99qlu2mhsp3766u68jktv6k", 0.3,
+                        "2N2x2bA28AsLZZEHss4SjFoyToQV5YYZsJM", 0.1
                 )
                 .entrySet().stream()
-                .map(e -> ReceiverAddressAndAmount.newBuilder().setAddress(e.getKey()).setAmount(e.getValue()).build())
-                .collect(Collectors.toList());
+                .map(e -> new BurningmanData(e.getKey(), e.getValue()))
+                .toList();
+        long feeRate = NonceSharesRequestUtil.getPreparedTxFeeRate();
+        return DelayedPayoutTxReceiverService.computeReceivers(burningmanShares, redirectionAmountMsat, feeRate);
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/PartialSignaturesRequestUtil.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/PartialSignaturesRequestUtil.java
@@ -19,18 +19,24 @@ package bisq.trade.mu_sig.messages.network.handler;
 
 import bisq.trade.protobuf.ReceiverAddressAndAmount;
 import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.stream.Collectors;
 
+@Slf4j
 public class PartialSignaturesRequestUtil {
     // TODO We need to publish from the oracle data from bisq 1 to bisq 2 network so that the BM
     // addresses and receiver shares are accessible.
     // As this data is p2p network data we need some tolerance handling in case the traders have a different view of the
     // p2p network data.
-    public static Iterable<ReceiverAddressAndAmount> getBurningMenDPTReceivers() {
+    public static Iterable<ReceiverAddressAndAmount> getBurningMenDPTReceivers(long redirectionAmountMsat) {
+        // TODO: To prevent server-side errors/warnings, the receiver costs (amount + tx fee cost of each output) should
+        //  sum exactly to the redirectionAmountMsat quantity computed by the server.
+        log.warn("Ignoring redirectionAmountMsat {} received from the MuSig server.", redirectionAmountMsat);
+        //noinspection SpellCheckingInspection
         return ImmutableMap.of(
-                        "tb1pwxlp4v9v7v03nx0e7vunlc87d4936wnyqegw0fuahudypan64wys5stxh7", 200_000,
-                        "tb1qpg889v22f3gefuvwpe3963t5a00nvfmkhlgqw5", 80_000,
+                        "bcrt1phc8m8vansnl4utths947mjquprw20puwrrdfrwx8akeeu2tqwklsnxsvf0", 200_000,
+                        "bcrt1qwk6p86mzqmstcsg99qlu2mhsp3766u68jktv6k", 80_000,
                         "2N2x2bA28AsLZZEHss4SjFoyToQV5YYZsJM", 12_345
                 )
                 .entrySet().stream()

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSetupTradeMessage_C_Handler.java
@@ -59,7 +59,7 @@ public abstract class BaseSetupTradeMessage_C_Handler extends MuSigTradeMessageH
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersNonceShares(peersNonceSharesMessage.toProto(true))
-                .addAllReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers())
+                .addAllRedirectionReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers())
                 .build();
         myPartialSignaturesMessage = PartialSignaturesMessage.fromProto(blockingStub.getPartialSignatures(partialSignaturesRequest));
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSetupTradeMessage_C_Handler.java
@@ -53,13 +53,15 @@ public abstract class BaseSetupTradeMessage_C_Handler extends MuSigTradeMessageH
     protected void process(SetupTradeMessage_C message) {
         peersNonceShares = message.getNonceShares();
         peersPartialSignatures = message.getPartialSignatures();
+        long redirectionAmountMsat = trade.getMyself().getMyNonceSharesMessage()
+                .orElseThrow().getRedirectionAmountMsat();
 
         NonceSharesMessage peersNonceSharesMessage = NonceSharesMessage.from(peersNonceShares);
 
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersNonceShares(peersNonceSharesMessage.toProto(true))
-                .addAllRedirectionReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers())
+                .addAllRedirectionReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers(redirectionAmountMsat))
                 .build();
         myPartialSignaturesMessage = PartialSignaturesMessage.fromProto(blockingStub.getPartialSignatures(partialSignaturesRequest));
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
@@ -100,6 +100,7 @@ public final class SetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerA
                 .setTradeAmount(NonceSharesRequestUtil.getTradeAmount(trade))
                 .setBuyersSecurityDeposit(NonceSharesRequestUtil.getBuyerSecurityDeposit())
                 .setSellersSecurityDeposit(NonceSharesRequestUtil.getSellersSecurityDeposit())
+                .setTradeFeeReceiver(NonceSharesRequestUtil.getTradeFeeReceiver())
                 .build();
         myNonceSharesMessage = NonceSharesMessage.fromProto(blockingStub.getNonceShares(nonceSharesRequest));
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_B_Handler.java
@@ -73,12 +73,13 @@ public abstract class BaseSetupTradeMessage_B_Handler extends MuSigTradeMessageH
                 .setSellersSecurityDeposit(NonceSharesRequestUtil.getSellersSecurityDeposit())
                 .build();
         myNonceSharesMessage = NonceSharesMessage.fromProto(blockingStub.getNonceShares(nonceSharesRequest));
+        long redirectionAmountMsat = myNonceSharesMessage.getRedirectionAmountMsat();
 
         NonceSharesMessage peersNonceSharesMessage = NonceSharesMessage.from(peersNonceShares);
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersNonceShares(peersNonceSharesMessage.toProto(true))
-                .addAllRedirectionReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers())
+                .addAllRedirectionReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers(redirectionAmountMsat))
                 .build();
         myPartialSignaturesMessage = PartialSignaturesMessage.fromProto(blockingStub.getPartialSignatures(partialSignaturesRequest));
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_B_Handler.java
@@ -78,7 +78,7 @@ public abstract class BaseSetupTradeMessage_B_Handler extends MuSigTradeMessageH
         PartialSignaturesRequest partialSignaturesRequest = PartialSignaturesRequest.newBuilder()
                 .setTradeId(trade.getId())
                 .setPeersNonceShares(peersNonceSharesMessage.toProto(true))
-                .addAllReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers())
+                .addAllRedirectionReceivers(PartialSignaturesRequestUtil.getBurningMenDPTReceivers())
                 .build();
         myPartialSignaturesMessage = PartialSignaturesMessage.fromProto(blockingStub.getPartialSignatures(partialSignaturesRequest));
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_B_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_B_Handler.java
@@ -71,6 +71,7 @@ public abstract class BaseSetupTradeMessage_B_Handler extends MuSigTradeMessageH
                 .setTradeAmount(NonceSharesRequestUtil.getTradeAmount(trade))
                 .setBuyersSecurityDeposit(NonceSharesRequestUtil.getBuyerSecurityDeposit())
                 .setSellersSecurityDeposit(NonceSharesRequestUtil.getSellersSecurityDeposit())
+                .setTradeFeeReceiver(NonceSharesRequestUtil.getTradeFeeReceiver())
                 .build();
         myNonceSharesMessage = NonceSharesMessage.fromProto(blockingStub.getNonceShares(nonceSharesRequest));
         long redirectionAmountMsat = myNonceSharesMessage.getRedirectionAmountMsat();

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_D_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_D_Handler.java
@@ -59,7 +59,7 @@ public abstract class BaseSetupTradeMessage_D_Handler extends MuSigTradeMessageH
 
         PublishDepositTxRequest publishDepositTxRequest = PublishDepositTxRequest.newBuilder()
                 .setTradeId(trade.getId())
-                .setDepositPsbt(myDepositPsbt.toProto(true))
+                .setPeersDepositPsbt(myDepositPsbt.toProto(true))
                 .build();
         blockingStub.publishDepositTx(publishDepositTxRequest);
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/NonceShares.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/NonceShares.java
@@ -31,6 +31,7 @@ public final class NonceShares implements NetworkProto {
         return new NonceShares(
                 nonceSharesMessage.getWarningTxFeeBumpAddress(),
                 nonceSharesMessage.getRedirectTxFeeBumpAddress(),
+                nonceSharesMessage.getClaimTxPayoutAddress(),
                 nonceSharesMessage.getHalfDepositPsbt().clone(),
                 nonceSharesMessage.getSwapTxInputNonceShare().clone(),
                 nonceSharesMessage.getBuyersWarningTxBuyerInputNonceShare().clone(),
@@ -38,12 +39,15 @@ public final class NonceShares implements NetworkProto {
                 nonceSharesMessage.getSellersWarningTxBuyerInputNonceShare().clone(),
                 nonceSharesMessage.getSellersWarningTxSellerInputNonceShare().clone(),
                 nonceSharesMessage.getBuyersRedirectTxInputNonceShare().clone(),
-                nonceSharesMessage.getSellersRedirectTxInputNonceShare().clone()
+                nonceSharesMessage.getSellersRedirectTxInputNonceShare().clone(),
+                nonceSharesMessage.getBuyersClaimTxInputNonceShare().clone(),
+                nonceSharesMessage.getSellersClaimTxInputNonceShare().clone()
         );
     }
 
     private final String warningTxFeeBumpAddress;
     private final String redirectTxFeeBumpAddress;
+    private final String claimTxPayoutAddress;
     private final byte[] halfDepositPsbt;
     private final byte[] swapTxInputNonceShare;
     private final byte[] buyersWarningTxBuyerInputNonceShare;
@@ -52,19 +56,25 @@ public final class NonceShares implements NetworkProto {
     private final byte[] sellersWarningTxSellerInputNonceShare;
     private final byte[] buyersRedirectTxInputNonceShare;
     private final byte[] sellersRedirectTxInputNonceShare;
+    private final byte[] buyersClaimTxInputNonceShare;
+    private final byte[] sellersClaimTxInputNonceShare;
 
     private NonceShares(String warningTxFeeBumpAddress,
-                       String redirectTxFeeBumpAddress,
-                       byte[] halfDepositPsbt,
-                       byte[] swapTxInputNonceShare,
-                       byte[] buyersWarningTxBuyerInputNonceShare,
-                       byte[] buyersWarningTxSellerInputNonceShare,
-                       byte[] sellersWarningTxBuyerInputNonceShare,
-                       byte[] sellersWarningTxSellerInputNonceShare,
-                       byte[] buyersRedirectTxInputNonceShare,
-                       byte[] sellersRedirectTxInputNonceShare) {
+                        String redirectTxFeeBumpAddress,
+                        String claimTxPayoutAddress,
+                        byte[] halfDepositPsbt,
+                        byte[] swapTxInputNonceShare,
+                        byte[] buyersWarningTxBuyerInputNonceShare,
+                        byte[] buyersWarningTxSellerInputNonceShare,
+                        byte[] sellersWarningTxBuyerInputNonceShare,
+                        byte[] sellersWarningTxSellerInputNonceShare,
+                        byte[] buyersRedirectTxInputNonceShare,
+                        byte[] sellersRedirectTxInputNonceShare,
+                        byte[] buyersClaimTxInputNonceShare,
+                        byte[] sellersClaimTxInputNonceShare) {
         this.warningTxFeeBumpAddress = warningTxFeeBumpAddress;
         this.redirectTxFeeBumpAddress = redirectTxFeeBumpAddress;
+        this.claimTxPayoutAddress = claimTxPayoutAddress;
         this.halfDepositPsbt = halfDepositPsbt;
         this.swapTxInputNonceShare = swapTxInputNonceShare;
         this.buyersWarningTxBuyerInputNonceShare = buyersWarningTxBuyerInputNonceShare;
@@ -73,6 +83,8 @@ public final class NonceShares implements NetworkProto {
         this.sellersWarningTxSellerInputNonceShare = sellersWarningTxSellerInputNonceShare;
         this.buyersRedirectTxInputNonceShare = buyersRedirectTxInputNonceShare;
         this.sellersRedirectTxInputNonceShare = sellersRedirectTxInputNonceShare;
+        this.buyersClaimTxInputNonceShare = buyersClaimTxInputNonceShare;
+        this.sellersClaimTxInputNonceShare = sellersClaimTxInputNonceShare;
 
         verify();
     }
@@ -87,6 +99,7 @@ public final class NonceShares implements NetworkProto {
         return bisq.trade.protobuf.NonceShares.newBuilder()
                 .setWarningTxFeeBumpAddress(warningTxFeeBumpAddress)
                 .setRedirectTxFeeBumpAddress(redirectTxFeeBumpAddress)
+                .setClaimTxPayoutAddress(claimTxPayoutAddress)
                 .setHalfDepositPsbt(ByteString.copyFrom(halfDepositPsbt))
                 .setSwapTxInputNonceShare(ByteString.copyFrom(swapTxInputNonceShare))
                 .setBuyersWarningTxBuyerInputNonceShare(ByteString.copyFrom(buyersWarningTxBuyerInputNonceShare))
@@ -94,7 +107,9 @@ public final class NonceShares implements NetworkProto {
                 .setSellersWarningTxBuyerInputNonceShare(ByteString.copyFrom(sellersWarningTxBuyerInputNonceShare))
                 .setSellersWarningTxSellerInputNonceShare(ByteString.copyFrom(sellersWarningTxSellerInputNonceShare))
                 .setBuyersRedirectTxInputNonceShare(ByteString.copyFrom(buyersRedirectTxInputNonceShare))
-                .setSellersRedirectTxInputNonceShare(ByteString.copyFrom(sellersRedirectTxInputNonceShare));
+                .setSellersRedirectTxInputNonceShare(ByteString.copyFrom(sellersRedirectTxInputNonceShare))
+                .setBuyersClaimTxInputNonceShare(ByteString.copyFrom(buyersClaimTxInputNonceShare))
+                .setSellersClaimTxInputNonceShare(ByteString.copyFrom(sellersClaimTxInputNonceShare));
     }
 
     @Override
@@ -105,6 +120,7 @@ public final class NonceShares implements NetworkProto {
     public static NonceShares fromProto(bisq.trade.protobuf.NonceShares proto) {
         return new NonceShares(proto.getWarningTxFeeBumpAddress(),
                 proto.getRedirectTxFeeBumpAddress(),
+                proto.getClaimTxPayoutAddress(),
                 proto.getHalfDepositPsbt().toByteArray(),
                 proto.getSwapTxInputNonceShare().toByteArray(),
                 proto.getBuyersWarningTxBuyerInputNonceShare().toByteArray(),
@@ -112,7 +128,9 @@ public final class NonceShares implements NetworkProto {
                 proto.getSellersWarningTxBuyerInputNonceShare().toByteArray(),
                 proto.getSellersWarningTxSellerInputNonceShare().toByteArray(),
                 proto.getBuyersRedirectTxInputNonceShare().toByteArray(),
-                proto.getSellersRedirectTxInputNonceShare().toByteArray());
+                proto.getSellersRedirectTxInputNonceShare().toByteArray(),
+                proto.getBuyersClaimTxInputNonceShare().toByteArray(),
+                proto.getSellersClaimTxInputNonceShare().toByteArray());
     }
 
     @Override
@@ -121,6 +139,7 @@ public final class NonceShares implements NetworkProto {
 
         return Objects.equals(warningTxFeeBumpAddress, that.warningTxFeeBumpAddress) &&
                 Objects.equals(redirectTxFeeBumpAddress, that.redirectTxFeeBumpAddress) &&
+                Objects.equals(claimTxPayoutAddress, that.claimTxPayoutAddress) &&
                 Arrays.equals(halfDepositPsbt, that.halfDepositPsbt) &&
                 Arrays.equals(swapTxInputNonceShare, that.swapTxInputNonceShare) &&
                 Arrays.equals(buyersWarningTxBuyerInputNonceShare, that.buyersWarningTxBuyerInputNonceShare) &&
@@ -128,13 +147,16 @@ public final class NonceShares implements NetworkProto {
                 Arrays.equals(sellersWarningTxBuyerInputNonceShare, that.sellersWarningTxBuyerInputNonceShare) &&
                 Arrays.equals(sellersWarningTxSellerInputNonceShare, that.sellersWarningTxSellerInputNonceShare) &&
                 Arrays.equals(buyersRedirectTxInputNonceShare, that.buyersRedirectTxInputNonceShare) &&
-                Arrays.equals(sellersRedirectTxInputNonceShare, that.sellersRedirectTxInputNonceShare);
+                Arrays.equals(sellersRedirectTxInputNonceShare, that.sellersRedirectTxInputNonceShare) &&
+                Arrays.equals(buyersClaimTxInputNonceShare, that.buyersClaimTxInputNonceShare) &&
+                Arrays.equals(sellersClaimTxInputNonceShare, that.sellersClaimTxInputNonceShare);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hashCode(warningTxFeeBumpAddress);
         result = 31 * result + Objects.hashCode(redirectTxFeeBumpAddress);
+        result = 31 * result + Objects.hashCode(claimTxPayoutAddress);
         result = 31 * result + Arrays.hashCode(halfDepositPsbt);
         result = 31 * result + Arrays.hashCode(swapTxInputNonceShare);
         result = 31 * result + Arrays.hashCode(buyersWarningTxBuyerInputNonceShare);
@@ -143,6 +165,8 @@ public final class NonceShares implements NetworkProto {
         result = 31 * result + Arrays.hashCode(sellersWarningTxSellerInputNonceShare);
         result = 31 * result + Arrays.hashCode(buyersRedirectTxInputNonceShare);
         result = 31 * result + Arrays.hashCode(sellersRedirectTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(buyersClaimTxInputNonceShare);
+        result = 31 * result + Arrays.hashCode(sellersClaimTxInputNonceShare);
         return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/PartialSignatures.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/PartialSignatures.java
@@ -39,6 +39,7 @@ public final class PartialSignatures implements NetworkProto {
                 partialSignaturesMessage.getPeersWarningTxBuyerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersWarningTxSellerInputPartialSignature().clone(),
                 partialSignaturesMessage.getPeersRedirectTxInputPartialSignature().clone(),
+                partialSignaturesMessage.getPeersClaimTxInputPartialSignature().clone(),
                 swapTxInputPartialSignature,
                 partialSignaturesMessage.getSwapTxInputSighash().map(byte[]::clone)
         );
@@ -52,6 +53,7 @@ public final class PartialSignatures implements NetworkProto {
                 redactedPartialSignatures.getPeersWarningTxBuyerInputPartialSignature().clone(),
                 redactedPartialSignatures.getPeersWarningTxSellerInputPartialSignature().clone(),
                 redactedPartialSignatures.getPeersRedirectTxInputPartialSignature().clone(),
+                redactedPartialSignatures.getPeersClaimTxInputPartialSignature().clone(),
                 Optional.of(swapTxInputPartialSignature.clone()),
                 redactedPartialSignatures.getSwapTxInputSighash().map(byte[]::clone)
         );
@@ -60,17 +62,20 @@ public final class PartialSignatures implements NetworkProto {
     private final byte[] peersWarningTxBuyerInputPartialSignature;
     private final byte[] peersWarningTxSellerInputPartialSignature;
     private final byte[] peersRedirectTxInputPartialSignature;
+    private final byte[] peersClaimTxInputPartialSignature;
     private final Optional<byte[]> swapTxInputPartialSignature;
     private final Optional<byte[]> swapTxInputSighash;
 
     private PartialSignatures(byte[] peersWarningTxBuyerInputPartialSignature,
                               byte[] peersWarningTxSellerInputPartialSignature,
                               byte[] peersRedirectTxInputPartialSignature,
+                              byte[] peersClaimTxInputPartialSignature,
                               Optional<byte[]> swapTxInputPartialSignature,
                               Optional<byte[]> swapTxInputSighash) {
         this.peersWarningTxBuyerInputPartialSignature = peersWarningTxBuyerInputPartialSignature;
         this.peersWarningTxSellerInputPartialSignature = peersWarningTxSellerInputPartialSignature;
         this.peersRedirectTxInputPartialSignature = peersRedirectTxInputPartialSignature;
+        this.peersClaimTxInputPartialSignature = peersClaimTxInputPartialSignature;
         this.swapTxInputPartialSignature = swapTxInputPartialSignature;
         this.swapTxInputSighash = swapTxInputSighash;
 
@@ -87,7 +92,8 @@ public final class PartialSignatures implements NetworkProto {
         bisq.trade.protobuf.PartialSignatures.Builder builder = bisq.trade.protobuf.PartialSignatures.newBuilder()
                 .setPeersWarningTxBuyerInputPartialSignature(ByteString.copyFrom(peersWarningTxBuyerInputPartialSignature))
                 .setPeersWarningTxSellerInputPartialSignature(ByteString.copyFrom(peersWarningTxSellerInputPartialSignature))
-                .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature));
+                .setPeersRedirectTxInputPartialSignature(ByteString.copyFrom(peersRedirectTxInputPartialSignature))
+                .setPeersClaimTxInputPartialSignature(ByteString.copyFrom(peersClaimTxInputPartialSignature));
         swapTxInputPartialSignature.ifPresent(e -> builder.setSwapTxInputPartialSignature(ByteString.copyFrom(e)));
         swapTxInputSighash.ifPresent(e -> builder.setSwapTxInputSighash(ByteString.copyFrom(e)));
         return builder;
@@ -102,6 +108,7 @@ public final class PartialSignatures implements NetworkProto {
         return new PartialSignatures(proto.getPeersWarningTxBuyerInputPartialSignature().toByteArray(),
                 proto.getPeersWarningTxSellerInputPartialSignature().toByteArray(),
                 proto.getPeersRedirectTxInputPartialSignature().toByteArray(),
+                proto.getPeersClaimTxInputPartialSignature().toByteArray(),
                 proto.hasSwapTxInputPartialSignature()
                         ? Optional.of(proto.getSwapTxInputPartialSignature().toByteArray())
                         : Optional.empty(),
@@ -117,6 +124,7 @@ public final class PartialSignatures implements NetworkProto {
         return Arrays.equals(peersWarningTxBuyerInputPartialSignature, that.peersWarningTxBuyerInputPartialSignature) &&
                 Arrays.equals(peersWarningTxSellerInputPartialSignature, that.peersWarningTxSellerInputPartialSignature) &&
                 Arrays.equals(peersRedirectTxInputPartialSignature, that.peersRedirectTxInputPartialSignature) &&
+                Arrays.equals(peersClaimTxInputPartialSignature, that.peersClaimTxInputPartialSignature) &&
                 OptionalUtils.optionalByteArrayEquals(swapTxInputPartialSignature, that.swapTxInputPartialSignature) &&
                 OptionalUtils.optionalByteArrayEquals(swapTxInputSighash, that.swapTxInputSighash);
     }
@@ -126,6 +134,7 @@ public final class PartialSignatures implements NetworkProto {
         int result = Arrays.hashCode(peersWarningTxBuyerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersWarningTxSellerInputPartialSignature);
         result = 31 * result + Arrays.hashCode(peersRedirectTxInputPartialSignature);
+        result = 31 * result + Arrays.hashCode(peersClaimTxInputPartialSignature);
         result = 31 * result + swapTxInputPartialSignature.map(Arrays::hashCode).orElse(0);
         result = 31 * result + swapTxInputSighash.map(Arrays::hashCode).orElse(0);
         return result;

--- a/trade/src/main/proto/rpc.proto
+++ b/trade/src/main/proto/rpc.proto
@@ -23,7 +23,7 @@ option java_package = "bisq.trade.protobuf";
 option java_multiple_files = true;
 
 /**
- * Same as teh rpc.proto from https://github.com/bisq-network/bisq-musig/blob/main/rpc/src/main/proto/rpc.proto
+ * Same as the rpc.proto from https://github.com/bisq-network/bisq-musig/blob/main/rpc/src/main/proto/rpc.proto
  */
 service Musig {
   rpc InitTrade (PubKeySharesRequest) returns (PubKeySharesResponse);
@@ -59,24 +59,27 @@ message PubKeySharesRequest {
 message PubKeySharesResponse {
   bytes buyerOutputPubKeyShare = 1;
   bytes sellerOutputPubKeyShare = 2;
-  sint32 currentBlockHeight = 3;
+  uint32 currentBlockHeight = 3;
 }
 
 message NonceSharesRequest {
   string tradeId = 1;
   bytes buyerOutputPeersPubKeyShare = 2;
   bytes sellerOutputPeersPubKeyShare = 3;
-  sint64 depositTxFeeRate = 4;       // sats per kwu
-  sint64 preparedTxFeeRate = 5;      // sats per kwu
-  sint64 tradeAmount = 6;            // sats
-  sint64 buyersSecurityDeposit = 7;  // sats
-  sint64 sellersSecurityDeposit = 8; // sats
+  uint64 depositTxFeeRate = 4;       // sats per kwu
+  uint64 preparedTxFeeRate = 5;      // sats per kwu
+  uint64 tradeAmount = 6;            // sats
+  uint64 buyersSecurityDeposit = 7;  // sats
+  uint64 sellersSecurityDeposit = 8; // sats
+  ReceiverAddressAndAmount tradeFeeReceiver = 9;
 }
 
 message NonceSharesMessage {
   string warningTxFeeBumpAddress = 1;
   string redirectTxFeeBumpAddress = 2;
+  string claimTxPayoutAddress = 11;
   bytes halfDepositPsbt = 3;
+  uint64 redirectionAmountMsat = 14; // (millisatoshis)
   bytes swapTxInputNonceShare = 4;
   bytes buyersWarningTxBuyerInputNonceShare = 5;
   bytes buyersWarningTxSellerInputNonceShare = 6;
@@ -84,17 +87,19 @@ message NonceSharesMessage {
   bytes sellersWarningTxSellerInputNonceShare = 8;
   bytes buyersRedirectTxInputNonceShare = 9;
   bytes sellersRedirectTxInputNonceShare = 10;
+  bytes buyersClaimTxInputNonceShare = 12;
+  bytes sellersClaimTxInputNonceShare = 13;
 }
 
 message ReceiverAddressAndAmount {
   string address = 1;
-  sint64 amount = 2; // sats
+  uint64 amount = 2; // sats
 }
 
 message PartialSignaturesRequest {
   string tradeId = 1;
   NonceSharesMessage peersNonceShares = 2;
-  repeated ReceiverAddressAndAmount receivers = 3;
+  repeated ReceiverAddressAndAmount redirectionReceivers = 3;
   bool buyerReadyToRelease = 4;
 }
 
@@ -102,6 +107,7 @@ message PartialSignaturesMessage {
   bytes peersWarningTxBuyerInputPartialSignature = 1;
   bytes peersWarningTxSellerInputPartialSignature = 2;
   bytes peersRedirectTxInputPartialSignature = 3;
+  bytes peersClaimTxInputPartialSignature = 6;
   optional bytes swapTxInputPartialSignature = 4;
   optional bytes swapTxInputSighash = 5;
 }
@@ -117,18 +123,17 @@ message DepositPsbt {
 
 message PublishDepositTxRequest {
   string tradeId = 1;
-  DepositPsbt depositPsbt = 2;
+  DepositPsbt peersDepositPsbt = 2;
 }
 
 message SubscribeTxConfirmationStatusRequest {
   string tradeId = 1;
-  DepositPsbt depositPsbt = 2;
 }
 
 message TxConfirmationStatus {
   bytes tx = 1;
-  sint32 currentBlockHeight = 2;
-  sint32 numConfirmations = 3;
+  uint32 currentBlockHeight = 2;
+  uint32 numConfirmations = 3;
 }
 
 message SwapTxSignatureRequest {

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -160,6 +160,7 @@ message PubKeyShares {
 message NonceShares {
   string warningTxFeeBumpAddress = 1;
   string redirectTxFeeBumpAddress = 2;
+  string claimTxPayoutAddress = 11;
   bytes halfDepositPsbt = 3;
   bytes swapTxInputNonceShare = 4;
   bytes buyersWarningTxBuyerInputNonceShare = 5;
@@ -168,12 +169,15 @@ message NonceShares {
   bytes sellersWarningTxSellerInputNonceShare = 8;
   bytes buyersRedirectTxInputNonceShare = 9;
   bytes sellersRedirectTxInputNonceShare = 10;
+  bytes buyersClaimTxInputNonceShare = 12;
+  bytes sellersClaimTxInputNonceShare = 13;
 }
 
 message PartialSignatures {
   bytes peersWarningTxBuyerInputPartialSignature = 1;
   bytes peersWarningTxSellerInputPartialSignature = 2;
   bytes peersRedirectTxInputPartialSignature = 3;
+  bytes peersClaimTxInputPartialSignature = 6;
   optional bytes swapTxInputPartialSignature = 4;
   optional bytes swapTxInputSighash = 5;
 }


### PR DESCRIPTION
Bring `rpc.proto` into sync with the latest Rust version, which makes the following changes to it:

1. Change sint32/64 field types back to uint32/64;
2. Rename `PartialSignaturesRequest.receivers` to `redirectionReceivers` and `PublishDepositTxRequest.depositPsbt` to `peersDepositPsbt`;
3. Remove unneeded `SubscribeTxConfirmationStatusRequest.depositPsbt`;
4. Add `tradeFeeReceiver` field to `NonceSharesRequest`;
5. Add `redirectionAmountMsat` field to `NonceSharesMessage`;
6. Add fields to `(NonceShares|PartialSignatures)Message` to create a prepared Claim Tx in addition to the other prepared txs. Previously, it was assumed that Claim spends would always be script spends with a tx generated on the fly. Now there's an additional keyspend path.

Also make corresponding changes to the Java DTOs, in particular exchanging extra Claim Tx-related fields with the peer in the `PartialSignatures` and `NonceShares` messages defined in `trade.proto`. Additionally, provide a dummy trade fee recipient to add to the Deposit Tx with the new `NonceSharesRequest.tradeFeeRecipent` field, and replace all the test/dummy Signet addresses with Regtest addresses that the Rust side now expects.

Finally, add code to `DelayedPayoutTxReceiverService` to compute a filtered list of receiver outputs (addresses + output values) from the provided BM shares, amount of available funds and target fee rate. Small outputs are filtered out under the same criteria currently used in Bisq1. No further capping or sanity checking post-filtering is being done, however, as there is no designated Legacy BM in the oracle data to act as a bin for any surplus funds in the event that caps or sanity checks prevent the adjusted shares from summing to 100%.

--

The changes fix all the soft (missing field, wrong receiver total, wrong network) warnings/errors currently showing up on the Rust side when carrying out a trade, due to changes to the API, which I plan to make into hard errors.

I'm not certain whether its better to keep the receiver amounts calculation on the Java side or move it to the Rust side. There isn't any complicated Bisq-specific logic (involving caps or LBM) in the calculation at present, but moving it to the Rust side may lead to issues with strict cross-platform floating-point determinism (that Java provides automatically) -- I'm not sure.
