### PR TITLE
Fix: Bash arithmetic causing batch upload failures in Transifex workflow

### DIFF
--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -398,7 +398,7 @@ jobs:
               echo "TX CLI output:"
               echo "$OUTPUT" | tail -5
               echo "::endgroup::"
-              ((UPLOADED_COUNT++))
+              UPLOADED_COUNT=$((UPLOADED_COUNT + 1))
             done
 
             echo "::endgroup::"


### PR DESCRIPTION
## Summary
- Fixes bash arithmetic expression `((UPLOADED_COUNT++))` that returns exit code 1 when count is 0
- This caused the script to exit after the first successful locale upload due to `set -e`

## Root Cause
In bash, `((expr))` returns exit code based on the expression value - 0 (falsy) returns exit 1. When `UPLOADED_COUNT` is 0, `((UPLOADED_COUNT++))` evaluates to 0 (pre-increment value), triggering script termination with `set -e`.

## Fix
Changed to `UPLOADED_COUNT=$((UPLOADED_COUNT + 1))` which always succeeds as a variable assignment.

## Test plan
- [ ] Verify next Transifex sync workflow run completes all batches successfully
- [ ] Check that all locales in each batch are uploaded (not just the first one)

## Related
Fixes failures in:
- https://github.com/bisq-network/bisq2/actions/runs/20705667617
- https://github.com/bisq-network/bisq2/actions/runs/20695411083