### PR TITLE
Remove display of thread chart

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/TransportController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/TransportController.java
@@ -40,14 +40,14 @@ public class TransportController implements Controller {
 
         Traffic traffic = new Traffic(serviceProvider, transportType);
         SystemLoad systemLoad = new SystemLoad(serviceProvider, transportType);
-        NumThreadStatistics numThreadStatistics= new NumThreadStatistics(serviceProvider, transportType);
+       // NumThreadStatistics numThreadStatistics= new NumThreadStatistics(serviceProvider, transportType);
         ConnectionsAndNodes connectionsAndNodes = new ConnectionsAndNodes(serviceProvider, transportType);
         model = new TransportModel(transportType, defaultNode);
         view = new TransportView(model, this,
                 traffic.getViewRoot(),
                 systemLoad.getViewRoot(),
-                connectionsAndNodes.getViewRoot(),
-                numThreadStatistics.getViewRoot());
+                connectionsAndNodes.getViewRoot()/*,
+                numThreadStatistics.getViewRoot()*/);
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/TransportView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/p2p_network/transport/TransportView.java
@@ -23,7 +23,6 @@ import bisq.desktop.main.content.settings.SettingsViewUtils;
 import bisq.i18n.Res;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 public class TransportView extends View<VBox, TransportModel, TransportController> {
@@ -33,8 +32,8 @@ public class TransportView extends View<VBox, TransportModel, TransportControlle
                          TransportController controller,
                          Pane traffic,
                          Pane systemLoad,
-                         Pane connectionAndNodes,
-                         Pane numThreadStatistics) {
+                         Pane connectionAndNodes/*,
+                         Pane numThreadStatistics*/) {
         super(new VBox(25), model, controller);
 
         Label headline = SettingsViewUtils.getHeadline(Res.get("network.transport.headline." + model.getTransportType().name()));
@@ -43,14 +42,15 @@ public class TransportView extends View<VBox, TransportModel, TransportControlle
         myAddress.setEditable(false);
         myAddress.showCopyIcon();
 
-        VBox.setVgrow(numThreadStatistics, Priority.ALWAYS);
+
+       // VBox.setVgrow(numThreadStatistics, Priority.ALWAYS);
         root.getChildren().addAll(headline,
                 SettingsViewUtils.getLineAfterHeadline(getRoot().getSpacing()),
                 myAddress,
                 connectionAndNodes,
                 traffic,
-                systemLoad,
-                numThreadStatistics);
+                systemLoad/*,
+                numThreadStatistics*/); // Commented out as only relevant for devs
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the thread statistics display from the P2P network transport monitoring view to streamline the network diagnostics interface in the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->