### PR TITLE
Add new fields to mu sig mediation details and nr of cases.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/details/BisqEasyMediationCaseDetailsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/details/BisqEasyMediationCaseDetailsModel.java
@@ -43,6 +43,16 @@ public class BisqEasyMediationCaseDetailsModel extends NavigationModel {
     private String tradeId;
     private String buyerUserName;
     private String sellerUserName;
+    private String buyerBotId;
+    private String buyerUserId;
+    private int buyerCaseCountTotal;
+    private int buyerCaseCountOpen;
+    private int buyerCaseCountClosed;
+    private String sellerBotId;
+    private String sellerUserId;
+    private int sellerCaseCountTotal;
+    private int sellerCaseCountOpen;
+    private int sellerCaseCountClosed;
     private String buyerNetworkAddress;
     private String sellerNetworkAddress;
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/details/BisqEasyMediationCaseDetailsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/details/BisqEasyMediationCaseDetailsView.java
@@ -29,6 +29,7 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -180,8 +181,22 @@ public class BisqEasyMediationCaseDetailsView extends NavigationView<VBox, BisqE
 
     @Override
     protected void onViewAttached() {
-        buyerUserNameLabel.setText(model.getBuyerUserName());
-        sellerUserNameLabel.setText(model.getSellerUserName());
+        buyerUserNameLabel.setText(String.format("%s (%d)", model.getBuyerUserName(), model.getBuyerCaseCountTotal()));
+        sellerUserNameLabel.setText(String.format("%s (%d)", model.getSellerUserName(), model.getSellerCaseCountTotal()));
+        buyerUserNameLabel.setTooltip(new Tooltip(Res.get(
+                "authorizedRole.mediator.caseCounts.tooltip",
+                model.getBuyerBotId(),
+                model.getBuyerUserId(),
+                model.getBuyerCaseCountOpen(),
+                model.getBuyerCaseCountClosed()
+        )));
+        sellerUserNameLabel.setTooltip(new Tooltip(Res.get(
+                "authorizedRole.mediator.caseCounts.tooltip",
+                model.getSellerBotId(),
+                model.getSellerUserId(),
+                model.getSellerCaseCountOpen(),
+                model.getSellerCaseCountClosed()
+        )));
         tradeDateLabel.setText(model.getTradeDate());
         offerTypeLabel.setText(model.getOfferType());
         marketLabel.setText(model.getMarket());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/details/MuSigMediationCaseDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/details/MuSigMediationCaseDetailsController.java
@@ -33,15 +33,18 @@ import bisq.offer.price.spec.PriceSpecFormatter;
 import bisq.presentation.formatters.DateFormatter;
 import bisq.presentation.formatters.PriceFormatter;
 import bisq.support.mediation.mu_sig.MuSigMediationCase;
+import bisq.support.mediation.mu_sig.MuSigMediatorService;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
 import bisq.trade.mu_sig.MuSigTradeFormatter;
 import bisq.trade.mu_sig.MuSigTradeUtils;
+import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class MuSigMediationCaseDetailsController extends NavigationController implements InitWithDataController<MuSigMediationCaseDetailsController.InitData> {
@@ -60,6 +63,7 @@ public class MuSigMediationCaseDetailsController extends NavigationController im
     private final MuSigMediationCaseDetailsModel model;
     @Getter
     private final MuSigMediationCaseDetailsView view;
+    private final MuSigMediatorService muSigMediatorService;
 
 
     public MuSigMediationCaseDetailsController(ServiceProvider serviceProvider) {
@@ -67,6 +71,7 @@ public class MuSigMediationCaseDetailsController extends NavigationController im
 
         model = new MuSigMediationCaseDetailsModel();
         view = new MuSigMediationCaseDetailsView(model, this);
+        muSigMediatorService = serviceProvider.getSupportService().getMuSigMediatorService();
     }
 
     @Override
@@ -91,6 +96,10 @@ public class MuSigMediationCaseDetailsController extends NavigationController im
                 : Res.get("bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.sellOffer"));
         model.setMarket(Res.get("bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.fiatMarket",
                 offer.getMarket().getQuoteCurrencyCode()));
+        model.setBuyerSecurityDeposit(Res.get("bisqEasy.openTrades.tradeDetails.dataNotYetProvided"));
+        model.setBuyerSecurityDepositEmpty(true);
+        model.setSellerSecurityDeposit(Res.get("bisqEasy.openTrades.tradeDetails.dataNotYetProvided"));
+        model.setSellerSecurityDepositEmpty(true);
         model.setFiatAmount(MuSigTradeFormatter.formatQuoteSideAmount(contract));
         model.setFiatCurrency(offer.getMarket().getQuoteCurrencyCode());
         model.setBtcAmount(MuSigTradeFormatter.formatBaseSideAmount(contract));
@@ -101,14 +110,28 @@ public class MuSigMediationCaseDetailsController extends NavigationController im
                 : String.format("(%s)", PriceSpecFormatter.getFormattedPriceSpec(offer.getPriceSpec(), true)));
         model.setPaymentMethod(contract.getQuoteSidePaymentMethodSpec().getShortDisplayString());
         model.setSettlementMethod(contract.getBaseSidePaymentMethodSpec().getShortDisplayString());
+        model.setDepositTxId(Res.get("bisqEasy.openTrades.tradeDetails.dataNotYetProvided"));
+        model.setDepositTxIdEmpty(true);
         model.setTradeId(tradeId);
 
         MuSigMediationCaseListItem.Trader maker = muSigMediationCaseListItem.getMaker();
         MuSigMediationCaseListItem.Trader taker = muSigMediationCaseListItem.getTaker();
         MuSigMediationCaseListItem.Trader buyer = offer.getDirection().isBuy() ? maker : taker;
         MuSigMediationCaseListItem.Trader seller = offer.getDirection().isSell() ? maker : taker;
+        CaseCounts buyerCaseCounts = getCaseCounts(buyer.getUserProfile());
+        CaseCounts sellerCaseCounts = getCaseCounts(seller.getUserProfile());
         model.setBuyerUserName(buyer.getUserName());
         model.setSellerUserName(seller.getUserName());
+        model.setBuyerBotId(buyer.getUserProfile().getNym());
+        model.setBuyerUserId(buyer.getUserProfile().getId());
+        model.setBuyerCaseCountTotal(buyerCaseCounts.total());
+        model.setBuyerCaseCountOpen(buyerCaseCounts.open());
+        model.setBuyerCaseCountClosed(buyerCaseCounts.closed());
+        model.setSellerBotId(seller.getUserProfile().getNym());
+        model.setSellerUserId(seller.getUserProfile().getId());
+        model.setSellerCaseCountTotal(sellerCaseCounts.total());
+        model.setSellerCaseCountOpen(sellerCaseCounts.open());
+        model.setSellerCaseCountClosed(sellerCaseCounts.closed());
         model.setBuyerNetworkAddress(buyer.getUserProfile().getAddressByTransportDisplayString(50));
         model.setSellerNetworkAddress(seller.getUserProfile().getAddressByTransportDisplayString(50));
     }
@@ -124,5 +147,21 @@ public class MuSigMediationCaseDetailsController extends NavigationController im
 
     void onClose() {
         OverlayController.hide();
+    }
+
+    private CaseCounts getCaseCounts(UserProfile userProfile) {
+        var counts = muSigMediatorService.getMediationCases().stream()
+                .filter(mediationCase -> {
+                    MuSigMediationRequest request = mediationCase.getMuSigMediationRequest();
+                    return userProfile.equals(request.getRequester()) || userProfile.equals(request.getPeer());
+                })
+                .collect(Collectors.partitioningBy(mediationCase -> mediationCase.getIsClosed().get(),
+                        Collectors.counting()));
+        int closed = counts.getOrDefault(true, 0L).intValue();
+        int open = counts.getOrDefault(false, 0L).intValue();
+        return new CaseCounts(open + closed, open, closed);
+    }
+
+    private record CaseCounts(int total, int open, int closed) {
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/details/MuSigMediationCaseDetailsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/details/MuSigMediationCaseDetailsModel.java
@@ -32,6 +32,10 @@ public class MuSigMediationCaseDetailsModel extends NavigationModel {
     private String tradeDate;
     private String offerType;
     private String market;
+    private String buyerSecurityDeposit;
+    private boolean isBuyerSecurityDepositEmpty;
+    private String sellerSecurityDeposit;
+    private boolean isSellerSecurityDepositEmpty;
     private String fiatAmount;
     private String fiatCurrency;
     private String btcAmount;
@@ -40,9 +44,21 @@ public class MuSigMediationCaseDetailsModel extends NavigationModel {
     private String priceSpec;
     private String paymentMethod;
     private String settlementMethod;
+    private String depositTxId;
+    private boolean isDepositTxIdEmpty;
     private String tradeId;
     private String buyerUserName;
     private String sellerUserName;
+    private String buyerBotId;
+    private String buyerUserId;
+    private int buyerCaseCountTotal;
+    private int buyerCaseCountOpen;
+    private int buyerCaseCountClosed;
+    private String sellerBotId;
+    private String sellerUserId;
+    private int sellerCaseCountTotal;
+    private int sellerCaseCountOpen;
+    private int sellerCaseCountClosed;
     private String buyerNetworkAddress;
     private String sellerNetworkAddress;
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/details/MuSigMediationCaseDetailsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/details/MuSigMediationCaseDetailsView.java
@@ -29,6 +29,7 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
@@ -40,12 +41,14 @@ import java.util.Optional;
 @Slf4j
 public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMediationCaseDetailsModel, MuSigMediationCaseDetailsController> {
     private final Button closeButton;
-    private final Label tradeDateLabel, offerTypeLabel, marketLabel, fiatAmountLabel,
+    private final Label tradeDateLabel, offerTypeLabel, marketLabel, buyerSecurityDepositLabel, sellerSecurityDepositLabel, fiatAmountLabel,
             fiatCurrencyLabel, btcAmountLabel, priceLabel, priceCodesLabel, priceSpecLabel, paymentMethodLabel,
             settlementMethodLabel, tradeIdLabel, buyerNetworkAddressLabel, sellerNetworkAddressLabel,
-            buyerUserNameLabel, sellerUserNameLabel;
-    private final BisqMenuItem tradeIdCopyButton, buyerNetworkAddressCopyButton, sellerNetworkAddressCopyButton,
+            buyerUserNameLabel, sellerUserNameLabel, depositTxTitleLabel, depositTxDetailsLabel;
+    private final BisqMenuItem tradeIdCopyButton, depositTxCopyButton,
+            buyerNetworkAddressCopyButton, sellerNetworkAddressCopyButton,
             buyerUserNameCopyButton, sellerUserNameCopyButton;
+    private final HBox depositTxBox;
 
     public MuSigMediationCaseDetailsView(MuSigMediationCaseDetailsModel model, MuSigMediationCaseDetailsController controller) {
         super(new VBox(), model, controller);
@@ -86,6 +89,16 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
         HBox offerTypeAndMarketBox = createAndGetDescriptionAndValueBox("bisqEasy.openTrades.tradeDetails.offerTypeAndMarket",
                 offerTypeAndMarketDetailsHBox);
 
+        // Security deposits
+        buyerSecurityDepositLabel = getValueLabel();
+        HBox buyerSecurityDepositBox = createAndGetDescriptionAndValueBox(
+                "authorizedRole.mediator.mediationCaseDetails.buyerSecurityDeposit",
+                buyerSecurityDepositLabel);
+        sellerSecurityDepositLabel = getValueLabel();
+        HBox sellerSecurityDepositBox = createAndGetDescriptionAndValueBox(
+                "authorizedRole.mediator.mediationCaseDetails.sellerSecurityDeposit",
+                sellerSecurityDepositLabel);
+
         // Amount and price
         fiatAmountLabel = getValueLabel();
         fiatCurrencyLabel = new Label();
@@ -124,6 +137,13 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
         HBox paymentMethodsBox = createAndGetDescriptionAndValueBox("bisqEasy.openTrades.tradeDetails.paymentAndSettlementMethods",
                 paymentMethodsDetailsHBox);
 
+        // Deposit transaction ID
+        depositTxTitleLabel = getDescriptionLabel("");
+        depositTxDetailsLabel = getValueLabel();
+        depositTxCopyButton = getTradeIdCopyButton("");
+        depositTxBox = createAndGetDescriptionAndValueBox(depositTxTitleLabel,
+                depositTxDetailsLabel, depositTxCopyButton);
+
         // Trade ID
         tradeIdLabel = getValueLabel();
         tradeIdCopyButton = getTradeIdCopyButton(Res.get("bisqEasy.openTrades.tradeDetails.tradeId.copy"));
@@ -159,11 +179,14 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
                 sellerUserNameBox,
                 amountAndPriceBox,
                 paymentMethodsBox,
+                depositTxBox,
                 detailsLabel,
                 detailsLine,
                 tradeIdBox,
                 tradeDateBox,
                 offerTypeAndMarketBox,
+                buyerSecurityDepositBox,
+                sellerSecurityDepositBox,
                 peerNetworkAddressBox,
                 sellerNetworkAddressBox
         );
@@ -171,7 +194,7 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
 
         root.setAlignment(Pos.TOP_CENTER);
         root.setPrefWidth(OverlayModel.WIDTH);
-        root.setPrefHeight(OverlayModel.HEIGHT - 60);
+        root.setPrefHeight(OverlayModel.HEIGHT);
 
         VBox.setMargin(content, new Insets(-40, 80, 0, 80));
         VBox.setVgrow(content, Priority.ALWAYS);
@@ -180,11 +203,27 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
 
     @Override
     protected void onViewAttached() {
-        buyerUserNameLabel.setText(model.getBuyerUserName());
-        sellerUserNameLabel.setText(model.getSellerUserName());
+        buyerUserNameLabel.setText(String.format("%s (%d)", model.getBuyerUserName(), model.getBuyerCaseCountTotal()));
+        sellerUserNameLabel.setText(String.format("%s (%d)", model.getSellerUserName(), model.getSellerCaseCountTotal()));
+        buyerUserNameLabel.setTooltip(new Tooltip(Res.get(
+                "authorizedRole.mediator.caseCounts.tooltip",
+                model.getBuyerBotId(),
+                model.getBuyerUserId(),
+                model.getBuyerCaseCountOpen(),
+                model.getBuyerCaseCountClosed()
+        )));
+        sellerUserNameLabel.setTooltip(new Tooltip(Res.get(
+                "authorizedRole.mediator.caseCounts.tooltip",
+                model.getSellerBotId(),
+                model.getSellerUserId(),
+                model.getSellerCaseCountOpen(),
+                model.getSellerCaseCountClosed()
+        )));
         tradeDateLabel.setText(model.getTradeDate());
         offerTypeLabel.setText(model.getOfferType());
         marketLabel.setText(model.getMarket());
+        buyerSecurityDepositLabel.setText(model.getBuyerSecurityDeposit());
+        sellerSecurityDepositLabel.setText(model.getSellerSecurityDeposit());
         fiatAmountLabel.setText(model.getFiatAmount());
         fiatCurrencyLabel.setText(model.getFiatCurrency());
         btcAmountLabel.setText(model.getBtcAmount());
@@ -194,13 +233,36 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
         paymentMethodLabel.setText(model.getPaymentMethod());
         settlementMethodLabel.setText(model.getSettlementMethod());
         tradeIdLabel.setText(model.getTradeId());
+        depositTxDetailsLabel.setText(model.getDepositTxId());
         buyerNetworkAddressLabel.setText(model.getBuyerNetworkAddress());
         sellerNetworkAddressLabel.setText(model.getSellerNetworkAddress());
+
+        depositTxTitleLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.txId"));
+        depositTxCopyButton.setTooltip(Res.get("bisqEasy.openTrades.tradeDetails.txId.copy"));
+        depositTxCopyButton.setVisible(!model.isDepositTxIdEmpty());
+        depositTxCopyButton.setManaged(!model.isDepositTxIdEmpty());
+        depositTxDetailsLabel.getStyleClass().clear();
+        depositTxDetailsLabel.getStyleClass().add(model.isDepositTxIdEmpty()
+                ? "text-fill-grey-dimmed"
+                : "text-fill-white");
+        depositTxDetailsLabel.getStyleClass().add("normal-text");
+
+        buyerSecurityDepositLabel.getStyleClass().clear();
+        buyerSecurityDepositLabel.getStyleClass().add(model.isBuyerSecurityDepositEmpty()
+                ? "text-fill-grey-dimmed"
+                : "text-fill-white");
+        buyerSecurityDepositLabel.getStyleClass().add("normal-text");
+        sellerSecurityDepositLabel.getStyleClass().clear();
+        sellerSecurityDepositLabel.getStyleClass().add(model.isSellerSecurityDepositEmpty()
+                ? "text-fill-grey-dimmed"
+                : "text-fill-white");
+        sellerSecurityDepositLabel.getStyleClass().add("normal-text");
 
         closeButton.setOnAction(e -> controller.onClose());
         buyerUserNameCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getBuyerUserName()));
         sellerUserNameCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getSellerUserName()));
         tradeIdCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getTradeId()));
+        depositTxCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getDepositTxId()));
         buyerNetworkAddressCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getBuyerNetworkAddress()));
         sellerNetworkAddressCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getSellerNetworkAddress()));
     }
@@ -211,6 +273,7 @@ public class MuSigMediationCaseDetailsView extends NavigationView<VBox, MuSigMed
         buyerUserNameCopyButton.setOnAction(null);
         sellerUserNameCopyButton.setOnAction(null);
         tradeIdCopyButton.setOnAction(null);
+        depositTxCopyButton.setOnAction(null);
         buyerNetworkAddressCopyButton.setOnAction(null);
         sellerNetworkAddressCopyButton.setOnAction(null);
     }

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -79,6 +79,9 @@ authorizedRole.mediator.mediationCaseDetails.buyerUserName=Buyer's username
 authorizedRole.mediator.mediationCaseDetails.sellerUserName=Seller's username
 authorizedRole.mediator.mediationCaseDetails.buyerUserName.copy=Copy buyer's username
 authorizedRole.mediator.mediationCaseDetails.sellerUserName.copy=Copy seller's username
+authorizedRole.mediator.caseCounts.tooltip=Bot ID: {0}\nUser ID: {1}\nNr. open cases: {2}\nNr. closed cases: {3}
+authorizedRole.mediator.mediationCaseDetails.buyerSecurityDeposit=Buyer's security deposit
+authorizedRole.mediator.mediationCaseDetails.sellerSecurityDeposit=Seller's security deposit
 
 ################################################################################
 ################################################################################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mediators can now view mediation case statistics (total, open, and closed case counts) for both buyers and sellers in case details.
  * Enhanced UI displays participant case counts in labels with tooltips showing Bot IDs, User IDs, and case breakdown.
  * Added security deposit and deposit transaction information display for MuSig mediation cases with improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->