### PR TITLE
Set ignoreBannedState at getAuthorizedBondedRoleStream to true at pro…

### DIFF
--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeRequestService.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/bisq1_bridge/Bisq1BridgeRequestService.java
@@ -213,7 +213,7 @@ public class Bisq1BridgeRequestService implements Service, PersistenceClient<Bis
                         false);
                 if (request.isCancellationRequest()) {
                     log.info("Remove authorizedBondedRole if matching data found");
-                    authorizedBondedRolesService.getAuthorizedBondedRoleStream()
+                    authorizedBondedRolesService.getAuthorizedBondedRoleStream(true)
                             .filter(authorizedBondedRole -> authorizedBondedRole.equals(data))
                             .forEach(authorizedBondedRole -> {
                                         log.info("Remove authorizedBondedRole {}", data);


### PR DESCRIPTION
…cessBondedRoleRegistrationRequest to allow to remove banned roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for authorized bonded roles in the Oracle Node application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->