### PR TITLE
Have chats respond to PgUp and PgDown

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/PageScrollHandler.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/PageScrollHandler.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.common.utils;
+
+import bisq.desktop.components.list_view.ListViewUtil;
+import javafx.event.EventHandler;
+import javafx.geometry.Orientation;
+import javafx.scene.AccessibleAction;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ScrollBar;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.fxmisc.easybind.Subscription;
+
+import java.util.Objects;
+
+/**
+ * Handler to enable page-wise keyboard scrolling for a JavaFX ListView Control.
+ * <p>
+ * Utility that installs a key event handler on a JavaFX ListView to perform page-wise
+ * scrolling when the PAGE_UP and PAGE_DOWN keys are pressed. The handler locates the
+ * control's vertical ScrollBar (if present) and adjusts its value by the ScrollBar's
+ * block increment, mimicking a page click on the scrollbar trough. The key event is
+ * consumed only when a scroll action is performed.
+ * </p>
+ * <p>
+ * Note: the handler is registered using {@code addEventFilter}, i.e. it runs in the
+ * capturing phase (filter phase) while events travel from the root toward the target node.
+ * This allows centralized preprocessing of PageUp/PageDown keys for the ListView before
+ * the event reaches the target node.
+ * </p>
+ * <p>
+ * To ensure that input fields keep their normal keyboard behavior, the handler
+ * checks with {@link #isInlineEditorActive()} whether a descendant editable
+ * {@link TextInputControl} is currently focused. If an editor is active, the filter does
+ * not consume the event — the event will continue to the normal target/bubbling phase and
+ * can be handled by the editor. If no editor is focused, the filter consumes the event
+ * (via {@code event.consume()}) after a scroll occurred.
+ * </p>
+ * <p>
+ * Typical usage:
+ * <ul>
+ *   <li>Instantiate with a JavaFX ListView Control.</li>
+ *   <li>Call {@link #subscribe()} to enable the handler.</li>
+ *   <li>Call {@link #unsubscribe()} to remove the handler.</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Note: methods that inspect or modify the scene graph (e.g. locating ScrollBars)
+ * must be called on the JavaFX Application Thread.
+ * </p>
+ */
+@Slf4j
+public class PageScrollHandler implements Subscription {
+
+    private final ListView<?> listView;
+    private final EventHandler<KeyEvent> keyEventFilter;
+
+    public PageScrollHandler(ListView<?> listView) {
+        this.listView = Objects.requireNonNull(listView);
+        this.keyEventFilter = createKeyEventFilter();
+    }
+
+    private EventHandler<KeyEvent> createKeyEventFilter() {
+        return event -> {
+            if (event.getCode() == KeyCode.PAGE_UP) {
+                if (!isInlineEditorActive()) {
+                    if (scrollPageUp()) {
+                        event.consume();
+                    }
+                }
+            } else if (event.getCode() == KeyCode.PAGE_DOWN) {
+                if (!isInlineEditorActive()) {
+                    if (scrollPageDown()) {
+                        event.consume();
+                    }
+                }
+            }
+        };
+    }
+
+    public void subscribe() {
+        unsubscribe();
+        listView.addEventFilter(KeyEvent.KEY_PRESSED, keyEventFilter);
+    }
+
+    public void unsubscribe() {
+        listView.removeEventFilter(KeyEvent.KEY_PRESSED, keyEventFilter);
+    }
+
+    public boolean scrollPageUp() {
+        return ListViewUtil.findScrollbar(listView, Orientation.VERTICAL)
+                .map(this::adjustScrollBarBlockDecrement)
+                .orElse(false);
+    }
+
+    public boolean scrollPageDown() {
+        return ListViewUtil.findScrollbar(listView, Orientation.VERTICAL)
+                .map(this::adjustScrollBarBlockIncrement)
+                .orElse(false);
+    }
+
+    private boolean adjustScrollBarBlockDecrement(ScrollBar vbar) {
+        return adjustScrollBar(vbar, AccessibleAction.BLOCK_DECREMENT);
+    }
+
+    private boolean adjustScrollBarBlockIncrement(ScrollBar vbar) {
+        return adjustScrollBar(vbar, AccessibleAction.BLOCK_INCREMENT);
+    }
+
+    private boolean adjustScrollBar(ScrollBar vbar, AccessibleAction action) {
+        double oldValue = vbar.getValue();
+        vbar.executeAccessibleAction(action);
+        return oldValue != vbar.getValue();
+    }
+
+    private boolean isInlineEditorActive() {
+        Scene scene = listView.getScene();
+        if (scene == null) {
+            return false;
+        }
+        Node focusOwner = scene.getFocusOwner();
+        return isEditable(focusOwner) && isChildOfList(focusOwner);
+    }
+
+    private boolean isEditable(Node focusOwner) {
+        return focusOwner instanceof TextInputControl && ((TextInputControl) focusOwner).isEditable();
+    }
+
+    private boolean isChildOfList(Node node) {
+        while (node != null) {
+            if (node == listView) {
+                return true;
+            }
+            node = node.getParent();
+        }
+        return false;
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -217,6 +217,14 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
         chatMessagesListController.editMyLastMessage();
     }
 
+    boolean onPageUpKeyPressed() {
+        return chatMessagesListController.scrollPageUp();
+    }
+
+    boolean onPageDownKeyPressed() {
+        return chatMessagesListController.scrollPageDown();
+    }
+
     void onUserProfileSelected(UserProfile user) {
         String content = model.getTextInput().get().replaceAll("@[a-zA-Z\\d]*$", "@" + user.getUserName() + " ");
         model.getTextInput().set(content);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -36,6 +36,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
@@ -89,6 +90,9 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
 
     @Override
     protected void onViewAttached() {
+        // Consume mouse pressed events on the root to prevent them from propagating to underlying layers
+        root.setOnMousePressed(MouseEvent::consume);
+
         userProfileSelectionRoot.visibleProperty().bind(model.getShouldShowUserProfileSelection());
         userProfileSelectionRoot.managedProperty().bind(model.getShouldShowUserProfileSelection());
         myProfileCatHashImageView.visibleProperty().bind(model.getShouldShowUserProfile());
@@ -152,6 +156,7 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
         inputField.removeEventFilter(KEY_PRESSED, keyPressedHandler);
         sendButton.setOnAction(null);
         userMentionPopup.cleanup();
+        root.setOnMousePressed(null);
     }
 
     private VBox createAndGetBottomBar(UserProfileSelection userProfileSelection) {
@@ -255,6 +260,14 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
                     keyEvent.consume();
                     inputField.positionCaret(0);
                 }
+            }
+        } else if (keyEvent.getCode() == KeyCode.PAGE_UP) {
+            if (controller.onPageUpKeyPressed()) {
+                keyEvent.consume();
+            }
+        } else if (keyEvent.getCode() == KeyCode.PAGE_DOWN) {
+            if (controller.onPageDownKeyPressed()) {
+                keyEvent.consume();
             }
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -669,6 +669,13 @@ public class ChatMessagesListController implements Controller {
         applyScrollValue(1);
     }
 
+    public boolean scrollPageUp() {
+       return view.getPageScrollHandler().scrollPageUp();
+    }
+
+    public boolean scrollPageDown() {
+        return view.getPageScrollHandler().scrollPageDown();
+    }
 
     /* --------------------------------------------------------------------- */
     // Private

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListView.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.chat.message_container.list;
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
 import bisq.desktop.common.ManagedDuration;
+import bisq.desktop.common.utils.PageScrollHandler;
 import bisq.desktop.components.controls.Badge;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.list_view.ListViewUtil;
@@ -46,6 +47,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
@@ -74,6 +76,8 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
     private final Label placeholderTitle = new Label("");
     private final Label placeholderDescription = new Label("");
     private final Pane scrollDownBackground;
+    @Getter(AccessLevel.PACKAGE)
+    private final PageScrollHandler pageScrollHandler;
     private Optional<ScrollBar> scrollBar = Optional.empty();
     private Subscription hasUnreadMessagesPin, showScrolledDownButtonPin;
     private Timeline fadeInScrollDownBadgeTimeline;
@@ -92,6 +96,8 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
         // https://stackoverflow.com/questions/20621752/javafx-make-listview-not-selectable-via-mouse
         listView.setSelectionModel(new NoSelectionModel<>());
         VBox.setVgrow(listView, Priority.ALWAYS);
+
+        pageScrollHandler = new PageScrollHandler(listView);
 
         scrollDownBackground = new Pane();
         scrollDownBackground.getStyleClass().add("scroll-down-bg");
@@ -171,6 +177,7 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
         model.getLayoutChildrenDone().bind(root.getLayoutChildrenDone());
 
         scrollDownBadge.setOnMouseClicked(e -> controller.onScrollToBottom());
+        pageScrollHandler.subscribe();
     }
 
     @Override
@@ -185,6 +192,7 @@ public class ChatMessagesListView extends bisq.desktop.common.view.View<ChatMess
         model.getLayoutChildrenDone().unbind();
         hasUnreadMessagesPin.unsubscribe();
         showScrolledDownButtonPin.unsubscribe();
+        pageScrollHandler.unsubscribe();
 
         Tooltip.uninstall(scrollDownBadge, scrollDownTooltip);
 


### PR DESCRIPTION
## Description

Resolves #2087

Enables pagewise scrolling with PAGE_UP/PAGE_DOWN keys in chat views.

### Changes

- Introduces `PageScrollHandler` to manage keyboard navigation in scrollable controls
- PAGE_UP and PAGE_DOWN scroll by one "page" (block increment)
- Integrated into `ChatMessagesListView` for improved UX

### Details

The `PageScrollHandler` installs a key event handler that detects PAGE_UP/PAGE_DOWN key presses and adjusts the vertical scrollbar by its block increment, mimicking a page click on the scrollbar trough. This provides a more intuitive and efficient navigation experience in chat message lists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page-wise keyboard navigation in chat message lists — PAGE_UP and PAGE_DOWN now move by a page.
  * Keyboard handler now attaches/detaches with the chat view so page-key behavior is active only when the view is shown.

* **Bug Fixes / UX**
  * PAGE_UP/PAGE_DOWN ignored while inline text editing is active and only trigger when input won't interfere.
  * Chat root consumes mouse-press events to prevent unintended propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->