### PR TITLE
Fix address validation for I2P

### DIFF
--- a/common/src/main/java/bisq/common/network/Address.java
+++ b/common/src/main/java/bisq/common/network/Address.java
@@ -64,7 +64,7 @@ public final class Address implements NetworkProto, Comparable<Address> {
             NetworkDataValidation.validateText(host, 45);
         } else {
             // I2P
-            NetworkDataValidation.validateText(host, 512);
+            NetworkDataValidation.validateText(host, 700);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed length for I2P host address validation to support longer address formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->