### PR TITLE
bugfix/for-mobile-based-on-2.1.8_fresh_install_crash_on_samsung_path.of

### DIFF
--- a/common/src/main/java/bisq/common/platform/LinuxDistribution.java
+++ b/common/src/main/java/bisq/common/platform/LinuxDistribution.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public enum LinuxDistribution {
     DEBIAN("debian"),
@@ -35,17 +36,17 @@ public enum LinuxDistribution {
     }
 
     public static boolean isDebian() {
-        return OS.isLinux() && Files.isRegularFile(Path.of("/etc/debian_version"));
+        return OS.isLinux() && Files.isRegularFile(Paths.get("/etc/debian_version"));
     }
 
     public static boolean isRedHat() {
-        return OS.isLinux() && Files.isRegularFile(Path.of("/etc/redhat-release"));
+        return OS.isLinux() && Files.isRegularFile(Paths.get("/etc/redhat-release"));
     }
 
     public static boolean isWhonix() {
         return OS.isLinux() &&
-                Files.isRegularFile(Path.of("/usr/share/whonix/marker")) &&
-                Files.isRegularFile(Path.of("/usr/share/anon-dist/marker"));
+                Files.isRegularFile(Paths.get("/usr/share/whonix/marker")) &&
+                Files.isRegularFile(Paths.get("/usr/share/anon-dist/marker"));
     }
 }
 

--- a/common/src/main/java/bisq/common/platform/PlatformUtils.java
+++ b/common/src/main/java/bisq/common/platform/PlatformUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,11 +34,11 @@ public class PlatformUtils {
 
     public static Path getUserDataDirPath() {
         if (OS.isWindows()) {
-            return Path.of(System.getenv("APPDATA"));
+            return Paths.get(System.getenv("APPDATA"));
         }
 
         if (OS.isMacOs()) {
-            return Path.of(System.getProperty("user.home"), "Library", "Application Support");
+            return Paths.get(System.getProperty("user.home"), "Library", "Application Support");
         }
 
         if (OS.isAndroid()) {
@@ -46,7 +47,7 @@ public class PlatformUtils {
         }
 
         // *nix
-        return Path.of(System.getProperty("user.home"), ".local", "share");
+        return Paths.get(System.getProperty("user.home"), ".local", "share");
     }
 
     public static int availableProcessors() {
@@ -154,6 +155,6 @@ public class PlatformUtils {
     }
 
     public static Path getHomeDirectoryPath() {
-        return Path.of(OS.isWindows() ? System.getenv("USERPROFILE") : System.getProperty("user.home"));
+        return Paths.get(OS.isWindows() ? System.getenv("USERPROFILE") : System.getProperty("user.home"));
     }
 }


### PR DESCRIPTION
 - fixes https://github.com/bisq-network/bisq-mobile/issues/1092
 - use Path.get() api instead of Path.of which is compatible with Android desugaring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to platform utility handling. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->