### PR TITLE
Limit TTL for mailbox messages to 15 days

### DIFF
--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessage.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeMessage.java
@@ -35,7 +35,6 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -43,13 +42,13 @@ import java.util.stream.Collectors;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
-import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_15_DAYS;
 
 @Slf4j
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class BisqEasyOpenTradeMessage extends PrivateChatMessage<BisqEasyOpenTradeMessageReaction> implements BisqEasyOfferMessage {
+    public final class BisqEasyOpenTradeMessage extends PrivateChatMessage<BisqEasyOpenTradeMessageReaction> implements BisqEasyOfferMessage {
     public static final String ACK_REQUESTING_MESSAGE_ID_SEPARATOR = "_";
 
     public static BisqEasyOpenTradeMessage createTakeOfferMessage(String tradeId,
@@ -70,7 +69,7 @@ public final class BisqEasyOpenTradeMessage extends PrivateChatMessage<BisqEasyO
 
     // Metadata needs to be symmetric with BisqEasyOpenTradeMessageReaction.
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
+    private transient final MetaData metaData = new MetaData(TTL_15_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     private final String tradeId;
     private final Optional<UserProfile> mediator;

--- a/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeMessage.java
+++ b/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeMessage.java
@@ -34,7 +34,6 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -42,7 +41,7 @@ import java.util.stream.Collectors;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
-import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_15_DAYS;
 
 @Slf4j
 @Getter
@@ -53,7 +52,7 @@ public final class MuSigOpenTradeMessage extends PrivateChatMessage<MuSigOpenTra
 
     // Metadata needs to be symmetric with MuSigOpenTradeMessageReaction.
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
+    private transient final MetaData metaData = new MetaData(TTL_15_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     private final String tradeId;
     private final Optional<UserProfile> mediator;

--- a/chat/src/main/java/bisq/chat/reactions/BisqEasyOpenTradeMessageReaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/BisqEasyOpenTradeMessageReaction.java
@@ -35,7 +35,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 public class BisqEasyOpenTradeMessageReaction extends PrivateChatMessageReaction {
     // Metadata needs to be symmetric with BisqEasyOpenTradeMessage.
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
+    private transient final MetaData metaData = new MetaData(TTL_15_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     public BisqEasyOpenTradeMessageReaction(String id,
                                             UserProfile senderUserProfile,

--- a/chat/src/main/java/bisq/chat/reactions/MuSigOpenTradeMessageReaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/MuSigOpenTradeMessageReaction.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
-import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_15_DAYS;
 
 @Slf4j
 @Getter
@@ -37,7 +37,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
 public class MuSigOpenTradeMessageReaction extends PrivateChatMessageReaction {
     // Metadata needs to be symmetric with BisqEasyOpenTradeMessage.
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
+    private transient final MetaData metaData = new MetaData(TTL_15_DAYS, HIGH_PRIORITY, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     public MuSigOpenTradeMessageReaction(String id,
                                          UserProfile senderUserProfile,

--- a/chat/src/main/java/bisq/chat/reactions/TwoPartyPrivateChatMessageReaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/TwoPartyPrivateChatMessageReaction.java
@@ -27,7 +27,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
-import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_15_DAYS;
 
 @Slf4j
 @Getter
@@ -36,7 +36,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_30_DAYS;
 public final class TwoPartyPrivateChatMessageReaction extends PrivateChatMessageReaction {
     // Metadata needs to be symmetric with TwoPartyPrivateChatMessage.
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
+    private transient final MetaData metaData = new MetaData(TTL_15_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     public TwoPartyPrivateChatMessageReaction(String id,
                                               UserProfile senderUserProfile,

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatMessage.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatMessage.java
@@ -44,7 +44,7 @@ import static bisq.network.p2p.services.data.storage.MetaData.*;
 public final class TwoPartyPrivateChatMessage extends PrivateChatMessage<TwoPartyPrivateChatMessageReaction> {
     // Metadata needs to be symmetric with TwoPartyPrivateChatMessageReaction.
     // MetaData is transient as it will be used indirectly by low level network classes. Only some low level network classes write the metaData to their protobuf representations.
-    private transient final MetaData metaData = new MetaData(TTL_30_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
+    private transient final MetaData metaData = new MetaData(TTL_15_DAYS, getClass().getSimpleName(), MAX_MAP_SIZE_100);
 
     public TwoPartyPrivateChatMessage(String messageId,
                                       ChatChannelDomain chatChannelDomain,


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/3980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized data retention for trade communications. Trade messages and chat reactions now persist for 15 days instead of 30 days across all trading features, reducing data storage requirements while maintaining sufficient retention for essential communication history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->