### PR TITLE
Refactor FileMutatorUtils methods by removing the term Restricted.

### DIFF
--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -153,7 +153,7 @@ public abstract class ApplicationService implements Service {
                 ? Path.of(rootConfig.getString("application.baseDir"))
                 : userDataDirPath.resolve(appName);
         try {
-            FileMutatorUtils.createRestrictedDirectories(appDataDirPath);
+            FileMutatorUtils.createDirectories(appDataDirPath);
         } catch (IOException e) {
             log.error("Could not create data directory {}", appDataDirPath, e);
             throw new RuntimeException(e);

--- a/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
+++ b/application/src/test/java/bisq/application/migration/migrations/MigrationsForV2_1_2Tests.java
@@ -61,7 +61,7 @@ public class MigrationsForV2_1_2Tests {
     }
 
     private void createFakeTorPath(Path torPath) throws IOException {
-        FileMutatorUtils.createRestrictedDirectories(torPath);
+        FileMutatorUtils.createDirectories(torPath);
 
         List<String> torPathFiles = List.of("lock",
                 "libssl.so.1.1",

--- a/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
+++ b/common/src/main/java/bisq/common/archive/ZipFileExtractor.java
@@ -47,7 +47,7 @@ public class ZipFileExtractor implements AutoCloseable {
 
     private void createDirIfNotPresent(Path destDirPath) {
         try {
-            FileMutatorUtils.createRestrictedDirectories(destDirPath);
+            FileMutatorUtils.createDirectories(destDirPath);
         } catch (IOException e) {
             throw new ZipFileExtractionFailedException("Couldn't create directory: " + destDirPath, e);
         }
@@ -69,10 +69,10 @@ public class ZipFileExtractor implements AutoCloseable {
                     throw new IOException("Entry is outside of the target directory");
                 }
                 if (zipEntry.isDirectory()) {
-                    FileMutatorUtils.createRestrictedDirectories(targetPath);
+                    FileMutatorUtils.createDirectories(targetPath);
                 } else {
                     // Ensure parent directories exist
-                    FileMutatorUtils.createRestrictedDirectories(targetPath.getParent());
+                    FileMutatorUtils.createDirectories(targetPath.getParent());
                     // Copy stream content to file
                     FileMutatorUtils.inputStreamToFile(zipInputStream, targetPath);
                 }

--- a/common/src/main/java/bisq/common/file/FileMutatorUtils.java
+++ b/common/src/main/java/bisq/common/file/FileMutatorUtils.java
@@ -238,7 +238,7 @@ public class FileMutatorUtils {
             throws IOException {
         if (Files.exists(storageFilePath)) {
             Path corruptedBackupDirPath = dirPath.resolve(backupFolderName);
-            createRestrictedDirectories(corruptedBackupDirPath);
+            createDirectories(corruptedBackupDirPath);
             String timestamp = String.valueOf(System.currentTimeMillis());
             String newFileName = fileName + "_at_" + timestamp;
             Path targetPath = dirPath.resolve(backupFolderName).resolve(newFileName);
@@ -247,7 +247,7 @@ public class FileMutatorUtils {
         }
     }
 
-    public static OutputStream newRestrictedOutputStream(Path filePath) throws IOException {
+    public static OutputStream newOutputStream(Path filePath) throws IOException {
         if (IS_POSIX) {
             if (!Files.exists(filePath)) {
                 Files.createFile(filePath, OWNER_READ_WRITE_PERMISSIONS_FILE_ATTRIBUTE);
@@ -262,7 +262,7 @@ public class FileMutatorUtils {
         return Files.newOutputStream(filePath);
     }
 
-    public static void createRestrictedFile(Path path) throws IOException {
+    public static void createFile(Path path) throws IOException {
         if (IS_POSIX) {
             Files.createFile(path, OWNER_READ_WRITE_PERMISSIONS_FILE_ATTRIBUTE);
             applyDefaultPermissions(path);
@@ -271,7 +271,7 @@ public class FileMutatorUtils {
         }
     }
 
-    public static void createRestrictedDirectories(Path path) throws IOException {
+    public static void createDirectories(Path path) throws IOException {
         if (IS_POSIX) {
             Files.createDirectories(path, OWNER_READ_WRITE_EXECUTE_PERMISSIONS_FILE_ATTRIBUTE);
             applyDefaultPermissions(path);
@@ -280,7 +280,7 @@ public class FileMutatorUtils {
         }
     }
 
-    public static void createRestrictedDirectory(Path path) throws IOException {
+    public static void createDirectory(Path path) throws IOException {
         if (IS_POSIX) {
             Files.createDirectory(path, OWNER_READ_WRITE_EXECUTE_PERMISSIONS_FILE_ATTRIBUTE);
             applyDefaultPermissions(path);
@@ -336,7 +336,7 @@ public class FileMutatorUtils {
             try {
                 Path parentPath = targetFilePath.getParent();
                 if (parentPath != null) {
-                    createRestrictedDirectories(parentPath);
+                    createDirectories(parentPath);
                 }
                 resourceToFile(resourcePath, targetFilePath);
             } catch (IOException e) {
@@ -354,7 +354,7 @@ public class FileMutatorUtils {
         try {
             connection.connect();
             try (InputStream inputStream = new BufferedInputStream(connection.getInputStream());
-                 OutputStream outputStream = newRestrictedOutputStream(destinationPath)) {
+                 OutputStream outputStream = newOutputStream(destinationPath)) {
                 // If server does not provide contentLength it is -1
                 fileSize = connection.getContentLength();
                 double totalReadBytes = 0d;

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
@@ -217,7 +217,7 @@ public class UpdaterService implements Service {
         String downloadFileName = UpdaterUtils.getDownloadFileName(version, isLauncherUpdate);
         Path destinationDirPath = isLauncherUpdate ? PlatformUtils.getDownloadOfHomeDirPath() :
                 appDataDirPath.resolve(UPDATES_DIR).resolve(version);
-        FileMutatorUtils.createRestrictedDirectories(destinationDirPath);
+        FileMutatorUtils.createDirectories(destinationDirPath);
         downloadItemList.setAll(DownloadItem.createDescriptorList(version, destinationDirPath, downloadFileName, keyIds));
         if (executorService == null) {
             executorService = ExecutorFactory.newSingleThreadExecutor("DownloadExecutor");

--- a/evolution/src/test/java/bisq/evolution/updater/UpdaterIntegrationTest.java
+++ b/evolution/src/test/java/bisq/evolution/updater/UpdaterIntegrationTest.java
@@ -76,7 +76,7 @@ public class UpdaterIntegrationTest {
         List<String> keyIds = List.of("387C8307");
         String downloadFileName = UpdaterUtils.getDownloadFileName(version, isLauncherUpdate);
         try {
-            FileMutatorUtils.createRestrictedDirectories(destinationDirPath);
+            FileMutatorUtils.createDirectories(destinationDirPath);
             List<DownloadItem> downloadItemList = new ArrayList<>(DownloadItem.createDescriptorList(version, destinationDirPath, downloadFileName, keyIds));
             simulateDownload(downloadItemList, sourceDirPath.toString(), executorService)
                     .thenCompose(nil -> UpdaterService.verify(version, isLauncherUpdate, destinationDirPath, keyIds, ignoreSigningKeyInResourcesCheck, executorService))
@@ -113,7 +113,7 @@ public class UpdaterIntegrationTest {
         List<String> keyIds = List.of("387C8307");
         String downloadFileName = UpdaterUtils.getDownloadFileName(version, isLauncherUpdate);
         try {
-            FileMutatorUtils.createRestrictedDirectories(destinationDirPath);
+            FileMutatorUtils.createDirectories(destinationDirPath);
             List<DownloadItem> downloadItemList = new ArrayList<>(DownloadItem.createDescriptorList(version, destinationDirPath, downloadFileName, keyIds));
             simulateDownload(downloadItemList, sourceDirPath.toString(), executorService)
                     .thenCompose(nil -> UpdaterService.verify(version, isLauncherUpdate, destinationDirPath, keyIds, ignoreSigningKeyInResourcesCheck, executorService))

--- a/network/i2p/src/main/java/bisq/network/i2p/router/RouterSetup.java
+++ b/network/i2p/src/main/java/bisq/network/i2p/router/RouterSetup.java
@@ -201,7 +201,7 @@ public class RouterSetup {
             }
         } else {
             try {
-                FileMutatorUtils.createRestrictedFile(configFilePath);
+                FileMutatorUtils.createFile(configFilePath);
             } catch (IOException e) {
                 log.warn("Could not create router.config file in i2p data directory {}", configFilePath.toAbsolutePath(), e);
             }
@@ -220,7 +220,7 @@ public class RouterSetup {
 
     private Path createDirectory(Path parent, String child) throws IOException {
         Path dirPath = parent.resolve(child);
-        FileMutatorUtils.createRestrictedDirectories(dirPath);
+        FileMutatorUtils.createDirectories(dirPath);
         return dirPath;
     }
 }

--- a/network/i2p/src/main/java/bisq/network/i2p/router/utils/RouterCertificateUtil.java
+++ b/network/i2p/src/main/java/bisq/network/i2p/router/utils/RouterCertificateUtil.java
@@ -34,7 +34,7 @@ public class RouterCertificateUtil {
 
     private static Path createDirectory(Path parentPath, String child) throws IOException {
         Path dirPath = parentPath.resolve(child);
-        FileMutatorUtils.createRestrictedDirectories(dirPath);
+        FileMutatorUtils.createDirectories(dirPath);
         return dirPath;
     }
 }

--- a/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/TorNetwork.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/TorNetwork.java
@@ -123,7 +123,7 @@ public class TorNetwork {
         }
 
         try {
-            FileMutatorUtils.createRestrictedDirectory(nodeDataDirPath);
+            FileMutatorUtils.createDirectory(nodeDataDirPath);
         } catch (IOException e) {
             throw new IllegalStateException("Couldn't create data directory: " + nodeDataDirPath.toAbsolutePath(), e);
         }

--- a/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/da/DirectoryAuthorityFactory.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/da/DirectoryAuthorityFactory.java
@@ -41,7 +41,7 @@ public class DirectoryAuthorityFactory {
         Path keysPath = dataDirPath.resolve("keys");
         if (!Files.exists(keysPath)) {
             try {
-                FileMutatorUtils.createRestrictedDirectories(keysPath);
+                FileMutatorUtils.createDirectories(keysPath);
             } catch (IOException e) {
                 throw new IllegalStateException("Couldn't create keys folder in data directory for directory authority.", e);
             }
@@ -54,7 +54,7 @@ public class DirectoryAuthorityFactory {
     private void createDataDirPathIfNotPresent(Path dataDirPath) {
         if(!Files.exists(dataDirPath)) {
             try {
-                FileMutatorUtils.createRestrictedDirectory(dataDirPath);
+                FileMutatorUtils.createDirectory(dataDirPath);
             } catch (IOException e) {
                 throw new IllegalStateException("Couldn't create data directory for directory authority.", e);
             }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -405,7 +405,7 @@ public class TorService implements Service {
     private void makeTorDir() {
         try {
             Path torDataDirPath = transportConfig.getDataDirPath();
-            FileMutatorUtils.createRestrictedDirectories(torDataDirPath);
+            FileMutatorUtils.createDirectories(torDataDirPath);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/network/tor/tor/src/main/java/bisq/network/tor/process/EmbeddedTorProcess.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/process/EmbeddedTorProcess.java
@@ -109,7 +109,7 @@ public class EmbeddedTorProcess {
         Path controlDirFilePath = torDataDirPath.resolve(BaseTorrcGenerator.CONTROL_DIR_NAME);
         if (!Files.exists(controlDirFilePath)) {
             try {
-                FileMutatorUtils.createRestrictedDirectories(controlDirFilePath);
+                FileMutatorUtils.createDirectories(controlDirFilePath);
             } catch (IOException e) {
                 throw new TorStartupFailedException("Couldn't create Tor control directory.");
             }

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreFileManager.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreFileManager.java
@@ -56,7 +56,7 @@ public class PersistableStoreFileManager {
     public void createParentDirectoriesIfNotExisting() {
         if (!Files.exists(parentDirectoryPath)) {
             try {
-                FileMutatorUtils.createRestrictedDirectories(parentDirectoryPath);
+                FileMutatorUtils.createDirectories(parentDirectoryPath);
             } catch (IOException e) {
                 throw new CouldNotCreateParentDirs("Couldn't create " + parentDirectoryPath);
             }

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
@@ -141,7 +141,7 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
     }
 
     private void writeStoreToFilePath(T persistableStore, Path filePath) {
-        try (OutputStream fileOutputStream = FileMutatorUtils.newRestrictedOutputStream(filePath)) {
+        try (OutputStream fileOutputStream = FileMutatorUtils.newOutputStream(filePath)) {
             // We use an Any container (byte blob) as we do not have the dependencies to the
             // external PersistableStore implementations (at deserialization we would have an issue otherwise as
             // it requires static access).

--- a/persistence/src/main/java/bisq/persistence/backup/BackupService.java
+++ b/persistence/src/main/java/bisq/persistence/backup/BackupService.java
@@ -290,7 +290,7 @@ public class BackupService {
         String formattedDate = DATE_FORMAT.format(localDateTime);
         String fileNamePath = fileName + "_" + formattedDate;
         Path backupFilePath = dirPath.resolve(fileNamePath);
-        FileMutatorUtils.createRestrictedDirectories(dirPath);
+        FileMutatorUtils.createDirectories(dirPath);
         return backupFilePath;
     }
 

--- a/persistence/src/test/java/bisq/persistence/backup/BackupServiceTest.java
+++ b/persistence/src/test/java/bisq/persistence/backup/BackupServiceTest.java
@@ -53,7 +53,7 @@ public class BackupServiceTest {
     @BeforeEach
     void setUp() throws IOException {
         Path dbDirPath = dataDirPath.resolve("db");
-        FileMutatorUtils.createRestrictedDirectories(dbDirPath);
+        FileMutatorUtils.createDirectories(dbDirPath);
         String storeFileName = "test_store" + Persistence.EXTENSION;
         storeFilePath = dbDirPath.resolve(storeFileName);
         backupService = new BackupService(dataDirPath, this.storeFilePath, MaxBackupSize.HUNDRED_MB);

--- a/security/src/test/java/bisq/security/PgPUtilsTest.java
+++ b/security/src/test/java/bisq/security/PgPUtilsTest.java
@@ -95,7 +95,7 @@ public class PgPUtilsTest {
         Path filePath = Path.of("temp", fileName);
         try {
             try (InputStream resource = FileReaderUtils.getResourceAsStream(fileName);
-                 OutputStream out = FileMutatorUtils.newRestrictedOutputStream(filePath)) {
+                 OutputStream out = FileMutatorUtils.newOutputStream(filePath)) {
                 FileMutatorUtils.copy(resource, out);
             }
             return PgPUtils.readPgpPublicKeyRing(filePath);
@@ -108,7 +108,7 @@ public class PgPUtilsTest {
         Path filePath = Path.of("temp", fileName);
         try {
             try (InputStream resource = FileReaderUtils.getResourceAsStream(fileName);
-                 OutputStream out = FileMutatorUtils.newRestrictedOutputStream(filePath)) {
+                 OutputStream out = FileMutatorUtils.newOutputStream(filePath)) {
                 FileMutatorUtils.copy(resource, out);
             }
             return PgPUtils.readPgpSignature(filePath);
@@ -121,7 +121,7 @@ public class PgPUtilsTest {
         Path filePath = Path.of("temp", fileName);
         try {
             try (InputStream resource = FileReaderUtils.getResourceAsStream(fileName)) {
-                OutputStream out = FileMutatorUtils.newRestrictedOutputStream(filePath);
+                OutputStream out = FileMutatorUtils.newOutputStream(filePath);
                 FileMutatorUtils.copy(resource, out);
             }
             return filePath;

--- a/user/src/main/java/bisq/user/cathash/CatHashService.java
+++ b/user/src/main/java/bisq/user/cathash/CatHashService.java
@@ -101,7 +101,7 @@ public abstract class CatHashService<T> {
 
             if (!Files.exists(iconsDirPath)) {
                 try {
-                    FileMutatorUtils.createRestrictedDirectories(iconsDirPath);
+                    FileMutatorUtils.createDirectories(iconsDirPath);
                 } catch (IOException e) {
                     log.error(e.toString());
                 }


### PR DESCRIPTION
Refactor FileMutatorUtils methods by removing the term Restricted from method names to improve clarity and consistency. No functional changes are made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored file and directory creation utilities to standardize permission handling across the application, affecting core services in networking (Tor, I2P), persistence, application initialization, and security components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->