### PR TITLE
Do not trigger onNext if text input field is focussed

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/KeyHandlerUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/KeyHandlerUtil.java
@@ -17,8 +17,10 @@
 
 package bisq.desktop.common.utils;
 
+import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.Node;
 
 public class KeyHandlerUtil {
 
@@ -40,6 +42,18 @@ public class KeyHandlerUtil {
         if (keyEvent.getCode() == KeyCode.ENTER) {
             keyEvent.consume();
             handler.run();
+        }
+    }
+
+    public static void handleEnterKeyEventWithTextInputFocusCheck(KeyEvent keyEvent, Node node, Runnable handler) {
+        if (node != null && node.getScene() != null && node.getScene().getFocusOwner() instanceof TextInputControl textInputControl) {
+            handleEnterKeyEvent(keyEvent, () -> {
+                if (textInputControl.getParent() != null) {
+                    textInputControl.getParent().requestFocus();
+                }
+            });
+        } else {
+            handleEnterKeyEvent(keyEvent, handler);
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/TakeOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/TakeOfferController.java
@@ -17,7 +17,8 @@
 
 package bisq.desktop.main.content.bisq_easy.take_offer;
 
-import bisq.desktop.navigation.NavigationTarget;
+import bisq.account.payment_method.BitcoinPaymentMethodSpec;
+import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
@@ -27,11 +28,10 @@ import bisq.desktop.common.view.NavigationController;
 import bisq.desktop.main.content.bisq_easy.take_offer.amount.TakeOfferAmountController;
 import bisq.desktop.main.content.bisq_easy.take_offer.payment_methods.TakeOfferPaymentController;
 import bisq.desktop.main.content.bisq_easy.take_offer.review.TakeOfferReviewController;
+import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayController;
 import bisq.i18n.Res;
 import bisq.offer.bisq_easy.BisqEasyOffer;
-import bisq.account.payment_method.BitcoinPaymentMethodSpec;
-import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
 import javafx.event.EventHandler;
 import javafx.scene.input.KeyEvent;
 import lombok.EqualsAndHashCode;
@@ -224,7 +224,7 @@ public class TakeOfferController extends NavigationController implements InitWit
 
     void onKeyPressed(KeyEvent keyEvent) {
         KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::onClose);
-        KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::onNext);
+        KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(keyEvent,getView().getRoot(),this::onNext);
     }
 
     private void closeAndNavigateTo(NavigationTarget navigationTarget) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/TradeWizardController.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.bisq_easy.trade_wizard;
 
 import bisq.account.payment_method.BitcoinPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
-import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
@@ -31,6 +30,7 @@ import bisq.desktop.main.content.bisq_easy.trade_wizard.direction_and_market.Tra
 import bisq.desktop.main.content.bisq_easy.trade_wizard.payment_methods.TradeWizardPaymentMethodsController;
 import bisq.desktop.main.content.bisq_easy.trade_wizard.review.TradeWizardReviewController;
 import bisq.desktop.main.content.bisq_easy.trade_wizard.select_offer.TradeWizardSelectOfferController;
+import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayController;
 import bisq.i18n.Res;
 import javafx.collections.ListChangeListener;
@@ -271,7 +271,7 @@ public class TradeWizardController extends NavigationController implements InitW
 
     void onKeyPressed(KeyEvent keyEvent) {
         KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::onClose);
-        KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::onNext);
+        KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(keyEvent,getView().getRoot(),this::onNext);
     }
 
     void onBack() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/MuSigCreateOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/MuSigCreateOfferController.java
@@ -210,7 +210,7 @@ public class MuSigCreateOfferController extends NavigationController implements 
 
     void onKeyPressed(KeyEvent keyEvent) {
         KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::onClose);
-        KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::onNext);
+        KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(keyEvent,getView().getRoot(),this::onNext);
     }
 
     void onBack() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/crypto_accounts/create/CreateCryptoAssetAccountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/crypto_accounts/create/CreateCryptoAssetAccountController.java
@@ -23,8 +23,8 @@ import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.common.view.NavigationController;
-import bisq.desktop.main.content.user.crypto_accounts.create.currency.CryptoAssetSelectionController;
 import bisq.desktop.main.content.user.crypto_accounts.create.address.AddressController;
+import bisq.desktop.main.content.user.crypto_accounts.create.currency.CryptoAssetSelectionController;
 import bisq.desktop.main.content.user.crypto_accounts.create.summary.SummaryController;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayController;
@@ -122,7 +122,7 @@ public class CreateCryptoAssetAccountController extends NavigationController {
 
     void onKeyPressed(KeyEvent keyEvent) {
         KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::onClose);
-        KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::navigateNext);
+        KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(keyEvent,getView().getRoot(),this::navigateNext);
     }
 
     void onNext() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/fiat_accounts/create/CreatePaymentAccountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/fiat_accounts/create/CreatePaymentAccountController.java
@@ -130,7 +130,7 @@ public class CreatePaymentAccountController extends NavigationController {
 
     void onKeyPressed(KeyEvent keyEvent) {
         KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::onClose);
-        KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::navigateNext);
+        KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(keyEvent,getView().getRoot(),this::navigateNext);
     }
 
     void onNext() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/wallet/setup_wallet_wizard/SetupWalletWizardController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/wallet/setup_wallet_wizard/SetupWalletWizardController.java
@@ -24,8 +24,8 @@ import bisq.desktop.common.view.Model;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.common.view.NavigationController;
 import bisq.desktop.common.view.View;
-import bisq.desktop.main.content.wallet.setup_wallet_wizard.protect.SetupWalletWizardProtectController;
 import bisq.desktop.main.content.wallet.setup_wallet_wizard.backup.SetupWalletWizardBackupController;
+import bisq.desktop.main.content.wallet.setup_wallet_wizard.protect.SetupWalletWizardProtectController;
 import bisq.desktop.main.content.wallet.setup_wallet_wizard.setup_or_restore.SetupWalletWizardSetupOrRestoreController;
 import bisq.desktop.main.content.wallet.setup_wallet_wizard.verify.SetupWalletWizardVerifyController;
 import bisq.desktop.navigation.NavigationTarget;
@@ -194,12 +194,12 @@ public class SetupWalletWizardController extends NavigationController {
 
     void onKeyPressed(KeyEvent keyEvent) {
         KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::onClose);
-        KeyHandlerUtil.handleEnterKeyEvent(keyEvent, this::onNext);
+        KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(keyEvent, getView().getRoot(), this::onNext);
     }
 
     private void closeAndNavigateTo(NavigationTarget navigationTarget) {
         reset();
-       // walletService.purgeSeedWords();
+        // walletService.purgeSeedWords();
         walletService.initialize();
         OverlayController.hide(() -> Navigation.navigateTo(navigationTarget));
     }


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/2056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enter key is now focus-aware: when typing in a text input, Enter will move focus within the input instead of advancing steps, preventing accidental navigation; when focus is elsewhere Enter continues to advance. This change is applied across offer flows, wallet/setup wizards, and account/payment creation screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->