### PR TITLE
Get default market in case no wallet market selected in settings.

### DIFF
--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -281,7 +281,7 @@ final public class SettingsStore implements PersistableStore<SettingsStore> {
                 proto.getAutoAddToContactsList(),
                 proto.getMuSigLastSelectedMarketByBaseCurrencyMapMap().entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, entry -> Market.fromProto(entry.getValue()))),
-                Market.fromProto(proto.getSelectedWalletMarket()));
+                proto.hasSelectedWalletMarket() ? Market.fromProto(proto.getSelectedWalletMarket()) : MarketRepository.getDefaultBtcFiatMarket());
     }
 
     @Override


### PR DESCRIPTION
@axpoems existing settings could not be loaded successfully after introducing new proto property:
https://github.com/bisq-network/bisq2/commit/2b839bad5dc2c8a24f50d4223785265d0836e0ad


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced wallet market selection to automatically use a default market configuration when no custom selection is specified, improving application stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->