### PR TITLE
Add I2P_ACTIVATIONE_DATE and consider AuthorizedDistributedData invalid if it contains an I2P address

### DIFF
--- a/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/oracle/AuthorizedOracleNode.java
@@ -20,12 +20,14 @@ package bisq.bonded_roles.oracle;
 import bisq.bonded_roles.AuthorizedPubKeys;
 import bisq.common.annotation.ExcludeForHash;
 import bisq.common.application.DevMode;
+import bisq.common.network.TransportType;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.identity.NetworkId;
 import bisq.network.p2p.services.data.storage.DistributedData;
 import bisq.network.p2p.services.data.storage.MetaData;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
 import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedDistributedData;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.EqualsAndHashCode;
@@ -35,7 +37,9 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Arrays;
 import java.util.Set;
 
-import static bisq.network.p2p.services.data.storage.MetaData.*;
+import static bisq.network.p2p.services.data.storage.MetaData.HIGHEST_PRIORITY;
+import static bisq.network.p2p.services.data.storage.MetaData.MAX_MAP_SIZE_100;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_100_DAYS;
 
 @Slf4j
 @EqualsAndHashCode
@@ -149,6 +153,12 @@ public final class AuthorizedOracleNode implements AuthorizedDistributedData {
 
     @Override
     public boolean isDataInvalid(byte[] pubKeyHash) {
+        // Can be removed after I2P is activated
+        if (!AuthorizedData.IS_I2P_ACTIVATED && networkId.getAddressByTransportTypeMap().containsKey(TransportType.I2P)) {
+            log.warn("AuthorizedOracleNode considered invalid as it contains an I2PAddress address and we have not yet activated I2P.\n" +
+                    "networkId={}", networkId);
+            return true;
+        }
         return !Arrays.equals(networkId.getPubKey().getHash(), pubKeyHash);
     }
 

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertData.java
@@ -27,6 +27,7 @@ import bisq.common.validation.NetworkDataValidation;
 import bisq.i18n.Res;
 import bisq.network.p2p.services.data.storage.DistributedData;
 import bisq.network.p2p.services.data.storage.MetaData;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
 import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedDistributedData;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.EqualsAndHashCode;
@@ -37,7 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Optional;
 import java.util.Set;
 
-import static bisq.network.p2p.services.data.storage.MetaData.*;
+import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_100_DAYS;
 
 @Slf4j
 @ToString
@@ -233,6 +235,15 @@ public final class AuthorizedAlertData implements AuthorizedDistributedData {
 
     @Override
     public boolean isDataInvalid(byte[] pubKeyHash) {
+        // Can be removed after I2P is activated
+        if (!AuthorizedData.IS_I2P_ACTIVATED ) {
+            Boolean isBannedRoleInvalid = bannedRole.map(node -> node.isDataInvalid(pubKeyHash)).orElse(false);
+            if(isBannedRoleInvalid){
+                log.warn("AuthorizedAlertData considered invalid as bannedRole is invalid.\n" +
+                        "bannedRole={}", bannedRole);
+                return true;
+            }
+        }
         return message.orElse("").length() > MAX_MESSAGE_LENGTH;
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/auth/authorized/AuthorizedData.java
@@ -18,6 +18,7 @@
 package bisq.network.p2p.services.data.storage.auth.authorized;
 
 import bisq.common.encoding.Hex;
+import bisq.common.util.DateUtils;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.p2p.services.data.storage.DistributedData;
 import bisq.network.p2p.services.data.storage.auth.AuthenticatedData;
@@ -30,6 +31,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -41,6 +44,11 @@ import java.util.Optional;
 @Slf4j
 @Getter
 public final class AuthorizedData extends AuthenticatedData {
+    // Can be removed after I2P is activated
+    public static final Date I2P_ACTIVATION_DATE = DateUtils.getUTCDate(2025, GregorianCalendar.DECEMBER, 1);
+    public static final boolean IS_I2P_ACTIVATED = new Date().after(I2P_ACTIVATION_DATE);
+
+
     private final Optional<byte[]> signature;
     private final byte[] authorizedPublicKeyBytes;
     transient private final PublicKey authorizedPublicKey;


### PR DESCRIPTION
Add I2P_ACTIVATIONE_DATE and consider AuthorizedOracleNode, AuthorizedBondedRole or AuthorizedAlertData invalid if they contain an I2P address.

We had oracle and seed nodes registered which had already I2P addresses defined, but later unregistered/banned those nodes. As the 2.1.7 versions have an incorrect address validation for I2P the inventory response fail if it contains such data. The removal of the nodes did not reach the whole network due the same issue with 2.1.7, thus we have such dangling data in the network.

Other I2P data is not expected in the network (e.g. user profiles, offers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * I2P privacy network support added with an activation date of December 1, 2025.

* **Improvements**
  * Validation now prevents use of I2P addresses before activation and emits warnings when such addresses are encountered.
  * Additional checks added to improve invalid-data detection across bonded roles and alerting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->