### PR TITLE
Trigger a new inventory request after all connections lost

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestPolicy.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestPolicy.java
@@ -112,6 +112,14 @@ class InventoryRequestPolicy {
                 isBelowMaxPendingRequests();
     }
 
+    public void onAllConnectionsLost() {
+        log.warn("We have lost all connections. " +
+                "We reset initialInventoryRequestsCompleted to false so that we trigger " +
+                "a new inventory request once we are reconnected.");
+        inventoryRequestModel.getNumInventoryRequestsCompleted().set(0);
+        inventoryRequestModel.getInitialInventoryRequestsCompleted().set(false);
+    }
+
 
     List<Connection> getCandidatesForPeriodicRequests() {
         List<Connection> candidates = peerGroupService.getShuffledNonSeedConnections(node)

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryService.java
@@ -151,6 +151,9 @@ public class InventoryService extends RequestResponseHandler<InventoryRequest, I
 
     @Override
     public void onDisconnect(Connection connection, CloseReason closeReason) {
+        if (node.getNumConnections() == 0) {
+            policy.onAllConnectionsLost();
+        }
         // Might let fail a pending request
         updateNumPendingRequests();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically re-initiates inventory syncing after all peer connections are lost and later restored, by resetting the sync state on full disconnect.
  * Prevents stale or incomplete data after reconnection, improving resilience during intermittent connectivity.
  * Users should see faster, more reliable recovery from network drops without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->