### PR TITLE
Fix icons in Musig onboarding trade rules

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradesWelcome.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradesWelcome.java
@@ -91,9 +91,9 @@ public class MuSigOpenTradesWelcome {
             infoHeadline.getStyleClass().add("bisq-easy-open-trades-welcome-info");
             infoHeadline.setMinHeight(80);
 
-            HBox line1 = getIconAndText(Res.get("bisqEasy.openTrades.welcome.line1"), "reputation");
-            HBox line2 = getIconAndText(Res.get("bisqEasy.openTrades.welcome.line2"), "trade-small-green");
-            HBox line3 = getIconAndText(Res.get("bisqEasy.openTrades.welcome.line3"), "thumbs-up");
+            HBox line1 = getIconAndText(Res.get("bisqEasy.openTrades.welcome.line1"), "thumbs-up-in-circle-green");
+            HBox line2 = getIconAndText(Res.get("bisqEasy.openTrades.welcome.line2"), "trading-in-circle-green");
+            HBox line3 = getIconAndText(Res.get("bisqEasy.openTrades.welcome.line3"), "learn-in-circle-green");
 
             button = new Button(Res.get("bisqEasy.tradeGuide.open"));
             button.setDefaultButton(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the MuSig Open Trades welcome screen with updated icons for the three info rows.
  * Replaced legacy symbols with modern circular green icons to improve visual consistency and readability.
  * Enhances recognition of key concepts (approval, trading, learning) at a glance without altering any interactions or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->