### PR TITLE
Add tolerance to maxNumPeers check

### DIFF
--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangePolicy.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangePolicy.java
@@ -192,9 +192,10 @@ class PeerExchangePolicy {
         Set<Peer> connectedPeers = getSortedAllConnectedPeers()
                 .filter(peer -> notSameAddress(requesterAddress, peer))
                 .collect(Collectors.toSet());
+        long maxSizeReportedPeers = Math.max(0L, REPORTED_PEERS_LIMIT - connectedPeers.size());
         Set<Peer> reportedPeers = getSortedReportedPeers()
                 .filter(peer -> notSameAddress(requesterAddress, peer))
-                .limit(Math.round(REPORTED_PEERS_LIMIT))
+                .limit(maxSizeReportedPeers)
                 .collect(Collectors.toSet());
 
         Set<Peer> peers = new HashSet<>(connectedPeers);

--- a/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeResponse.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/peer_group/exchange/PeerExchangeResponse.java
@@ -56,7 +56,10 @@ public final class PeerExchangeResponse implements EnvelopePayloadMessage, Respo
 
     @Override
     public void verify() {
-        checkArgument(peers.size() <= maxNumPeers, "Size of peers (" + peers.size() + ") exceed limit of " + maxNumPeers);
+        // We had a bug at filling the peers at the request not considering the connected peers size, thus we add some
+        // tolerance to not fail.
+        long toleratedMaxNumPeers = maxNumPeers + 30;
+        checkArgument(peers.size() <= toleratedMaxNumPeers, "Size of peers (" + peers.size() + ") exceed limit of " + toleratedMaxNumPeers);
     }
 
     @Override


### PR DESCRIPTION
The getPeersForReporting method had only applied the limit to the reported peers but adds the connected peers, thus can result in a size > as the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Peer reporting now scales reported-peer limits based on current connections to avoid over-reporting.
  * Increased tolerance for peer-list validation, reducing false rejections and improving network compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->