### PR TITLE
Centralize file capabilities.

### DIFF
--- a/api/src/main/java/bisq/api/ApiTorOnionService.java
+++ b/api/src/main/java/bisq/api/ApiTorOnionService.java
@@ -18,8 +18,8 @@
 package bisq.api;
 
 import bisq.common.application.Service;
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.network.Address;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.network.TransportType;
 import bisq.network.NetworkService;
 import bisq.security.SecurityService;
@@ -78,7 +78,7 @@ public class ApiTorOnionService implements Service {
                     log.info("{} published for {}", onionAddressWithPort, identityTag);
                     try {
                         Path path = appDataDirPath.resolve(identityTag + "_onionAddress.txt");
-                        FacadeProvider.getJdkFacade().writeString(onionAddressWithPort, path);
+                        FileMutatorUtils.writeToPath(onionAddressWithPort, path);
                         return true;
                     } catch (IOException e) {
                         log.error("Error at write onionAddress", e);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/overlay/Overlay.java
@@ -19,7 +19,6 @@ package bisq.desktop.components.overlay;
 
 import bisq.application.ShutDownHandler;
 import bisq.common.application.ApplicationVersion;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.FileReaderUtils;
 import bisq.common.locale.LanguageRepository;
@@ -1020,9 +1019,9 @@ public abstract class Overlay<T extends Overlay<T>> {
                     try {
                         Files.deleteIfExists(debugLogForZipFilePath);
                         FileMutatorUtils.copyFile(debugLogPath, debugLogForZipFilePath);
-                        String logContent = FacadeProvider.getJdkFacade().readString(debugLogForZipFilePath);
+                        String logContent = FileReaderUtils.readUTF8String(debugLogForZipFilePath);
                         logContent = StringUtils.maskHomeDirectory(logContent);
-                        FacadeProvider.getJdkFacade().writeString(logContent, debugLogForZipFilePath);
+                        FileMutatorUtils.writeToPath(logContent, debugLogForZipFilePath);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/RichTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/table/RichTableView.java
@@ -18,7 +18,6 @@
 package bisq.desktop.components.table;
 
 import bisq.common.encoding.Csv;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.desktop.common.Layout;
 import bisq.desktop.common.utils.FileChooserUtil;
@@ -248,7 +247,7 @@ public class RichTableView<T> extends VBox {
             FileChooserUtil.saveFile(tableView.getScene(), initialFileName)
                     .ifPresent(filePath -> {
                         try {
-                            FacadeProvider.getJdkFacade().writeString(csv, filePath);
+                            FileMutatorUtils.writeToPath(csv, filePath);
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/MediationTableView.java
@@ -1,7 +1,6 @@
 package bisq.desktop.main.content.authorized_role.mediator;
 
 import bisq.common.encoding.Csv;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.util.StringUtils;
 import bisq.desktop.common.Layout;
@@ -20,7 +19,11 @@ import bisq.i18n.Res;
 import javafx.collections.ListChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.control.*;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableColumnBase;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
@@ -113,7 +116,7 @@ class MediationTableView extends VBox {
             FileChooserUtil.saveFile(tableView.getScene(), initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FacadeProvider.getJdkFacade().writeString(csv, file);
+                            FileMutatorUtils.writeToPath(csv, file);
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
@@ -3,7 +3,6 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelService;
 import bisq.common.encoding.Csv;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
@@ -62,7 +61,7 @@ public class OpenTradesUtils {
             FileChooserUtil.saveFile(scene, initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FacadeProvider.getJdkFacade().writeString(csv, file);
+                            FileMutatorUtils.writeToPath(csv, file);
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigOpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigOpenTradesUtils.java
@@ -3,7 +3,6 @@ package bisq.desktop.main.content.mu_sig.open_trades.trade_state;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannelService;
 import bisq.common.encoding.Csv;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
@@ -59,7 +58,7 @@ public class MuSigOpenTradesUtils {
             FileChooserUtil.saveFile(scene, initialFileName)
                     .ifPresent(file -> {
                         try {
-                            FacadeProvider.getJdkFacade().writeString(csv, file);
+                            FileMutatorUtils.writeToPath(csv, file);
                         } catch (IOException e) {
                             new Popup().error(e).show();
                         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/nodes/tabs/registration/NodeRegistrationController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/network/bonded_roles/nodes/tabs/registration/NodeRegistrationController.java
@@ -19,7 +19,7 @@ package bisq.desktop.main.content.network.bonded_roles.nodes.tabs.registration;
 
 import bisq.bonded_roles.BondedRoleType;
 import bisq.common.encoding.Hex;
-import bisq.common.facades.FacadeProvider;
+import bisq.common.file.FileReaderUtils;
 import bisq.common.network.Address;
 import bisq.common.network.AddressByTransportTypeMap;
 import bisq.common.network.ClearnetAddress;
@@ -42,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.util.Map;
@@ -96,7 +95,7 @@ public class NodeRegistrationController extends BondedRolesRegistrationControlle
         FileChooserUtil.openFile(getView().getRoot().getScene(), path.toAbsolutePath().toString())
                 .ifPresent(p -> {
                     try {
-                        String json = FacadeProvider.getJdkFacade().readString(p);
+                        String json = FileReaderUtils.readUTF8String(p);
                         checkArgument(StringUtils.isNotEmpty(json), "Json must not be empty");
                         getNodesRegistrationModel().getAddressInfoJson().set(json);
                     } catch (Exception e) {

--- a/apps/oracle-node-app/src/main/java/bisq/oracle_node/OracleNodeApp.java
+++ b/apps/oracle-node-app/src/main/java/bisq/oracle_node/OracleNodeApp.java
@@ -18,7 +18,6 @@
 package bisq.oracle_node;
 
 import bisq.application.Executable;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.network.AddressByTransportTypeMap;
 import com.google.gson.GsonBuilder;
@@ -48,7 +47,7 @@ public class OracleNodeApp extends Executable<OracleNodeApplicationService> {
         String json = new GsonBuilder().setPrettyPrinting().create().toJson(addressByTransportTypeMap);
         Path path = applicationService.getConfig().getAppDataDirPath().resolve("default_node_address.json");
         try {
-            FacadeProvider.getJdkFacade().writeString(json, path);
+            FileMutatorUtils.writeToPath(json, path);
         } catch (IOException e) {
             log.error("Error at write json", e);
         }

--- a/apps/seed-node-app/src/main/java/bisq/seed_node/SeedNodeApp.java
+++ b/apps/seed-node-app/src/main/java/bisq/seed_node/SeedNodeApp.java
@@ -18,7 +18,6 @@
 package bisq.seed_node;
 
 import bisq.application.Executable;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.network.AddressByTransportTypeMap;
 import com.google.gson.GsonBuilder;
@@ -45,7 +44,7 @@ public class SeedNodeApp extends Executable<SeedNodeApplicationService> {
         String json = new GsonBuilder().setPrettyPrinting().create().toJson(addressByTransportTypeMap);
         Path path = applicationService.getConfig().getAppDataDirPath().resolve("default_node_address.json");
         try {
-            FacadeProvider.getJdkFacade().writeString(json, path);
+            FileMutatorUtils.writeToPath(json, path);
         } catch (IOException e) {
             log.error("Error at write json", e);
         }

--- a/common/src/main/java/bisq/common/facades/JdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/JdkFacade.java
@@ -17,8 +17,6 @@
 
 package bisq.common.facades;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.stream.Stream;
 
 /**
@@ -38,32 +36,4 @@ public interface JdkFacade {
     void redirectError(ProcessBuilder processBuilder);
 
     void redirectOutput(ProcessBuilder processBuilder);
-
-    /**
-     * Reads the entire content of a file as a UTF-8 encoded string.
-     *
-     * @param path the path to the file
-     * @return the file content as a string
-     * @throws IOException if an I/O error occurs
-     */
-    String readString(Path path) throws IOException;
-
-    /**
-     * Writes a string to a file using UTF-8 encoding.
-     * On POSIX systems, applies owner-only read/write permissions.
-     *
-     * @param data the string to write
-     * @param path the path to the file
-     * @throws IOException if an I/O error occurs
-     */
-    void writeString(String data, Path path) throws IOException;
-
-    /**
-     * Creates a directory and all necessary parent directories.
-     * On POSIX systems, applies owner-only read/write/execute permissions.
-     *
-     * @param path the directory path to create
-     * @throws IOException if an I/O error occurs
-     */
-    void createDirectories(Path path) throws IOException;
 }

--- a/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
@@ -20,10 +20,6 @@ package bisq.common.facades.android;
 import bisq.common.facades.JdkFacade;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.stream.Stream;
 
 public class AndroidJdkFacade implements JdkFacade {
@@ -55,25 +51,5 @@ public class AndroidJdkFacade implements JdkFacade {
     public void redirectOutput(ProcessBuilder processBuilder) {
         // ProcessBuilder.Redirect.DISCARD not supported on Android
         processBuilder.redirectError(new File("/dev/null"));
-    }
-
-    @Override
-    public String readString(Path path) throws IOException {
-        // Android 33+ compatible; Files.readString is not available on all Android API levels
-        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
-    }
-
-    @Override
-    public void writeString(String data, Path path) throws IOException {
-        // Android handles file permissions through its own security model (app sandboxing).
-        // Files in app-private directories are already protected by the OS.
-        Files.write(path, data.getBytes(StandardCharsets.UTF_8));
-    }
-
-    @Override
-    public void createDirectories(Path path) throws IOException {
-        // Android handles file permissions through its own security model (app sandboxing).
-        // POSIX file permissions are not typically used on Android.
-        Files.createDirectories(path);
     }
 }

--- a/common/src/main/java/bisq/common/file/FileReaderUtils.java
+++ b/common/src/main/java/bisq/common/file/FileReaderUtils.java
@@ -43,8 +43,29 @@ import java.util.stream.Stream;
 public class FileReaderUtils {
     public static final String FILE_SEP = File.separator;
 
+    private static boolean supportsModernFilesApi = true;
+    private static boolean configured = false;
+
+    /**
+     * Sets platform file capabilities.
+     * Intended to be called once at startup.
+     */
+    public static synchronized void setup(boolean supportsModernFilesApi) {
+        if (configured) {
+            log.warn("FileReaderUtils already configured, ignoring repeated setup call");
+            return;
+        }
+
+        FileReaderUtils.supportsModernFilesApi = supportsModernFilesApi;
+        configured = true;
+    }
+
     public static String readUTF8String(Path path) throws IOException {
-        return Files.readString(path, StandardCharsets.UTF_8);
+        if (supportsModernFilesApi) {
+            return Files.readString(path, StandardCharsets.UTF_8);
+        } else {
+            return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+        }
     }
 
     /**

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
@@ -26,7 +26,6 @@ import bisq.bonded_roles.security_manager.alert.AlertType;
 import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.observable.Observable;
 import bisq.common.observable.Pin;
@@ -331,7 +330,7 @@ public class UpdaterService implements Service {
                                                   ExecutorService executorService) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                FacadeProvider.getJdkFacade().writeString(version, appDataDirPath.resolve(VERSION_FILE_NAME));
+                FileMutatorUtils.writeToPath(version, appDataDirPath.resolve(VERSION_FILE_NAME));
                 return null;
             } catch (Exception e) {
                 e.printStackTrace();

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
@@ -17,7 +17,6 @@
 
 package bisq.evolution.updater;
 
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileReaderUtils;
 import bisq.common.platform.Platform;
 import bisq.common.platform.PlatformUtils;
@@ -38,11 +37,11 @@ public class UpdaterUtils {
     public static final String ASC_EXTENSION = ".asc";
 
     public static String getSigningKeyId(Path dirPath) throws IOException {
-        return FacadeProvider.getJdkFacade().readString(dirPath.resolve(SIGNING_KEY_FILE));
+        return FileReaderUtils.readUTF8String(dirPath.resolve(SIGNING_KEY_FILE));
     }
 
     public static String getSigningKey(Path dirPath, String signingKeyId) throws IOException {
-        return FacadeProvider.getJdkFacade().readString(dirPath.resolve(signingKeyId + ASC_EXTENSION));
+        return FileReaderUtils.readUTF8String(dirPath.resolve(signingKeyId + ASC_EXTENSION));
     }
 
     public static String getDownloadFileName(String version, boolean isLauncherUpdate) {

--- a/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
+++ b/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
@@ -20,30 +20,11 @@ package bisq.java_se.facades;
 import bisq.common.facades.JdkFacade;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.EnumSet;
-import java.util.Set;
 import java.util.stream.Stream;
 
 @Slf4j
 public class JavaSeJdkFacade implements JdkFacade {
-    private static final boolean IS_POSIX = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
-
-    private static final Set<PosixFilePermission> OWNER_READ_WRITE_PERMISSIONS =
-            EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
-    private static final Set<PosixFilePermission> OWNER_READ_WRITE_EXECUTE_PERMISSIONS =
-            EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE);
-
-    private static final FileAttribute<Set<PosixFilePermission>> OWNER_READ_WRITE_EXECUTE_PERMISSIONS_FILE_ATTRIBUTE =
-            PosixFilePermissions.asFileAttribute(OWNER_READ_WRITE_EXECUTE_PERMISSIONS);
 
     @Override
     public String getMyPid() {
@@ -64,46 +45,5 @@ public class JavaSeJdkFacade implements JdkFacade {
     @Override
     public void redirectOutput(ProcessBuilder processBuilder) {
         processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
-    }
-
-    @Override
-    public String readString(Path path) throws IOException {
-        return Files.readString(path, StandardCharsets.UTF_8);
-    }
-
-    @Override
-    public void writeString(String data, Path path) throws IOException {
-        Files.writeString(path, data, StandardCharsets.UTF_8);
-        applyFilePermissions(path);
-    }
-
-    @Override
-    public void createDirectories(Path path) throws IOException {
-        if (IS_POSIX) {
-            Files.createDirectories(path, OWNER_READ_WRITE_EXECUTE_PERMISSIONS_FILE_ATTRIBUTE);
-            applyDirectoryPermissions(path);
-        } else {
-            Files.createDirectories(path);
-        }
-    }
-
-    private void applyFilePermissions(Path path) {
-        if (IS_POSIX) {
-            try {
-                Files.setPosixFilePermissions(path, OWNER_READ_WRITE_PERMISSIONS);
-            } catch (IOException | UnsupportedOperationException e) {
-                log.warn("Could not apply file permissions to {}", path, e);
-            }
-        }
-    }
-
-    private void applyDirectoryPermissions(Path path) {
-        if (IS_POSIX) {
-            try {
-                Files.setPosixFilePermissions(path, OWNER_READ_WRITE_EXECUTE_PERMISSIONS);
-            } catch (IOException | UnsupportedOperationException e) {
-                log.warn("Could not apply directory permissions to {}", path, e);
-            }
-        }
     }
 }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
@@ -17,7 +17,6 @@
 
 package bisq.network.tor.common.torrc;
 
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 
 import java.io.IOException;
@@ -57,7 +56,7 @@ public class TorrcFileGenerator {
 
 
         try {
-            FacadeProvider.getJdkFacade().writeString(torrcStringBuilder.toString(), torrcPath);
+            FileMutatorUtils.writeToPath(torrcStringBuilder.toString(), torrcPath);
         } catch (IOException e) {
             throw new IllegalStateException("Couldn't create torrc file: " + torrcPath.toAbsolutePath());
         }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -370,9 +370,9 @@ public class TorService implements Service {
             String torConfig;
             if (!Files.exists(torConfigFilePath)) {
                 torConfig = FileReaderUtils.readStringFromResource("tor/" + torConfigFileName);
-                FacadeProvider.getJdkFacade().writeString(torConfig, torConfigFilePath);
+                FileMutatorUtils.writeToPath(torConfig, torConfigFilePath);
             } else {
-                torConfig = FacadeProvider.getJdkFacade().readString(torConfigFilePath);
+                torConfig = FileReaderUtils.readUTF8String(torConfigFilePath);
             }
             Set<String> lines = torConfig.lines().collect(Collectors.toSet());
             for (String line : lines) {

--- a/network/tor/tor/src/main/java/bisq/network/tor/installer/TorInstaller.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/installer/TorInstaller.java
@@ -17,7 +17,6 @@
 
 package bisq.network.tor.installer;
 
-import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.FileReaderUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +59,7 @@ public class TorInstaller {
         if (!Files.exists(versionFilePath)) {
             return false;
         }
-        String torVersion = FacadeProvider.getJdkFacade().readString(versionFilePath);
+        String torVersion = FileReaderUtils.readUTF8String(versionFilePath);
         return VERSION.equals(torVersion);
     }
 
@@ -70,7 +69,7 @@ public class TorInstaller {
             log.info("Tor files installed to {}", torDirPath.toAbsolutePath());
             // Only if we have successfully extracted all files we write our version file which is used to
             // check if we need to call installFiles.
-            FacadeProvider.getJdkFacade().writeString(VERSION, versionFilePath);
+            FileMutatorUtils.writeToPath(VERSION, versionFilePath);
         } catch (IOException e) {
             deleteVersionFile();
             throw e;

--- a/network/tor/tor/src/main/java/bisq/network/tor/process/control_port/ControlPortFileParser.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/process/control_port/ControlPortFileParser.java
@@ -17,7 +17,7 @@
 
 package bisq.network.tor.process.control_port;
 
-import bisq.common.facades.FacadeProvider;
+import bisq.common.file.FileReaderUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -27,7 +27,7 @@ public class ControlPortFileParser {
 
     public static int parse(Path controlPortFilePath) {
         try {
-            String fileContent = FacadeProvider.getJdkFacade().readString(controlPortFilePath);
+            String fileContent = FileReaderUtils.readUTF8String(controlPortFilePath);
             if (isControlPortFileReady(fileContent)) {
                 for (String line : fileContent.split("\n")) {
                     // Lines end on Windows with "\r\n". Previous String.split("\n") removed "\n" already.

--- a/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/I2PKeyUtils.java
@@ -17,7 +17,7 @@
 
 package bisq.security.keys;
 
-import bisq.common.facades.FacadeProvider;
+import bisq.common.file.FileMutatorUtils;
 import lombok.extern.slf4j.Slf4j;
 import net.i2p.client.I2PSessionException;
 import net.i2p.data.Base64;
@@ -37,10 +37,10 @@ public class I2PKeyUtils {
         Path destination_b32Path = I2PKeyGeneration.getDestinationFilePath(storageDirPath, tag, "destination_b32");
         Path identityBase64Path = I2PKeyGeneration.getDestinationFilePath(storageDirPath, tag, "identity_b64");
         try {
-            FacadeProvider.getJdkFacade().createDirectories(i2pPrivateKeyDirPath);
-            FacadeProvider.getJdkFacade().writeString(i2pKeyPair.getDestinationBase64(), destination_b64Path);
-            FacadeProvider.getJdkFacade().writeString(i2pKeyPair.getDestinationBase32(), destination_b32Path);
-            FacadeProvider.getJdkFacade().writeString(Base64.encode(i2pKeyPair.getIdentityBytes()), identityBase64Path);
+            FileMutatorUtils.createDirectories(i2pPrivateKeyDirPath);
+            FileMutatorUtils.writeToPath(i2pKeyPair.getDestinationBase64(), destination_b64Path);
+            FileMutatorUtils.writeToPath(i2pKeyPair.getDestinationBase32(), destination_b32Path);
+            FileMutatorUtils.writeToPath(Base64.encode(i2pKeyPair.getIdentityBytes()), identityBase64Path);
             log.info("Persisted the I2P private key and destinations into {}", i2pPrivateKeyDirPath);
         } catch (Exception e) {
             log.error("Could not persist I2P destination files", e);

--- a/security/src/main/java/bisq/security/keys/KeyBundleService.java
+++ b/security/src/main/java/bisq/security/keys/KeyBundleService.java
@@ -19,7 +19,7 @@ package bisq.security.keys;
 
 import bisq.common.application.Service;
 import bisq.common.encoding.Hex;
-import bisq.common.facades.FacadeProvider;
+import bisq.common.file.FileMutatorUtils;
 import bisq.common.timer.Scheduler;
 import bisq.persistence.DbSubDirectory;
 import bisq.persistence.Persistence;
@@ -213,14 +213,14 @@ public class KeyBundleService extends RateLimitedPersistenceClient<KeyBundleStor
             }
             if (writeKeyStoreSecretUidToFile) {
                 try {
-                    FacadeProvider.getJdkFacade().createDirectories(defaultKeyStoragePath);
+                    FileMutatorUtils.createDirectories(defaultKeyStoragePath);
                 } catch (IOException e) {
                     log.error("Could not create {}", defaultKeyStoragePath);
                     throw new RuntimeException(e);
                 }
                 Path filePath = defaultKeyStoragePath.resolve("keyStoreSecretUid");
                 try {
-                    FacadeProvider.getJdkFacade().writeString(persistableStore.getSecretUid(), filePath);
+                    FileMutatorUtils.writeToPath(persistableStore.getSecretUid(), filePath);
                 } catch (IOException e) {
                     log.error("Could not write keyStoreSecretUid to {}", filePath);
                 }

--- a/security/src/main/java/bisq/security/keys/KeyPairUtils.java
+++ b/security/src/main/java/bisq/security/keys/KeyPairUtils.java
@@ -1,7 +1,7 @@
 package bisq.security.keys;
 
 import bisq.common.encoding.Hex;
-import bisq.common.facades.FacadeProvider;
+import bisq.common.file.FileMutatorUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -30,12 +30,12 @@ public class KeyPairUtils {
     public static void writePrivateKey(KeyPair keyPair, Path storageDirPath, String tag) {
         Path targetPath = storageDirPath.resolve(tag);
         try {
-            FacadeProvider.getJdkFacade().createDirectories(targetPath);
+            FileMutatorUtils.createDirectories(targetPath);
 
             ECPrivateKey ecPrivate = (ECPrivateKey) keyPair.getPrivate();
             byte[] priv32 = toUnsignedFixedLength(ecPrivate.getS(), 32);
 
-            FacadeProvider.getJdkFacade().writeString(Hex.encode(priv32), targetPath.resolve("private_key_hex"));
+            FileMutatorUtils.writeToPath(Hex.encode(priv32), targetPath.resolve("private_key_hex"));
             log.info("Persisted hex encoded 32-byte secp256k1 private key for tag {} at {}", tag, targetPath);
         } catch (Exception e) {
             log.error("Could not persist private key", e);

--- a/security/src/main/java/bisq/security/keys/TorKeyUtils.java
+++ b/security/src/main/java/bisq/security/keys/TorKeyUtils.java
@@ -1,7 +1,7 @@
 package bisq.security.keys;
 
 import bisq.common.encoding.Hex;
-import bisq.common.facades.FacadeProvider;
+import bisq.common.file.FileMutatorUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Base32;
 
@@ -20,10 +20,10 @@ public class TorKeyUtils {
     public static void writePrivateKey(TorKeyPair torKeyPair, Path storageDirPath, String tag) {
         Path targetPath = storageDirPath.resolve(tag);
         try {
-            FacadeProvider.getJdkFacade().createDirectories(targetPath);
+            FileMutatorUtils.createDirectories(targetPath);
 
-            FacadeProvider.getJdkFacade().writeString(Hex.encode(torKeyPair.getPrivateKey()), targetPath.resolve("private_key_hex"));
-            FacadeProvider.getJdkFacade().writeString(torKeyPair.getOnionAddress(), targetPath.resolve("hostname"));
+            FileMutatorUtils.writeToPath(Hex.encode(torKeyPair.getPrivateKey()), targetPath.resolve("private_key_hex"));
+            FileMutatorUtils.writeToPath(torKeyPair.getOnionAddress(), targetPath.resolve("hostname"));
 
             log.info("We persisted the tor private key in hex encoding for onionAddress {} for tag {} to {}.",
                     torKeyPair.getOnionAddress(), tag, targetPath);


### PR DESCRIPTION
FileReaderUtils and FileMutatorUtils already provide a unified API for file and directory access. By configuring platform capabilities at startup, these utilities internally handle platform differences and deliver a consistent API to all callers. Compared to a facade, this approach keeps call sites simple, centralizes platform logic, avoids duplication, and ensures maintainable behavior across platforms.

@rodvar @HenrikJannsen For Android, the file utilities should be initialized at startup as follows:
`FileMutatorUtils.setup(false, false);`
`FileReaderUtils.setup(false);`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal file I/O operations by migrating from a facade-based pattern to dedicated utility classes for improved code maintainability and clarity across desktop, network, security, and core modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->