### PR TITLE
Refactor payment account endpoints to use query parameters and allow special characters in account names

### DIFF
--- a/http-api/src/main/java/bisq/dto/DtoMappings.java
+++ b/http-api/src/main/java/bisq/dto/DtoMappings.java
@@ -1132,7 +1132,18 @@ public class DtoMappings {
 
     // paymentaccount
     public static class UserDefinedFiatAccountMapping {
+        private static final int MIN_ACCOUNT_NAME_LENGTH = 2;
+        private static final int MAX_ACCOUNT_NAME_LENGTH = 20;
+
         public static UserDefinedFiatAccount toBisq2Model(UserDefinedFiatAccountDto dto) {
+            // Validate account name
+            String accountName = dto.accountName();
+            if (accountName == null || accountName.trim().length() < MIN_ACCOUNT_NAME_LENGTH || accountName.length() > MAX_ACCOUNT_NAME_LENGTH) {
+                throw new IllegalArgumentException(
+                        "Account name must be between " + MIN_ACCOUNT_NAME_LENGTH + " and " + MAX_ACCOUNT_NAME_LENGTH + " characters");
+            }
+
+            // Validate account data
             String accountData = dto.accountPayload().accountData();
             if (accountData == null || accountData.isEmpty()) {
                 throw new IllegalArgumentException("Account data cannot be empty");
@@ -1149,7 +1160,7 @@ public class DtoMappings {
             return new UserDefinedFiatAccount(
                     StringUtils.createUid(),
                     System.currentTimeMillis(),
-                    dto.accountName(),
+                    accountName,
                     accountPayload
             );
         }

--- a/http-api/src/main/java/bisq/http_api/validator/RequestValidator.java
+++ b/http-api/src/main/java/bisq/http_api/validator/RequestValidator.java
@@ -9,11 +9,11 @@ import java.util.regex.Pattern;
 
 @Slf4j
 public class RequestValidator {
-    // Only allow alphanumeric characters and some special characters like /, -, _, .
-    // ~, and : chars are used in i2p addresses
+    // Allow all printable characters in query strings
+    // Block only control characters (newlines, tabs, null bytes, etc.) for security
     // Path traversal is blocked separately
-    private static final Pattern DEFAULT_SAFE_PATH = Pattern.compile("^[a-zA-Z0-9/_\\-,.:=~]*$");
-    private static final Pattern DEFAULT_SAFE_QUERY = Pattern.compile("^[a-zA-Z0-9/_\\-,.:?&=~]*$");
+    private static final Pattern DEFAULT_SAFE_PATH = Pattern.compile("^[a-zA-Z0-9/_\\-,.:=~ ]*$");
+    private static final Pattern DEFAULT_SAFE_QUERY = Pattern.compile("^[^\\p{Cc}]*$");
 
     private final Set<Pattern> endpointWhitelistPatterns;
     private final Set<Pattern> endpointBlacklistPatterns;

--- a/http-api/src/test/java/bisq/http_api/validator/RequestValidatorIsValidPathTest.java
+++ b/http-api/src/test/java/bisq/http_api/validator/RequestValidatorIsValidPathTest.java
@@ -113,4 +113,14 @@ class RequestValidatorIsValidPathTest {
         RequestValidator validator = new RequestValidator(List.of(), List.of("/blocked"));
         assertTrue(validator.isValidUri("/allowed"));
     }
+
+    @Test
+    void testValidPathWithSpaces() {
+        RequestValidator validator = new RequestValidator(List.of(), List.of());
+        // Spaces must be URL-encoded as %20 in the URI string.
+        // The URI class decodes them to actual spaces when getPath() is called.
+        assertTrue(validator.isValidUri("/api/v1/payment-accounts/fiat/test%201"));
+        assertTrue(validator.isValidUri("/foo/bar%20baz"));
+        assertTrue(validator.isValidUri("/path%20with/multiple%20spaces"));
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added account name validation with character length restrictions (2-20 characters).
  * Account management endpoints now accept account names as query parameters instead of path parameters.
  * Added input validation for account operations with appropriate error responses for missing or invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->