### PR TITLE
Improve action buttons in dismiss chat rules popup

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -605,10 +605,11 @@ public class ChatMessagesListController implements Controller {
 
     public void onDismissChatRulesWarning() {
         new Popup().information(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.info"))
-                .closeButtonText(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.closeButtonText"))
-                .onClose(this::permanentlyDismissChatRulesWarning)
+                .hideCloseButton()
+                .secondaryActionButtonText(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.secondaryActionButtonText"))
+                .onSecondaryAction(this::dismissChatRulesWarningJustOnce)
                 .actionButtonText(Res.get("chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.actionButtonText"))
-                .onAction(this::dismissChatRulesWarningJustOnce)
+                .onAction(this::permanentlyDismissChatRulesWarning)
                 .show();
     }
 

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -121,8 +121,8 @@ chat.private.chatRulesWarningMessage.text=Do not exchange contact information to
   Users who engage in these practices will be banned from the network.
 chat.private.chatRulesWarningMessage.learnMore=Learn more
 chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.info=This warning message will be removed.
-chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.closeButtonText=Remove permanently
-chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.actionButtonText=Remove just once
+chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.secondaryActionButtonText=Remove just once
+chat.private.chatRulesWarningMessage.onDismissChatRulesPopup.actionButtonText=Remove permanently
 
 
 ######################################################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated chat rules dismissal with two clear options: “Remove just once” or “Remove permanently,” replacing the old close-button flow for a more explicit choice.
- Chores
  - Refreshed localization strings to reflect the new dual-action buttons, removing the close button label and adding text for the secondary action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->