### PR TITLE
Hide Bisq Connect setting tab until pairing is production ready

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/SettingsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/SettingsView.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.settings;
 
+import bisq.common.application.DevMode;
 import bisq.desktop.main.content.ContentTabView;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.i18n.Res;
@@ -29,7 +30,11 @@ public class SettingsView extends ContentTabView<SettingsModel, SettingsControll
         addTab(Res.get("settings.notifications"), NavigationTarget.NOTIFICATION_SETTINGS);
         addTab(Res.get("settings.trade"), NavigationTarget.TRADE_SETTINGS);
         addTab(Res.get("settings.network"), NavigationTarget.NETWORK_SETTINGS);
-        addTab(Res.get("settings.bisqConnect"), NavigationTarget.BISQ_CONNECT_SETTINGS);
+
+        // Hide it until pairing is production ready
+        if (DevMode.isDevMode()) {
+            addTab(Res.get("settings.bisqConnect"), NavigationTarget.BISQ_CONNECT_SETTINGS);
+        }
         addTab(Res.get("settings.misc"), NavigationTarget.MISC_SETTINGS);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * BISQ Connect settings tab is now hidden in production and only visible during development until the feature is fully ready for release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->