### PR TITLE
bugfix/for-mobile-based-on-2.1.7_guards_npe_fixes

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/BanList.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/BanList.java
@@ -55,6 +55,9 @@ public class BanList {
     }
 
     public boolean isBanned(Address address) {
+        if (address == null) {
+            return false;
+        }
         return entryMap.containsKey(address);
     }
 

--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/PeerGroupService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/PeerGroupService.java
@@ -127,6 +127,9 @@ public class PeerGroupService extends RateLimitedPersistenceClient<PeerGroupStor
 
     private boolean doAddPeer(Peer peerToAdd, Map<Address, Peer> map) {
         Address address = peerToAdd.getAddress();
+        if (address == null) {
+            return false;
+        }
         if (map.containsKey(address)) {
             if (peerToAdd.getCreated() > map.get(address).getCreated()) {
                 map.put(address, peerToAdd);

--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeStrategy.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeStrategy.java
@@ -241,6 +241,7 @@ public class PeerExchangeStrategy {
 
     private List<Address> getSeedAddresses() {
         return CollectionUtil.toShuffledList(peerGroupService.getSeedNodeAddresses()).stream()
+                .filter(address -> address != null)
                 .filter(node::notMyself)
                 .filter(peerGroupService::isNotBanned)
                 .limit(config.getNumSeedNodesAtBoostrap())
@@ -251,6 +252,7 @@ public class PeerExchangeStrategy {
         return getSortedReportedPeers()
                 .limit(config.getNumReportedPeersAtBoostrap())
                 .map(Peer::getAddress)
+                .filter(address -> address != null)
                 .collect(Collectors.toList());
     }
 
@@ -261,12 +263,14 @@ public class PeerExchangeStrategy {
                 .sorted()
                 .limit(config.getNumPersistedPeersAtBoostrap())
                 .map(Peer::getAddress)
+                .filter(address -> address != null)
                 .collect(Collectors.toList());
     }
 
     private List<Address> getAllConnectedPeerAddresses() {
         return getSortedAllConnectedPeers()
                 .map(Peer::getAddress)
+                .filter(address -> address != null)
                 .collect(Collectors.toList());
     }
 
@@ -305,7 +309,11 @@ public class PeerExchangeStrategy {
     }
 
     private boolean notSameAddress(Address address, Peer peer) {
-        return !peer.getAddress().equals(address);
+        Address peerAddress = peer.getAddress();
+        if (peerAddress == null || address == null) {
+            return false;
+        }
+        return !peerAddress.equals(address);
     }
 
     private Stream<Peer> getSortedAllConnectedPeers() {


### PR DESCRIPTION
 - guards NPE fixes making the http-api server crash randomly
 - found whilst testing for first Bisq Connect release on a real prod environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened peer management services with comprehensive null-safety checks to prevent runtime errors when processing peer address information across ban lists and peer selection flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->