### PR TITLE
bugfix/persistance_of_certain_language_tags

### DIFF
--- a/settings/src/test/java/bisq/settings/SettingsServiceLanguageTest.java
+++ b/settings/src/test/java/bisq/settings/SettingsServiceLanguageTest.java
@@ -1,0 +1,81 @@
+package bisq.settings;
+
+import bisq.common.locale.LanguageRepository;
+import bisq.common.locale.LocaleRepository;
+import bisq.persistence.PersistenceService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SettingsServiceLanguageTest {
+
+    @TempDir
+    Path tempDir;
+
+    private String originalDefaultLanguage;
+    private Locale originalDefaultLocale;
+
+    @BeforeEach
+    void setUp() {
+        originalDefaultLanguage = LanguageRepository.getDefaultLanguage();
+        originalDefaultLocale = LocaleRepository.getDefaultLocale();
+    }
+
+    @AfterEach
+    void tearDown() {
+        LanguageRepository.setDefaultLanguage(originalDefaultLanguage);
+        LocaleRepository.setDefaultLocale(originalDefaultLocale);
+    }
+
+    private SettingsService newService() {
+        PersistenceService ps = new PersistenceService(tempDir.toFile().getAbsolutePath());
+        return new SettingsService(ps);
+    }
+
+    @Test
+    void setLanguageCode_normalizesUnderscoreToHyphen() {
+        SettingsService service = newService();
+        service.setLanguageCode("pt_BR");
+        assertThat(service.getLanguageCode().get()).isEqualTo("pt-BR");
+    }
+
+    @Test
+    void setLanguageCode_acceptsHyphenatedTags() {
+        SettingsService service = newService();
+        service.setLanguageCode("af-ZA");
+        assertThat(service.getLanguageCode().get()).isEqualTo("af-ZA");
+    }
+
+    @Test
+    void setLanguageCode_acceptsPcmLowercase() {
+        SettingsService service = newService();
+        service.setLanguageCode("pcm");
+        assertThat(service.getLanguageCode().get()).isEqualTo("pcm");
+    }
+
+    @Test
+    void onPersistedApplied_migratesLegacyUnderscoreValue() {
+        SettingsService service = newService();
+        // Simulate persisted legacy underscore value
+        service.getPersistableStore().languageCode.set("pt_BR");
+
+        // Apply persisted and migration logic
+        service.onPersistedApplied(new SettingsStore());
+
+        // Should be normalized and stored as hyphenated tag
+        assertThat(service.getLanguageCode().get()).isEqualTo("pt-BR");
+
+        // Default language and default locale should be consistent
+        assertThat(LanguageRepository.getDefaultLanguage()).isEqualTo("pt-BR");
+        Locale defaultLocale = LocaleRepository.getDefaultLocale();
+        assertThat(defaultLocale.getLanguage()).isEqualTo("pt");
+        assertThat(defaultLocale.getCountry()).isEqualTo("BR");
+    }
+}
+

--- a/settings/src/test/java/bisq/settings/SettingsServicePersistenceRoundTripTest.java
+++ b/settings/src/test/java/bisq/settings/SettingsServicePersistenceRoundTripTest.java
@@ -1,0 +1,39 @@
+package bisq.settings;
+
+import bisq.persistence.PersistenceService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SettingsServicePersistenceRoundTripTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void persistsAndReadsBack_pcm() {
+        PersistenceService ps1 = new PersistenceService(tempDir.toFile().getAbsolutePath());
+        SettingsService s1 = new SettingsService(ps1);
+        s1.initialize().join();
+
+        s1.setLanguageCode("pcm");
+
+        // Force a persist by calling the persistence directly and wait for it to complete
+        // This bypasses the rate limiter
+        s1.getPersistence().persistAsync(s1.getPersistableStore().getClone()).join();
+
+        // Simulate restart: new service with same persistence dir
+        PersistenceService ps2 = new PersistenceService(tempDir.toFile().getAbsolutePath());
+        SettingsService s2 = new SettingsService(ps2);
+        // Read persisted data BEFORE initializing (this is what the application does)
+        ps2.readAllPersisted().join();
+        s2.initialize().join();
+
+        assertThat(s2.getLanguageCode().get()).isEqualTo("pcm");
+    }
+}
+


### PR DESCRIPTION
 - Needed to fix https://github.com/bisq-network/bisq-mobile/issues/567 and enable PCM, Portuguese and Afrikaans in Bisq Mobile
 - this PR goes against mobile branch off 2.1.7 but probably worth cherry-picking to main as well
 - fix persistance for certain language tags (pcm, pt-BR and af-) + unit tests
 - probably fixes the same issue in Bisq2 desktop (untested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data persistence with atomic file operations and improved error recovery
  * Improved language code handling with automatic normalization and migration support

* **Tests**
  * Added language code validation tests
  * Added persistence round-trip testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->