### PR TITLE
Revert "Move activation dates to 1.Feb 2026"

### DIFF
--- a/support/src/main/java/bisq/support/mediation/MediationRequestService.java
+++ b/support/src/main/java/bisq/support/mediation/MediationRequestService.java
@@ -58,7 +58,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  */
 @Slf4j
 public class MediationRequestService implements Service, ConfidentialMessageService.Listener {
-    public final static Date MEDIATION_SELECTION_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2026, GregorianCalendar.FEBRUARY, 1);
+    public final static Date MEDIATION_SELECTION_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.JUNE, 1);
 
     private final NetworkService networkService;
     private final UserProfileService userProfileService;

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -43,7 +43,7 @@ import java.util.UUID;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P extends TradeParty> extends FsmModel implements PersistableProto {
-    public final static Date TRADE_ID_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2026, GregorianCalendar.FEBRUARY, 1);
+    public final static Date TRADE_ID_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.JUNE, 1);
 
     public static String createId(String offerId, String takerPubKeyHash) {
         return createId(offerId, takerPubKeyHash, Optional.empty());


### PR DESCRIPTION
This reverts commit c9e4597b1f2a18bca41acf0bc37cf0d88cea9032.

The activation dates have been already in 2.1.7, thus they are deployed.