### PR TITLE
bugfix/for-mobile-based-on-2.1.8_path.of_not_desugar_supported

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -150,7 +151,7 @@ public abstract class ApplicationService implements Service {
 
         String appName = rootConfig.getString("application.appName");
         Path appDataDirPath = rootConfig.hasPath("application.baseDir")
-                ? Path.of(rootConfig.getString("application.baseDir"))
+                ? Paths.get(rootConfig.getString("application.baseDir"))
                 : userDataDirPath.resolve(appName);
         try {
             Files.createDirectories(appDataDirPath);

--- a/common/src/main/java/bisq/common/facades/JdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/JdkFacade.java
@@ -18,6 +18,7 @@
 package bisq.common.facades;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
@@ -53,4 +54,27 @@ public interface JdkFacade {
      * @throws IOException if an I/O error occurs
      */
     void writeString(String data, Path path) throws IOException;
+
+    /**
+     * Converts a path string, or a sequence of strings that when joined form a path string, to a Path.
+     * <p>
+     * On Android, this uses {@link java.nio.file.Paths#get(String, String...)} which is compatible with desugaring.
+     * On Java SE, this uses {@link Path#of(String, String...)} which is the modern API.
+     *
+     * @param first the path string or initial part of the path string
+     * @param more  additional strings to be joined to form the path string
+     * @return the resulting Path
+     */
+    Path pathOf(String first, String... more);
+
+    /**
+     * Converts a URI to a Path.
+     * <p>
+     * On Android, this uses {@link java.nio.file.Paths#get(URI)} which is compatible with desugaring.
+     * On Java SE, this uses {@link Path#of(URI)} which is the modern API.
+     *
+     * @param uri the URI to convert
+     * @return the resulting Path
+     */
+    Path pathOf(URI uri);
 }

--- a/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
@@ -21,9 +21,11 @@ import bisq.common.facades.JdkFacade;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 public class AndroidJdkFacade implements JdkFacade {
@@ -66,5 +68,17 @@ public class AndroidJdkFacade implements JdkFacade {
     @Override
     public void writeString(String data, Path path) throws IOException {
         Files.write(path, data.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public Path pathOf(String first, String... more) {
+        // Paths.get is compatible with Android desugaring, unlike Path.of
+        return Paths.get(first, more);
+    }
+
+    @Override
+    public Path pathOf(URI uri) {
+        // Paths.get is compatible with Android desugaring, unlike Path.of
+        return Paths.get(uri);
     }
 }

--- a/common/src/main/java/bisq/common/file/FileReaderUtils.java
+++ b/common/src/main/java/bisq/common/file/FileReaderUtils.java
@@ -28,6 +28,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Optional;
@@ -162,7 +163,9 @@ public class FileReaderUtils {
         }
         String protocol = dirURL.getProtocol();
         if ("file".equals(protocol)) {
-            Path dirPath = Path.of(dirURL.toURI());
+            // Using Paths.get() directly as this method is used in tests where
+            // FacadeProvider may not be initialized
+            Path dirPath = Paths.get(dirURL.toURI());
             if (!Files.isDirectory(dirPath)) {
                 throw new IOException("Resource path is not a directory: " + dirPath);
             }

--- a/common/src/main/java/bisq/common/jvm/DeleteOnExitHook.java
+++ b/common/src/main/java/bisq/common/jvm/DeleteOnExitHook.java
@@ -43,6 +43,7 @@
 
 package bisq.common.jvm;
 
+import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -111,7 +112,7 @@ public class DeleteOnExitHook {
         // Last in first deleted.
         Collections.reverse(toBeDeleted);
         for (String filename : toBeDeleted) {
-            Path path = Path.of(filename);
+            Path path = FacadeProvider.getJdkFacade().pathOf(filename);
             try {
                 FileMutatorUtils.deleteFileOrDirectory(path);
             } catch (IOException e) {

--- a/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
+++ b/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,5 +59,15 @@ public class JavaSeJdkFacade implements JdkFacade {
     @Override
     public void writeString(String data, Path path) throws IOException {
         Files.writeString(path, data, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Path pathOf(String first, String... more) {
+        return Path.of(first, more);
+    }
+
+    @Override
+    public Path pathOf(URI uri) {
+        return Path.of(uri);
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/transport/i2p/Bi2pProcessLauncher.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/transport/i2p/Bi2pProcessLauncher.java
@@ -20,6 +20,7 @@ package bisq.network.p2p.node.transport.i2p;
 import bisq.common.application.DevMode;
 import bisq.common.application.Service;
 import bisq.common.archive.ZipFileExtractor;
+import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.FileReaderUtils;
 import bisq.common.locale.LanguageRepository;
@@ -155,7 +156,7 @@ public class Bi2pProcessLauncher implements Service {
     private static String getJavaExePath() {
         String javaHome = System.getProperty("java.home");
         String exe = OS.isWindows() ? "java.exe" : "java";
-        return Path.of(javaHome, "bin", exe).toString();
+        return FacadeProvider.getJdkFacade().pathOf(javaHome, "bin", exe).toString();
     }
 
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -313,7 +313,7 @@ public class TorService implements Service {
             if (torConfigMap.containsKey(COOKIE_AUTH_FILE)) {
                 String authCookiePath = torConfigMap.get(COOKIE_AUTH_FILE);
                 try {
-                    byte[] authCookie = Files.readAllBytes(Path.of(authCookiePath));
+                    byte[] authCookie = Files.readAllBytes(FacadeProvider.getJdkFacade().pathOf(authCookiePath));
                     torController.authenticate(authCookie);
                     isAuthenticated = true;
                 } catch (TorControlAuthenticationFailed e) {

--- a/network/tor/tor/src/main/java/bisq/network/tor/process/EmbeddedTorProcess.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/process/EmbeddedTorProcess.java
@@ -95,7 +95,7 @@ public class EmbeddedTorProcess {
         String[] searchPaths = pathEnvironmentVariable.split(":");
 
         for (var path : searchPaths) {
-            Path torBinaryPath = Path.of(path, "tor");
+            Path torBinaryPath = getJdkFacade().pathOf(path, "tor");
             if (Files.exists(torBinaryPath)) {
                 return Optional.of(torBinaryPath);
             }

--- a/persistence/src/main/java/bisq/persistence/DbSubDirectory.java
+++ b/persistence/src/main/java/bisq/persistence/DbSubDirectory.java
@@ -3,6 +3,7 @@ package bisq.persistence;
 import lombok.Getter;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @Getter
 public enum DbSubDirectory {
@@ -14,6 +15,6 @@ public enum DbSubDirectory {
     private final Path dbPath;
 
     DbSubDirectory(String subDir) {
-        this.dbPath = Path.of("db", subDir);
+        this.dbPath = Paths.get("db", subDir);
     }
 }

--- a/persistence/src/main/java/bisq/persistence/backup/BackupService.java
+++ b/persistence/src/main/java/bisq/persistence/backup/BackupService.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -258,7 +259,9 @@ public class BackupService {
                 .replace(Persistence.EXTENSION, "")
                 .replace("_store", "");
         // We don't use `resolve` as we use it in unit test which need to be OS independent.
-        return Path.of(dataDir.toString() + relativeBackupDirString);
+        // Using Paths.get() directly as this is a static utility method used in tests
+        // where FacadeProvider may not be initialized
+        return Paths.get(dataDir.toString() + relativeBackupDirString);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
 - fixes https://github.com/bisq-network/bisq-mobile/issues/1063
 - split usages of modern Path.of() api to use older desugaring-compatible Path.get() api when running on Android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to path resolution mechanisms across multiple modules for consistency and maintainability.

**Note:** This release contains backend optimizations with no visible changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->