### PR TITLE
Restrict file permissions.

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -22,6 +22,7 @@ import bisq.common.application.ApplicationVersion;
 import bisq.common.application.DevMode;
 import bisq.common.application.Service;
 import bisq.common.asset.FiatCurrencyRepository;
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.locale.CountryRepository;
 import bisq.common.locale.LanguageRepository;
 import bisq.common.locale.LocaleRepository;
@@ -38,7 +39,6 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -153,7 +153,7 @@ public abstract class ApplicationService implements Service {
                 ? Path.of(rootConfig.getString("application.baseDir"))
                 : userDataDirPath.resolve(appName);
         try {
-            Files.createDirectories(appDataDirPath);
+            FileMutatorUtils.createRestrictedDirectories(appDataDirPath);
         } catch (IOException e) {
             log.error("Could not create data directory {}", appDataDirPath, e);
             throw new RuntimeException(e);

--- a/application/src/main/java/bisq/application/migration/Migrator.java
+++ b/application/src/main/java/bisq/application/migration/Migrator.java
@@ -1,13 +1,13 @@
 package bisq.application.migration;
 
-import bisq.common.application.ApplicationVersion;
-import bisq.common.platform.Version;
 import bisq.application.migration.migrations.Migration;
 import bisq.application.migration.migrations.MigrationFailedException;
+import bisq.common.application.ApplicationVersion;
+import bisq.common.file.FileMutatorUtils;
+import bisq.common.platform.Version;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -43,7 +43,7 @@ public class Migrator {
         if (allMigrationsSucceeded) {
             try {
                 Path versionFilePath = appDataDirPath.resolve("version");
-                Files.writeString(versionFilePath, ApplicationVersion.getVersion().toString());
+                FileMutatorUtils.writeToPath(ApplicationVersion.getVersion().toString(), versionFilePath);
             } catch (IOException e) {
                 throw new MigrationFailedException(e);
             }

--- a/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
+++ b/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
@@ -1,5 +1,6 @@
 package bisq.application.migration.migrations;
 
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.platform.Version;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -60,7 +61,7 @@ public class MigrationsForV2_1_2Tests {
     }
 
     private void createFakeTorPath(Path torPath) throws IOException {
-        Files.createDirectories(torPath);
+        FileMutatorUtils.createRestrictedDirectories(torPath);
 
         List<String> torPathFiles = List.of("lock",
                 "libssl.so.1.1",

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/CatHashImageUtil.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/CatHashImageUtil.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.common.utils;
 
+import bisq.common.file.FileMutatorUtils;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
@@ -76,7 +77,7 @@ public class CatHashImageUtil {
 
     public static void writeRawImage(Image image, Path filePath) throws IOException {
         byte[] rawData = imageToByteArray(image);
-        Files.write(filePath, rawData);
+        FileMutatorUtils.writeToPath(rawData, filePath);
     }
 
     public static Image byteArrayToImage(byte[] data) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -90,7 +90,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1035,7 +1034,7 @@ public abstract class Overlay<T extends Overlay<T>> {
                         logPaths.forEach(logPath -> {
                             if (Files.isRegularFile(logPath)) {
                                 try {
-                                    Files.copy(logPath, zipFileSystem.getPath(logPath.getFileName().toString()), StandardCopyOption.REPLACE_EXISTING);
+                                    FileMutatorUtils.copyFile(logPath, zipFileSystem.getPath(logPath.getFileName().toString()));
                                 } catch (IOException e) {
                                     throw new RuntimeException(e);
                                 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/network/NetworkSettingsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/network/NetworkSettingsController.java
@@ -22,6 +22,7 @@ import bisq.application.ShutDownHandler;
 import bisq.application.TypesafeConfigUtils;
 import bisq.bonded_roles.security_manager.difficulty_adjustment.DifficultyAdjustmentService;
 import bisq.common.application.DevMode;
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.network.Address;
 import bisq.common.network.ClearnetAddress;
 import bisq.common.network.TransportType;
@@ -41,7 +42,6 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -206,7 +206,7 @@ public class NetworkSettingsController implements Controller {
 
         Path customConfigFilePath = appDataDirPath.resolve(ApplicationService.CUSTOM_CONFIG_FILE_NAME);
         try {
-            Files.writeString(customConfigFilePath, rendered);
+            FileMutatorUtils.writeToPath(rendered, customConfigFilePath);
         } catch (IOException e) {
             log.error("Could not write config file {}", customConfigFilePath.toAbsolutePath(), e);
             throw new RuntimeException(e);

--- a/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
+++ b/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
@@ -17,11 +17,11 @@
 
 package bisq.common.archive;
 
+import bisq.common.file.FileMutatorUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -47,7 +47,7 @@ public class ZipFileExtractor implements AutoCloseable {
 
     private void createDirIfNotPresent(Path destDirPath) {
         try {
-            Files.createDirectories(destDirPath);
+            FileMutatorUtils.createRestrictedDirectories(destDirPath);
         } catch (IOException e) {
             throw new ZipFileExtractionFailedException("Couldn't create directory: " + destDirPath, e);
         }
@@ -69,12 +69,12 @@ public class ZipFileExtractor implements AutoCloseable {
                     throw new IOException("Entry is outside of the target directory");
                 }
                 if (zipEntry.isDirectory()) {
-                    Files.createDirectories(targetPath);
+                    FileMutatorUtils.createRestrictedDirectories(targetPath);
                 } else {
                     // Ensure parent directories exist
-                    Files.createDirectories(targetPath.getParent());
+                    FileMutatorUtils.createRestrictedDirectories(targetPath.getParent());
                     // Copy stream content to file
-                    Files.copy(zipInputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    FileMutatorUtils.inputStreamToFile(zipInputStream, targetPath);
                 }
             } while ((zipEntry = zipInputStream.getNextEntry()) != null);
         } catch (IOException e) {

--- a/common/src/main/java/bisq/common/logging/LogSetup.java
+++ b/common/src/main/java/bisq/common/logging/LogSetup.java
@@ -52,7 +52,7 @@ public class LogSetup {
 
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
-        RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
+        RollingFileAppender<ILoggingEvent> appender = new RestrictedRollingFileAppender();
         appender.setContext(loggerContext);
         appender.setFile(fileName + ".log");
 

--- a/common/src/main/java/bisq/common/logging/RestrictedRollingFileAppender.java
+++ b/common/src/main/java/bisq/common/logging/RestrictedRollingFileAppender.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+
+public class RestrictedRollingFileAppender extends RollingFileAppender<ILoggingEvent> {
+    @Override
+    public void openFile(String fileName) throws IOException {
+        super.openFile(fileName);
+        try {
+            Files.setPosixFilePermissions(Paths.get(fileName),
+                    EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException e) {
+            // For non-posix file systems, we ignore this exception
+        }
+    }
+}

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -209,7 +208,7 @@ public class UpdaterService implements Service {
         String downloadFileName = UpdaterUtils.getDownloadFileName(version, isLauncherUpdate);
         Path destinationDirPath = isLauncherUpdate ? PlatformUtils.getDownloadOfHomeDirPath() :
                 appDataDirPath.resolve(UPDATES_DIR).resolve(version);
-        Files.createDirectories(destinationDirPath);
+        FileMutatorUtils.createRestrictedDirectories(destinationDirPath);
         downloadItemList.setAll(DownloadItem.createDescriptorList(version, destinationDirPath, downloadFileName, keyIds));
         if (executorService == null) {
             executorService = ExecutorFactory.newSingleThreadExecutor("DownloadExecutor");

--- a/evolution/src/test/java/bisq/evolution/updater/UpdaterIntegrationTest.java
+++ b/evolution/src/test/java/bisq/evolution/updater/UpdaterIntegrationTest.java
@@ -76,7 +76,7 @@ public class UpdaterIntegrationTest {
         List<String> keyIds = List.of("387C8307");
         String downloadFileName = UpdaterUtils.getDownloadFileName(version, isLauncherUpdate);
         try {
-            Files.createDirectories(destinationDirPath);
+            FileMutatorUtils.createRestrictedDirectories(destinationDirPath);
             List<DownloadItem> downloadItemList = new ArrayList<>(DownloadItem.createDescriptorList(version, destinationDirPath, downloadFileName, keyIds));
             simulateDownload(downloadItemList, sourceDirPath.toString(), executorService)
                     .thenCompose(nil -> UpdaterService.verify(version, isLauncherUpdate, destinationDirPath, keyIds, ignoreSigningKeyInResourcesCheck, executorService))
@@ -113,7 +113,7 @@ public class UpdaterIntegrationTest {
         List<String> keyIds = List.of("387C8307");
         String downloadFileName = UpdaterUtils.getDownloadFileName(version, isLauncherUpdate);
         try {
-            Files.createDirectories(destinationDirPath);
+            FileMutatorUtils.createRestrictedDirectories(destinationDirPath);
             List<DownloadItem> downloadItemList = new ArrayList<>(DownloadItem.createDescriptorList(version, destinationDirPath, downloadFileName, keyIds));
             simulateDownload(downloadItemList, sourceDirPath.toString(), executorService)
                     .thenCompose(nil -> UpdaterService.verify(version, isLauncherUpdate, destinationDirPath, keyIds, ignoreSigningKeyInResourcesCheck, executorService))

--- a/network/i2p/src/main/java/bisq/network/i2p/router/RouterSetup.java
+++ b/network/i2p/src/main/java/bisq/network/i2p/router/RouterSetup.java
@@ -17,6 +17,7 @@
 
 package bisq.network.i2p.router;
 
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.PropertiesReader;
 import bisq.common.logging.LogSetup;
 import bisq.network.i2p.router.utils.I2PLogLevel;
@@ -200,7 +201,7 @@ public class RouterSetup {
             }
         } else {
             try {
-                Files.createFile(configFilePath);
+                FileMutatorUtils.createRestrictedFile(configFilePath);
             } catch (IOException e) {
                 log.warn("Could not create router.config file in i2p data directory {}", configFilePath.toAbsolutePath(), e);
             }
@@ -219,7 +220,7 @@ public class RouterSetup {
 
     private Path createDirectory(Path parent, String child) throws IOException {
         Path dirPath = parent.resolve(child);
-        Files.createDirectories(dirPath);
+        FileMutatorUtils.createRestrictedDirectories(dirPath);
         return dirPath;
     }
 }

--- a/network/i2p/src/main/java/bisq/network/i2p/router/utils/RouterCertificateUtil.java
+++ b/network/i2p/src/main/java/bisq/network/i2p/router/utils/RouterCertificateUtil.java
@@ -21,7 +21,6 @@ import bisq.common.file.FileMutatorUtils;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class RouterCertificateUtil {
@@ -35,7 +34,7 @@ public class RouterCertificateUtil {
 
     private static Path createDirectory(Path parentPath, String child) throws IOException {
         Path dirPath = parentPath.resolve(child);
-        Files.createDirectories(dirPath);
+        FileMutatorUtils.createRestrictedDirectories(dirPath);
         return dirPath;
     }
 }

--- a/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/TorNetwork.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/TorNetwork.java
@@ -17,6 +17,7 @@
 
 package bisq.network.tor.local_network;
 
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.util.NetworkUtils;
 import bisq.network.tor.common.torrc.DirectoryAuthority;
 import bisq.network.tor.common.torrc.TorrcConfigGenerator;
@@ -122,7 +123,7 @@ public class TorNetwork {
         }
 
         try {
-            Files.createDirectory(nodeDataDirPath);
+            FileMutatorUtils.createRestrictedDirectory(nodeDataDirPath);
         } catch (IOException e) {
             throw new IllegalStateException("Couldn't create data directory: " + nodeDataDirPath.toAbsolutePath(), e);
         }

--- a/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/da/DirectoryAuthorityFactory.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/da/DirectoryAuthorityFactory.java
@@ -17,6 +17,7 @@
 
 package bisq.network.tor.local_network.da;
 
+import bisq.common.file.FileMutatorUtils;
 import bisq.network.tor.local_network.TorNode;
 import bisq.network.tor.local_network.da.keygen.process.DirectoryAuthorityKeyGenerator;
 import lombok.Getter;
@@ -40,7 +41,7 @@ public class DirectoryAuthorityFactory {
         Path keysPath = dataDirPath.resolve("keys");
         if (!Files.exists(keysPath)) {
             try {
-                Files.createDirectories(keysPath);
+                FileMutatorUtils.createRestrictedDirectories(keysPath);
             } catch (IOException e) {
                 throw new IllegalStateException("Couldn't create keys folder in data directory for directory authority.", e);
             }
@@ -53,7 +54,7 @@ public class DirectoryAuthorityFactory {
     private void createDataDirPathIfNotPresent(Path dataDirPath) {
         if(!Files.exists(dataDirPath)) {
             try {
-                Files.createDirectory(dataDirPath);
+                FileMutatorUtils.createRestrictedDirectory(dataDirPath);
             } catch (IOException e) {
                 throw new IllegalStateException("Couldn't create data directory for directory authority.", e);
             }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -405,7 +405,7 @@ public class TorService implements Service {
     private void makeTorDir() {
         try {
             Path torDataDirPath = transportConfig.getDataDirPath();
-            Files.createDirectories(torDataDirPath);
+            FileMutatorUtils.createRestrictedDirectories(torDataDirPath);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/network/tor/tor/src/main/java/bisq/network/tor/process/EmbeddedTorProcess.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/process/EmbeddedTorProcess.java
@@ -17,6 +17,7 @@
 
 package bisq.network.tor.process;
 
+import bisq.common.file.FileMutatorUtils;
 import bisq.network.tor.common.torrc.BaseTorrcGenerator;
 import lombok.extern.slf4j.Slf4j;
 
@@ -108,7 +109,7 @@ public class EmbeddedTorProcess {
         Path controlDirFilePath = torDataDirPath.resolve(BaseTorrcGenerator.CONTROL_DIR_NAME);
         if (!Files.exists(controlDirFilePath)) {
             try {
-                Files.createDirectories(controlDirFilePath);
+                FileMutatorUtils.createRestrictedDirectories(controlDirFilePath);
             } catch (IOException e) {
                 throw new TorStartupFailedException("Couldn't create Tor control directory.");
             }

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreFileManager.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreFileManager.java
@@ -54,7 +54,7 @@ public class PersistableStoreFileManager {
     public void createParentDirectoriesIfNotExisting() {
         if (!Files.exists(parentDirectoryPath)) {
             try {
-                Files.createDirectories(parentDirectoryPath);
+                FileMutatorUtils.createRestrictedDirectories(parentDirectoryPath);
             } catch (IOException e) {
                 throw new CouldNotCreateParentDirs("Couldn't create " + parentDirectoryPath);
             }

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
@@ -110,7 +110,7 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
     }
 
     private void writeStoreToFilePath(T persistableStore, Path filePath) {
-        try (OutputStream fileOutputStream = Files.newOutputStream(filePath)) {
+        try (OutputStream fileOutputStream = FileMutatorUtils.newRestrictedOutputStream(filePath)) {
             // We use an Any container (byte blob) as we do not have the dependencies to the
             // external PersistableStore implementations (at deserialization we would have an issue otherwise as
             // it requires static access).

--- a/persistence/src/main/java/bisq/persistence/backup/BackupService.java
+++ b/persistence/src/main/java/bisq/persistence/backup/BackupService.java
@@ -290,7 +290,7 @@ public class BackupService {
         String formattedDate = DATE_FORMAT.format(localDateTime);
         String fileNamePath = fileName + "_" + formattedDate;
         Path backupFilePath = dirPath.resolve(fileNamePath);
-        Files.createDirectories(dirPath);
+        FileMutatorUtils.createRestrictedDirectories(dirPath);
         return backupFilePath;
     }
 

--- a/persistence/src/test/java/bisq/persistence/backup/BackupServiceTest.java
+++ b/persistence/src/test/java/bisq/persistence/backup/BackupServiceTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -51,7 +50,7 @@ public class BackupServiceTest {
     @BeforeEach
     void setUp() throws IOException {
         Path dbDirPath = dataDirPath.resolve("db");
-        Files.createDirectories(dbDirPath);
+        FileMutatorUtils.createRestrictedDirectories(dbDirPath);
         String storeFileName = "test_store" + Persistence.EXTENSION;
         storeFilePath = dbDirPath.resolve(storeFileName);
         backupService = new BackupService(dataDirPath, this.storeFilePath, MaxBackupSize.HUNDRED_MB);

--- a/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
@@ -27,7 +27,6 @@ import net.i2p.data.PrivateKeyFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 @Slf4j
@@ -38,7 +37,7 @@ public class I2PKeyUtils {
         Path destination_b32Path = I2PKeyGeneration.getDestinationFilePath(storageDirPath, tag, "destination_b32");
         Path identityBase64Path = I2PKeyGeneration.getDestinationFilePath(storageDirPath, tag, "identity_b64");
         try {
-            Files.createDirectories(i2pPrivateKeyDirPath);
+            FileMutatorUtils.createRestrictedDirectories(i2pPrivateKeyDirPath);
             FileMutatorUtils.writeToPath(i2pKeyPair.getDestinationBase64(), destination_b64Path);
             FileMutatorUtils.writeToPath(i2pKeyPair.getDestinationBase32(), destination_b32Path);
             FileMutatorUtils.writeToPath(Base64.encode(i2pKeyPair.getIdentityBytes()), identityBase64Path);

--- a/security/src/main/java/bisq/security/keys/KeyBundleService.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundleService.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.util.Objects;
@@ -214,7 +213,7 @@ public class KeyBundleService extends RateLimitedPersistenceClient<KeyBundleStor
             }
             if (writeKeyStoreSecretUidToFile) {
                 try {
-                    Files.createDirectories(defaultKeyStoragePath);
+                    FileMutatorUtils.createRestrictedDirectories(defaultKeyStoragePath);
                 } catch (IOException e) {
                     log.error("Could not create {}", defaultKeyStoragePath);
                     throw new RuntimeException(e);

--- a/security/src/main/java/bisq/security/keys/KeyPairUtils.java
+++ b/security/src/main/java/bisq/security/keys/KeyPairUtils.java
@@ -11,7 +11,6 @@ import org.bouncycastle.jce.spec.ECPublicKeySpec;
 import org.bouncycastle.math.ec.ECPoint;
 
 import java.math.BigInteger;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -31,7 +30,7 @@ public class KeyPairUtils {
     public static void writePrivateKey(KeyPair keyPair, Path storageDirPath, String tag) {
         Path targetPath = storageDirPath.resolve(tag);
         try {
-            Files.createDirectories(targetPath);
+            FileMutatorUtils.createRestrictedDirectories(targetPath);
 
             ECPrivateKey ecPrivate = (ECPrivateKey) keyPair.getPrivate();
             byte[] priv32 = toUnsignedFixedLength(ecPrivate.getS(), 32);

--- a/security/src/main/java/bisq/security/keys/TorKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyUtils.java
@@ -5,7 +5,6 @@ import bisq.common.file.FileMutatorUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Base32;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Locale;
@@ -21,7 +20,7 @@ public class TorKeyUtils {
     public static void writePrivateKey(TorKeyPair torKeyPair, Path storageDirPath, String tag) {
         Path targetPath = storageDirPath.resolve(tag);
         try {
-            Files.createDirectories(targetPath);
+            FileMutatorUtils.createRestrictedDirectories(targetPath);
 
             FileMutatorUtils.writeToPath(Hex.encode(torKeyPair.getPrivateKey()), targetPath.resolve("private_key_hex"));
             FileMutatorUtils.writeToPath(torKeyPair.getOnionAddress(), targetPath.resolve("hostname"));

--- a/security/src/test/java/bisq/security/PgPUtilsTest.java
+++ b/security/src/test/java/bisq/security/PgPUtilsTest.java
@@ -95,7 +95,7 @@ public class PgPUtilsTest {
         Path filePath = Path.of("temp", fileName);
         try {
             try (InputStream resource = FileReaderUtils.getResourceAsStream(fileName);
-                 OutputStream out = Files.newOutputStream(filePath)) {
+                 OutputStream out = FileMutatorUtils.newRestrictedOutputStream(filePath)) {
                 FileMutatorUtils.copy(resource, out);
             }
             return PgPUtils.readPgpPublicKeyRing(filePath);
@@ -108,7 +108,7 @@ public class PgPUtilsTest {
         Path filePath = Path.of("temp", fileName);
         try {
             try (InputStream resource = FileReaderUtils.getResourceAsStream(fileName);
-                 OutputStream out = Files.newOutputStream(filePath)) {
+                 OutputStream out = FileMutatorUtils.newRestrictedOutputStream(filePath)) {
                 FileMutatorUtils.copy(resource, out);
             }
             return PgPUtils.readPgpSignature(filePath);
@@ -121,7 +121,7 @@ public class PgPUtilsTest {
         Path filePath = Path.of("temp", fileName);
         try {
             try (InputStream resource = FileReaderUtils.getResourceAsStream(fileName)) {
-                OutputStream out = Files.newOutputStream(filePath);
+                OutputStream out = FileMutatorUtils.newRestrictedOutputStream(filePath);
                 FileMutatorUtils.copy(resource, out);
             }
             return filePath;

--- a/user/src/main/java/bisq/user/cathash/CatHashService.java
+++ b/user/src/main/java/bisq/user/cathash/CatHashService.java
@@ -18,6 +18,7 @@
 package bisq.user.cathash;
 
 import bisq.common.encoding.Hex;
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.threading.ExecutorFactory;
 import bisq.common.util.ByteArrayUtils;
 import bisq.user.profile.UserProfile;
@@ -97,7 +98,7 @@ public abstract class CatHashService<T> {
 
             if (!Files.exists(iconsDirPath)) {
                 try {
-                    Files.createDirectories(iconsDirPath);
+                    FileMutatorUtils.createRestrictedDirectories(iconsDirPath);
                 } catch (IOException e) {
                     log.error(e.toString());
                 }


### PR DESCRIPTION
resolves #3781 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened file and directory permission handling across the app: logs, configs, keys, backups, extracted files, avatars, and temporary/downloaded files are now created and written with restricted access on POSIX systems to reduce risk of unauthorized reads/writes.
  * Tests and internal operations updated to use the restricted I/O behavior; no public APIs, user workflows, or error-handling semantics changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->