### PR TITLE
Those activation dates have been already in 2.1.7 and have been already activated

### DIFF
--- a/support/src/main/java/bisq/support/mediation/MediationRequestService.java
+++ b/support/src/main/java/bisq/support/mediation/MediationRequestService.java
@@ -68,7 +68,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Slf4j
 public class MediationRequestService implements Service, ConfidentialMessageService.Listener {
     // TODO adjust at release date
-    public final static Date MEDIATION_SELECTION_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.NOVEMBER, 1);
+    public final static Date MEDIATION_SELECTION_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.JUNE, 1);
 
     private final NetworkService networkService;
     private final UserProfileService userProfileService;

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -44,7 +44,7 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P extends TradeParty> extends FsmModel implements PersistableProto {
     // TODO adjust at release date
-    public final static Date TRADE_ID_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.NOVEMBER, 1);
+    public final static Date TRADE_ID_V1_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.JUNE, 1);
 
     public static String createId(String offerId, String takerPubKeyHash) {
         return createId(offerId, takerPubKeyHash, Optional.empty());


### PR DESCRIPTION
This is just a quick fix to not get overlooked when we release. We should remove them as already activated.