### PR TITLE
Revert exclude for hash commits

### DIFF
--- a/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/bonded_role/AuthorizedBondedRole.java
@@ -59,12 +59,15 @@ public final class AuthorizedBondedRole implements AuthorizedDistributedData {
     private final Optional<AddressByTransportTypeMap> addressByTransportTypeMap;
     private final NetworkId networkId;
     // The oracle node which did the validation and publishing
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final Optional<AuthorizedOracleNode> authorizingOracleNode;
 
-
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/AuthorizedMarketPriceData.java
@@ -56,8 +56,11 @@ public final class AuthorizedMarketPriceData implements AuthorizedDistributedDat
     // We need deterministic sorting or the map, so we use a treemap
     private final TreeMap<Market, MarketPrice> marketPriceByCurrencyMap;
 
-
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
@@ -54,8 +54,11 @@ public final class AuthorizedOracleNode implements AuthorizedDistributedData {
     private final String bondUserName;                // username from DAO proposal
     private final String signatureBase64;             // signature created by bond with username as message
 
-
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/release/ReleaseNotification.java
@@ -58,7 +58,11 @@ public final class ReleaseNotification implements AuthorizedDistributedData {
     private final String versionString;
     private final String releaseManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
@@ -64,7 +64,11 @@ public final class AuthorizedAlertData implements AuthorizedDistributedData {
     private final Optional<AuthorizedBondedRole> bannedRole;
     private final String securityManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/difficulty_adjustment/AuthorizedDifficultyAdjustmentData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/difficulty_adjustment/AuthorizedDifficultyAdjustmentData.java
@@ -53,7 +53,11 @@ public final class AuthorizedDifficultyAdjustmentData implements AuthorizedDistr
     private final double difficultyAdjustmentFactor;
     private final String securityManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/min_reputation_score/AuthorizedMinRequiredReputationScoreData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/min_reputation_score/AuthorizedMinRequiredReputationScoreData.java
@@ -54,7 +54,11 @@ public final class AuthorizedMinRequiredReputationScoreData implements Authorize
     private final long minRequiredReputationScore;
     private final String securityManagerProfileId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/network/network/src/main/java/bisq/network/p2p/node/Capability.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/Capability.java
@@ -49,8 +49,11 @@ public final class Capability implements NetworkProto {
     private final int version;
     private final Address address;
     private final List<TransportType> supportedTransportTypes;
+    // ExcludeForHash from version 1 on to not break hash for pow check or version 0. We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final List<Feature> features;
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String applicationVersion;

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryResponse.java
@@ -35,8 +35,10 @@ public final class InventoryResponse implements BroadcastMessage, Response {
     @EqualsAndHashCode.Exclude
     @ExcludeForHash
     private final int version;
+    // After v 2.1.0 version 0 should not be used anymore. Then we can remove the excludeOnlyInVersions param to
+    // not need to maintain future versions. We add though hypothetical versions 2 and 3 for safety
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final Inventory inventory;
     private final int requestNonce;
 

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/RemoveAuthenticatedDataRequest.java
@@ -63,7 +63,7 @@ public final class RemoveAuthenticatedDataRequest implements AuthenticatedDataRe
                 signature);
     }
 
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
     @ExcludeForHash

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/MailboxData.java
@@ -41,7 +41,7 @@ public final class MailboxData implements StorageData {
     public final static long MAX_TLL = TimeUnit.DAYS.toMillis(15);
 
     @EqualsAndHashCode.Exclude
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
     @EqualsAndHashCode.Exclude

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/mailbox/RemoveMailboxRequest.java
@@ -60,7 +60,7 @@ public final class RemoveMailboxRequest implements MailboxRequest, RemoveDataReq
                 created);
     }
 
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final MetaData metaData;
 
     @ExcludeForHash

--- a/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
+++ b/user/src/main/java/bisq/user/banned/BannedUserProfileData.java
@@ -48,7 +48,11 @@ public final class BannedUserProfileData implements AuthorizedDistributedData {
     private final int version;
     private final UserProfile userProfile;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/profile/UserProfile.java
+++ b/user/src/main/java/bisq/user/profile/UserProfile.java
@@ -97,7 +97,7 @@ public final class UserProfile implements DistributedData, PublishDateAware {
     @EqualsAndHashCode.Include
     private final String statement;
 
-    @ExcludeForHash
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final int avatarVersion;
     @ExcludeForHash
     private final int version;

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedAccountAgeData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedAccountAgeData.java
@@ -52,7 +52,11 @@ public final class AuthorizedAccountAgeData implements AuthorizedDistributedData
     private final String profileId;
     private final long date;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedBondedReputationData.java
@@ -60,7 +60,11 @@ public final class AuthorizedBondedReputationData implements AuthorizedDistribut
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedProofOfBurnData.java
@@ -58,7 +58,11 @@ public final class AuthorizedProofOfBurnData implements AuthorizedDistributedDat
     @ExcludeForHash(excludeOnlyInVersions = {0})
     private final String txId;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     private final boolean staticPublicKeysProvided;
 
     public AuthorizedProofOfBurnData(long blockTime,

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedSignedWitnessData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedSignedWitnessData.java
@@ -52,7 +52,11 @@ public final class AuthorizedSignedWitnessData implements AuthorizedDistributedD
     private final String profileId;
     private final long witnessSignDate;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 

--- a/user/src/main/java/bisq/user/reputation/data/AuthorizedTimestampData.java
+++ b/user/src/main/java/bisq/user/reputation/data/AuthorizedTimestampData.java
@@ -52,7 +52,11 @@ public final class AuthorizedTimestampData implements AuthorizedDistributedData 
     private final String profileId;
     private final long date;
 
-    @ExcludeForHash
+    // ExcludeForHash from version 1 on to not treat data from different oracle nodes with different staticPublicKeysProvided value as duplicate data.
+    // We add version 2 and 3 for extra safety...
+    // Once no nodes with versions below 2.1.0  are expected anymore in the network we can remove the parameter
+    // and use default `@ExcludeForHash` instead.
+    @ExcludeForHash(excludeOnlyInVersions = {1, 2, 3})
     @EqualsAndHashCode.Exclude
     private final boolean staticPublicKeysProvided;
 


### PR DESCRIPTION
Those commits broke the authorized data validation as it seems the existing data are published by the old oracle node, and data from the new node is still not distributed.