### PR TITLE
Remove incorrect test.

### DIFF
--- a/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/ConnectionHandshakeResponderTest.java
@@ -145,24 +145,6 @@ public class ConnectionHandshakeResponderTest {
     }
 
     @Test
-    void invalidPoW() throws IOException {
-        ConnectionHandshake.Request request = new ConnectionHandshake.Request(responderCapability, Optional.empty(), new NetworkLoad(), 0);
-        AuthorizationToken token = authorizationService.createToken(request,
-                new NetworkLoad(),
-                LocalHostAddressTypeFacade.toLocalHostAddress(1234).toString(),
-                5, new ArrayList<>());
-        NetworkEnvelope requestNetworkEnvelope = new NetworkEnvelope(token, request);
-        List<NetworkEnvelope> allEnvelopesToReceive = List.of(requestNetworkEnvelope);
-        when(networkEnvelopeSocketChannel.receiveNetworkEnvelopes()).thenReturn(allEnvelopesToReceive);
-
-        Exception exception = assertThrows(ConnectionException.class, handshakeResponder::verifyAndBuildRespond);
-
-        assertThat(exception.getMessage())
-                .containsIgnoringCase("authorization")
-                .containsIgnoringCase("failed");
-    }
-
-    @Test
     void correctPoW() throws IOException {
         Capability peerCapability = createCapability(LocalHostAddressTypeFacade.toLocalHostAddress(2345), supportedTransportTypes);
         ConnectionHandshake.Request request = new ConnectionHandshake.Request(peerCapability, Optional.empty(), new NetworkLoad(), 0);


### PR DESCRIPTION
The test only failed previously as it used the toString of the address which resulted in `[1234]` then at the verify method we used the full address `127.0.0.1:1234` thus the challenge was different and the verification failed.