### PR TITLE
Improve UX to dismiss chat rules

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -604,17 +604,12 @@ public class ChatMessagesListController implements Controller {
     }
 
     public void onDismissChatRulesWarning() {
-        dontShowAgainService.putDontShowAgain(DONT_SHOW_CHAT_RULES_WARNING_KEY, true);
-
-        model.getSortedChatMessages().stream()
-                .filter(item -> item.getChatMessage().getChatMessageType() == ChatMessageType.CHAT_RULES_WARNING)
-                .findFirst()
-                .ifPresent(itemToRemove -> {
-                    UIThread.run(() -> {
-                        itemToRemove.dispose();
-                        model.getChatMessages().remove(itemToRemove);
-                    });
-                });
+        new Popup().information(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.info"))
+                .closeButtonText(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.closeButtonText"))
+                .onClose(this::permanentlyDismissChatRulesWarning)
+                .actionButtonText(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.actionButtonText"))
+                .onAction(this::dismissChatRulesWarningJustOnce)
+                .show();
     }
 
     public void onClickQuoteMessage(Optional<String> chatMessageId) {
@@ -916,7 +911,6 @@ public class ChatMessagesListController implements Controller {
                 authorizedBondedRolesService);
     }
 
-
     private Predicate<? super ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> getPredicate() {
         return item -> {
             Optional<UserProfile> senderUserProfile = item.getSenderUserProfile();
@@ -945,5 +939,26 @@ public class ChatMessagesListController implements Controller {
 
             return isCorrectMessageType;
         };
+    }
+
+    private void dismissChatRulesWarningJustOnce() {
+        deleteChatRulesWarning();
+    }
+
+    private void permanentlyDismissChatRulesWarning() {
+        dontShowAgainService.putDontShowAgain(DONT_SHOW_CHAT_RULES_WARNING_KEY, true);
+        deleteChatRulesWarning();
+    }
+
+    private void deleteChatRulesWarning() {
+        model.getSortedChatMessages().stream()
+            .filter(item -> item.getChatMessage().getChatMessageType() == ChatMessageType.CHAT_RULES_WARNING)
+            .findFirst()
+            .ifPresent(itemToRemove -> {
+                UIThread.run(() -> {
+                    itemToRemove.dispose();
+                    model.getChatMessages().remove(itemToRemove);
+                });
+            });
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/ChatRulesWarningMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/ChatRulesWarningMessageBox.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public final class ChatRulesWarningMessageBox extends MessageBox {
     private final Hyperlink learnMoreLink;
     private final BisqMenuItem closeIcon;
-    private final Tooltip closeTooltip = new BisqTooltip(Res.get("action.dontShowAgain"));
+    private final Tooltip closeTooltip = new BisqTooltip(Res.get("action.close"));
 
     public ChatRulesWarningMessageBox(
             ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item,

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -120,6 +120,9 @@ chat.private.chatRulesWarningMessage.text=Do not exchange contact information to
   In case of such activity, peers should report it to moderators to identify potential Bisq rules violations. \
   Users who engage in these practices will be banned from the network.
 chat.private.chatRulesWarningMessage.learnMore=Learn more
+chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.info=This warning message will be removed.
+chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.closeButtonText=Remove permanently
+chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.actionButtonText=Remove just once
 
 
 ######################################################


### PR DESCRIPTION
Allows deleting the message warning just once or permanently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat rules warning now opens a popup on close with two choices: “Remove permanently” or “Remove just once.”
  * The warning is removed from the chat list according to the selected option.
  * Close icon tooltip updated to “Close” for clarity.
  * Added localized texts for the popup info and action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->