### PR TITLE
Use EUR for Bulgaria

### DIFF
--- a/common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java
+++ b/common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java
@@ -102,6 +102,10 @@ public class FiatCurrencyRepository {
                 return new FiatCurrency("EUR");
             }
 
+            if (countryCode.equals("BG")) {
+                return new FiatCurrency("EUR");
+            }
+
             checkNotNull(locale, "locale must not be null");
             localeLanguage = locale.getLanguage();
             checkNotNull(localeLanguage, "localeLanguage must not be null");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fiat currency assignment to ensure users in Bulgaria see EUR currency properly applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->