### PR TITLE
Add failure popup for trade failures

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -147,6 +147,7 @@ public abstract class Overlay<T extends Overlay<T>> {
 
         WARNING(AnimationType.ScaleDownToCenter),
         INVALID(AnimationType.SlideDownFromCenterTop, Transitions.Type.LIGHT_BLUR_LIGHT),
+        FAILURE(AnimationType.ScaleDownToCenter),
         ERROR(AnimationType.ScaleDownToCenter);
 
         public final AnimationType animationType;
@@ -426,6 +427,28 @@ public abstract class Overlay<T extends Overlay<T>> {
         return cast();
     }
 
+    public T failure(String header, String errorMessage, String footer) {
+        type = Type.FAILURE;
+        width = 800;
+        if (headline == null) {
+            this.headline = Res.get("popup.headline.failure");
+        }
+
+        processMessage(header);
+
+        Label footerLabel = new Label(footer);
+        footerLabel.getStyleClass().add("overlay-message");
+        footerLabel.setWrapText(true);
+        footerLabel.setMinWidth(width);
+
+        TextArea textArea = getFailureTextArea(errorMessage, width);
+        VBox.setMargin(textArea, new Insets(-15, 0, 5, 0));
+        VBox vBox = new VBox(10, textArea, footerLabel);
+        content(vBox);
+
+        return cast();
+    }
+
     public T invalid(String message) {
         type = Type.INVALID;
 
@@ -468,6 +491,18 @@ public abstract class Overlay<T extends Overlay<T>> {
 
     private static TextArea getErrorTextArea(String text, double width) {
         TextArea textArea = new TextArea(text);
+        textArea.setContextMenu(new ContextMenu());
+        textArea.setEditable(false);
+        textArea.setPrefWidth(width);
+        textArea.setWrapText(true);
+        textArea.getStyleClass().addAll("code-block", "error-log");
+        return textArea;
+    }
+
+    private static TextArea getFailureTextArea(String text, double width) {
+        TextArea textArea = new TextArea(text);
+        textArea.setPadding(new Insets(5));
+        textArea.setMaxHeight(140);
         textArea.setContextMenu(new ContextMenu());
         textArea.setEditable(false);
         textArea.setPrefWidth(width);
@@ -874,6 +909,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                     headlineLabel.getStyleClass().add("overlay-headline-warning");
                     headlineIcon.getStyleClass().add("overlay-icon-warning");
                     break;
+                case FAILURE:
                 case ERROR:
                     Icons.getIconForLabel(AwesomeIcon.EXCLAMATION_SIGN, headlineIcon, "1.5em");
                     headlineLabel.getStyleClass().add("overlay-headline-error");
@@ -901,7 +937,7 @@ public abstract class Overlay<T extends Overlay<T>> {
             headlineIcon.setManaged(false);
             headlineIcon.setVisible(false);
             headlineIcon.setAlignment(Pos.CENTER);
-            headlineIcon.setPadding(new Insets(-2, 5, 0, 0));
+            headlineIcon.setPadding(new Insets(0, 5, 0, 0));
             headlineLabel.setMouseTransparent(true);
 
             if (headlineStyle != null)

--- a/http-api/src/main/java/bisq/dto/DtoMappings.java
+++ b/http-api/src/main/java/bisq/dto/DtoMappings.java
@@ -97,6 +97,7 @@ import bisq.dto.security.keys.PublicKeyDto;
 import bisq.dto.security.keys.TorKeyPairDto;
 import bisq.dto.security.pow.ProofOfWorkDto;
 import bisq.dto.settings.SettingsDto;
+import bisq.dto.trade.TradeProtocolFailureDto;
 import bisq.dto.trade.TradeRoleDto;
 import bisq.dto.trade.bisq_easy.BisqEasyTradeDto;
 import bisq.dto.trade.bisq_easy.BisqEasyTradePartyDto;
@@ -134,6 +135,7 @@ import bisq.trade.TradeRole;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeParty;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.user.identity.UserIdentity;
 import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
@@ -1161,6 +1163,32 @@ public class DtoMappings {
                 case BUYER_AS_MAKER -> TradeRoleDto.BUYER_AS_MAKER;
                 case SELLER_AS_TAKER -> TradeRoleDto.SELLER_AS_TAKER;
                 case SELLER_AS_MAKER -> TradeRoleDto.SELLER_AS_MAKER;
+            };
+        }
+    }
+
+    public static class TradeProtocolFailureMapping {
+        public static TradeProtocolFailure toBisq2Model(TradeProtocolFailureDto value) {
+            if (value == null) {
+                return null;
+            }
+            return switch (value) {
+                case UNKNOWN -> TradeProtocolFailure.UNKNOWN;
+                case PRICE_DEVIATION -> TradeProtocolFailure.PRICE_DEVIATION;
+                case NO_MATCHING_OFFER_FOUND -> TradeProtocolFailure.NO_MATCHING_OFFER_FOUND;
+                case MEDIATORS_NOT_MATCHING -> TradeProtocolFailure.MEDIATORS_NOT_MATCHING;
+            };
+        }
+
+        public static TradeProtocolFailureDto fromBisq2Model(TradeProtocolFailure value) {
+            if (value == null) {
+                return null;
+            }
+            return switch (value) {
+                case UNKNOWN -> TradeProtocolFailureDto.UNKNOWN;
+                case PRICE_DEVIATION -> TradeProtocolFailureDto.PRICE_DEVIATION;
+                case NO_MATCHING_OFFER_FOUND -> TradeProtocolFailureDto.NO_MATCHING_OFFER_FOUND;
+                case MEDIATORS_NOT_MATCHING -> TradeProtocolFailureDto.MEDIATORS_NOT_MATCHING;
             };
         }
     }

--- a/http-api/src/main/java/bisq/dto/trade/TradeProtocolFailureDto.java
+++ b/http-api/src/main/java/bisq/dto/trade/TradeProtocolFailureDto.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.dto.trade;
+
+public enum TradeProtocolFailureDto {
+    UNKNOWN,
+    PRICE_DEVIATION,
+    NO_MATCHING_OFFER_FOUND,
+    MEDIATORS_NOT_MATCHING;
+}

--- a/http-api/src/main/java/bisq/http_api/web_socket/domain/trades/TradePropertiesDto.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/domain/trades/TradePropertiesDto.java
@@ -18,6 +18,7 @@
 package bisq.http_api.web_socket.domain.trades;
 
 import bisq.dto.contract.RoleDto;
+import bisq.dto.trade.TradeProtocolFailureDto;
 import bisq.dto.trade.bisq_easy.protocol.BisqEasyTradeStateDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.EqualsAndHashCode;
@@ -41,6 +42,8 @@ public class TradePropertiesDto {
     public Optional<String> paymentProof = Optional.empty();
     public Optional<String> errorMessage = Optional.empty();
     public Optional<String> errorStackTrace = Optional.empty();
+    public Optional<TradeProtocolFailureDto> tradeProtocolFailure = Optional.empty();
     public Optional<String> peersErrorMessage = Optional.empty();
     public Optional<String> peersErrorStackTrace = Optional.empty();
+    public Optional<TradeProtocolFailureDto> peersTradeProtocolFailure = Optional.empty();
 }

--- a/http-api/src/main/java/bisq/http_api/web_socket/domain/trades/TradePropertiesWebSocketService.java
+++ b/http-api/src/main/java/bisq/http_api/web_socket/domain/trades/TradePropertiesWebSocketService.java
@@ -72,8 +72,10 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
                 pins.add(observePaymentProof(bisqEasyTrade, tradeId));
                 pins.add(observeErrorMessage(bisqEasyTrade, tradeId));
                 pins.add(observeErrorStackTrace(bisqEasyTrade, tradeId));
+                pins.add(observeTradeProtocolFailure(bisqEasyTrade, tradeId));
                 pins.add(observePeersErrorMessage(bisqEasyTrade, tradeId));
                 pins.add(observePeersErrorStackTrace(bisqEasyTrade, tradeId));
+                pins.add(observePeersTradeProtocolFailure(bisqEasyTrade, tradeId));
             }
 
             @Override
@@ -165,6 +167,16 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
         });
     }
 
+    private Pin observeTradeProtocolFailure(BisqEasyTrade bisqEasyTrade, String tradeId) {
+        return bisqEasyTrade.tradeProtocolFailureObservable().addObserver(value -> {
+            if (value != null) {
+                var data = new TradePropertiesDto();
+                data.tradeProtocolFailure = Optional.of(DtoMappings.TradeProtocolFailureMapping.fromBisq2Model(value));
+                send(Map.of(tradeId, data));
+            }
+        });
+    }
+
     private Pin observePeersErrorMessage(BisqEasyTrade bisqEasyTrade, String tradeId) {
         return bisqEasyTrade.peersErrorMessageObservable().addObserver(value -> {
             if (value != null) {
@@ -180,6 +192,15 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
             if (value != null) {
                 var data = new TradePropertiesDto();
                 data.peersErrorStackTrace = Optional.of(value);
+                send(Map.of(tradeId, data));
+            }
+        });
+    }
+    private Pin observePeersTradeProtocolFailure(BisqEasyTrade bisqEasyTrade, String tradeId) {
+        return bisqEasyTrade.peersTradeProtocolFailureObservable().addObserver(value -> {
+            if (value != null) {
+                var data = new TradePropertiesDto();
+                data.peersTradeProtocolFailure = Optional.of(DtoMappings.TradeProtocolFailureMapping.fromBisq2Model(value));
                 send(Map.of(tradeId, data));
             }
         });
@@ -208,8 +229,10 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
                     data.paymentProof = Optional.ofNullable(bisqEasyTrade.getPaymentProof().get());
                     data.errorMessage = Optional.ofNullable(bisqEasyTrade.getErrorMessage());
                     data.errorStackTrace = Optional.ofNullable(bisqEasyTrade.getErrorStackTrace());
+                    data.tradeProtocolFailure = Optional.ofNullable(DtoMappings.TradeProtocolFailureMapping.fromBisq2Model(bisqEasyTrade.getTradeProtocolFailure()));
                     data.peersErrorMessage = Optional.ofNullable(bisqEasyTrade.getPeersErrorMessage());
                     data.peersErrorStackTrace = Optional.ofNullable(bisqEasyTrade.getPeersErrorStackTrace());
+                    data.peersTradeProtocolFailure = Optional.ofNullable(DtoMappings.TradeProtocolFailureMapping.fromBisq2Model(bisqEasyTrade.getPeersTradeProtocolFailure()));
                     return Map.of(bisqEasyTrade.getId(), data);
                 })
                 .collect(Collectors.toList());

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -264,6 +264,7 @@ popup.headline.feedback=Completed
 popup.headline.confirmation=Confirmation
 popup.headline.information=Information
 popup.headline.warning=Warning
+popup.headline.failure=Failure
 popup.headline.invalid=Invalid input
 popup.headline.error=Error
 popup.reportBug=Report bug to Bisq developers

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -605,12 +605,18 @@ bisqEasy.tradeState.requestMediation.resendRequest=Try resending the mediation r
 
 bisqEasy.openTrades.inMediation.requestSent=Sending mediation request   |   {0}
 bisqEasy.openTrades.inMediation.info=A mediator has joined the trade chat. Please use the trade chat below to get assistance from the mediator.
-bisqEasy.openTrades.failed=The trade failed: ''{0}''
-bisqEasy.openTrades.failed.popup=The trade failed: ''{0}''\n\n\
+
+bisqEasy.openTrades.failed.errorMessage=The trade failed: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=The trade failed: ''{0}''\n\n\
   Stack trace: {1}
-bisqEasy.openTrades.failedAtPeer=The trade failed at your peer: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=The trade failed at your peer: ''{0}''\n\n\
+bisqEasy.openTrades.failedAtPeer.errorMessage=The trade failed at your peer: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=The trade failed at your peer: ''{0}''\n\n\
   Stack trace: {1}
+bisqEasy.openTrades.failure.popup.headline=Trade Failed
+bisqEasy.openTrades.failure.popup.message.header=An error occurred during trade execution:
+bisqEasy.openTrades.failure.popup.message.footer=This can happen under certain conditions. If you need help, you can request mediation or contact the Bisq support team in the Support chat room.
+bisqEasy.openTrades.atPeer.failure.popup.headline=Trade failed at your peer
+
 bisqEasy.openTrades.table.tradePeer=Peer
 bisqEasy.openTrades.table.me=Me
 bisqEasy.openTrades.table.mediator=Mediator

--- a/i18n/src/main/resources/bisq_easy_af_ZA.properties
+++ b/i18n/src/main/resources/bisq_easy_af_ZA.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Probeer om die bemiddelingsve
 
 bisqEasy.openTrades.inMediation.requestSent=Stuur bemiddelingsversoek   |   {0}
 bisqEasy.openTrades.inMediation.info=''n Bemiddelaar het by die handel geselskap aangesluit. Gebruik asseblief die handel geselskap hieronder om hulp van die bemiddelaar te kry.
-bisqEasy.openTrades.failed=Die handel het misluk: ''{0}''
-bisqEasy.openTrades.failed.popup=Die handel het misluk: ''{0}''\n\nStapeloproep: {1}
-bisqEasy.openTrades.failedAtPeer=Die handel het by jou vennoot misluk: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=Die handel het by jou vennoot gefaal: ''{0}''\n\nStapelspoor: {1}
+bisqEasy.openTrades.failed.errorMessage=Die handel het misluk: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=Die handel het misluk: ''{0}''\n\nStapeloproep: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=Die handel het by jou vennoot misluk: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=Die handel het by jou vennoot gefaal: ''{0}''\n\nStapelspoor: {1}
 bisqEasy.openTrades.table.tradePeer=Vennote
 bisqEasy.openTrades.table.me=Ek
 bisqEasy.openTrades.table.mediator=Bemiddelaar

--- a/i18n/src/main/resources/bisq_easy_cs.properties
+++ b/i18n/src/main/resources/bisq_easy_cs.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Zkuste znovu odeslat žádost
 
 bisqEasy.openTrades.inMediation.requestSent=Odesílání žádosti o mediaci   |   {0}
 bisqEasy.openTrades.inMediation.info=Mediátor se připojil k obchodnímu chatu. Prosím, použijte obchodní chat níže pro získání pomoci od mediátora.
-bisqEasy.openTrades.failed=Obchod selhal: ''{0}''
-bisqEasy.openTrades.failed.popup=Obchod selhal: ''{0}''\n\nSledovací stopa: {1}
-bisqEasy.openTrades.failedAtPeer=Obchod selhal u vašeho partnera: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=Obchod selhal u vašeho partnera: ''{0}''\n\nSledovací zásobník: {1}
+bisqEasy.openTrades.failed.errorMessage=Obchod selhal: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=Obchod selhal: ''{0}''\n\nSledovací stopa: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=Obchod selhal u vašeho partnera: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=Obchod selhal u vašeho partnera: ''{0}''\n\nSledovací zásobník: {1}
 bisqEasy.openTrades.table.tradePeer=Partner
 bisqEasy.openTrades.table.me=Já
 bisqEasy.openTrades.table.mediator=Zmocněnec

--- a/i18n/src/main/resources/bisq_easy_de.properties
+++ b/i18n/src/main/resources/bisq_easy_de.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Versuchen Sie, die Mediations
 
 bisqEasy.openTrades.inMediation.requestSent=Mediation-Anfrage wird gesendet   |   {0}
 bisqEasy.openTrades.inMediation.info=Ein Mediator ist dem Handels-Chat beigetreten. Bitte benutze den Handels-Chat unten, um Unterstützung vom Mediator zu erhalten.
-bisqEasy.openTrades.failed=Der Handel ist fehlgeschlagen: ''{0}''
-bisqEasy.openTrades.failed.popup=Der Handel ist fehlgeschlagen: ''{0}''\n\nStack-Trace: {1}
-bisqEasy.openTrades.failedAtPeer=Der Handel ist bei Ihrem Peer fehlgeschlagen: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=Der Handel ist bei Ihrem Peer fehlgeschlagen: ''{0}''\n\nStack-Trace: {1}
+bisqEasy.openTrades.failed.errorMessage=Der Handel ist fehlgeschlagen: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=Der Handel ist fehlgeschlagen: ''{0}''\n\nStack-Trace: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=Der Handel ist bei Ihrem Peer fehlgeschlagen: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=Der Handel ist bei Ihrem Peer fehlgeschlagen: ''{0}''\n\nStack-Trace: {1}
 bisqEasy.openTrades.table.tradePeer=Handelspartner
 bisqEasy.openTrades.table.me=Ich
 bisqEasy.openTrades.table.mediator=Mediator

--- a/i18n/src/main/resources/bisq_easy_es.properties
+++ b/i18n/src/main/resources/bisq_easy_es.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Intenta reenviar la solicitud
 
 bisqEasy.openTrades.inMediation.requestSent=Enviando solicitud de mediación   |   {0}
 bisqEasy.openTrades.inMediation.info=Un mediador se ha unido al chat de intercambio. Utiliza el chat de intercambio a continuación para obtener asistencia del mediador.
-bisqEasy.openTrades.failed=El comercio falló: ''{0}''
-bisqEasy.openTrades.failed.popup=El comercio falló: ''{0}''\n\nTraza de pila: {1}
-bisqEasy.openTrades.failedAtPeer=El comercio falló en tu par: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=El comercio falló en tu par: ''{0}''\n\nRastro de pila: {1}
+bisqEasy.openTrades.failed.errorMessage=El comercio falló: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=El comercio falló: ''{0}''\n\nTraza de pila: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=El comercio falló en tu par: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=El comercio falló en tu par: ''{0}''\n\nRastro de pila: {1}
 bisqEasy.openTrades.table.tradePeer=Compañero de intercambio
 bisqEasy.openTrades.table.me=Yo
 bisqEasy.openTrades.table.mediator=Mediador

--- a/i18n/src/main/resources/bisq_easy_it.properties
+++ b/i18n/src/main/resources/bisq_easy_it.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Riprova a inviare la richiest
 
 bisqEasy.openTrades.inMediation.requestSent=Invio della richiesta di mediazione   |   {0}
 bisqEasy.openTrades.inMediation.info=Un mediatore si è unito alla chat di compravendita. Utilizza la chat di compravendita sottostante per ottenere assistenza dal mediatore.
-bisqEasy.openTrades.failed=Il commercio è fallito: ''{0}''
-bisqEasy.openTrades.failed.popup=Il commercio è fallito: ''{0}''\n\nTraccia dello stack: {1}
-bisqEasy.openTrades.failedAtPeer=Il commercio è fallito presso il tuo peer: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=Il commercio è fallito presso il tuo peer: ''{0}''\n\nTraccia dello stack: {1}
+bisqEasy.openTrades.failed.errorMessage=Il commercio è fallito: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=Il commercio è fallito: ''{0}''\n\nTraccia dello stack: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=Il commercio è fallito presso il tuo peer: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=Il commercio è fallito presso il tuo peer: ''{0}''\n\nTraccia dello stack: {1}
 bisqEasy.openTrades.table.tradePeer=Partner
 bisqEasy.openTrades.table.me=Io
 bisqEasy.openTrades.table.mediator=Mediatore

--- a/i18n/src/main/resources/bisq_easy_pcm.properties
+++ b/i18n/src/main/resources/bisq_easy_pcm.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Try resend di mediashon reque
 
 bisqEasy.openTrades.inMediation.requestSent=Dey send mediashon request | {0}
 bisqEasy.openTrades.inMediation.info=A mediator don join the trade chat. Abeg use the trade chat below to get assistance from the mediator.
-bisqEasy.openTrades.failed=Di trade fail wit error message: {0}
-bisqEasy.openTrades.failed.popup=Di trade fail because of error.\nError message: {0}\n\nStack trace: {1}
-bisqEasy.openTrades.failedAtPeer=Di peer im trade fail wit error wey be say: {0}
-bisqEasy.openTrades.failedAtPeer.popup=Di peer im trade fail because of error.\nError wey cause am: {0}\n\nStack trace: {1}
+bisqEasy.openTrades.failed.errorMessage=Di trade fail wit error message: {0}
+bisqEasy.openTrades.failed.errorPopup.message=Di trade fail because of error.\nError message: {0}\n\nStack trace: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=Di peer im trade fail wit error wey be say: {0}
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=Di peer im trade fail because of error.\nError wey cause am: {0}\n\nStack trace: {1}
 bisqEasy.openTrades.table.tradePeer=Peer
 bisqEasy.openTrades.table.me=Me
 bisqEasy.openTrades.table.mediator=Mediata

--- a/i18n/src/main/resources/bisq_easy_pt_BR.properties
+++ b/i18n/src/main/resources/bisq_easy_pt_BR.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Tente reenviar o pedido de me
 
 bisqEasy.openTrades.inMediation.requestSent=Enviando solicitação de mediação   |   {0}
 bisqEasy.openTrades.inMediation.info=Um mediador se juntou ao chat de negociação. Por favor, use o chat de negociação abaixo para obter assistência do mediador.
-bisqEasy.openTrades.failed=A negociação falhou: ''{0}''
-bisqEasy.openTrades.failed.popup=A negociação falhou: ''{0}''\n\nRastreamento de pilha: {1}
-bisqEasy.openTrades.failedAtPeer=A negociação falhou com seu par: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=A negociação falhou com seu par: ''{0}''\n\nRastreamento de pilha: {1}
+bisqEasy.openTrades.failed.errorMessage=A negociação falhou: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=A negociação falhou: ''{0}''\n\nRastreamento de pilha: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=A negociação falhou com seu par: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=A negociação falhou com seu par: ''{0}''\n\nRastreamento de pilha: {1}
 bisqEasy.openTrades.table.tradePeer=Par
 bisqEasy.openTrades.table.me=Eu
 bisqEasy.openTrades.table.mediator=Mediador

--- a/i18n/src/main/resources/bisq_easy_ru.properties
+++ b/i18n/src/main/resources/bisq_easy_ru.properties
@@ -511,10 +511,10 @@ bisqEasy.tradeState.requestMediation.resendRequest=Попробуйте повт
 
 bisqEasy.openTrades.inMediation.requestSent=Отправка запроса на медиацию   |   {0}
 bisqEasy.openTrades.inMediation.info=К торговому чату присоединился посредник. Пожалуйста, воспользуйтесь торговым чатом ниже, чтобы получить помощь посредника.
-bisqEasy.openTrades.failed=Сделка не удалась: ''{0}''
-bisqEasy.openTrades.failed.popup=Сделка не удалась: ''{0}''\n\nТрассировка стека: {1}
-bisqEasy.openTrades.failedAtPeer=Сделка не удалась у вашего сверстника: ''{0}''
-bisqEasy.openTrades.failedAtPeer.popup=Сделка не удалась у вашего сверстника: ''{0}''\n\nТрассировка стека: {1}
+bisqEasy.openTrades.failed.errorMessage=Сделка не удалась: ''{0}''
+bisqEasy.openTrades.failed.errorPopup.message=Сделка не удалась: ''{0}''\n\nТрассировка стека: {1}
+bisqEasy.openTrades.failedAtPeer.errorMessage=Сделка не удалась у вашего сверстника: ''{0}''
+bisqEasy.openTrades.failedAtPeer.errorPopup.message=Сделка не удалась у вашего сверстника: ''{0}''\n\nТрассировка стека: {1}
 bisqEasy.openTrades.table.tradePeer=Сверстник
 bisqEasy.openTrades.table.me=Я
 bisqEasy.openTrades.table.mediator=Медиатор

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash/HashCashTokenService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash/HashCashTokenService.java
@@ -259,7 +259,7 @@ public class HashCashTokenService extends AuthorizationTokenService<HashCashToke
                     if (averagePowTimePerMessage > 1000) {
                         log.warn("Average time/message used for PoW is very high");
                     } else if (averagePowTimePerMessage > 300) {
-                        log.warn("Average time/message used for PoW is higher as expected");
+                        log.warn("Average time/message used for PoW is higher than expected");
                     }
                     log.info("Total time used for PoW: {} sec; Average time/message used for PoW: {} ms; Average network load value: {}; Number of messages: {}",
                             MathUtils.roundDoubleToLong(accumulatedPoWDuration / 1000d),

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash_v2/HashCashV2TokenService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/token/hash_cash_v2/HashCashV2TokenService.java
@@ -258,7 +258,7 @@ public class HashCashV2TokenService extends AuthorizationTokenService<HashCashV2
                     if (averagePowTimePerMessage > 1000) {
                         log.warn("Average time/message used for PoW is very high");
                     } else if (averagePowTimePerMessage > 300) {
-                        log.warn("Average time/message used for PoW is higher as expected");
+                        log.warn("Average time/message used for PoW is higher than expected");
                     }
                     log.info("Total time used for PoW: {} sec; Average time/message used for PoW: {} ms; Average network load value: {}; Number of messages: {}",
                             MathUtils.roundDoubleToLong(accumulatedPoWDuration / 1000d),

--- a/trade/src/main/java/bisq/trade/TradeLifecycleState.java
+++ b/trade/src/main/java/bisq/trade/TradeLifecycleState.java
@@ -17,5 +17,4 @@ public enum TradeLifecycleState implements ProtoEnum {
     public static TradeLifecycleState fromProto(bisq.trade.protobuf.TradeLifecycleState proto) {
         return ProtobufUtils.enumFromProto(TradeLifecycleState.class, proto.name(), ACTIVE);
     }
-
 }

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -29,6 +29,7 @@ import bisq.trade.Trade;
 import bisq.trade.TradeLifecycleState;
 import bisq.trade.TradeParty;
 import bisq.trade.TradeRole;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -82,14 +83,14 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
     }
 
     private BisqEasyTrade(BisqEasyContract contract,
-                         BisqEasyTradeState state,
-                         String id,
-                         TradeRole tradeRole,
-                         Identity myIdentity,
-                         BisqEasyTradeParty taker,
-                         BisqEasyTradeParty maker,
-                         TradeLifecycleState lifecycleState) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker,lifecycleState);
+                          BisqEasyTradeState state,
+                          String id,
+                          TradeRole tradeRole,
+                          Identity myIdentity,
+                          BisqEasyTradeParty taker,
+                          BisqEasyTradeParty maker,
+                          TradeLifecycleState lifecycleState) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState);
 
         stateObservable().addObserver(s -> tradeState.set((BisqEasyTradeState) s));
     }
@@ -138,6 +139,12 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
         }
         if (proto.hasPeersErrorStackTrace()) {
             trade.setPeersErrorStackTrace(proto.getPeersErrorStackTrace());
+        }
+        if (proto.hasTradeProtocolFailure()) {
+            trade.setTradeProtocolFailure(TradeProtocolFailure.fromProto(proto.getTradeProtocolFailure()));
+        }
+        if (proto.hasPeersTradeProtocolFailure()) {
+            trade.setPeersTradeProtocolFailure(TradeProtocolFailure.fromProto(proto.getPeersTradeProtocolFailure()));
         }
 
         bisq.trade.protobuf.BisqEasyTrade bisqEasyTradeProto = proto.getBisqEasyTrade();

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyReportErrorMessage.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyReportErrorMessage.java
@@ -19,6 +19,7 @@ package bisq.trade.bisq_easy.protocol.messages;
 
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.identity.NetworkId;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -34,6 +35,7 @@ public final class BisqEasyReportErrorMessage extends BisqEasyTradeMessage {
 
     private final String errorMessage;
     private final String stackTrace;
+    private final TradeProtocolFailure tradeProtocolFailure;
 
     public BisqEasyReportErrorMessage(String id,
                                       String tradeId,
@@ -41,10 +43,12 @@ public final class BisqEasyReportErrorMessage extends BisqEasyTradeMessage {
                                       NetworkId sender,
                                       NetworkId receiver,
                                       String errorMessage,
-                                      String stackTrace) {
+                                      String stackTrace,
+                                      TradeProtocolFailure tradeProtocolFailure) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.errorMessage = errorMessage;
         this.stackTrace = stackTrace;
+        this.tradeProtocolFailure = tradeProtocolFailure;
 
         verify();
     }
@@ -71,7 +75,8 @@ public final class BisqEasyReportErrorMessage extends BisqEasyTradeMessage {
     private bisq.trade.protobuf.BisqEasyReportErrorMessage.Builder getBisqEasyReportErrorMessageBuilder(boolean serializeForHash) {
         return bisq.trade.protobuf.BisqEasyReportErrorMessage.newBuilder()
                 .setErrorMessage(errorMessage)
-                .setStackTrace(stackTrace);
+                .setStackTrace(stackTrace)
+                .setTradeProtocolFailure(tradeProtocolFailure.toProtoEnum());
     }
 
     public static BisqEasyReportErrorMessage fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -83,7 +88,8 @@ public final class BisqEasyReportErrorMessage extends BisqEasyTradeMessage {
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
                 bisqEasyReportErrorMessage.getErrorMessage(),
-                bisqEasyReportErrorMessage.getStackTrace());
+                bisqEasyReportErrorMessage.getStackTrace(),
+                TradeProtocolFailure.fromProto(bisqEasyReportErrorMessage.getTradeProtocolFailure()));
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyReportErrorMessageHandler.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyReportErrorMessageHandler.java
@@ -19,6 +19,7 @@ package bisq.trade.bisq_easy.protocol.messages;
 
 import bisq.trade.ServiceProvider;
 import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.bisq_easy.handler.BisqEasyTradeMessageHandler;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BisqEasyReportErrorMessageHandler extends BisqEasyTradeMessageHandler<BisqEasyTrade, BisqEasyReportErrorMessage> {
     private String stackTrace;
     private String errorMessage;
+    private TradeProtocolFailure tradeProtocolFailure;
 
     public BisqEasyReportErrorMessageHandler(ServiceProvider serviceProvider, BisqEasyTrade model) {
         super(serviceProvider, model);
@@ -42,11 +44,11 @@ public class BisqEasyReportErrorMessageHandler extends BisqEasyTradeMessageHandl
                 message.getErrorMessage(), message.getStackTrace(), trade.getId());
         stackTrace = message.getStackTrace();
         errorMessage = message.getErrorMessage();
+        tradeProtocolFailure = message.getTradeProtocolFailure();
     }
 
     @Override
     protected void commit() {
-        trade.setPeersErrorStackTrace(stackTrace);
-        trade.setPeersErrorMessage(errorMessage);
+        trade.setPeersErrorData(tradeProtocolFailure, stackTrace, errorMessage);
     }
 }

--- a/trade/src/main/java/bisq/trade/exceptions/TradeProtocolException.java
+++ b/trade/src/main/java/bisq/trade/exceptions/TradeProtocolException.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.exceptions;
+
+import lombok.Getter;
+
+public class TradeProtocolException extends RuntimeException {
+    @Getter
+    private final TradeProtocolFailure tradeProtocolFailure;
+
+    public TradeProtocolException(TradeProtocolFailure tradeProtocolFailure) {
+        this.tradeProtocolFailure = tradeProtocolFailure;
+    }
+
+    public TradeProtocolException(String message, TradeProtocolFailure tradeProtocolFailure) {
+        super(message);
+        this.tradeProtocolFailure = tradeProtocolFailure;
+    }
+
+    public TradeProtocolException(String message, TradeProtocolFailure tradeProtocolFailure, Throwable cause) {
+        super(message, cause);
+        this.tradeProtocolFailure = tradeProtocolFailure;
+    }
+
+    public TradeProtocolException(Throwable cause, TradeProtocolFailure tradeProtocolFailure) {
+        super(cause);
+        this.tradeProtocolFailure = tradeProtocolFailure;
+    }
+
+    public TradeProtocolException(String message,
+                                  TradeProtocolFailure tradeProtocolFailure,
+                                  Throwable cause,
+                                  boolean enableSuppression,
+                                  boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.tradeProtocolFailure = tradeProtocolFailure;
+    }
+}

--- a/trade/src/main/java/bisq/trade/exceptions/TradeProtocolFailure.java
+++ b/trade/src/main/java/bisq/trade/exceptions/TradeProtocolFailure.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.exceptions;
+
+import bisq.common.proto.ProtoEnum;
+import bisq.common.proto.ProtobufUtils;
+import lombok.Getter;
+
+public enum TradeProtocolFailure implements ProtoEnum {
+    UNKNOWN(true),
+    PRICE_DEVIATION(false),
+    NO_MATCHING_OFFER_FOUND(false),
+    MEDIATORS_NOT_MATCHING(false);
+
+    @Getter
+    private final boolean isUnexpected;
+
+    TradeProtocolFailure(boolean isUnexpected) {
+        this.isUnexpected = isUnexpected;
+    }
+
+    @Override
+    public bisq.trade.protobuf.TradeProtocolFailure toProtoEnum() {
+        return bisq.trade.protobuf.TradeProtocolFailure.valueOf(getProtobufEnumPrefix() + name());
+    }
+
+    public static TradeProtocolFailure fromProto(bisq.trade.protobuf.TradeProtocolFailure proto) {
+        return ProtobufUtils.enumFromProto(TradeProtocolFailure.class, proto.name(), UNKNOWN);
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
@@ -29,6 +29,7 @@ import bisq.trade.Trade;
 import bisq.trade.TradeLifecycleState;
 import bisq.trade.TradeParty;
 import bisq.trade.TradeRole;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.mu_sig.messages.grpc.TxConfirmationStatus;
 import bisq.trade.mu_sig.protocol.MuSigTradeState;
 import lombok.EqualsAndHashCode;
@@ -131,6 +132,12 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
         }
         if (proto.hasPeersErrorStackTrace()) {
             trade.setPeersErrorStackTrace(proto.getPeersErrorStackTrace());
+        }
+        if (proto.hasTradeProtocolFailure()) {
+            trade.setTradeProtocolFailure(TradeProtocolFailure.fromProto(proto.getTradeProtocolFailure()));
+        }
+        if (proto.hasPeersTradeProtocolFailure()) {
+            trade.setPeersTradeProtocolFailure(TradeProtocolFailure.fromProto(proto.getPeersTradeProtocolFailure()));
         }
 
         if (muSigTradeProto.hasTradeCompletedDate()) {

--- a/trade/src/main/java/bisq/trade/mu_sig/events/MuSigReportErrorMessageHandler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/events/MuSigReportErrorMessageHandler.java
@@ -18,6 +18,7 @@
 package bisq.trade.mu_sig.events;
 
 import bisq.trade.ServiceProvider;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.handler.MuSigTradeMessageHandler;
 import bisq.trade.mu_sig.messages.network.MuSigReportErrorMessage;
@@ -27,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public final class MuSigReportErrorMessageHandler extends MuSigTradeMessageHandler<MuSigTrade, MuSigReportErrorMessage> {
     private String errorMessage;
     private String stackTrace;
+    private TradeProtocolFailure tradeProtocolFailure;
 
     public MuSigReportErrorMessageHandler(ServiceProvider serviceProvider, MuSigTrade model) {
         super(serviceProvider, model);
@@ -40,6 +42,7 @@ public final class MuSigReportErrorMessageHandler extends MuSigTradeMessageHandl
     protected void process(MuSigReportErrorMessage message) {
         errorMessage = message.getErrorMessage();
         stackTrace = message.getStackTrace();
+        tradeProtocolFailure = message.getTradeProtocolFailure();
         log.warn("We received an error report from our peer.\n" +
                         "errorMessage={}\nstackTrace={}\ntradeId={}",
                 errorMessage, stackTrace, trade.getId());
@@ -47,8 +50,7 @@ public final class MuSigReportErrorMessageHandler extends MuSigTradeMessageHandl
 
     @Override
     protected void commit() {
-        trade.setPeersErrorStackTrace(stackTrace);
-        trade.setPeersErrorMessage(errorMessage);
+        trade.setPeersErrorData(tradeProtocolFailure, stackTrace, errorMessage);
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigReportErrorMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigReportErrorMessage.java
@@ -19,6 +19,7 @@ package bisq.trade.mu_sig.messages.network;
 
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.identity.NetworkId;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -34,6 +35,7 @@ public final class MuSigReportErrorMessage extends MuSigTradeMessage {
 
     private final String errorMessage;
     private final String stackTrace;
+    private final TradeProtocolFailure tradeProtocolFailure;
 
     public MuSigReportErrorMessage(String id,
                                    String tradeId,
@@ -41,10 +43,12 @@ public final class MuSigReportErrorMessage extends MuSigTradeMessage {
                                    NetworkId sender,
                                    NetworkId receiver,
                                    String errorMessage,
-                                   String stackTrace) {
+                                   String stackTrace,
+                                   TradeProtocolFailure tradeProtocolFailure) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.errorMessage = errorMessage;
         this.stackTrace = stackTrace;
+        this.tradeProtocolFailure = tradeProtocolFailure;
 
         verify();
     }
@@ -71,7 +75,8 @@ public final class MuSigReportErrorMessage extends MuSigTradeMessage {
     private bisq.trade.protobuf.MuSigReportErrorMessage.Builder getMuSigReportErrorMessageBuilder(boolean serializeForHash) {
         return bisq.trade.protobuf.MuSigReportErrorMessage.newBuilder()
                 .setErrorMessage(errorMessage)
-                .setStackTrace(stackTrace);
+                .setStackTrace(stackTrace)
+                .setTradeProtocolFailure(tradeProtocolFailure.toProtoEnum());
     }
 
     public static MuSigReportErrorMessage fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -83,7 +88,8 @@ public final class MuSigReportErrorMessage extends MuSigTradeMessage {
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
                 muSigReportErrorMessage.getErrorMessage(),
-                muSigReportErrorMessage.getStackTrace());
+                muSigReportErrorMessage.getStackTrace(),
+                TradeProtocolFailure.fromProto(muSigReportErrorMessage.getTradeProtocolFailure()));
     }
 
     @Override

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -54,6 +54,14 @@ enum TradeLifecycleState {
   TRADELIFECYCLESTATE_FAILED = 3;
 }
 
+enum TradeProtocolFailure {
+  TRADEPROTOCOLFAILURE_UNSPECIFIED = 0;
+  TRADEPROTOCOLFAILURE_UNKNOWN = 1;
+  TRADEPROTOCOLFAILURE_PRICE_DEVIATION = 2;
+  TRADEPROTOCOLFAILURE_NO_MATCHING_OFFER_FOUND = 3;
+  TRADEPROTOCOLFAILURE_MEDIATORS_NOT_MATCHING = 4;
+}
+
 message Trade {
   string state = 1;
   string id = 2;
@@ -67,6 +75,8 @@ message Trade {
   optional string peersErrorMessage = 10;
   optional string peersErrorStackTrace = 11;
   TradeLifecycleState lifecycleState = 12;
+  optional TradeProtocolFailure tradeProtocolFailure = 13;
+  optional TradeProtocolFailure peersTradeProtocolFailure = 14;
 
   oneof message {
     BisqEasyTrade bisqEasyTrade = 30;
@@ -146,6 +156,7 @@ message BisqEasyCancelTradeMessage {
 message BisqEasyReportErrorMessage {
   string errorMessage = 1;
   string stackTrace = 2;
+  TradeProtocolFailure tradeProtocolFailure = 3;
 }
 
 
@@ -232,6 +243,7 @@ message MuSigTradeMessage {
 message MuSigReportErrorMessage {
   string errorMessage = 1;
   string stackTrace = 2;
+  TradeProtocolFailure tradeProtocolFailure = 3;
 }
 
 message SetupTradeMessage_A {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/3170, https://github.com/bisq-network/bisq2/issues/3563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a dedicated "Failure" popup and a styled failure panel to show expected protocol-failure details and reasons.

* **Improvements**
  * Clearer distinction between unexpected errors and expected protocol failures with tailored UI and truncated diagnostic details.
  * More specific protocol-failure reasons surface in trade details and live trade updates.
  * Minor headline icon alignment tweak for improved visual alignment.

* **Localization**
  * Reorganized and added error-related translation keys across supported locales for consistent messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->