### PR TITLE
Do not send empty string for NO_CONTENT response

### DIFF
--- a/api/src/main/java/bisq/api/rest_api/endpoints/RestApiBase.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/RestApiBase.java
@@ -41,7 +41,7 @@ public abstract class RestApiBase {
      *
      * @return The HTTP response.
      */
-    protected Response buildNoContentResponse( ) {
+    protected Response buildNoContentResponse() {
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 

--- a/api/src/main/java/bisq/api/rest_api/endpoints/chat/trade/TradeChatMessagesRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/chat/trade/TradeChatMessagesRestApi.java
@@ -91,7 +91,7 @@ public class TradeChatMessagesRestApi extends RestApiBase {
                         Optional<Citation> citation = Optional.ofNullable(request.citation())
                                 .map(DtoMappings.CitationMapping::toBisq2Model);
                         bisqEasyOpenTradeChannelService.sendTextMessage(request.text(), citation, channel);
-                        asyncResponse.resume(buildResponse(Response.Status.NO_CONTENT, ""));
+                        asyncResponse.resume(buildNoContentResponse());
                     }, () -> {
                         asyncResponse.resume(buildResponse(Response.Status.NOT_FOUND,
                                 "No channel found for channel ID " + channelId));
@@ -173,7 +173,7 @@ public class TradeChatMessagesRestApi extends RestApiBase {
                     .orElse(false);
 
             if (wasSent) {
-                asyncResponse.resume(buildResponse(Response.Status.NO_CONTENT, ""));
+                asyncResponse.resume(buildNoContentResponse());
             } else {
                 asyncResponse.resume(buildResponse(Response.Status.NOT_FOUND,
                         "No message found for message ID: " + messageId));

--- a/api/src/main/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApi.java
@@ -130,7 +130,7 @@ public class OfferbookRestApi extends RestApiBase {
 
             UserIdentity userIdentity = optionalUserIdentity.get();
             bisqEasyOfferbookChannelService.deleteChatMessage(offerbookMessage, userIdentity.getNetworkIdWithKeyPair()).get();
-            asyncResponse.resume(buildResponse(Response.Status.NO_CONTENT, ""));
+            asyncResponse.resume(buildNoContentResponse());
         } catch (InterruptedException e) {
             log.warn("Thread got interrupted at deleteOffer method", e);
             Thread.currentThread().interrupt(); // Restore interrupted state

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
@@ -108,11 +108,11 @@ public class PaymentAccountsRestApi extends RestApiBase {
                     UserDefinedFiatAccountDto userAccount = DtoMappings.UserDefinedFiatAccountMapping.fromBisq2Model(castedAccount);
                     return buildOkResponse(userAccount);
                 } else {
-                    return buildResponse(Response.Status.NO_CONTENT, "");
+                    return buildNoContentResponse();
                 }
             }
 
-            return buildResponse(Response.Status.NO_CONTENT, "");
+            return buildNoContentResponse();
         } catch (Exception e) {
             log.error("Failed to retrieve payment accounts", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
@@ -171,7 +171,7 @@ public class PaymentAccountsRestApi extends RestApiBase {
             if (result.isPresent()) {
                 Account<? extends PaymentMethod<?>, ?> toRemove = result.get();
                 accountService.removePaymentAccount(toRemove);
-                asyncResponse.resume(buildResponse(Response.Status.NO_CONTENT, ""));
+                asyncResponse.resume(buildNoContentResponse());
             } else {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found"));
             }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
@@ -264,7 +264,7 @@ public class TradeRestApi extends RestApiBase {
                         handleSellerConfirmBtcSent(channel, trade, tradeEvent, paymentRail, userName);
                 case BTC_CONFIRMED -> handleBtcConfirmed(channel, trade, paymentRail, userName);
             }
-            asyncResponse.resume(buildResponse(Response.Status.NO_CONTENT, ""));
+            asyncResponse.resume(buildNoContentResponse());
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
@@ -408,7 +408,7 @@ public class TradeRestApi extends RestApiBase {
 
             bisqEasyMediationRequestService.requestMediation(channel, contract);
 
-            asyncResponse.resume(buildResponse(Response.Status.NO_CONTENT, ""));
+            asyncResponse.resume(buildNoContentResponse());
         } catch (NoSuchElementException e) {
             asyncResponse.resume(buildResponse(Response.Status.CONFLICT, "No mediator found for this trade."));
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/4306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency in REST API response handling by consolidating how empty content responses are constructed across multiple endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->