### PR TITLE
Update jdk version

### DIFF
--- a/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
+++ b/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
@@ -30,7 +30,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             when (javaVersion) {
                 11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-linux_x64.zip"
                 17 -> "https://cdn.azul.com/zulu/bin/zulu17.44.15-ca-jdk17.0.8-linux_x64.zip"
-                21 -> "https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-linux_x64.zip"
+                21 -> "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.zip"
                 else -> null
             }
 
@@ -42,7 +42,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15_1-ca-jdk11.0.20-macosx_" + macOsArchName + ".tar.gz"
             15 -> "https://cdn.azul.com/zulu/bin/zulu15.46.17-ca-jdk15.0.10-macosx_" + macOsArchName + ".tar.gz"
             17 -> "https://cdn.azul.com/zulu/bin/zulu17.44.15_1-ca-jdk17.0.8-macosx_" + macOsArchName + ".tar.gz"
-            21 -> "https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-macosx_" + macOsArchName + ".tar.gz"
+            21 -> "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-macosx_" + macOsArchName + ".tar.gz"
             else -> null
         }
     }
@@ -51,7 +51,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             when (javaVersion) {
                 11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_x64.zip"
                 17 -> "https://cdn.azul.com/zulu/bin/zulu17.44.15-ca-jdk17.0.8-win_x64.zip"
-                21 -> "https://cdn.azul.com/zulu/bin/zulu21.40.17-ca-jdk21.0.6-win_x64.zip"
+                21 -> "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-win_x64.zip"
                 else -> null
             }
 }


### PR DESCRIPTION
Update jdk from `zulu21.40.17-ca-jdk21.0.6` to `zulu21.48.15-ca-jdk21.0.10`.

This includes the fix for Bulgaria to use EUR as currency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java 21 toolchain version across all supported platforms (Linux, macOS, Windows) for improved build stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->