### PR TITLE
Fix wrong check against CODES instead of I18N_CODES

### DIFF
--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -31,8 +31,8 @@ import bisq.i18n.Res;
 import bisq.network.p2p.node.network_load.NetworkLoad;
 import bisq.persistence.DbSubDirectory;
 import bisq.persistence.Persistence;
-import bisq.persistence.RateLimitedPersistenceClient;
 import bisq.persistence.PersistenceService;
+import bisq.persistence.RateLimitedPersistenceClient;
 import bisq.persistence.backup.BackupService;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -291,7 +291,7 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
     }
 
     public void setLanguageCode(String languageCode) {
-        if (languageCode != null && LanguageRepository.CODES.contains(languageCode)) {
+        if (languageCode != null && LanguageRepository.I18N_CODES.contains(languageCode)) {
             persistableStore.languageCode.set(languageCode);
         }
     }


### PR DESCRIPTION
The issue was only the wrong check against `LanguageRepository.CODES` (country code only) instead of `LanguageRepository.I18N_CODES` (includes region code and is the code we use for i18n handling).

Replaces: https://github.com/bisq-network/bisq2/pull/3994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated language code validation to use the correct set of supported languages during settings configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->