### PR TITLE
Allow to pass null to BisqEasyOfferbookSelectionService.selectChannel

### DIFF
--- a/chat/src/main/java/bisq/chat/ChatChannelSelectionService.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelSelectionService.java
@@ -27,6 +27,7 @@ import bisq.persistence.PersistenceService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
 import java.util.Locale;
 import java.util.stream.Stream;
 
@@ -56,7 +57,7 @@ public abstract class ChatChannelSelectionService implements PersistenceClient<C
                 .orElse(null));
     }
 
-    public void selectChannel(ChatChannel<? extends ChatMessage> chatChannel) {
+    public void selectChannel(@Nullable ChatChannel<? extends ChatMessage> chatChannel) {
         persistableStore.setSelectedChannelId(chatChannel != null ? chatChannel.getId() : null);
         persist();
 

--- a/chat/src/main/java/bisq/chat/ChatChannelSelectionStore.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelSelectionStore.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 @Getter(AccessLevel.PACKAGE)
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Slf4j
-final class ChatChannelSelectionStore implements PersistableStore<ChatChannelSelectionStore> {
+public final class ChatChannelSelectionStore implements PersistableStore<ChatChannelSelectionStore> {
     @Nullable
     @Setter(AccessLevel.PACKAGE)
     private String selectedChannelId;

--- a/chat/src/main/java/bisq/chat/bisq_easy/offerbook/BisqEasyOfferbookSelectionService.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/offerbook/BisqEasyOfferbookSelectionService.java
@@ -25,6 +25,7 @@ import bisq.persistence.PersistenceService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -48,8 +49,10 @@ public class BisqEasyOfferbookSelectionService extends ChatChannelSelectionServi
     }
 
     @Override
-    public void selectChannel(ChatChannel<? extends ChatMessage> chatChannel) {
-        if (chatChannel instanceof BisqEasyOfferbookChannel) {
+    public void selectChannel(@Nullable ChatChannel<? extends ChatMessage> chatChannel) {
+        if (chatChannel == null) {
+            super.selectChannel(null);
+        } else if (chatChannel instanceof BisqEasyOfferbookChannel) {
             channelService.removeExpiredMessages(chatChannel);
             super.selectChannel(chatChannel);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deselecting a chat channel, allowing the app to reflect “no channel selected” states correctly.

* **Bug Fixes**
  * Improved reliability when switching between chat channels to prevent occasional errors and stale selections.
  * Enhanced null handling in channel selection to reduce crashes and edge-case failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->