### PR TITLE
Add publishOnionService method

### DIFF
--- a/network/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/network/src/main/java/bisq/network/NetworkService.java
@@ -37,6 +37,7 @@ import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.message.NetworkEnvelope;
 import bisq.network.p2p.node.Node;
 import bisq.network.p2p.node.network_load.NetworkLoadService;
+import bisq.network.p2p.node.transport.TorTransportService;
 import bisq.network.p2p.services.confidential.ConfidentialMessageService;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.confidential.ack.MessageDeliveryStatus;
@@ -59,6 +60,7 @@ import bisq.persistence.PersistenceClient;
 import bisq.persistence.PersistenceService;
 import bisq.security.SignatureUtil;
 import bisq.security.keys.KeyBundleService;
+import bisq.security.keys.TorKeyPair;
 import bisq.security.pow.equihash.EquihashProofOfWorkService;
 import bisq.security.pow.hashcash.HashCashProofOfWorkService;
 import lombok.Getter;
@@ -81,6 +83,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static bisq.common.network.TransportType.TOR;
 import static bisq.common.threading.ExecutorFactory.commonForkJoinPool;
 import static bisq.network.p2p.services.data.DataService.Listener;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -518,5 +521,18 @@ public class NetworkService implements PersistenceClient<NetworkServiceStore>, S
 
     public CompletableFuture<Report> requestReport(Address address) {
         return serviceNodesByTransport.requestReport(address);
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // Publish onion service
+    /* --------------------------------------------------------------------- */
+
+    public CompletableFuture<String> publishOnionService(int localPort, int onionServicePort, TorKeyPair torKeyPair) {
+        return serviceNodesByTransport.findServiceNode(TOR)
+                .map(ServiceNode::getTransportService)
+                .map(TorTransportService.class::cast)
+                .map(torTransportService -> torTransportService.publishOnionService(localPort, onionServicePort, torKeyPair))
+                .orElse(CompletableFuture.failedFuture(new UnsupportedOperationException("Calling publishOnionService requires to have a TorTransportService running.")));
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/transport/TorTransportService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/transport/TorTransportService.java
@@ -74,7 +74,7 @@ public class TorTransportService implements TransportService {
             TorKeyPair torKeyPair = keyBundle.getTorKeyPair();
             String onionAddress = torKeyPair.getOnionAddress();
             TorAddress address = new TorAddress(onionAddress, port);
-            ServerSocket serverSocket = torService.publishOnionService(port, torKeyPair).get();
+            ServerSocket serverSocket = torService.publishOnionServiceAndCreateServerSocket(port, torKeyPair).get();
             initializedServerSocketTimestampByNetworkId.put(networkId, System.currentTimeMillis());
             return new ServerSocketResult(serverSocket, address);
         } catch (InterruptedException e) {
@@ -123,5 +123,9 @@ public class TorTransportService implements TransportService {
 
     public Observable<Boolean> getUseExternalTor() {
         return torService.getUseExternalTor();
+    }
+
+    public CompletableFuture<String> publishOnionService(int localPort, int onionServicePort, TorKeyPair torKeyPair) {
+        return torService.publishOnionService(localPort, onionServicePort, torKeyPair);
     }
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -216,7 +216,27 @@ public class TorService implements Service {
         }, commonForkJoinPool());
     }
 
-    public CompletableFuture<ServerSocket> publishOnionService(int port, TorKeyPair torKeyPair) {
+    public CompletableFuture<String> publishOnionService(int localPort, int onionServicePort, TorKeyPair torKeyPair) {
+        long ts = System.currentTimeMillis();
+        try {
+            String onionAddress = torKeyPair.getOnionAddress();
+            log.info("Publish onion service for address {}:{} (localPort={})", onionAddress, onionServicePort, localPort);
+            if (!publishedOnionServices.contains(onionAddress)) {
+                torController.publish(torKeyPair, onionServicePort, localPort);
+                publishedOnionServices.add(onionAddress);
+            }
+
+            log.info("Tor onion service Ready. Took {} ms. Onion address={}:{} (localPort={})",
+                    System.currentTimeMillis() - ts, onionAddress, onionServicePort, localPort);
+
+            return CompletableFuture.completedFuture(onionAddress);
+        } catch (InterruptedException e) {
+            log.error("Can't create onion service", e);
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    public CompletableFuture<ServerSocket> publishOnionServiceAndCreateServerSocket(int port, TorKeyPair torKeyPair) {
         long ts = System.currentTimeMillis();
         try {
             InetAddress bindAddress = !LinuxDistribution.isWhonix() ? Inet4Address.getLoopbackAddress()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added capability to publish a Tor onion service and retrieve its address without creating a server socket.
  - Exposed a higher-level API to initiate onion service publishing from the network layer.

- Bug Fixes
  - Prevents duplicate publishing of the same onion address, improving reliability.
  - Improved handling when Tor transport is unavailable, returning clear failures instead of silent errors.

- Performance/Logging
  - Added detailed readiness timing logs for onion service publishing to aid diagnostics and startup visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->