### PR TITLE
Prevent LogSetup reconfiguration on repeated calls.

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -159,11 +159,6 @@ public abstract class ApplicationService implements Service {
             throw new RuntimeException(e);
         }
 
-        log.info(AsciiLogo.getAsciiLogo());
-        log.info("Data directory: {}", appDataDirPath);
-        log.info("Version: v{} / Commit hash: {}", ApplicationVersion.getVersion().getVersionAsString(), ApplicationVersion.getBuildCommitShortHash());
-        log.info("Tor Version: v{}", ApplicationVersion.getTorVersionString());
-
         customConfig = TypesafeConfigUtils.resolveCustomConfig(appDataDirPath).orElse(ConfigFactory.empty());
 
         // Precedence Order: Program Arguments > JVM options > Custom config > Resource config
@@ -236,6 +231,11 @@ public abstract class ApplicationService implements Service {
         String maxFileSize = loggingConfig.getString("maxFileSize");
         Level logLevel = Level.toLevel(loggingConfig.getString("logLevel"));
         LogSetup.setup(appDataDirPath.resolve("bisq").toString(), rollingPolicyMaxIndex, maxFileSize, logLevel);
+
+        log.info(AsciiLogo.getAsciiLogo());
+        log.info("Data directory: {}", appDataDirPath);
+        log.info("Version: v{} / Commit hash: {}", ApplicationVersion.getVersion().getVersionAsString(), ApplicationVersion.getBuildCommitShortHash());
+        log.info("Tor Version: v{}", ApplicationVersion.getTorVersionString());
     }
 
     protected void checkInstanceLock() {

--- a/apps/desktop/desktop-app-launcher/src/main/java/bisq/desktop_app_launcher/DesktopAppLauncher.java
+++ b/apps/desktop/desktop-app-launcher/src/main/java/bisq/desktop_app_launcher/DesktopAppLauncher.java
@@ -18,7 +18,6 @@
 package bisq.desktop_app_launcher;
 
 import bisq.common.application.BuildVersion;
-import bisq.common.logging.LogSetup;
 import bisq.common.platform.PlatformUtils;
 import bisq.common.util.ExceptionUtil;
 import bisq.desktop_app.DesktopApp;
@@ -85,7 +84,6 @@ public class DesktopAppLauncher {
         options = new Options(args);
         String appName = options.getAppName().orElse(DesktopAppLauncher.APP_NAME);
         Path appDataDirPath = PlatformUtils.getUserDataDirPath().resolve(appName);
-        LogSetup.setup(appDataDirPath.resolve("bisq").toString());
         String version = UpdaterUtils.readVersionFromVersionFile(appDataDirPath)
                 .or(options::getVersion)
                 .orElse(BuildVersion.VERSION);

--- a/common/src/main/java/bisq/common/logging/LogSetup.java
+++ b/common/src/main/java/bisq/common/logging/LogSetup.java
@@ -42,12 +42,8 @@ public class LogSetup {
     }
 
     public static void setup(String fileName, int rollingPolicyMaxIndex, String maxFileSize, Level logLevel) {
-        // If setup is called multiple times (e.g. when the app is launched from different entry points),
-        // we reset the logger context to ensure logging is reconfigured as intended.
-        // Note: resetting the logger context will remove all existing loggers and appenders,
-        // which may affect other parts of the application or libraries using the same logging context.
-        if (logbackLogger != null && LoggerFactory.getILoggerFactory() instanceof LoggerContext loggerContext) {
-            loggerContext.reset();
+        if (logbackLogger != null && LoggerFactory.getILoggerFactory() instanceof LoggerContext) {
+            return;
         }
 
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
@@ -82,9 +78,5 @@ public class LogSetup {
         logbackLogger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logbackLogger.addAppender(appender);
         logbackLogger.setLevel(logLevel);
-    }
-
-    public static void setCustomLogLevel(String pattern, Level logLevel) {
-        ((Logger) LoggerFactory.getLogger(pattern)).setLevel(logLevel);
     }
 }


### PR DESCRIPTION
fixes #4073 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Logging initialization now skips reconfiguration when already initialized, preventing logger resets on repeated startup.
  * Removed the runtime API for per-pattern log level adjustments.
  * Startup diagnostic messages (logo, data directory, version, Tor version) are now logged after logging is configured.
  * Launcher no longer performs a separate logging setup at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->