### PR TITLE
bugfix/tor_Connectivity_http_api_broken

### DIFF
--- a/apps/http-api-app/src/main/resources/http_api_app.conf
+++ b/apps/http-api-app/src/main/resources/http_api_app.conf
@@ -47,7 +47,7 @@ application {
         blackListEndPoints = []
         supportedAuth = []   // supported auth schemes. If empty no authentication is required
         password = ""
-        publishOnionService = false
+        publishOnionService = true  // Required for mobile apps to connect via Tor
     }
 
     security = {


### PR DESCRIPTION
 - with the new programatic default false publishing, this flag is needed for the http-api service to work (headless)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tor connectivity is now enabled for REST API and WebSocket endpoints. Users can securely access the service through the Tor network, providing enhanced privacy and anonymity. This capability is particularly beneficial for mobile applications and other clients requiring secure Tor-based network connectivity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->