### PR TITLE
Persist on observable change only.

### DIFF
--- a/account/src/main/java/bisq/account/AccountService.java
+++ b/account/src/main/java/bisq/account/AccountService.java
@@ -114,8 +114,9 @@ public class AccountService extends RateLimitedPersistenceClient<AccountStore> i
 
     //todo do we need that?
     public void setSelectedAccount(Account<? extends PaymentMethod<?>, ?> account) {
-        selectedAccountAsObservable().set(account);
-        persist();
+        if (selectedAccountAsObservable().set(account)) {
+            persist();
+        }
     }
 
     public Set<Account<? extends PaymentMethod<?>, ?>> getAccounts(PaymentMethod<?> paymentMethod) {

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceService.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceService.java
@@ -145,8 +145,9 @@ public class MarketPriceService extends RateLimitedPersistenceClient<MarketPrice
     /* --------------------------------------------------------------------- */
 
     public void setSelectedMarket(Market market) {
-        getSelectedMarket().set(market);
-        persist();
+        if (getSelectedMarket().set(market)) {
+            persist();
+        }
     }
 
     public Optional<MarketPrice> findMarketPrice(Market market) {

--- a/chat/src/main/java/bisq/chat/ChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/ChatChannelService.java
@@ -55,10 +55,13 @@ public abstract class ChatChannelService<M extends ChatMessage, C extends ChatCh
 
     public void setChatChannelNotificationType(ChatChannel<? extends ChatMessage> chatChannel,
                                                ChatChannelNotificationType chatChannelNotificationType) {
+        boolean valueChanged;
         synchronized (this) {
-            chatChannel.getChatChannelNotificationType().set(chatChannelNotificationType);
+            valueChanged = chatChannel.getChatChannelNotificationType().set(chatChannelNotificationType);
         }
-        persist();
+        if (valueChanged) {
+            persist();
+        }
     }
 
     public void addMessage(M message, C channel) {

--- a/common/src/main/java/bisq/common/observable/Observable.java
+++ b/common/src/main/java/bisq/common/observable/Observable.java
@@ -54,9 +54,9 @@ public class Observable<S> implements ReadOnlyObservable<S> {
         observers.remove(observer);
     }
 
-    public void set(S value) {
+    public boolean set(S value) {
         if ((this.value == null && value == null) || (this.value != null && this.value.equals(value))) {
-            return;
+            return false;
         }
         this.value = value;
         observers.forEach(observer -> {
@@ -66,6 +66,7 @@ public class Observable<S> implements ReadOnlyObservable<S> {
                 log.error("Observer {} caused an exception at handling update.", observer, e);
             }
         });
+        return true;
     }
 
     public S get() {

--- a/support/src/main/java/bisq/support/mediation/MediationCase.java
+++ b/support/src/main/java/bisq/support/mediation/MediationCase.java
@@ -5,7 +5,6 @@ import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.util.Date;
 import java.util.Optional;
 
 @Getter
@@ -54,8 +53,11 @@ public class MediationCase implements PersistableProto {
                 proto.hasCloseCaseDate() ? Optional.of(proto.getCloseCaseDate()) : Optional.empty());
     }
 
-    public void setClosed(boolean closed) {
-        closeCaseDate = closed ? Optional.of(System.currentTimeMillis()) : Optional.empty();
-        isClosed.set(closed);
+    public boolean setClosed(boolean closed) {
+        boolean changed = isClosed.set(closed);
+        if (changed) {
+            closeCaseDate = closed ? Optional.of(System.currentTimeMillis()) : Optional.empty();
+        }
+        return changed;
     }
 }

--- a/support/src/main/java/bisq/support/mediation/MediatorService.java
+++ b/support/src/main/java/bisq/support/mediation/MediatorService.java
@@ -115,8 +115,9 @@ public class MediatorService extends RateLimitedPersistenceClient<MediatorStore>
     /* --------------------------------------------------------------------- */
 
     public void closeMediationCase(MediationCase mediationCase) {
-        mediationCase.setClosed(true);
-        persist();
+        if (mediationCase.setClosed(true)) {
+            persist();
+        }
     }
 
     public void removeMediationCase(MediationCase mediationCase) {
@@ -125,8 +126,9 @@ public class MediatorService extends RateLimitedPersistenceClient<MediatorStore>
     }
 
     public void reOpenMediationCase(MediationCase mediationCase) {
-        mediationCase.setClosed(false);
-        persist();
+        if (mediationCase.setClosed(false)) {
+            persist();
+        }
     }
 
     public ObservableSet<MediationCase> getMediationCases() {

--- a/user/src/main/java/bisq/user/contact_list/ContactListService.java
+++ b/user/src/main/java/bisq/user/contact_list/ContactListService.java
@@ -105,6 +105,9 @@ public class ContactListService extends RateLimitedPersistenceClient<ContactList
         }
 
         findContactListEntry(contactListEntry).ifPresent(cle -> {
+            if (cle.getTag().isPresent() && cle.getTag().get().equals(newTag)) {
+                return;
+            }
             cle.setTag(newTag);
             persist();
         });
@@ -116,6 +119,9 @@ public class ContactListService extends RateLimitedPersistenceClient<ContactList
         }
 
         findContactListEntry(contactListEntry).ifPresent(cle -> {
+            if (cle.getNotes().isPresent() && cle.getNotes().get().equals(newNotes)) {
+                return;
+            }
             cle.setNotes(newNotes);
             persist();
         });
@@ -129,6 +135,9 @@ public class ContactListService extends RateLimitedPersistenceClient<ContactList
         }
 
         findContactListEntry(contactListEntry).ifPresent(cle -> {
+            if (cle.getTrustScore().isPresent() && cle.getTrustScore().get().equals(newTrustScore)) {
+                return;
+            }
             cle.setTrustScore(newTrustScore);
             persist();
         });


### PR DESCRIPTION
relates #3990 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced redundant saves and writes across account/market selection, chat notifications, mediation cases, and contact updates so persistence now occurs only when values actually change.
  * Made observable updates idempotent so unchanged values no longer trigger notifications or downstream saves, improving performance and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->