### PR TITLE
Fix: Transifex workflow hanging on API token prompt

### DIFF
--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -247,7 +247,7 @@ jobs:
     # Uses scripts/generate_transifex_batches.py for optimal batch configuration
     strategy:
       matrix: ${{ fromJson(needs.calculate_and_push_sources.outputs.t_matrix) }}
-      max-parallel: 1  # DEBUG: Serialize batches to test for concurrent batch conflicts
+      max-parallel: 2  # Controlled parallelism to avoid Transifex API rate limits
       fail-fast: false  # Don't cancel all jobs if one fails
     steps:
       - name: Checkout the repository
@@ -343,10 +343,12 @@ jobs:
               fi
 
               echo "TX config check:"
-              if grep -q "${FIRST_RESOURCE}" .tx/config; then
-                echo "✓ Resource '${FIRST_RESOURCE}' found in .tx/config"
+              # Extract resource slug from "bisq-2.applicationproperties" -> "applicationproperties"
+              RESOURCE_SLUG=$(echo "$FIRST_RESOURCE" | sed 's/^bisq-2\.//')
+              if grep -q "r:${RESOURCE_SLUG}]" .tx/config; then
+                echo "✓ Resource '${RESOURCE_SLUG}' found in .tx/config"
               else
-                echo "⚠ Resource '${FIRST_RESOURCE}' not found in .tx/config"
+                echo "⚠ Resource '${RESOURCE_SLUG}' not found in .tx/config"
               fi
               echo "::endgroup::"
 


### PR DESCRIPTION
## Summary
- Fix TX_TOKEN environment variable not being passed to `tx push` and `tx pull` steps
- Restore `max-parallel` from `1` (DEBUG) back to `2` (production value)
- Fix diagnostic grep pattern to correctly verify resources in `.tx/config`

## Root Cause
The Transifex CLI was hanging indefinitely because:
1. **Missing TX_TOKEN**: The `TX_TOKEN` env var was only passed to the CLI installation step, not to the steps that actually run `tx push` and `tx pull` commands. Without the token, the CLI prompts for interactive input which never comes in CI.
2. **DEBUG setting left in**: `max-parallel: 1` was set for debugging but not restored to `2` for production.

## Evidence
From the failing run logs:
```
Executing: tx push -t -l "pcm" -r "bisq-2.applicationproperties,bisq-2.trade_appsproperties"
Notice: Watching TX CLI output in real-time (buffering disabled for debugging)
API token not found. Please provide it and it will be saved in '~/.transifexrc'.
```

## Changes
1. Add `env: TX_TOKEN: ${{ secrets.TX_TOKEN }}` to the retry step that runs `tx push`
2. Add `env: TX_TOKEN: ${{ secrets.TX_TOKEN }}` to the verification step that runs `tx pull`
3. Change `max-parallel: 1` back to `max-parallel: 2`
4. Fix grep pattern in diagnostic check to search for `r:${RESOURCE_SLUG}]` instead of `${FIRST_RESOURCE}`

## Testing
- Verified locally that `tx push` works with the correct command format
- Verified the grep pattern correctly matches resources in `.tx/config`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced translation synchronization workflow with improved parallelism for faster batch processing.
  * Strengthened environment variable management for translation service integration.
  * Refined resource verification logic during batch operations for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->