### PR TITLE
Show newly created offer as selected in Musig offerbook

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/MuSigCreateOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/MuSigCreateOfferController.java
@@ -94,8 +94,7 @@ public class MuSigCreateOfferController extends NavigationController implements 
                 view.getRoot(),
                 this::setMainButtonsVisibleState);
         muSigCreateOfferReviewController = new MuSigCreateOfferReviewController(serviceProvider,
-                this::setMainButtonsVisibleState,
-                this::closeAndNavigateTo);
+                this::setMainButtonsVisibleState);
     }
 
     @Override
@@ -106,6 +105,10 @@ public class MuSigCreateOfferController extends NavigationController implements 
 
     @Override
     public void onActivate() {
+        // We reset the offer in onActivate instead of onDeactivate because we need to pass
+        // this data to the offerbook controller
+        muSigCreateOfferReviewController.resetOffer();
+
         overlayController.setUseEscapeKeyHandler(false);
         overlayController.setEnterKeyHandler(null);
         overlayController.getApplicationRoot().addEventHandler(KeyEvent.KEY_PRESSED, onKeyPressedHandler);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewController.java
@@ -35,10 +35,13 @@ import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
+import bisq.desktop.common.view.Navigation;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.components.PriceInput;
 import bisq.desktop.main.content.mu_sig.components.MuSigReviewDataDisplay;
+import bisq.desktop.main.content.mu_sig.offerbook.MuSigOfferbookController;
 import bisq.desktop.navigation.NavigationTarget;
+import bisq.desktop.overlay.OverlayController;
 import bisq.i18n.Res;
 import bisq.mu_sig.MuSigService;
 import bisq.offer.Direction;
@@ -75,7 +78,6 @@ public class MuSigCreateOfferReviewController implements Controller {
     private final MuSigCreateOfferReviewModel model;
     @Getter
     private final MuSigCreateOfferReviewView view;
-    private final Consumer<NavigationTarget> closeAndNavigateToHandler;
     private final Consumer<Boolean> mainButtonsVisibleHandler;
     private final PriceInput priceInput;
     private final MarketPriceService marketPriceService;
@@ -85,10 +87,8 @@ public class MuSigCreateOfferReviewController implements Controller {
     private UIScheduler timeoutScheduler;
 
     public MuSigCreateOfferReviewController(ServiceProvider serviceProvider,
-                                            Consumer<Boolean> mainButtonsVisibleHandler,
-                                            Consumer<NavigationTarget> closeAndNavigateToHandler) {
+                                            Consumer<Boolean> mainButtonsVisibleHandler) {
         this.mainButtonsVisibleHandler = mainButtonsVisibleHandler;
-        this.closeAndNavigateToHandler = closeAndNavigateToHandler;
 
         marketPriceService = serviceProvider.getBondedRolesService().getMarketPriceService();
         muSigService = serviceProvider.getMuSigService();
@@ -318,6 +318,10 @@ public class MuSigCreateOfferReviewController implements Controller {
         model.reset();
     }
 
+    public void resetOffer() {
+        model.setOffer(null);
+    }
+
     @Override
     public void onActivate() {
         model.getShowCreateOfferSuccess().set(false);
@@ -345,7 +349,8 @@ public class MuSigCreateOfferReviewController implements Controller {
     }
 
     void onShowOfferbook() {
-        closeAndNavigateToHandler.accept(NavigationTarget.MU_SIG_OFFERBOOK);
+        OverlayController.hide(() -> Navigation.navigateTo(NavigationTarget.MU_SIG_OFFERBOOK,
+                new MuSigOfferbookController.InitData(model.getOffer())));
     }
 
     private void resetSelectedPaymentMethod() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewModel.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.mu_sig.create_offer.review;
 
 import bisq.account.payment_method.PaymentMethod;
 import bisq.common.market.Market;
-import bisq.common.market.MarketRepository;
 import bisq.common.monetary.Monetary;
 import bisq.desktop.common.view.Model;
 import bisq.offer.Direction;
@@ -89,7 +88,6 @@ class MuSigCreateOfferReviewModel implements Model {
     void reset() {
         direction = null;
         market = null;
-        offer = null;
         takersSelectedPaymentMethod = null;
         minBaseSideAmount = null;
         maxBaseSideAmount = null;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offerbook/MuSigOfferbookController.java
@@ -142,6 +142,7 @@ public class MuSigOfferbookController implements InitWithDataController<MuSigOff
                                 accountService));
                         model.getMuSigOfferIds().add(offerId);
                         updateFilteredMuSigOfferListItems();
+                        maybeSelectOffer();
                     }
                 });
             }
@@ -603,8 +604,10 @@ public class MuSigOfferbookController implements InitWithDataController<MuSigOff
             Optional<MuSigOfferListItem> toSelect = model.getMuSigOfferListItems().stream()
                     .filter(item -> item.getOffer().getId().equals(selectedOffer.getId()))
                     .findAny();
-            toSelect.ifPresent(item -> model.getSelectedMuSigOfferListItem().set(item));
-            model.setSelectedMuSigOffer(null);
+            if (toSelect.isPresent()) {
+                model.getSelectedMuSigOfferListItem().set(toSelect.get());
+                model.setSelectedMuSigOffer(null);
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review step now resets the pending offer on activation for a clean start.
* **Bug Fixes**
  * Offerbook selection is no longer cleared unexpectedly; new offers are auto-selected when applicable.
* **Refactor**
  * Simplified review screen initialization and streamlined navigation to the MuSig Offerbook, improving overlay handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->