### PR TITLE
Add new setting to allow adding contacts automatically

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/misc/MiscSettingsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/misc/MiscSettingsController.java
@@ -40,10 +40,9 @@ public class MiscSettingsController implements Controller {
     private final SettingsService settingsService;
     private final DifficultyAdjustmentService difficultyAdjustmentService;
     private final DontShowAgainService dontShowAgainService;
-    private Pin useAnimationsPin, preventStandbyModePin;
-
-    private Pin ignoreDiffAdjustmentFromSecManagerPin,
-            mostRecentDifficultyAdjustmentFactorOrDefaultPin, difficultyAdjustmentFactorPin, totalMaxBackupSizeInMBPin;
+    private Pin useAnimationsPin, preventStandbyModePin, ignoreDiffAdjustmentFromSecManagerPin,
+            mostRecentDifficultyAdjustmentFactorOrDefaultPin, difficultyAdjustmentFactorPin, totalMaxBackupSizeInMBPin,
+            addContactsAutomaticallyPin;
     private Subscription difficultyAdjustmentFactorDescriptionTextPin;
 
     public MiscSettingsController(ServiceProvider serviceProvider) {
@@ -86,6 +85,9 @@ public class MiscSettingsController implements Controller {
 
         totalMaxBackupSizeInMBPin = FxBindings.bindBiDir(model.getTotalMaxBackupSizeInMB())
                 .to(settingsService.getTotalMaxBackupSizeInMB(), settingsService::setTotalMaxBackupSizeInMB);
+
+        addContactsAutomaticallyPin = FxBindings.bindBiDir(model.getAddContactsAutomatically())
+                .to(settingsService.getAutoAddToContactsList(), settingsService::setAutoAddToContactsList);
     }
 
     @Override
@@ -103,6 +105,8 @@ public class MiscSettingsController implements Controller {
         if (mostRecentDifficultyAdjustmentFactorOrDefaultPin != null) {
             mostRecentDifficultyAdjustmentFactorOrDefaultPin.unbind();
         }
+
+        addContactsAutomaticallyPin.unbind();
     }
 
     void onResetDontShowAgain() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/misc/MiscSettingsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/misc/MiscSettingsModel.java
@@ -30,7 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Getter
-public class MiscSettingsModel implements Model { private final BooleanProperty useAnimations = new SimpleBooleanProperty();
+public class MiscSettingsModel implements Model {
+    private final BooleanProperty useAnimations = new SimpleBooleanProperty();
     private final BooleanProperty preventStandbyMode = new SimpleBooleanProperty();
 
     private final DoubleProperty difficultyAdjustmentFactor = new SimpleDoubleProperty();
@@ -49,6 +50,8 @@ public class MiscSettingsModel implements Model { private final BooleanProperty 
             new NumberValidator(Res.get("settings.backup.totalMaxBackupSizeInMB.invalid",
                     SettingsService.MIN_TOTAL_MAX_BACKUP_SIZE_IN_MB, SettingsService.MAX_TOTAL_MAX_BACKUP_SIZE_IN_MB),
                     SettingsService.MIN_TOTAL_MAX_BACKUP_SIZE_IN_MB, SettingsService.MAX_TOTAL_MAX_BACKUP_SIZE_IN_MB);
+
+    private final BooleanProperty addContactsAutomatically = new SimpleBooleanProperty();
 
     public MiscSettingsModel() {
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/misc/MiscSettingsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/misc/MiscSettingsView.java
@@ -39,15 +39,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MiscSettingsView extends View<VBox, MiscSettingsModel, MiscSettingsController> {
     private static final double TEXT_FIELD_WIDTH = 500;
-    private final Button resetDontShowAgain;
-    private final Switch useAnimations, preventStandbyMode;
 
+    private final Button resetDontShowAgain;
+    private final Switch useAnimations, preventStandbyMode, addContactsAutomatically;
     private final MaterialTextField totalMaxBackupSizeInMB;
 
     public MiscSettingsView(MiscSettingsModel model, MiscSettingsController controller) {
         super(new VBox(), model, controller);
 
-        root.setAlignment(Pos.TOP_LEFT);
+        // Display settings
         Label displayHeadline = SettingsViewUtils.getHeadline(Res.get("settings.display.headline"));
 
         useAnimations = new Switch(Res.get("settings.display.useAnimations"));
@@ -58,8 +58,7 @@ public class MiscSettingsView extends View<VBox, MiscSettingsModel, MiscSettings
         VBox.setMargin(resetDontShowAgain, new Insets(10, 0, 0, 0));
         VBox displayVBox = new VBox(10, useAnimations, preventStandbyMode, resetDontShowAgain);
 
-
-        // Backup
+        // Backup settings
         Label backupHeadline = SettingsViewUtils.getHeadline(Res.get("settings.backup.headline"));
         ImageView infoIcon = ImageUtil.getImageViewById("info");
         infoIcon.setOpacity(0.6);
@@ -71,11 +70,20 @@ public class MiscSettingsView extends View<VBox, MiscSettingsModel, MiscSettings
         totalMaxBackupSizeInMB.setMaxWidth(TEXT_FIELD_WIDTH);
         totalMaxBackupSizeInMB.setValidators(model.getTotalMaxBackupSizeValidator());
 
+        // Contacts settings
+        Label contactsHeadline = SettingsViewUtils.getHeadline(Res.get("settings.contacts.headline"));
+        Label contactsDescription = new Label(Res.get("settings.contacts.addContactsAutomatically.description"));
+        contactsDescription.getStyleClass().addAll("normal-text", "wrap-text", "text-fill-grey-dimmed");
+        addContactsAutomatically = new Switch(Res.get("settings.contacts.addContactsAutomatically.switch"));
+        VBox contactsVBox = new VBox(20, contactsDescription, addContactsAutomatically);
+
         VBox.setMargin(displayVBox, new Insets(0, 5, 0, 5));
         VBox contentBox = new VBox(50,
                 displayHeadline, separator(), displayVBox,
-                backupHeadlineHBox, separator(), totalMaxBackupSizeInMB);
+                backupHeadlineHBox, separator(), totalMaxBackupSizeInMB,
+                contactsHeadline, separator(), contactsVBox);
         contentBox.getStyleClass().add("bisq-common-bg");
+        root.setAlignment(Pos.TOP_LEFT);
         root.getChildren().add(contentBox);
         root.setPadding(new Insets(0, 40, 20, 40));
     }
@@ -89,6 +97,8 @@ public class MiscSettingsView extends View<VBox, MiscSettingsModel, MiscSettings
         Bindings.bindBidirectional(totalMaxBackupSizeInMB.textProperty(), model.getTotalMaxBackupSizeInMB(),
                 model.getTotalMaxBackupSizeConverter());
         totalMaxBackupSizeInMB.validate();
+
+        addContactsAutomatically.selectedProperty().bindBidirectional(model.getAddContactsAutomatically());
     }
 
     @Override
@@ -99,6 +109,8 @@ public class MiscSettingsView extends View<VBox, MiscSettingsModel, MiscSettings
 
         Bindings.unbindBidirectional(totalMaxBackupSizeInMB.textProperty(), model.getTotalMaxBackupSizeInMB());
         totalMaxBackupSizeInMB.resetValidation();
+
+        addContactsAutomatically.selectedProperty().unbindBidirectional(model.getAddContactsAutomatically());
     }
 
     private static Region separator() {

--- a/i18n/src/main/resources/settings.properties
+++ b/i18n/src/main/resources/settings.properties
@@ -32,6 +32,11 @@ settings.display.useAnimations=Use animations
 settings.display.preventStandbyMode=Prevent standby mode
 settings.display.resetDontShowAgain=Reset all 'Don't show again' flags
 
+settings.contacts.headline=Contacts settings
+settings.contacts.addContactsAutomatically.switch=Add contacts automatically
+settings.contacts.addContactsAutomatically.description=Activate the following option to streamline the process of keeping track \
+  of user profiles you have previously interacted with, as they will be automatically added to your contacts list.
+
 settings.trade.headline=Offer and trade settings
 settings.trade.maxTradePriceDeviation=Max. trade price tolerance
 settings.trade.maxTradePriceDeviation.help=The max. trade price difference a maker tolerates when their offer gets taken.

--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -122,7 +122,7 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
         pins.add(getBisqEasyOfferbookMessageTypeFilter().addObserver(value -> persist()));
         pins.add(getNumDaysAfterRedactingTradeData().addObserver(value -> persist()));
         pins.add(getMuSigActivated().addObserver(value -> persist()));
-        pins.add(getDoNotAutoAddToContactList().addObserver(value -> persist()));
+        pins.add(getAutoAddToContactsList().addObserver(value -> persist()));
 
         isInitialized = true;
 
@@ -267,12 +267,12 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
         return persistableStore.muSigActivated;
     }
 
-    public ReadOnlyObservable<Boolean> getDoNotAutoAddToContactList() {
-        return persistableStore.doNotAutoAddToContactList;
+    public ReadOnlyObservable<Boolean> getAutoAddToContactsList() {
+        return persistableStore.autoAddToContactsList;
     }
 
     public boolean getDoAutoAddToContactList() {
-        return !getDoNotAutoAddToContactList().get();
+        return getAutoAddToContactsList().get();
     }
 
     public Map<String, Market> getMuSigLastSelectedMarketByBaseCurrencyMap() {
@@ -378,8 +378,8 @@ public class SettingsService implements PersistenceClient<SettingsStore>, Servic
         persistableStore.muSigActivated.set(DevMode.isDevMode() && muSigActivated);
     }
 
-    public void setDoNotAutoAddToContactList(boolean value) {
-        persistableStore.doNotAutoAddToContactList.set(value);
+    public void setAutoAddToContactsList(boolean value) {
+        persistableStore.autoAddToContactsList.set(value);
     }
 
     public void setMuSigLastSelectedMarketByBaseCurrencyMap(Market market) {

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -81,7 +81,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
     final Observable<ChatMessageType> bisqEasyOfferbookMessageTypeFilter = new Observable<>();
     final Observable<Integer> numDaysAfterRedactingTradeData = new Observable<>();
     final Observable<Boolean> muSigActivated = new Observable<>();
-    final Observable<Boolean> doNotAutoAddToContactList = new Observable<>();
+    final Observable<Boolean> autoAddToContactsList = new Observable<>();
     final Map<String, Market> muSigLastSelectedMarketByBaseCurrencyMap = new ConcurrentHashMap<>();
 
     SettingsStore() {
@@ -113,7 +113,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
                 ChatMessageType.ALL,
                 DEFAULT_NUM_DAYS_AFTER_REDACTING_TRADE_DATA,
                 DevMode.isDevMode(),
-                false,
+                true,
                 new HashMap<>());
     }
 
@@ -145,7 +145,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
                   ChatMessageType bisqEasyOfferbookMessageTypeFilter,
                   int numDaysAfterRedactingTradeData,
                   boolean muSigActivated,
-                  boolean doNotAutoAddToContactList,
+                  boolean autoAddToContactsList,
                   Map<String, Market> muSigLastSelectedMarketByBaseCurrencyMap) {
         this.cookie = cookie;
         this.dontShowAgainMap.putAll(dontShowAgainMap);
@@ -175,7 +175,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
         this.bisqEasyOfferbookMessageTypeFilter.set(bisqEasyOfferbookMessageTypeFilter);
         this.numDaysAfterRedactingTradeData.set(numDaysAfterRedactingTradeData);
         this.muSigActivated.set(muSigActivated);
-        this.doNotAutoAddToContactList.set(doNotAutoAddToContactList);
+        this.autoAddToContactsList.set(autoAddToContactsList);
         this.muSigLastSelectedMarketByBaseCurrencyMap.putAll(muSigLastSelectedMarketByBaseCurrencyMap);
     }
 
@@ -210,7 +210,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
                 .setBisqEasyOfferbookMessageTypeFilter(bisqEasyOfferbookMessageTypeFilter.get().toProtoEnum())
                 .setNumDaysAfterRedactingTradeData(numDaysAfterRedactingTradeData.get())
                 .setMuSigActivated(muSigActivated.get())
-                .setDoNotAutoAddToContactList(doNotAutoAddToContactList.get())
+                .setAutoAddToContactsList(autoAddToContactsList.get())
                 .putAllMuSigLastSelectedMarketByBaseCurrencyMap(muSigLastSelectedMarketByBaseCurrencyMap.entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toProto(serializeForHash))));
     }
@@ -268,7 +268,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
                 ChatMessageType.fromProto(proto.getBisqEasyOfferbookMessageTypeFilter()),
                 numDaysAfterRedactingTradeData,
                 proto.getMuSigActivated(),
-                proto.getDoNotAutoAddToContactList(),
+                proto.getAutoAddToContactsList(),
                 proto.getMuSigLastSelectedMarketByBaseCurrencyMapMap().entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, entry -> Market.fromProto(entry.getValue()))));
     }
@@ -314,7 +314,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
                 bisqEasyOfferbookMessageTypeFilter.get(),
                 numDaysAfterRedactingTradeData.get(),
                 muSigActivated.get(),
-                doNotAutoAddToContactList.get(),
+                autoAddToContactsList.get(),
                 new HashMap<>(muSigLastSelectedMarketByBaseCurrencyMap));
     }
 
@@ -349,7 +349,7 @@ final class SettingsStore implements PersistableStore<SettingsStore> {
             bisqEasyOfferbookMessageTypeFilter.set(persisted.bisqEasyOfferbookMessageTypeFilter.get());
             numDaysAfterRedactingTradeData.set(persisted.numDaysAfterRedactingTradeData.get());
             muSigActivated.set(persisted.muSigActivated.get());
-            doNotAutoAddToContactList.set(persisted.doNotAutoAddToContactList.get());
+            autoAddToContactsList.set(persisted.autoAddToContactsList.get());
             muSigLastSelectedMarketByBaseCurrencyMap.putAll(persisted.muSigLastSelectedMarketByBaseCurrencyMap);
         } catch (Exception e) {
             log.error("Exception at applyPersisted", e);

--- a/settings/src/main/proto/settings.proto
+++ b/settings/src/main/proto/settings.proto
@@ -74,6 +74,6 @@ message SettingsStore {
   ChatMessageType bisqEasyOfferbookMessageTypeFilter = 26;
   sint32 numDaysAfterRedactingTradeData = 27;
   bool muSigActivated = 28;
-  bool doNotAutoAddToContactList = 29;
+  bool autoAddToContactsList = 29;
   map<string, common.Market> muSigLastSelectedMarketByBaseCurrencyMap = 30;
 }


### PR DESCRIPTION
Towards #3731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a Contacts section in Settings > Misc with an “Add contacts automatically” toggle. When enabled, counterparts you interact with are saved as contacts automatically; the preference is persisted and applied across sessions.

* Localization
  * Added translations for the new Contacts section, switch label, and description to support international users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->