### PR TITLE
Use toUpperCase(Locale.ROOT) / toLowerCase(Locale.ROOT) where appropriate.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/security_manager/SecurityManagerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/security_manager/SecurityManagerController.java
@@ -225,7 +225,7 @@ public class SecurityManagerController implements Controller {
         String profileId = authorizedBondedRole.getProfileId();
         String nickNameOrBondName = userProfileService.findUserProfile(profileId)
                 .map(UserProfile::getNickName)
-                .orElseGet(() -> authorizedBondedRole.getBondUserName());
+                .orElseGet(authorizedBondedRole::getBondUserName);
         Optional<String> addresses = authorizedBondedRole.getAddressByTransportTypeMap()
                 .map(e -> e.values().stream()
                         .map(Address::getFullAddress)
@@ -239,7 +239,7 @@ public class SecurityManagerController implements Controller {
         String profileId = authorizedBondedRole.getProfileId();
         String nickNameOrBondName = userProfileService.findUserProfile(profileId)
                 .map(UserProfile::getNickName)
-                .orElseGet(() -> authorizedBondedRole.getBondUserName());
+                .orElseGet(authorizedBondedRole::getBondUserName);
         return Res.get("authorizedRole.securityManager.alert.table.bannedRole.value", roleType, nickNameOrBondName, profileId);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState1a.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState1a.java
@@ -69,6 +69,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import java.util.Locale;
+
 @Slf4j
 public class BuyerState1a extends BaseState {
     private final Controller controller;
@@ -189,7 +191,7 @@ public class BuyerState1a extends BaseState {
                         // QR code is more efficient with uppercase, thus many wallets provide it uppercase.
                         // As lower case is the common display style and bitcoin addresses and LN invoices are
                         // case-insensitive, we convert it to lowercase.
-                        String payload = qrCode.toLowerCase();
+                        String payload = qrCode.toLowerCase(Locale.ROOT);
                         if (BitcoinURIScheme.isBitcoinUriScheme(payload)) {
                             payload = BitcoinURIScheme.extractBitcoinAddress(payload);
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ReactionItem.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.TreeSet;
 
 @Slf4j
@@ -54,7 +55,7 @@ public class ReactionItem {
         this.selectedUserProfile = selectedUserProfile;
         this.isMyMessage = isMyMessage;
 
-        this.iconId = reaction.toString().replace("_", "").toLowerCase();
+        this.iconId = reaction.toString().replace("_", "").toLowerCase(Locale.ROOT);
     }
 
     public boolean hasActiveReactions() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyOfferMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyOfferMessageBox.java
@@ -35,6 +35,8 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
+import java.util.Locale;
+
 import static com.google.common.base.Preconditions.checkArgument;
 
 public final class MyOfferMessageBox extends BubbleMessageBox {
@@ -105,7 +107,7 @@ public final class MyOfferMessageBox extends BubbleMessageBox {
                 "Bisq Easy Offerbook message must contain an offer");
 
         Direction direction = bisqEasyOfferbookMessage.getBisqEasyOffer().get().getDirection();
-        String directionString = StringUtils.capitalize(Res.get("offer." + direction.name().toLowerCase()));
+        String directionString = StringUtils.capitalize(Res.get("offer." + direction.name().toLowerCase(Locale.ROOT)));
         String title = Res.get("bisqEasy.tradeWizard.review.chatMessage.myMessageTitle", directionString);
         Label label = new Label(title);
         label.getStyleClass().addAll("bisq-easy-offer-title", "normal-text", "font-default");

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/components/MarketImageComposition.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -68,8 +69,8 @@ public class MarketImageComposition {
     }
 
     private static StackPane getMarketIcons(Market market, Optional<Map<String, StackPane>> dedicatedCache) {
-        String baseCurrencyCode = market.getBaseCurrencyCode().toLowerCase();
-        String quoteCurrencyCode = market.getQuoteCurrencyCode().toLowerCase();
+        String baseCurrencyCode = market.getBaseCurrencyCode().toLowerCase(Locale.ROOT);
+        String quoteCurrencyCode = market.getQuoteCurrencyCode().toLowerCase(Locale.ROOT);
         String key = baseCurrencyCode + "." + quoteCurrencyCode;
 
         if (dedicatedCache.isPresent()) {
@@ -162,7 +163,7 @@ public class MarketImageComposition {
     }
 
     public static Node createMarketLogo(String marketCode) {
-        String market = marketCode.toLowerCase();
+        String market = marketCode.toLowerCase(Locale.ROOT);
         String iconId = String.format("market-%s", market);
         return FIAT_MARKETS_WITH_LOGO.contains(market) || CRYPTO_MARKETS_WITH_LOGO.contains(market)
                 ? ImageUtil.getImageViewById(iconId)

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/MuSigOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/MuSigOfferListItem.java
@@ -54,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -126,7 +127,7 @@ public class MuSigOfferListItem {
         offerIntentText = offer.getDirection().isBuy()
                 ? Res.get("muSig.myOffers.table.cell.offerType.buying")
                 : Res.get("muSig.myOffers.table.cell.offerType.selling");
-        offerId = offer.getShortId().toUpperCase();
+        offerId = offer.getShortId().toUpperCase(Locale.ROOT);
         offerDate = DateFormatter.formatDateTime(offer.getDate());
         deposit = "15%";
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/direction_and_market/MuSigCreateOfferDirectionAndMarketView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/direction_and_market/MuSigCreateOfferDirectionAndMarketView.java
@@ -54,6 +54,7 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.util.Comparator;
+import java.util.Locale;
 
 @Slf4j
 public class MuSigCreateOfferDirectionAndMarketView extends View<StackPane, MuSigCreateOfferDirectionAndMarketModel,
@@ -392,7 +393,7 @@ public class MuSigCreateOfferDirectionAndMarketView extends View<StackPane, MuSi
             numOffers = String.valueOf(numOffersAsInteger);
             displayName = cryptoAsset.getCodeAndDisplayName();
             cryptoAssetLogo = new Label();
-            String imageId = String.format("market-%s", cryptoAsset.getCode().toLowerCase());
+            String imageId = String.format("market-%s", cryptoAsset.getCode().toLowerCase(Locale.ROOT));
             cryptoAssetLogo.setGraphic(ImageUtil.getImageViewById(imageId));
             cryptoAssetLogo.setCache(true);
             cryptoAssetLogo.setCacheHint(CacheHint.SPEED);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
@@ -63,6 +63,7 @@ import org.fxmisc.easybind.Subscription;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -487,7 +488,7 @@ public class MuSigOfferbookController implements Controller {
     }
 
     private String getMarketListTitleString(CryptoAsset cryptoAsset) {
-        String key = "muSig.offerbook.marketListTitle." + cryptoAsset.getCode().toLowerCase();
+        String key = "muSig.offerbook.marketListTitle." + cryptoAsset.getCode().toLowerCase(Locale.ROOT);
         return Res.get(key);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/trade_apps/overview/ProtocolListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/trade_apps/overview/ProtocolListItem.java
@@ -26,6 +26,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Locale;
+
 @Slf4j
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -67,6 +69,6 @@ public class ProtocolListItem {
         this.markets = Res.get("tradeApps.overview.markets." + name);
         this.securityInfo = Res.get("tradeApps.overview.security." + name);
         this.convenienceInfo = Res.get("tradeApps.overview.convenience." + name);
-        this.iconId = "protocol-" + StringUtils.snakeCaseToKebapCase(name.toLowerCase());
+        this.iconId = "protocol-" + StringUtils.snakeCaseToKebapCase(name.toLowerCase(Locale.ROOT), Locale.ROOT);
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/trade_apps/roadmap/ProtocolRoadmapModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/trade_apps/roadmap/ProtocolRoadmapModel.java
@@ -22,6 +22,8 @@ import bisq.common.util.StringUtils;
 import bisq.desktop.common.view.Model;
 import lombok.Getter;
 
+import java.util.Locale;
+
 @Getter
 public class ProtocolRoadmapModel implements Model {
     private final TradeProtocolType tradeProtocolType;
@@ -31,6 +33,7 @@ public class ProtocolRoadmapModel implements Model {
     public ProtocolRoadmapModel(TradeProtocolType tradeProtocolType, String url) {
         this.tradeProtocolType = tradeProtocolType;
         this.url = url;
-        this.iconId = "protocol-" + StringUtils.snakeCaseToKebapCase(tradeProtocolType.name().toLowerCase());
+        this.iconId = "protocol-" + StringUtils.snakeCaseToKebapCase(
+                tradeProtocolType.name().toLowerCase(Locale.ROOT), Locale.ROOT);
     }
 }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -354,7 +355,7 @@ public class MarketPriceRequestService {
                 if (!currencyCode.startsWith("NON_EXISTING_SYMBOL")) {
                     String provider = (String) treeMap.get("provider"); // Bisq-Aggregate or name of exchange of price feed
                     // Convert Bisq-Aggregate to BISQAGGREGATE
-                    provider = provider.replace("-", "").toUpperCase();
+                    provider = provider.replace("-", "").toUpperCase(Locale.ROOT);
 
                     double price = (Double) treeMap.get("price");
                     // json uses double for our timestamp long value...

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/Architecture.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/Architecture.kt
@@ -31,6 +31,6 @@ fun is64Bit(archName: String): Boolean {
 }
 
 fun getArchitectureName(): String {
-    return System.getProperty("os.arch").toLowerCase()
+    return System.getProperty("os.arch").lowercase(Locale.US)
 }
 

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/OS.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/common/OS.kt
@@ -34,5 +34,5 @@ private fun isWindows(osName: String): Boolean {
 }
 
 fun getOSName(): String {
-    return System.getProperty("os.name").toLowerCase()
+    return System.getProperty("os.name").lowercase(Locale.US)
 }

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/OS.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/OS.kt
@@ -7,7 +7,7 @@ enum class OS {
 }
 
 fun getOS(): OS {
-    val osName = System.getProperty("os.name").toLowerCase(Locale.US)
+    val osName = System.getProperty("os.name").lowercase(Locale.US)
     if (isLinux(osName)) {
         return OS.LINUX
     } else if (isMacOs(osName)) {

--- a/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PgpFingerprint.kt
+++ b/build-logic/gradle-tasks/src/main/kotlin/bisq/gradle/tasks/PgpFingerprint.kt
@@ -1,7 +1,9 @@
 package bisq.gradle.tasks
 
+import java.util.Locale.ROOT
+
 object PgpFingerprint {
     fun normalize(fingerprint: String): String =
         fingerprint.filterNot { it.isWhitespace() }  // Remove all spaces
-                .toLowerCase()
+            .lowercase(ROOT)
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
@@ -1,6 +1,7 @@
 package bisq.gradle.packaging.jpackage.package_formats
 
 import java.nio.file.Path
+import java.util.*
 
 class LinuxPackages(private val resourcesPath: Path, private val appName: String) : JPackagePackageFormatConfigs {
     override val packageFormats = setOf(PackageFormat.DEB, PackageFormat.RPM)
@@ -11,7 +12,7 @@ class LinuxPackages(private val resourcesPath: Path, private val appName: String
                 resourcesPath.resolve("icon.png")
                         .toAbsolutePath().toString(),
 
-                "--linux-package-name", appName.lowercase().replace(" ", ""),
+                "--linux-package-name", appName.lowercase(Locale.ROOT).replace(" ", ""),
                 "--linux-app-release", "1",
 
                 "--linux-package-deps", "tor",

--- a/chat/src/main/java/bisq/chat/ChatChannelSelectionService.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelSelectionService.java
@@ -27,6 +27,7 @@ import bisq.persistence.PersistenceService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Locale;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -38,7 +39,9 @@ public abstract class ChatChannelSelectionService implements PersistenceClient<C
 
     public ChatChannelSelectionService(PersistenceService persistenceService,
                                        ChatChannelDomain chatChannelDomain) {
-        String prefix = StringUtils.capitalize(StringUtils.snakeCaseToCamelCase(chatChannelDomain.name().toLowerCase()));
+        String prefix = StringUtils.capitalize(
+                StringUtils.snakeCaseToCamelCase(chatChannelDomain.name().toLowerCase(Locale.ROOT), Locale.ROOT),
+                Locale.ROOT);
         persistence = persistenceService.getOrCreatePersistence(this,
                 DbSubDirectory.SETTINGS,
                 prefix + "ChannelSelectionStore",

--- a/chat/src/main/java/bisq/chat/bisq_easy/offerbook/BisqEasyOfferbookChannel.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/offerbook/BisqEasyOfferbookChannel.java
@@ -27,6 +27,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -35,7 +36,7 @@ import java.util.stream.Stream;
 @EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public final class BisqEasyOfferbookChannel extends PublicChatChannel<BisqEasyOfferbookMessage> {
     static String createId(Market market) {
-        return ChatChannelDomain.BISQ_EASY_OFFERBOOK.name().toLowerCase() + "." +
+        return ChatChannelDomain.BISQ_EASY_OFFERBOOK.name().toLowerCase(Locale.ROOT) + "." +
                 market.getBaseCurrencyCode() + "-" +
                 market.getQuoteCurrencyCode();
     }

--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannel.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannel.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -50,7 +51,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public final class BisqEasyOpenTradeChannel extends PrivateGroupChatChannel<BisqEasyOpenTradeMessage> {
     public static String createId(String tradeId) {
-        return ChatChannelDomain.BISQ_EASY_OPEN_TRADES.name().toLowerCase() + "." + tradeId;
+        return ChatChannelDomain.BISQ_EASY_OPEN_TRADES.name().toLowerCase(Locale.ROOT) + "." + tradeId;
     }
 
     public static BisqEasyOpenTradeChannel createByTrader(String tradeId,

--- a/chat/src/main/java/bisq/chat/common/CommonPublicChatChannel.java
+++ b/chat/src/main/java/bisq/chat/common/CommonPublicChatChannel.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Getter
@@ -98,11 +99,11 @@ public final class CommonPublicChatChannel extends PublicChatChannel<CommonPubli
 
     @Override
     public String getDisplayString() {
-        return Res.get(chatChannelDomain.name().toLowerCase() + "." + getChannelTitle() + ".title");
+        return Res.get(chatChannelDomain.name().toLowerCase(Locale.ROOT) + "." + getChannelTitle() + ".title");
     }
 
     public String getDescription() {
-        return Res.get(chatChannelDomain.name().toLowerCase() + "." + getChannelTitle() + ".description");
+        return Res.get(chatChannelDomain.name().toLowerCase(Locale.ROOT) + "." + getChannelTitle() + ".description");
     }
 
 

--- a/chat/src/main/java/bisq/chat/common/CommonPublicChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/common/CommonPublicChatChannelService.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Slf4j
@@ -58,7 +59,9 @@ public final class CommonPublicChatChannelService extends PublicChatChannelServi
 
         this.channels = channels;
 
-        String name = StringUtils.capitalize(StringUtils.snakeCaseToCamelCase(chatChannelDomain.name().toLowerCase()));
+        String name = StringUtils.capitalize(
+                StringUtils.snakeCaseToCamelCase(chatChannelDomain.name().toLowerCase(Locale.ROOT), Locale.ROOT),
+                Locale.ROOT);
         persistence = persistenceService.getOrCreatePersistence(this,
                 DbSubDirectory.CACHE,
                 "Public" + name + "ChatChannelStore",

--- a/chat/src/main/java/bisq/chat/common/SubDomain.java
+++ b/chat/src/main/java/bisq/chat/common/SubDomain.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 
 @Slf4j
@@ -48,7 +49,8 @@ public enum SubDomain {
 
     public static SubDomain from(ChatChannelDomain chatChannelDomain, String channelTitle) {
         try {
-            String name = chatChannelDomain.name().toUpperCase() + "_" + StringUtils.camelCaseToSnakeCase(channelTitle).toUpperCase();
+            String name = chatChannelDomain.name().toUpperCase(Locale.ROOT) + "_" +
+                    StringUtils.camelCaseToSnakeCase(channelTitle).toUpperCase(Locale.ROOT);
             return valueOf(name);
         } catch (Exception e) {
             log.error("Cannot resolve ChatChannelSubDomain from chatChannelDomain {} and channelTitle={}.",
@@ -60,7 +62,7 @@ public enum SubDomain {
     public static SubDomain from(String channelId) {
         try {
             String[] tokens = channelId.split("\\.");
-            String name = tokens[0].toUpperCase();
+            String name = tokens[0].toUpperCase(Locale.ROOT);
             ChatChannelDomain chatChannelDomain = ChatChannelDomain.valueOf(name);
             String channelTitle = tokens[1];
             return from(chatChannelDomain, channelTitle);
@@ -83,7 +85,7 @@ public enum SubDomain {
         this.chatChannelDomain = chatChannelDomain;
         this.title = title;
         this.fallback = Optional.ofNullable(fallback);
-        this.channelId = chatChannelDomain.name().toLowerCase() + "." + title;
+        this.channelId = chatChannelDomain.name().toLowerCase(Locale.ROOT) + "." + title;
     }
 
     public SubDomain migrate() {

--- a/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeChannel.java
+++ b/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeChannel.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,7 +50,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public final class MuSigOpenTradeChannel extends PrivateGroupChatChannel<MuSigOpenTradeMessage> {
     public static String createId(String tradeId) {
-        return ChatChannelDomain.MU_SIG_OPEN_TRADES.name().toLowerCase() + "." + tradeId;
+        return ChatChannelDomain.MU_SIG_OPEN_TRADES.name().toLowerCase(Locale.ROOT) + "." + tradeId;
     }
 
     public static MuSigOpenTradeChannel createByTrader(String tradeId,

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannel.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannel.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,7 +43,7 @@ public final class TwoPartyPrivateChatChannel extends PrivateChatChannel<TwoPart
         List<String> userIds = Stream.of(userProfileId1, userProfileId2)
                 .sorted()
                 .toList();
-        return chatChannelDomain.migrate().name().toLowerCase() + "." + userIds.get(0) + "-" + userIds.get(1);
+        return chatChannelDomain.migrate().name().toLowerCase(Locale.ROOT) + "." + userIds.get(0) + "-" + userIds.get(1);
     }
 
     @Getter
@@ -119,7 +120,7 @@ public final class TwoPartyPrivateChatChannel extends PrivateChatChannel<TwoPart
         public static String migrateChannelId(String chatChannelId) {
             try {
                 String[] tokens = chatChannelId.split("\\.");
-                String chatChannelDomainName = tokens[0].toUpperCase();
+                String chatChannelDomainName = tokens[0].toUpperCase(Locale.ROOT);
                 ChatChannelDomain chatChannelDomain = ChatChannelDomain.valueOf(chatChannelDomainName).migrate();
                 String[] peers = tokens[1].split("-");
                 String userProfileId1 = peers[0];

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -64,7 +65,9 @@ public class TwoPartyPrivateChatChannelService extends PrivateChatChannelService
         contactListService = userService.getContactListService();
         this.settingsService = settingsService;
 
-        String name = StringUtils.capitalize(StringUtils.snakeCaseToCamelCase(chatChannelDomain.name().toLowerCase()));
+        String name = StringUtils.capitalize(
+                StringUtils.snakeCaseToCamelCase(chatChannelDomain.name().toLowerCase(Locale.ROOT), Locale.ROOT),
+                Locale.ROOT);
         persistence = persistenceService.getOrCreatePersistence(this,
                 DbSubDirectory.PRIVATE,
                 "Private" + name + "ChatChannelStore",

--- a/common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java
+++ b/common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java
@@ -154,6 +154,6 @@ public class FiatCurrencyRepository {
 
 
     public static String getSymbol(String code) {
-        return Currency.getInstance(code.toUpperCase()).getSymbol();
+        return Currency.getInstance(code.toUpperCase(Locale.ROOT)).getSymbol();
     }
 }

--- a/common/src/main/java/bisq/common/encoding/BitcoinURIScheme.java
+++ b/common/src/main/java/bisq/common/encoding/BitcoinURIScheme.java
@@ -17,6 +17,8 @@
 
 package bisq.common.encoding;
 
+import java.util.Locale;
+
 // See: https://en.bitcoin.it/wiki/BIP_0021
 public class BitcoinURIScheme {
     public static String extractBitcoinAddress(String input) {
@@ -31,7 +33,7 @@ public class BitcoinURIScheme {
     }
 
     public static boolean isBitcoinUriScheme(String input) {
-        return input.toLowerCase().startsWith("bitcoin:");
+        return input.toLowerCase(Locale.ROOT).startsWith("bitcoin:");
     }
 
     public static String normalizePrefix(String input) {

--- a/common/src/main/java/bisq/common/encoding/Hex.java
+++ b/common/src/main/java/bisq/common/encoding/Hex.java
@@ -19,9 +19,11 @@ package bisq.common.encoding;
 
 import com.google.common.io.BaseEncoding;
 
+import java.util.Locale;
+
 public class Hex {
     public static byte[] decode(String hex) {
-        return BaseEncoding.base16().lowerCase().decode(hex.toLowerCase());
+        return BaseEncoding.base16().lowerCase().decode(hex.toLowerCase(Locale.ROOT));
     }
 
     public static String encode(byte[] bytes) {

--- a/common/src/main/java/bisq/common/proto/ProtoEnum.java
+++ b/common/src/main/java/bisq/common/proto/ProtoEnum.java
@@ -20,6 +20,8 @@ package bisq.common.proto;
 import bisq.common.util.StringUtils;
 import com.google.protobuf.ProtocolMessageEnum;
 
+import java.util.Locale;
+
 /**
  * Interface for any enum which gets serialized using protobuf
  */
@@ -31,6 +33,6 @@ public interface ProtoEnum {
     }
 
     static String getProtobufEnumPrefix(Class<?> clazz) {
-        return StringUtils.capitalizeAll(clazz.getSimpleName()) + "_";
+        return StringUtils.capitalizeAll(clazz.getSimpleName(), Locale.ROOT) + "_";
     }
 }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -110,32 +111,44 @@ public class StringUtils {
         return null;
     }
 
-    public static String capitalize(String value) {
+    public static String capitalize(String value, Locale locale) {
         if (value == null || value.isEmpty()) {
             return value;
         } else if (value.length() == 1) {
-            return value.toUpperCase();
+            return value.toUpperCase(locale);
         } else {
-            return value.substring(0, 1).toUpperCase() + value.substring(1);
+            return value.substring(0, 1).toUpperCase(locale) + value.substring(1);
+        }
+    }
+
+    public static String capitalize(String value) {
+        return capitalize(value, Locale.getDefault());
+    }
+
+    public static String unCapitalize(String value, Locale locale) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        } else if (value.length() == 1) {
+            return value.toLowerCase(locale);
+        } else {
+            return value.substring(0, 1).toLowerCase(locale) + value.substring(1);
         }
     }
 
     public static String unCapitalize(String value) {
+        return unCapitalize(value, Locale.getDefault());
+    }
+
+    public static String capitalizeAll(String value, Locale locale) {
         if (value == null || value.isEmpty()) {
             return value;
-        } else if (value.length() == 1) {
-            return value.toLowerCase();
         } else {
-            return value.substring(0, 1).toLowerCase() + value.substring(1);
+            return value.toUpperCase(locale);
         }
     }
 
     public static String capitalizeAll(String value) {
-        if (value == null || value.isEmpty()) {
-            return value;
-        } else {
-            return value.toUpperCase();
-        }
+        return capitalizeAll(value, Locale.getDefault());
     }
 
     // Replaces the content inside the brackets marked with HYPERLINK with the hyperlink and the number of the hyperlink
@@ -169,12 +182,20 @@ public class StringUtils {
         return Optional.ofNullable(toNullIfEmpty(value));
     }
 
+    public static String snakeCaseToCamelCase(String value, Locale locale) {
+        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, value.toLowerCase(locale));
+    }
+
     public static String snakeCaseToCamelCase(String value) {
-        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, value.toLowerCase());
+        return snakeCaseToCamelCase(value, Locale.getDefault());
+    }
+
+    public static String kebapCaseToCamelCase(String value, Locale locale) {
+        return CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, value.toLowerCase(locale));
     }
 
     public static String kebapCaseToCamelCase(String value) {
-        return CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, value.toLowerCase());
+        return kebapCaseToCamelCase(value, Locale.getDefault());
     }
 
     public static String camelCaseToSnakeCase(String value) {
@@ -185,8 +206,12 @@ public class StringUtils {
         return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, value);
     }
 
+    public static String snakeCaseToKebapCase(String value, Locale locale) {
+        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_HYPHEN, value.toLowerCase(locale));
+    }
+
     public static String snakeCaseToKebapCase(String value) {
-        return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_HYPHEN, value.toLowerCase());
+        return snakeCaseToKebapCase(value, Locale.getDefault());
     }
 
     public static List<Pair<String, List<String>>> getTextStylePairs(String input) {

--- a/common/src/main/java/bisq/common/util/TextFormatterUtils.java
+++ b/common/src/main/java/bisq/common/util/TextFormatterUtils.java
@@ -17,6 +17,7 @@
 
 package bisq.common.util;
 
+import java.util.Locale;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -60,7 +61,7 @@ public class TextFormatterUtils {
         return StringUtils.toOptional(iban)
                 .filter(StringUtils::isNotEmpty)
                 .map(value -> {
-                    String cleanIban = value.replaceAll("\\s", "").toUpperCase();
+                    String cleanIban = value.replaceAll("\\s", "").toUpperCase(Locale.ROOT);
                     StringBuilder formatted = new StringBuilder();
                     for (int i = 0; i < cleanIban.length(); i++) {
                         if (i > 0 && i % 4 == 0) {

--- a/common/src/main/java/bisq/common/validation/SepaPaymentAccountValidation.java
+++ b/common/src/main/java/bisq/common/validation/SepaPaymentAccountValidation.java
@@ -109,7 +109,7 @@ public class SepaPaymentAccountValidation {
         checkArgument(StringUtils.isNotEmpty(countryCode), "Country code must not be empty for IBAN consistency check");
         checkArgument(iban.length() >= 2, "IBAN too short for country code extraction.");
 
-        String cleanIban = iban.replaceAll("\\s", "").toUpperCase();
+        String cleanIban = iban.replaceAll("\\s", "").toUpperCase(Locale.ROOT);
         String ibanCountryCode = cleanIban.substring(0, 2);
 
         checkArgument(countryCode.equals(ibanCountryCode),

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/offers/OfferbookRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/offers/OfferbookRestApi.java
@@ -66,6 +66,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -304,7 +305,7 @@ public class OfferbookRestApi extends RestApiBase {
     @Path("markets/{currencyCode}/offers")
     public Response getOffers(@PathParam("currencyCode") String currencyCode) {
         try {
-            String marketCodes = "BTC/" + currencyCode.toUpperCase();
+            String marketCodes = "BTC/" + currencyCode.toUpperCase(Locale.ROOT);
             return findOffer(marketCodes)
                     .map(this::buildOkResponse)
                     .orElseGet(() -> {

--- a/network/network/src/main/java/bisq/network/NetworkServiceConfig.java
+++ b/network/network/src/main/java/bisq/network/NetworkServiceConfig.java
@@ -38,6 +38,7 @@ import lombok.Getter;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -138,7 +139,7 @@ public final class NetworkServiceConfig {
     }
 
     private static TransportConfig createTransportConfig(TransportType transportType, Config config, Path baseDir) {
-        Config transportConfig = config.getConfig("configByTransportType." + transportType.name().toLowerCase());
+        Config transportConfig = config.getConfig("configByTransportType." + transportType.name().toLowerCase(Locale.ROOT));
         Path dataDir;
         return switch (transportType) {
             case TOR -> {

--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/PeerGroupService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/PeerGroupService.java
@@ -100,7 +100,7 @@ public class PeerGroupService implements PersistenceClient<PeerGroupStore> {
 
         persistence = persistenceService.getOrCreatePersistence(this,
                 DbSubDirectory.SETTINGS,
-                transportType.name().toLowerCase() + persistableStore.getClass().getSimpleName(),
+                transportType.name().toLowerCase(Locale.ROOT) + persistableStore.getClass().getSimpleName(),
                 persistableStore);
     }
 

--- a/offer/src/main/java/bisq/offer/Direction.java
+++ b/offer/src/main/java/bisq/offer/Direction.java
@@ -21,6 +21,8 @@ import bisq.common.proto.ProtoEnum;
 import bisq.common.proto.ProtobufUtils;
 import bisq.i18n.Res;
 
+import java.util.Locale;
+
 public enum Direction implements ProtoEnum {
     BUY,
     SELL;
@@ -47,7 +49,7 @@ public enum Direction implements ProtoEnum {
     }
 
     public String getDisplayString() {
-        return Res.get("offer." + name().toLowerCase());
+        return Res.get("offer." + name().toLowerCase(Locale.ROOT));
     }
 
     public String getDirectionalTitle() {

--- a/security/src/main/java/bisq/security/keys/TorKeyGeneration.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyGeneration.java
@@ -24,6 +24,7 @@ import org.bouncycastle.util.encoders.Base32;
 
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+import java.util.Locale;
 
 @Slf4j
 public class TorKeyGeneration {
@@ -62,7 +63,7 @@ public class TorKeyGeneration {
         byte[] byteArray = byteBuffer.array();
         String base32String = Base32.toBase32String(byteArray);
 
-        return base32String.toLowerCase() + ".onion";
+        return base32String.toLowerCase(Locale.ROOT) + ".onion";
     }
 
     private static byte[] computeOnionAddressChecksum(byte[] publicKey) {

--- a/security/src/main/java/bisq/security/keys/TorKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyUtils.java
@@ -9,12 +9,13 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Locale;
 
 @Slf4j
 public class TorKeyUtils {
     public static byte[] getPublicKeyFromOnionAddress(String onionAddress) {
         onionAddress = onionAddress.substring(0, onionAddress.length() - ".onion".length());
-        byte[] decodedOnionAddress = Base32.decode(onionAddress.toUpperCase());
+        byte[] decodedOnionAddress = Base32.decode(onionAddress.toUpperCase(Locale.ROOT));
         return Arrays.copyOfRange(decodedOnionAddress, 0, 32);
     }
 

--- a/security/src/test/java/bisq/security/PgPUtilsTest.java
+++ b/security/src/test/java/bisq/security/PgPUtilsTest.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SignatureException;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -49,7 +50,7 @@ public class PgPUtilsTest {
     public void testReadPgpPublicKeyRing() {
         try {
             PGPPublicKeyRing pgpPublicKeyRing = getPGPPublicKeyRing("387C8307.asc");
-            String keyId = Integer.toHexString((int) pgpPublicKeyRing.getPublicKey().getKeyID()).toUpperCase();
+            String keyId = Integer.toHexString((int) pgpPublicKeyRing.getPublicKey().getKeyID()).toUpperCase(Locale.ROOT);
             assertEquals("387C8307", keyId);
         } catch (Exception e) {
             log.error(e.toString());
@@ -63,7 +64,7 @@ public class PgPUtilsTest {
         // gpg --digest-algo SHA256 -u [KEY ID] --output testData.txt.asc --detach-sig --armor testData.txt
         try {
             PGPSignature signature = getPGPSignature("testData.txt.asc");
-            String keyId = Integer.toHexString((int) signature.getKeyID()).toUpperCase();
+            String keyId = Integer.toHexString((int) signature.getKeyID()).toUpperCase(Locale.ROOT);
             assertEquals("387C8307", keyId);
         } catch (Exception e) {
             log.error(e.toString());


### PR DESCRIPTION
Fixes #3820

Using Locale.ROOT makes sense in several places:
- id generation: ensures strings are normalized consistently
- persistence: stored values are predictable and consistent across locales
- enums: prevent failures in lookups
- interaction with currency codes: avoids locale-sensitive transformations that could break comparisons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Make string casing and ID generation locale‑independent across the app (chat IDs, market/asset icons, offer directions, protocol icons, network/persistence keys).
  - Improve normalization/parsing for Bitcoin URIs, hex strings, SEPA IBANs, HTTP API market codes, Tor addresses/keys, and related identifiers.

- **Chores**
  - Standardize build tooling locale usage for OS/architecture detection and packaging.
  - Minor performance cleanup to reduce lambda allocations.

- **Refactor**
  - Introduced locale-aware string utilities to ensure consistent casing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->