### PR TITLE
Add defensive null checks

### DIFF
--- a/common/src/main/java/bisq/common/asset/Asset.java
+++ b/common/src/main/java/bisq/common/asset/Asset.java
@@ -26,6 +26,8 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 @Slf4j
 @EqualsAndHashCode
 @ToString
@@ -39,6 +41,9 @@ public abstract class Asset implements Comparable<Asset>, PersistableProto {
     protected final String name;
 
     public Asset(String code, String name) {
+        checkNotNull(code, "code must not be null");
+        checkNotNull(name, "name must not be null");
+
         this.code = code;
         this.name = name;
 

--- a/common/src/main/java/bisq/common/locale/LanguageRepository.java
+++ b/common/src/main/java/bisq/common/locale/LanguageRepository.java
@@ -26,10 +26,17 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 @SuppressWarnings("SpellCheckingInspection")
 @Slf4j
 public class LanguageRepository {
+    // IETF BCP 47 language tag string.  E.g. pt-BR
+    @Getter
+    private static String defaultLanguageTag = "en";
+
     public static void setDefaultLanguageTag(String languageTag) {
+        checkNotNull(languageTag, "languageTag must not be null at setDefaultLanguageTag");
         if (LANGUAGE_TAGS.contains(languageTag)) {
             defaultLanguageTag = languageTag;
         } else {
@@ -42,10 +49,6 @@ public class LanguageRepository {
                     .orElse("en");
         }
     }
-
-    // IETF BCP 47 language tag string.  E.g. pt-BR
-    @Getter
-    private static String defaultLanguageTag = "en";
 
     public static final List<String> LANGUAGE_CODES = LocaleRepository.LOCALES.stream()
             .filter(locale -> !locale.getLanguage().isEmpty() &&

--- a/common/src/main/java/bisq/common/locale/LocaleRepository.java
+++ b/common/src/main/java/bisq/common/locale/LocaleRepository.java
@@ -29,6 +29,8 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 @SuppressWarnings("SpellCheckingInspection")
 @Slf4j
 public class LocaleRepository {
@@ -55,6 +57,7 @@ public class LocaleRepository {
     }
 
     public static void setDefaultLocale(Locale locale) {
+        checkNotNull(locale, "locale must not be null at setDefaultLocale");
         LocaleRepository.defaultLocale = locale;
     }
 
@@ -81,6 +84,7 @@ public class LocaleRepository {
      * @see <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP 47 - Tags for Identifying Languages</a>
      */
     public static Locale ensureValidLocale(Locale locale) {
+        checkNotNull(locale, "locale must not be null at ensureValidLocale");
         // Script-based locales (e.g., zh-Hans, zh-Hant) don't have a country code
         // but are still valid BCP 47 language tags. Only require country for
         // locales that don't have a script subtag.


### PR DESCRIPTION
Should fix https://github.com/bisq-network/bisq2/issues/4203

The bug could not be reproduced on OSX and Windows with db data from an affected user.

I suspect it is caused by handling of Locale on certain Windows versions (updates).
I added defensive checks and logs to make further debugging easier if the issue would still persist.

Once the bug is localized we can revert the unnecessary checks as it contradicts Bisq2 dev conventions (e.g. expect non null parameters if not annotated). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened null-safety and input validation across currency, asset, country, language and locale handling.
  * Improved error handling and diagnostic logging to avoid failures during initialization and lookup flows.

* **Chores**
  * Made initialization more resilient by filtering invalid entries and adding defensive guards.

* **New Features**
  * Exposed additional default/getter accessors for language and currency defaults to improve configurability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->