### PR TITLE
Refactor FileUtils to use NIO instead of old IO

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -22,7 +22,6 @@ import bisq.common.application.ApplicationVersion;
 import bisq.common.application.DevMode;
 import bisq.common.application.Service;
 import bisq.common.asset.FiatCurrencyRepository;
-import bisq.common.file.FileUtils;
 import bisq.common.locale.CountryRepository;
 import bisq.common.locale.LanguageRepository;
 import bisq.common.locale.LocaleRepository;
@@ -39,6 +38,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -153,7 +153,7 @@ public abstract class ApplicationService implements Service {
                 ? Path.of(rootConfig.getString("application.baseDir"))
                 : userDataDir.resolve(appName);
         try {
-            FileUtils.makeDirs(baseDir.toFile());
+            Files.createDirectories(baseDir);
         } catch (IOException e) {
             log.error("Could not create data directory {}", baseDir, e);
             throw new RuntimeException(e);

--- a/apps/desktop/bi2p/src/main/java/bisq/bi2p/common/standby/SoundPlayer.java
+++ b/apps/desktop/bi2p/src/main/java/bisq/bi2p/common/standby/SoundPlayer.java
@@ -28,8 +28,8 @@ import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
@@ -67,15 +67,15 @@ class SoundPlayer implements PreventStandbyMode {
     private void playSound() {
         try {
             String fileName = "prevent-app-nap-silent-sound.aiff";
-            File soundFile = Path.of(baseDir, fileName).toFile();
-            if (!soundFile.exists()) {
+            Path soundFile = Path.of(baseDir, fileName);
+            if (!Files.exists(soundFile)) {
                 FileUtils.resourceToFile(fileName, soundFile);
             }
             AudioInputStream audioInputStream = null;
             SourceDataLine sourceDataLine = null;
             while (isPlaying) {
                 try {
-                    audioInputStream = AudioSystem.getAudioInputStream(soundFile);
+                    audioInputStream = AudioSystem.getAudioInputStream(soundFile.toFile());
                     sourceDataLine = getSourceDataLine(audioInputStream.getFormat());
                     byte[] tempBuffer = new byte[8192];
                     sourceDataLine.open(audioInputStream.getFormat());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/standby/SoundPlayer.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/standby/SoundPlayer.java
@@ -29,8 +29,8 @@ import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
@@ -68,15 +68,15 @@ class SoundPlayer implements PreventStandbyMode {
     private void playSound() {
         try {
             String fileName = "prevent-app-nap-silent-sound.aiff";
-            File soundFile = Path.of(baseDir, fileName).toFile();
-            if (!soundFile.exists()) {
+            Path soundFile = Path.of(baseDir, fileName);
+            if (!Files.exists(soundFile)) {
                 FileUtils.resourceToFile(fileName, soundFile);
             }
             AudioInputStream audioInputStream = null;
             SourceDataLine sourceDataLine = null;
             while (isPlaying) {
                 try {
-                    audioInputStream = AudioSystem.getAudioInputStream(soundFile);
+                    audioInputStream = AudioSystem.getAudioInputStream(soundFile.toFile());
                     sourceDataLine = getSourceDataLine(audioInputStream.getFormat());
                     byte[] tempBuffer = new byte[8192];
                     sourceDataLine.open(audioInputStream.getFormat());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/CatHashImageUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/CatHashImageUtil.java
@@ -17,11 +17,15 @@
 
 package bisq.desktop.common.utils;
 
-import bisq.common.file.FileUtils;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.image.*;
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.PixelReader;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
+import javafx.scene.image.WritablePixelFormat;
 import javafx.scene.paint.Color;
 
 import java.io.ByteArrayInputStream;
@@ -29,6 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 
 public class CatHashImageUtil {
     private static final String BASE_PATH = "images/cathash/";
@@ -65,13 +70,13 @@ public class CatHashImageUtil {
     }
 
     public static Image readRawImage(File file) throws IOException {
-        byte[] rawData = FileUtils.read(file.getAbsolutePath());
+        byte[] rawData = Files.readAllBytes(file.toPath());
         return byteArrayToImage(rawData);
     }
 
     public static void writeRawImage(Image image, File file) throws IOException {
         byte[] rawData = imageToByteArray(image);
-        FileUtils.write(file.getAbsolutePath(), rawData);
+        Files.write(file.toPath(), rawData);
     }
 
     public static Image byteArrayToImage(byte[] data) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -981,13 +981,11 @@ public abstract class Overlay<T extends Overlay<T>> {
                     // Copy debug log file and replace users home directory with "<HOME_DIR>" to avoid that
                     // private data gets leaked in case the user used their real name as their OS user.
                     Path debugLogPath = Path.of(baseDir + "/tor/").resolve("debug.log");
-                    File debugLogForZipFile = Path.of(baseDir + "/tor/").resolve("debug_for_zip.log").toFile();
+                    Path debugLogForZipFile = Path.of(baseDir + "/tor/").resolve("debug_for_zip.log");
                     try {
-                        if (debugLogForZipFile.exists()) {
-                            debugLogForZipFile.delete();
-                        }
-                        FileUtils.copyFile(debugLogPath.toFile(), debugLogForZipFile);
-                        String logContent = FileUtils.readAsString(debugLogForZipFile.getAbsolutePath());
+                        Files.deleteIfExists(debugLogForZipFile);
+                        FileUtils.copyFile(debugLogPath, debugLogForZipFile);
+                        String logContent = FileUtils.readUTF8String(debugLogForZipFile);
                         logContent = StringUtils.maskHomeDirectory(logContent);
                         FileUtils.writeToFile(logContent, debugLogForZipFile);
                     } catch (IOException e) {
@@ -998,7 +996,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     Map<String, String> env = Map.of("create", "true");
                     List<Path> logPaths = Arrays.asList(
                             Path.of(baseDir).resolve("bisq.log"),
-                            debugLogForZipFile.toPath());
+                            debugLogForZipFile);
                     try (FileSystem zipFileSystem = FileSystems.newFileSystem(uri, env)) {
                         logPaths.forEach(logPath -> {
                             if (logPath.toFile().isFile()) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/RichTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/RichTableView.java
@@ -234,7 +234,7 @@ public class RichTableView<T> extends VBox {
             FileChooserUtil.saveFile(tableView.getScene(), initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FileUtils.writeToFile(csv, file);
+                            FileUtils.writeToFile(csv, file.toPath());
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediationTableView.java
@@ -112,7 +112,7 @@ class MediationTableView extends VBox {
             FileChooserUtil.saveFile(tableView.getScene(), initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FileUtils.writeToFile(csv, file);
+                            FileUtils.writeToFile(csv, file.toPath());
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
@@ -61,7 +61,7 @@ public class OpenTradesUtils {
             FileChooserUtil.saveFile(scene, initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FileUtils.writeToFile(csv, file);
+                            FileUtils.writeToFile(csv, file.toPath());
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigOpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigOpenTradesUtils.java
@@ -58,7 +58,7 @@ public class MuSigOpenTradesUtils {
             FileChooserUtil.saveFile(scene, initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FileUtils.writeToFile(csv, file);
+                            FileUtils.writeToFile(csv, file.toPath());
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/nodes/tabs/registration/NodeRegistrationController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/nodes/tabs/registration/NodeRegistrationController.java
@@ -19,7 +19,9 @@ package bisq.desktop.main.content.network.bonded_roles.nodes.tabs.registration;
 
 import bisq.bonded_roles.BondedRoleType;
 import bisq.common.encoding.Hex;
-import bisq.common.file.FileUtils;
+import bisq.common.network.Address;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.TransportType;
 import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.utils.FileChooserUtil;
@@ -28,9 +30,6 @@ import bisq.desktop.main.content.components.UserProfileSelection;
 import bisq.desktop.main.content.network.bonded_roles.tabs.registration.BondedRolesRegistrationController;
 import bisq.desktop.main.content.network.bonded_roles.tabs.registration.BondedRolesRegistrationModel;
 import bisq.desktop.main.content.network.bonded_roles.tabs.registration.BondedRolesRegistrationView;
-import bisq.common.network.Address;
-import bisq.common.network.AddressByTransportTypeMap;
-import bisq.common.network.TransportType;
 import bisq.user.identity.UserIdentity;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -39,6 +38,7 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.lang.reflect.Type;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.util.HashMap;
@@ -93,7 +93,7 @@ public class NodeRegistrationController extends BondedRolesRegistrationControlle
         FileChooserUtil.openFile(getView().getRoot().getScene(), path.toAbsolutePath().toString())
                 .ifPresent(file -> {
                     try {
-                        String json = FileUtils.readStringFromFile(file);
+                        String json = Files.readString(file.toPath());
                         checkArgument(StringUtils.isNotEmpty(json), "Json must not be empty");
                         getNodesRegistrationModel().getAddressInfoJson().set(json);
                     } catch (Exception e) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/splash/SplashController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/splash/SplashController.java
@@ -33,7 +33,8 @@ import bisq.network.NetworkService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -104,8 +105,8 @@ public class SplashController implements Controller {
 
     public void onDeleteTor() {
         var conf = serviceProvider.getConfig();
-        File torDir = conf.getBaseDir().resolve("tor").toFile();
-        if (torDir.exists()) {
+        Path torDir = conf.getBaseDir().resolve("tor");
+        if (Files.exists(torDir)) {
             FileUtils.deleteOnExit(torDir);
             serviceProvider.getShutDownHandler().shutdown();
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLauncher.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLauncher.java
@@ -29,6 +29,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +56,7 @@ public class WebcamProcessLauncher {
                 if (!jarFile.exists() || DevMode.isDevMode()) {
                     String resourcePath = "webcam-app/webcam-app-" + version + ".zip";
                     InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath);
-                    File destDir = new File(webcamDir);
+                    Path destDir = Path.of(webcamDir);
                     ZipFileExtractor zipFileExtractor = new ZipFileExtractor(inputStream, destDir);
                     zipFileExtractor.extractArchive();
                     log.info("Extracted zip file {} to {}", resourcePath, webcamDir);
@@ -68,8 +70,8 @@ public class WebcamProcessLauncher {
                 ProcessBuilder processBuilder;
                 if (OS.isMacOs()) {
                     String iconPath = webcamDir + "/webcam-app-icon.png";
-                    File bisqIcon = new File(iconPath);
-                    if (!bisqIcon.exists()) {
+                    Path bisqIcon = Path.of(iconPath);
+                    if (!Files.exists(bisqIcon)) {
                         FileUtils.resourceToFile("images/webcam/webcam-app-icon@2x.png", bisqIcon);
                     }
                     String jvmArgs = "-Xdock:icon=" + iconPath;

--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/OracleNodeApp.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/OracleNodeApp.java
@@ -47,7 +47,7 @@ public class OracleNodeApp extends Executable<OracleNodeApplicationService> {
         String json = new GsonBuilder().setPrettyPrinting().create().toJson(addressByTransportTypeMap);
         Path path = applicationService.getConfig().getBaseDir().resolve("default_node_address.json");
         try {
-            FileUtils.writeToFile(json, path.toFile());
+            FileUtils.writeToFile(json, path);
         } catch (IOException e) {
             log.error("Error at write json", e);
         }

--- a/apps/seed-node-app/src/main/java/bisq/seed_node/SeedNodeApp.java
+++ b/apps/seed-node-app/src/main/java/bisq/seed_node/SeedNodeApp.java
@@ -44,7 +44,7 @@ public class SeedNodeApp extends Executable<SeedNodeApplicationService> {
         String json = new GsonBuilder().setPrettyPrinting().create().toJson(addressByTransportTypeMap);
         Path path = applicationService.getConfig().getBaseDir().resolve("default_node_address.json");
         try {
-            FileUtils.writeToFile(json, path.toFile());
+            FileUtils.writeToFile(json, path);
         } catch (IOException e) {
             log.error("Error at write json", e);
         }

--- a/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
+++ b/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
@@ -17,21 +17,20 @@
 
 package bisq.common.archive;
 
-import bisq.common.file.FileUtils;
-
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class ZipFileExtractor implements AutoCloseable {
 
     private final InputStream zipFileInputStream;
-    private final File destDir;
+    private final Path destDir;
 
-    public ZipFileExtractor(InputStream zipFileInputStream, File destDir) {
+    public ZipFileExtractor(InputStream zipFileInputStream, Path destDir) {
         this.zipFileInputStream = zipFileInputStream;
         this.destDir = destDir;
     }
@@ -46,9 +45,9 @@ public class ZipFileExtractor implements AutoCloseable {
         zipFileInputStream.close();
     }
 
-    private void createDirIfNotPresent(File destDir) {
+    private void createDirIfNotPresent(Path destDir) {
         try {
-            FileUtils.makeDirs(destDir);
+            Files.createDirectories(destDir);
         } catch (IOException e) {
             throw new ZipFileExtractionFailedException("Couldn't create directory: " + destDir, e);
         }
@@ -63,7 +62,7 @@ public class ZipFileExtractor implements AutoCloseable {
                 String fileName = zipEntry.getName();
 
                 if (zipEntry.isDirectory()) {
-                    File dirFile = new File(destDir, fileName);
+                    Path dirFile = destDir.resolve(fileName);
                     createDirIfNotPresent(dirFile);
                 } else {
                     writeStreamToFile(buffer, zipInputStream, fileName);
@@ -79,8 +78,8 @@ public class ZipFileExtractor implements AutoCloseable {
     }
 
     private void writeStreamToFile(byte[] buffer, InputStream inputStream, String fileName) {
-        File destFile = new File(destDir, fileName);
-        try (FileOutputStream outputStream = new FileOutputStream(destFile)) {
+        Path destFile = destDir.resolve(fileName);
+        try (OutputStream outputStream = Files.newOutputStream(destFile)) {
             int length;
             while ((length = inputStream.read(buffer)) > 0) {
                 outputStream.write(buffer, 0, length);

--- a/common/src/main/java/bisq/common/jvm/DeleteOnExitHook.java
+++ b/common/src/main/java/bisq/common/jvm/DeleteOnExitHook.java
@@ -47,8 +47,8 @@ import bisq.common.file.FileUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -111,14 +111,12 @@ public class DeleteOnExitHook {
         // Last in first deleted.
         Collections.reverse(toBeDeleted);
         for (String filename : toBeDeleted) {
+            Path path = Path.of(filename);
             try {
-                FileUtils.deleteFileOrDirectory(new File(filename));
+                FileUtils.deleteFileOrDirectory(path);
             } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            File file = new File(filename);
-            if (file.exists() && !file.delete()) {
                 log.warn("Deleting {} failed", filename);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/common/src/test/java/bisq/common/util/FileUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/FileUtilsTest.java
@@ -3,8 +3,24 @@ package bisq.common.util;
 import bisq.common.file.FileUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("SpellCheckingInspection")
 @Slf4j
@@ -14,5 +30,258 @@ public class FileUtilsTest {
     public void hasResourceFile() {
         assertTrue(FileUtils.hasResourceFile("logback.xml"));
         assertFalse(FileUtils.hasResourceFile("logback.xml1"));
+    }
+
+    @Test
+    void testReadUtf8StringFile(@TempDir Path tempDir) throws IOException {
+        Path path = tempDir.resolve("test2.txt");
+        Files.write(path, "abc".getBytes());
+        assertEquals("abc", FileUtils.readUTF8String(path));
+    }
+
+    @Test
+    void testDeleteOnExitAndReleaseTempFile(@TempDir Path tempDir) throws IOException {
+        Path path = tempDir.resolve("deleteOnExit.txt");
+        Files.createFile(path);
+        FileUtils.deleteOnExit(path);
+        FileUtils.releaseTempFile(path);
+        assertThat(path).doesNotExist();
+    }
+
+    @Test
+    void testDeleteFileOrDirectory(@TempDir Path tempDir) throws IOException {
+        Path dir = tempDir.resolve("dir");
+        Files.createDirectory(dir);
+        Path file = dir.resolve("file.txt");
+        Files.createFile(file);
+        FileUtils.deleteFileOrDirectory(dir);
+        assertThat(file).doesNotExist();
+    }
+
+    @Test
+    void testDeleteFileOrDirectoryWithComplexDirectory(@TempDir Path tempDir) throws IOException {
+        // Setup complex nested directories and files
+        Path subDir1 = tempDir.resolve("subDir1");
+        Path subDir2 = tempDir.resolve("subDir2");
+        Files.createDirectories(subDir1);
+        Files.createDirectories(subDir2);
+
+        // Create files at multiple levels
+        Files.writeString(tempDir.resolve("rootFile.txt"), "root");
+        Files.writeString(subDir1.resolve("file1.txt"), "file1");
+        Files.writeString(subDir1.resolve("file2.txt"), "file2");
+        Files.writeString(subDir2.resolve("file3.txt"), "file3");
+
+        Path nested = subDir2.resolve("nested");
+        Files.createDirectory(nested);
+        Files.writeString(nested.resolve("nestedFile.txt"), "nested");
+
+        // Ensure files exist before deletion
+        assertThat(tempDir.resolve("rootFile.txt")).exists();
+        assertThat(subDir1.resolve("file1.txt")).exists();
+        assertThat(nested.resolve("nestedFile.txt")).exists();
+
+        // Perform recursive delete
+        FileUtils.deleteFileOrDirectory(tempDir);
+
+        // Assert everything is deleted
+        assertThat(tempDir).doesNotExist();
+        assertThat(subDir1).doesNotExist();
+        assertThat(nested).doesNotExist();
+    }
+
+    @Test
+    void testDeleteFileAndWait(@TempDir Path tempDir) throws IOException, InterruptedException {
+        Path path = tempDir.resolve("wait.txt");
+        Files.createFile(path);
+        FileUtils.deleteFileAndWait(path, 1000);
+        assertThat(path).doesNotExist();
+    }
+
+    @Test
+    void testWaitUntilFileExists(@TempDir Path tempDir) throws InterruptedException, TimeoutException {
+        Path path = tempDir.resolve("waitExists.txt");
+        new Thread(() -> {
+            try {
+                Thread.sleep(200);
+                Files.createFile(path);
+            } catch (Exception ignored) {
+            }
+        }).start();
+        FileUtils.waitUntilFileExists(path, 1000);
+        assertThat(path).exists();
+    }
+
+    @Test
+    void testCreateTempDir() throws IOException {
+        Path temp = FileUtils.createTempDir();
+        assertTrue(Files.isDirectory(temp));
+        // Clean up
+        FileUtils.deleteFileOrDirectory(temp);
+    }
+
+    @Test
+    void testListFilesInDirectory(@TempDir Path tempDir) throws IOException {
+        Path dir = tempDir.resolve("listdir");
+        Files.createDirectory(dir);
+        Files.createFile(dir.resolve("a.txt"));
+        Files.createFile(dir.resolve("b.txt"));
+        Set<String> files = FileUtils.listFilesInDirectory(dir, 1);
+        assertTrue(files.contains("a.txt"));
+        assertTrue(files.contains("b.txt"));
+    }
+
+    @Test
+    void testRenameFileOverExistingFile(@TempDir Path tempDir) throws IOException {
+        // Create the source file
+        Path sourceFile = tempDir.resolve("source.txt");
+        Files.writeString(sourceFile, "Hello source");
+
+        // Create the target file that already exists
+        Path targetFile = tempDir.resolve("target.txt");
+        Files.writeString(targetFile, "Existing target");
+
+        // Perform the rename (should overwrite existing target)
+        boolean success = FileUtils.renameFile(sourceFile, targetFile);
+
+        assertTrue(success, "Rename should succeed");
+
+        // Source file should no longer exist
+        assertFalse(Files.exists(sourceFile), "Source file should be deleted");
+
+        // Target file should exist and contain the source content
+        assertTrue(Files.exists(targetFile), "Target file should exist");
+        String content = Files.readString(targetFile);
+        assertEquals("Hello source", content, "Target file should have the source content");
+    }
+
+    @Test
+    void testWriteToFile(@TempDir Path tempDir) throws IOException {
+        Path path = tempDir.resolve("writefile.txt");
+        FileUtils.writeToFile("data", path);
+        assertEquals("data", Files.readString(path));
+    }
+
+    @Test
+    void testReadFromFileIfPresent(@TempDir Path tempDir) throws IOException {
+        Path path = tempDir.resolve("present.txt");
+        Files.write(path, "abc".getBytes());
+        Optional<String> result = FileUtils.readFromFileIfPresent(path);
+        assertTrue(result.isPresent());
+        assertEquals("abc", result.get());
+    }
+
+    @Test
+    void testReadFromScanner() {
+        Scanner scanner = new Scanner("line1\nline2");
+        assertEquals("line1\nline2", FileUtils.readFromScanner(scanner));
+    }
+
+    @Test
+    void testGetResourceAsStream() throws IOException {
+        InputStream is = FileUtils.getResourceAsStream("logback.xml");
+        assertNotNull(is);
+        is.close();
+    }
+
+    @Test
+    void testResourceToFile(@TempDir Path tempDir) throws IOException {
+        Path path = tempDir.resolve("resource.txt");
+        FileUtils.resourceToFile("logback.xml", path);
+        assertThat(path).exists();
+    }
+
+    @Test
+    void testCopyFile(@TempDir Path tempDir) throws IOException {
+        Path src = tempDir.resolve("src.txt");
+        Path dest = tempDir.resolve("dest.txt");
+        Files.write(src, "copy".getBytes());
+        FileUtils.copyFile(src, dest);
+        assertEquals("copy", Files.readString(dest));
+    }
+
+    @Test
+    void testCopyInputStream() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream("abc".getBytes());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        FileUtils.copy(in, out);
+        assertEquals("abc", out.toString());
+    }
+
+    @Test
+    void testListDirectories(@TempDir Path tempDir) throws IOException {
+        Path dir = tempDir.resolve("listdirs");
+        Files.createDirectory(dir);
+
+        // Create subdirectories
+        Path sub1 = dir.resolve("subdir1");
+        Path sub2 = dir.resolve("subdir2");
+        Files.createDirectory(sub1);
+        Files.createDirectory(sub2);
+
+        // Create a file to ensure it is not included
+        Path file = dir.resolve("file.txt");
+        Files.createFile(file);
+
+        // Call method under test
+        Set<String> dirs = FileUtils.listDirectories(dir);
+
+        // Assertions
+        assertEquals(2, dirs.size(), "Should only contain 2 directories");
+        assertTrue(dirs.contains("subdir1"), "subdir1 should be listed");
+        assertTrue(dirs.contains("subdir2"), "subdir2 should be listed");
+        assertFalse(dirs.contains("file.txt"), "Files should not be listed");
+    }
+
+    @Test
+    void testRenameFile(@TempDir Path tempDir) throws IOException {
+        Path oldPath = tempDir.resolve("old.txt");
+        Path newPath = tempDir.resolve("new.txt");
+        Files.write(oldPath, "rename".getBytes());
+        assertTrue(FileUtils.renameFile(oldPath, newPath));
+        assertTrue(Files.exists(newPath));
+        assertFalse(Files.exists(oldPath));
+    }
+
+    @Test
+    void testBackupCorruptedFile(@TempDir Path tempDir) throws IOException {
+        Path dir = tempDir.resolve("backup");
+        Files.createDirectory(dir);
+        Path path = dir.resolve("corrupt.txt");
+        Files.write(path, "data".getBytes());
+        FileUtils.backupCorruptedFile(dir.toString(), path, "corrupt.txt", "backup");
+        Set<String> files = FileUtils.listFiles(dir.resolve("backup"));
+        assertTrue(files.stream().anyMatch(f -> f.startsWith("corrupt.txt_at_")));
+    }
+
+    @Test
+    void testHasResourceFile() {
+        assertTrue(FileUtils.hasResourceFile("logback.xml"));
+        assertFalse(FileUtils.hasResourceFile("nonexistent.xml"));
+    }
+
+    @Test
+    void testCopyDirectoryWithExtensionsToSkip(@TempDir Path tempDir) throws IOException {
+        Path srcDir = tempDir.resolve("srcdir2");
+        Path destDir = tempDir.resolve("destdir2");
+        Files.createDirectory(srcDir);
+        Files.write(srcDir.resolve("file.txt"), "abc".getBytes());
+        Files.write(srcDir.resolve("file.skip"), "skip".getBytes());
+        FileUtils.copyDirectory(srcDir.toString(), destDir.toString(), Set.of("skip"));
+        assertTrue(Files.exists(destDir.resolve("file.txt")));
+        assertFalse(Files.exists(destDir.resolve("file.skip")));
+    }
+
+    @Test
+    void testListResources() throws Exception {
+        Set<String> resources = FileUtils.listResources("bisq/common/util/");
+        assertTrue(resources.contains("FileUtilsTest.class"));
+    }
+
+    @Test
+    void testCopyResourceDirectory(@TempDir Path tempDir) throws Exception {
+        Path targetDir = tempDir.resolve("resourceCopy");
+        FileUtils.copyResourceDirectory("bisq/common/util/", targetDir);
+        assertTrue(Files.exists(targetDir.resolve("FileUtilsTest.class")));
     }
 }

--- a/evolution/src/main/java/bisq/evolution/updater/DownloadedFilesVerification.java
+++ b/evolution/src/main/java/bisq/evolution/updater/DownloadedFilesVerification.java
@@ -71,8 +71,8 @@ public class DownloadedFilesVerification {
                                                          File sigFile,
                                                          File dataFile) throws IOException {
         String signingKeyFileName = FROM_RESOURCES_PREFIX + signingKeyId + ASC_EXTENSION;
-        File signingKeyFile = Path.of(directory, signingKeyFileName).toFile(); // E.g. from_resources_E222AA02.asc
+        Path signingKeyFile = Path.of(directory, signingKeyFileName); // E.g. from_resources_E222AA02.asc
         FileUtils.resourceToFile("keys/" + signingKeyId + ASC_EXTENSION, signingKeyFile); // We copy key from resources to download directory
-        checkArgument(PgPUtils.isSignatureValid(signingKeyFile, sigFile, dataFile), "Signature verification failed: signingKeyFileName=" + signingKeyFileName);
+        checkArgument(PgPUtils.isSignatureValid(signingKeyFile.toFile(), sigFile, dataFile), "Signature verification failed: signingKeyFileName=" + signingKeyFileName);
     }
 }

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
@@ -21,8 +21,8 @@ import bisq.common.file.FileUtils;
 import bisq.common.platform.Platform;
 import bisq.common.platform.PlatformUtils;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -38,11 +38,11 @@ public class UpdaterUtils {
     public static final String ASC_EXTENSION = ".asc";
 
     public static String getSigningKeyId(String directory) throws IOException {
-        return FileUtils.readStringFromFile(Path.of(directory, SIGNING_KEY_FILE).toFile());
+        return Files.readString(Path.of(directory, SIGNING_KEY_FILE));
     }
 
     public static String getSigningKey(String directory, String signingKeyId) throws IOException {
-        return FileUtils.readStringFromFile(Path.of(directory, signingKeyId + ASC_EXTENSION).toFile());
+        return Files.readString(Path.of(directory, signingKeyId + ASC_EXTENSION));
     }
 
     public static String getDownloadFileName(String version, boolean isLauncherUpdate) {
@@ -59,8 +59,8 @@ public class UpdaterUtils {
     }
 
     public static Optional<String> readVersionFromVersionFile(String userDataDir) {
-        String versionFilePath = userDataDir + File.separator + VERSION_FILE_NAME;
-        return FileUtils.readFromFileIfPresent(new File(versionFilePath));
+        Path versionFilePath = Path.of(userDataDir, VERSION_FILE_NAME);
+        return FileUtils.readFromFileIfPresent(versionFilePath);
     }
 
     public static boolean isDownloadedFile(String fileName) {

--- a/http-api/src/main/java/bisq/http_api/ApiTorOnionService.java
+++ b/http-api/src/main/java/bisq/http_api/ApiTorOnionService.java
@@ -26,7 +26,6 @@ import bisq.security.keys.KeyBundle;
 import bisq.security.keys.KeyBundleService;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
@@ -69,9 +68,8 @@ public class ApiTorOnionService implements Service {
                     log.info("{} published for {}", onionAddressWithPort, identityTag);
                     try {
                         Path path = baseDir.resolve(identityTag + "_onionAddress.txt");
-                        File file = path.toFile();
 
-                        FileUtils.writeToFile(onionAddressWithPort, file);
+                        FileUtils.writeToFile(onionAddressWithPort, path);
                         return true;
                     } catch (IOException e) {
                         log.error("Error at write onionAddress", e);

--- a/network/i2p/src/main/java/bisq/network/i2p/router/utils/RouterCertificateUtil.java
+++ b/network/i2p/src/main/java/bisq/network/i2p/router/utils/RouterCertificateUtil.java
@@ -19,22 +19,23 @@ package bisq.network.i2p.router.utils;
 
 import bisq.common.file.FileUtils;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class RouterCertificateUtil {
-    public static void copyCertificatesFromResources(File i2pDir) throws IOException, URISyntaxException {
-        File certDir = createDirectory(i2pDir, "certificates");
-        File seedDir = createDirectory(certDir, "reseed");
-        File sslDir = createDirectory(certDir, "ssl");
-        FileUtils.copyResourceDirectory("certificates/reseed/", seedDir.toPath());
-        FileUtils.copyResourceDirectory("certificates/ssl/", sslDir.toPath());
+    public static void copyCertificatesFromResources(Path i2pDir) throws IOException, URISyntaxException {
+        Path certDir = createDirectory(i2pDir, "certificates");
+        Path seedDir = createDirectory(certDir, "reseed");
+        Path sslDir = createDirectory(certDir, "ssl");
+        FileUtils.copyResourceDirectory("certificates/reseed/", seedDir);
+        FileUtils.copyResourceDirectory("certificates/ssl/", sslDir);
     }
 
-    private static File createDirectory(File parent, String child) throws IOException {
-        File dir = new File(parent, child);
-        FileUtils.makeDirIfNotExists(dir);
+    private static Path createDirectory(Path parent, String child) throws IOException {
+        Path dir = parent.resolve(child);
+        Files.createDirectories(dir);
         return dir;
     }
 }

--- a/network/network/src/main/java/bisq/network/NetworkIdService.java
+++ b/network/network/src/main/java/bisq/network/NetworkIdService.java
@@ -166,7 +166,7 @@ public class NetworkIdService implements PersistenceClient<NetworkIdStore>, Serv
         try {
             FileUtils.backupCorruptedFile(
                     parentDirectoryPath.toAbsolutePath().toString(),
-                    storeFilePath.toFile(),
+                    storeFilePath,
                     storeFilePath.getFileName().toString(),
                     "corruptedNetworkId"
             );

--- a/network/network/src/main/java/bisq/network/p2p/node/transport/i2p/Bi2pProcessLauncher.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/transport/i2p/Bi2pProcessLauncher.java
@@ -80,7 +80,7 @@ public class Bi2pProcessLauncher implements Service {
                     String resourcePath = "bi2p/bi2p-" + version + ".zip";
                     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
                         if (inputStream == null) throw new FileNotFoundException("Resource not found: " + resourcePath);
-                        new ZipFileExtractor(inputStream, i2pRouterDir.toFile()).extractArchive();
+                        new ZipFileExtractor(inputStream, i2pRouterDir).extractArchive();
                     }
                     log.info("Extracted zip {} to {}", resourcePath, i2pRouterDir);
                 }
@@ -104,7 +104,7 @@ public class Bi2pProcessLauncher implements Service {
                 if (OS.isMacOs()) {
                     Path iconPath = i2pRouterDir.resolve("bi2p-app_512.png");
                     if (!Files.exists(iconPath)) {
-                        FileUtils.resourceToFile("images/bi2p/bi2p-app_512.png", iconPath.toFile());
+                        FileUtils.resourceToFile("images/bi2p/bi2p-app_512.png", iconPath);
                     }
                     command.add("-Xdock:icon=" + iconPath);
                 }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
@@ -56,7 +56,7 @@ public class TorrcFileGenerator {
 
 
         try {
-            FileUtils.writeToFile(torrcStringBuilder.toString(), torrcPath.toFile());
+            FileUtils.writeToFile(torrcStringBuilder.toString(), torrcPath);
         } catch (IOException e) {
             throw new IllegalStateException("Couldn't create torrc file: " + torrcPath.toAbsolutePath());
         }

--- a/network/tor/tor/src/main/java/bisq/network/tor/installer/TorBinaryZipExtractor.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/installer/TorBinaryZipExtractor.java
@@ -22,18 +22,18 @@ import bisq.common.archive.ZipFileExtractor;
 import bisq.common.platform.OS;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 
 @Slf4j
 public class TorBinaryZipExtractor {
 
     private static final String ARCHIVE_FILENAME = "tor.zip";
 
-    private final File destDir;
+    private final Path destDir;
 
-    public TorBinaryZipExtractor(File destDir) {
+    public TorBinaryZipExtractor(Path destDir) {
         this.destDir = destDir;
     }
 
@@ -60,8 +60,8 @@ public class TorBinaryZipExtractor {
             return;
         }
 
-        File torBinaryFile = new File(destDir, "tor");
-        if (!torBinaryFile.setExecutable(true)) {
+        Path torBinaryFile = destDir.resolve("tor");
+        if (!torBinaryFile.toFile().setExecutable(true)) {
             throw new ZipFileExtractionFailedException("Couldn't make tor binary executable: " + ARCHIVE_FILENAME);
         }
     }

--- a/network/tor/tor/src/main/java/bisq/network/tor/installer/TorInstallationFiles.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/installer/TorInstallationFiles.java
@@ -19,20 +19,19 @@ package bisq.network.tor.installer;
 
 import lombok.Getter;
 
-import java.io.File;
 import java.nio.file.Path;
 
 @Getter
 public class TorInstallationFiles {
-    private final File torDir;
-    private final File torBinary;
-    private final File torrcFile;
-    private final File versionFile;
+    private final Path torDir;
+    private final Path torBinary;
+    private final Path torrcFile;
+    private final Path versionFile;
 
     public TorInstallationFiles(Path torDirPath) {
-        torDir = torDirPath.toFile();
-        torBinary = new File(torDir, "tor");
-        torrcFile = new File(torDir, "torrc");
-        versionFile = new File(torDir, "version");
+        torDir = torDirPath;
+        torBinary = torDir.resolve("tor");
+        torrcFile = torDir.resolve("torrc");
+        versionFile = torDir.resolve("version");
     }
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/process/control_port/ControlPortFileParser.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/process/control_port/ControlPortFileParser.java
@@ -27,7 +27,7 @@ public class ControlPortFileParser {
 
     public static int parse(Path controlPortFilePath) {
         try {
-            String fileContent = FileUtils.readAsString(controlPortFilePath.toString());
+            String fileContent = FileUtils.readUTF8String(controlPortFilePath);
             if (isControlPortFileReady(fileContent)) {
                 for (String line : fileContent.split("\n")) {
                     // Lines end on Windows with "\r\n". Previous String.split("\n") removed "\n" already.

--- a/os-specific/src/main/java/bisq/os_specific/notifications/linux/LinuxNotificationService.java
+++ b/os-specific/src/main/java/bisq/os_specific/notifications/linux/LinuxNotificationService.java
@@ -25,8 +25,8 @@ import bisq.settings.SettingsService;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,16 +65,16 @@ public class LinuxNotificationService implements OsSpecificNotificationService {
 
                     // We are running from source code and use icon from resources as Bisq2.png is not available
                     String fileName = "linux-notification-icon.png";
-                    File destination = Path.of(baseDir.toAbsolutePath().toString(), fileName).toFile();
-                    if (!destination.exists()) {
+                    Path destination = baseDir.resolve(fileName);
+                    if (!Files.exists(destination)) {
                         try {
                             FileUtils.resourceToFile(fileName, destination);
-                            iconPath = destination.getAbsolutePath();
+                            iconPath = destination.toAbsolutePath().toString();
                         } catch (IOException e) {
                             log.error("Copying notificationIcon from resources failed", e);
                         }
                     } else {
-                        iconPath = destination.getAbsolutePath();
+                        iconPath = destination.toAbsolutePath().toString();
                     }
                 }
 

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -71,8 +72,7 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
             writeStoreToTempFile(persistableStore);
             boolean hasFileBeenBackedUp = storeFileManager.maybeBackup();
             if (!hasFileBeenBackedUp) {
-                File storeFile = storeFilePath.toFile();
-                FileUtils.deleteFile(storeFile);
+                Files.deleteIfExists(storeFilePath);
             }
             storeFileManager.renameTempFileToCurrentFile();
         } catch (CouldNotSerializePersistableStore e) {
@@ -98,7 +98,7 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
         try {
             FileUtils.backupCorruptedFile(
                     parentDirectoryPath.toAbsolutePath().toString(),
-                    storeFilePath.toFile(),
+                    storeFilePath,
                     storeFilePath.getFileName().toString(),
                     "corruptedFilesAtRead"
             );

--- a/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
@@ -27,6 +27,7 @@ import net.i2p.data.PrivateKeyFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 @Slf4j
@@ -37,10 +38,10 @@ public class I2PKeyUtils {
         Path destination_b32Path = I2PKeyGeneration.getDestinationFilePath(storageDir, tag, "destination_b32");
         Path identityBase64Path = I2PKeyGeneration.getDestinationFilePath(storageDir, tag, "identity_b64");
         try {
-            FileUtils.makeDirs(i2pPrivateKeyDir);
-            FileUtils.writeToFile(i2pKeyPair.getDestinationBase64(), destination_b64Path.toFile());
-            FileUtils.writeToFile(i2pKeyPair.getDestinationBase32(), destination_b32Path.toFile());
-            FileUtils.writeToFile(Base64.encode(i2pKeyPair.getIdentityBytes()), identityBase64Path.toFile());
+            Files.createDirectories(i2pPrivateKeyDir);
+            FileUtils.writeToFile(i2pKeyPair.getDestinationBase64(), destination_b64Path);
+            FileUtils.writeToFile(i2pKeyPair.getDestinationBase32(), destination_b32Path);
+            FileUtils.writeToFile(Base64.encode(i2pKeyPair.getIdentityBytes()), identityBase64Path);
             log.info("Persisted the I2P private key and destinations into {}", i2pPrivateKeyDir);
         } catch (Exception e) {
             log.error("Could not persist I2P destination files", e);

--- a/security/src/main/java/bisq/security/keys/KeyBundleService.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundleService.java
@@ -30,9 +30,9 @@ import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
@@ -216,12 +216,12 @@ public class KeyBundleService implements PersistenceClient<KeyBundleStore>, Serv
             }
             if (writeKeyStoreSecretUidToFile) {
                 try {
-                    FileUtils.makeDirs(defaultKeyStoragePath);
+                    Files.createDirectories(defaultKeyStoragePath);
                 } catch (IOException e) {
                     log.error("Could not create {}", defaultKeyStoragePath);
                     throw new RuntimeException(e);
                 }
-                File file = defaultKeyStoragePath.resolve("keyStoreSecretUid").toFile();
+                Path file = defaultKeyStoragePath.resolve("keyStoreSecretUid");
                 try {
                     FileUtils.writeToFile(persistableStore.getSecretUid(), file);
                 } catch (IOException e) {

--- a/security/src/main/java/bisq/security/keys/KeyPairUtils.java
+++ b/security/src/main/java/bisq/security/keys/KeyPairUtils.java
@@ -11,6 +11,7 @@ import org.bouncycastle.jce.spec.ECPublicKeySpec;
 import org.bouncycastle.math.ec.ECPoint;
 
 import java.math.BigInteger;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -30,12 +31,12 @@ public class KeyPairUtils {
     public static void writePrivateKey(KeyPair keyPair, Path storageDir, String tag) {
         Path targetPath = storageDir.resolve(tag);
         try {
-            FileUtils.makeDirs(targetPath);
+            Files.createDirectories(targetPath);
 
             ECPrivateKey ecPrivate = (ECPrivateKey) keyPair.getPrivate();
             byte[] priv32 = toUnsignedFixedLength(ecPrivate.getS(), 32);
 
-            FileUtils.writeToFile(Hex.encode(priv32), targetPath.resolve("private_key_hex").toFile());
+            FileUtils.writeToFile(Hex.encode(priv32), targetPath.resolve("private_key_hex"));
             log.info("Persisted hex encoded 32-byte secp256k1 private key for tag {} at {}", tag, targetPath);
         } catch (Exception e) {
             log.error("Could not persist private key", e);

--- a/security/src/main/java/bisq/security/keys/TorKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyUtils.java
@@ -5,7 +5,7 @@ import bisq.common.file.FileUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Base32;
 
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -21,13 +21,12 @@ public class TorKeyUtils {
 
     public static void writePrivateKey(TorKeyPair torKeyPair, Path storageDir, String tag) {
         Path targetPath = Paths.get(storageDir.toString(), tag);
-        File torPrivateKeyDir = targetPath.toFile();
         try {
-            FileUtils.makeDirs(torPrivateKeyDir);
-            String dir = torPrivateKeyDir.getAbsolutePath();
+            Files.createDirectories(targetPath);
+            String dir = targetPath.toAbsolutePath().toString();
 
-            FileUtils.writeToFile(Hex.encode(torKeyPair.getPrivateKey()), Paths.get(dir, "private_key_hex").toFile());
-            FileUtils.writeToFile(torKeyPair.getOnionAddress(), Paths.get(dir, "hostname").toFile());
+            FileUtils.writeToFile(Hex.encode(torKeyPair.getPrivateKey()), Paths.get(dir, "private_key_hex"));
+            FileUtils.writeToFile(torKeyPair.getOnionAddress(), Paths.get(dir, "hostname"));
 
             log.info("We persisted the tor private key in hex encoding for onionAddress {} for tag {} to {}.",
                     torKeyPair.getOnionAddress(), tag, dir);

--- a/security/src/test/java/bisq/security/PgPUtilsTest.java
+++ b/security/src/test/java/bisq/security/PgPUtilsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SignatureException;
@@ -38,12 +39,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class PgPUtilsTest {
     @BeforeEach
     void setUp() throws IOException {
-        FileUtils.makeDirs(Path.of("temp").toFile());
+        Files.createDirectories(Path.of("temp"));
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        FileUtils.deleteFileOrDirectory(Path.of("temp").toFile());
+        FileUtils.deleteFileOrDirectory(Path.of("temp"));
     }
 
     @Test


### PR DESCRIPTION
This PR relates to #3915 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Migrated file and I/O handling across the app to modern Path/NIO APIs, improving cross-platform reliability for backups, Tor/I2P setup, CSV export, media (icons/sounds), webcam resources, notifications, and log packaging; several public utilities updated to Path-centric usage.
- Tests
  - Expanded file-utility tests and backup/resource-copying coverage to reduce regressions and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->