### PR TITLE
fix(auth): prevent indefinite read on normal conditions

### DIFF
--- a/http-api/src/main/java/bisq/http_api/auth/HttpApiAuthFilter.java
+++ b/http-api/src/main/java/bisq/http_api/auth/HttpApiAuthFilter.java
@@ -52,8 +52,12 @@ public class HttpApiAuthFilter implements ContainerRequestFilter {
 
     @Nullable
     private String getBodySha256Hex(ContainerRequestContext ctx) {
-        // Content-Length may be spoofed; we always consume the stream to confirm whether a body is present.
+        // Content-Length may be spoofed; But it is an important indicator of a present body set by clients
         int declaredLength = ctx.getLength();
+
+        if (declaredLength == 0) {
+            return null;
+        }
 
         // If length is known and too large, return early
         if (declaredLength > MAX_BODY_SIZE_BYTES) {


### PR DESCRIPTION
Sorry, I should have tested the latest change

So the problem is that when the body is empty, the read never returns, blocking the function

Client can spoof the content-length but thats an important indicator for us to know if body is present, so I'm not sure if we can work around that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTTP request handling for improved performance in authentication processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->