### PR TITLE
Add AliPay and WeChatPay

### DIFF
--- a/account/src/main/java/bisq/account/accounts/fiat/AliPayAccount.java
+++ b/account/src/main/java/bisq/account/accounts/fiat/AliPayAccount.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.accounts.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.timestamp.KeyAlgorithm;
+import bisq.security.keys.KeyPairProtoUtil;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.KeyPair;
+
+@Getter
+@Slf4j
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public final class AliPayAccount extends CountryBasedAccount<AliPayAccountPayload> {
+    public AliPayAccount(String id,
+                         long creationDate,
+                         String accountName,
+                         AliPayAccountPayload accountPayload,
+                         KeyPair keyPair,
+                         KeyAlgorithm keyAlgorithm,
+                         AccountOrigin accountOrigin) {
+        super(id, creationDate, accountName, accountPayload, keyPair, keyAlgorithm, accountOrigin);
+    }
+
+    @Override
+    protected bisq.account.protobuf.CountryBasedAccount.Builder getCountryBasedAccountBuilder(boolean serializeForHash) {
+        return super.getCountryBasedAccountBuilder(serializeForHash)
+                .setAliPayAccount(toAliPayAccountProto(serializeForHash));
+    }
+
+    private bisq.account.protobuf.AliPayAccount toAliPayAccountProto(boolean serializeForHash) {
+        return resolveBuilder(getAliPayAccountBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    private bisq.account.protobuf.AliPayAccount.Builder getAliPayAccountBuilder(boolean serializeForHash) {
+        return bisq.account.protobuf.AliPayAccount.newBuilder();
+    }
+
+    public static AliPayAccount fromProto(bisq.account.protobuf.Account proto) {
+        KeyAlgorithm keyAlgorithm = KeyAlgorithm.fromProto(proto.getKeyAlgorithm());
+        AccountOrigin accountOrigin = AccountOrigin.fromProto(proto.getAccountOrigin());
+        return new AliPayAccount(proto.getId(),
+                proto.getCreationDate(),
+                proto.getAccountName(),
+                AliPayAccountPayload.fromProto(proto.getAccountPayload()),
+                KeyPairProtoUtil.fromProto(proto.getKeyPair(), keyAlgorithm.getAlgorithm()),
+                keyAlgorithm,
+                accountOrigin);
+    }
+}

--- a/account/src/main/java/bisq/account/accounts/fiat/AliPayAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/fiat/AliPayAccountPayload.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.accounts.fiat;
+
+import bisq.account.accounts.SingleCurrencyAccountPayload;
+import bisq.account.accounts.util.AccountDataDisplayStringBuilder;
+import bisq.account.accounts.util.AccountUtils;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.util.ByteArrayUtils;
+import bisq.common.validation.NetworkDataValidation;
+import bisq.i18n.Res;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@Slf4j
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public final class AliPayAccountPayload extends CountryBasedAccountPayload implements SingleCurrencyAccountPayload {
+    public static final int ACCOUNT_NR_MIN_LENGTH = 1;
+    public static final int ACCOUNT_NR_MAX_LENGTH = 50;
+
+    private final String accountNr;
+
+    public AliPayAccountPayload(String id, String accountNr) {
+        this(id, AccountUtils.generateSalt(), accountNr);
+    }
+
+    public AliPayAccountPayload(String id, byte[] salt, String accountNr) {
+        super(id, salt, "CN");
+        this.accountNr = accountNr;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+
+        NetworkDataValidation.validateRequiredText(accountNr, ACCOUNT_NR_MIN_LENGTH, ACCOUNT_NR_MAX_LENGTH);
+    }
+
+    @Override
+    protected bisq.account.protobuf.CountryBasedAccountPayload.Builder getCountryBasedAccountPayloadBuilder(boolean serializeForHash) {
+        return super.getCountryBasedAccountPayloadBuilder(serializeForHash)
+                .setAliPayAccountPayload(toAliPayAccountPayloadProto(serializeForHash));
+    }
+
+    private bisq.account.protobuf.AliPayAccountPayload toAliPayAccountPayloadProto(boolean serializeForHash) {
+        return resolveBuilder(getAliPayAccountPayloadBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    private bisq.account.protobuf.AliPayAccountPayload.Builder getAliPayAccountPayloadBuilder(boolean serializeForHash) {
+        return bisq.account.protobuf.AliPayAccountPayload.newBuilder()
+                .setAccountNr(accountNr);
+    }
+
+    public static AliPayAccountPayload fromProto(bisq.account.protobuf.AccountPayload proto) {
+        var payload = proto.getCountryBasedAccountPayload().getAliPayAccountPayload();
+        return new AliPayAccountPayload(
+                proto.getId(),
+                proto.getSalt().toByteArray(),
+                payload.getAccountNr()
+        );
+    }
+
+    @Override
+    public FiatPaymentMethod getPaymentMethod() {
+        return FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ALI_PAY);
+    }
+
+    @Override
+    public String getAccountDataDisplayString() {
+        return new AccountDataDisplayStringBuilder(
+                Res.get("paymentAccounts.accountNr"), accountNr
+        ).toString();
+    }
+
+    @Override
+    public byte[] getFingerprint() {
+        byte[] data = accountNr.getBytes(StandardCharsets.UTF_8);
+        // We do not call super.getFingerprint(data) to not include the countryCode to stay compatible with
+        // Bisq 1 account age fingerprint.
+        String paymentMethodId = getBisq1CompatiblePaymentMethodId();
+        return ByteArrayUtils.concat(paymentMethodId.getBytes(StandardCharsets.UTF_8), data);
+    }
+}

--- a/account/src/main/java/bisq/account/accounts/fiat/CountryBasedAccount.java
+++ b/account/src/main/java/bisq/account/accounts/fiat/CountryBasedAccount.java
@@ -75,6 +75,8 @@ public abstract class CountryBasedAccount<P extends CountryBasedAccountPayload> 
             case FASTERPAYMENTSACCOUNT -> FasterPaymentsAccount.fromProto(proto);
             case IMPSACCOUNT -> ImpsAccount.fromProto(proto);
             case NEFTACCOUNT -> NeftAccount.fromProto(proto);
+            case ALIPAYACCOUNT -> AliPayAccount.fromProto(proto);
+            case WECHATPAYACCOUNT -> WeChatPayAccount.fromProto(proto);
             case MESSAGE_NOT_SET -> throw new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", proto);
         };
     }

--- a/account/src/main/java/bisq/account/accounts/fiat/CountryBasedAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/fiat/CountryBasedAccountPayload.java
@@ -82,6 +82,8 @@ public abstract class CountryBasedAccountPayload extends AccountPayload<FiatPaym
             case SBPACCOUNTPAYLOAD -> SbpAccountPayload.fromProto(proto);
             case IMPSACCOUNTPAYLOAD -> ImpsAccountPayload.fromProto(proto);
             case NEFTACCOUNTPAYLOAD -> NeftAccountPayload.fromProto(proto);
+            case ALIPAYACCOUNTPAYLOAD -> AliPayAccountPayload.fromProto(proto);
+            case WECHATPAYACCOUNTPAYLOAD -> WeChatPayAccountPayload.fromProto(proto);
             case MESSAGE_NOT_SET -> throw new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", proto);
         };
     }

--- a/account/src/main/java/bisq/account/accounts/fiat/WeChatPayAccount.java
+++ b/account/src/main/java/bisq/account/accounts/fiat/WeChatPayAccount.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.accounts.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.timestamp.KeyAlgorithm;
+import bisq.security.keys.KeyPairProtoUtil;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.KeyPair;
+
+@Getter
+@Slf4j
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public final class WeChatPayAccount extends CountryBasedAccount<WeChatPayAccountPayload> {
+    public WeChatPayAccount(String id,
+                            long creationDate,
+                            String accountName,
+                            WeChatPayAccountPayload accountPayload,
+                            KeyPair keyPair,
+                            KeyAlgorithm keyAlgorithm,
+                            AccountOrigin accountOrigin) {
+        super(id, creationDate, accountName, accountPayload, keyPair, keyAlgorithm, accountOrigin);
+    }
+
+    @Override
+    protected bisq.account.protobuf.CountryBasedAccount.Builder getCountryBasedAccountBuilder(boolean serializeForHash) {
+        return super.getCountryBasedAccountBuilder(serializeForHash)
+                .setWeChatPayAccount(toWeChatPayAccountProto(serializeForHash));
+    }
+
+    private bisq.account.protobuf.WeChatPayAccount toWeChatPayAccountProto(boolean serializeForHash) {
+        return resolveBuilder(getWeChatPayAccountBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    private bisq.account.protobuf.WeChatPayAccount.Builder getWeChatPayAccountBuilder(boolean serializeForHash) {
+        return bisq.account.protobuf.WeChatPayAccount.newBuilder();
+    }
+
+    public static WeChatPayAccount fromProto(bisq.account.protobuf.Account proto) {
+        KeyAlgorithm keyAlgorithm = KeyAlgorithm.fromProto(proto.getKeyAlgorithm());
+        AccountOrigin accountOrigin = AccountOrigin.fromProto(proto.getAccountOrigin());
+        return new WeChatPayAccount(proto.getId(),
+                proto.getCreationDate(),
+                proto.getAccountName(),
+                WeChatPayAccountPayload.fromProto(proto.getAccountPayload()),
+                KeyPairProtoUtil.fromProto(proto.getKeyPair(), keyAlgorithm.getAlgorithm()),
+                keyAlgorithm,
+                accountOrigin);
+    }
+}

--- a/account/src/main/java/bisq/account/accounts/fiat/WeChatPayAccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/fiat/WeChatPayAccountPayload.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.accounts.fiat;
+
+import bisq.account.accounts.SingleCurrencyAccountPayload;
+import bisq.account.accounts.util.AccountDataDisplayStringBuilder;
+import bisq.account.accounts.util.AccountUtils;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.util.ByteArrayUtils;
+import bisq.common.validation.NetworkDataValidation;
+import bisq.i18n.Res;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@Slf4j
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public final class WeChatPayAccountPayload extends CountryBasedAccountPayload implements SingleCurrencyAccountPayload {
+    public static final int ACCOUNT_NR_MIN_LENGTH = 1;
+    public static final int ACCOUNT_NR_MAX_LENGTH = 50;
+
+    private final String accountNr;
+
+    public WeChatPayAccountPayload(String id, String accountNr) {
+        this(id, AccountUtils.generateSalt(), accountNr);
+    }
+
+    public WeChatPayAccountPayload(String id, byte[] salt, String accountNr) {
+        super(id, salt, "CN");
+        this.accountNr = accountNr;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+
+        NetworkDataValidation.validateRequiredText(accountNr, ACCOUNT_NR_MIN_LENGTH, ACCOUNT_NR_MAX_LENGTH);
+    }
+
+    @Override
+    protected bisq.account.protobuf.CountryBasedAccountPayload.Builder getCountryBasedAccountPayloadBuilder(boolean serializeForHash) {
+        return super.getCountryBasedAccountPayloadBuilder(serializeForHash)
+                .setWeChatPayAccountPayload(toWeChatPayAccountPayloadProto(serializeForHash));
+    }
+
+    private bisq.account.protobuf.WeChatPayAccountPayload toWeChatPayAccountPayloadProto(boolean serializeForHash) {
+        return resolveBuilder(getWeChatPayAccountPayloadBuilder(serializeForHash), serializeForHash).build();
+    }
+
+    private bisq.account.protobuf.WeChatPayAccountPayload.Builder getWeChatPayAccountPayloadBuilder(boolean serializeForHash) {
+        return bisq.account.protobuf.WeChatPayAccountPayload.newBuilder()
+                .setAccountNr(accountNr);
+    }
+
+    public static WeChatPayAccountPayload fromProto(bisq.account.protobuf.AccountPayload proto) {
+        var payload = proto.getCountryBasedAccountPayload().getWeChatPayAccountPayload();
+        return new WeChatPayAccountPayload(
+                proto.getId(),
+                proto.getSalt().toByteArray(),
+                payload.getAccountNr()
+        );
+    }
+
+    @Override
+    public FiatPaymentMethod getPaymentMethod() {
+        return FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.WECHAT_PAY);
+    }
+
+    @Override
+    public String getAccountDataDisplayString() {
+        return new AccountDataDisplayStringBuilder(
+                Res.get("paymentAccounts.accountNr"), accountNr
+        ).toString();
+    }
+
+    @Override
+    public byte[] getFingerprint() {
+        byte[] data = accountNr.getBytes(StandardCharsets.UTF_8);
+        // We do not call super.getFingerprint(data) to not include the countryCode to stay compatible with
+        // Bisq 1 account age fingerprint.
+        String paymentMethodId = getBisq1CompatiblePaymentMethodId();
+        return ByteArrayUtils.concat(paymentMethodId.getBytes(StandardCharsets.UTF_8), data);
+    }
+}

--- a/account/src/main/java/bisq/account/bisq1_import/ImportBisq1AccountsParser.java
+++ b/account/src/main/java/bisq/account/bisq1_import/ImportBisq1AccountsParser.java
@@ -22,6 +22,7 @@ import bisq.account.bisq1_import.crypto.ImportMoneroAccountParser;
 import bisq.account.bisq1_import.crypto.ImportOtherCryptoAssetAccountParser;
 import bisq.account.bisq1_import.fiat.ImportAchTransferAccountParser;
 import bisq.account.bisq1_import.fiat.ImportAdvancedCashAccountParser;
+import bisq.account.bisq1_import.fiat.ImportAliPayAccountParser;
 import bisq.account.bisq1_import.fiat.ImportAmazonGiftCardAccountParser;
 import bisq.account.bisq1_import.fiat.ImportBizumAccountParser;
 import bisq.account.bisq1_import.fiat.ImportCashByMailAccountParser;
@@ -55,6 +56,7 @@ import bisq.account.bisq1_import.fiat.ImportUSPostalMoneyOrderAccountParser;
 import bisq.account.bisq1_import.fiat.ImportUpholdAccountParser;
 import bisq.account.bisq1_import.fiat.ImportUpiAccountParser;
 import bisq.account.bisq1_import.fiat.ImportVerseAccountParser;
+import bisq.account.bisq1_import.fiat.ImportWeChatPayAccountParser;
 import bisq.account.bisq1_import.fiat.ImportWiseAccountParser;
 import bisq.account.bisq1_import.fiat.ImportWiseUsdAccountParser;
 import bisq.account.bisq1_import.fiat.ImportZelleAccountParser;
@@ -119,6 +121,7 @@ public class ImportBisq1AccountsParser {
         return switch (paymentMethodId) {
             case "ACH_TRANSFER" -> new ImportAchTransferAccountParser(accountNode).parse(dsaKeyPair);
             case "ADVANCED_CASH" -> new ImportAdvancedCashAccountParser(accountNode).parse(dsaKeyPair);
+            case "ALI_PAY" -> new ImportAliPayAccountParser(accountNode).parse(dsaKeyPair);
             case "AMAZON_GIFT_CARD" -> new ImportAmazonGiftCardAccountParser(accountNode).parse(dsaKeyPair);
             case "AUSTRALIA_PAYID" -> new ImportPayIdAccountParser(accountNode).parse(dsaKeyPair);
             case "BIZUM" -> new ImportBizumAccountParser(accountNode).parse(dsaKeyPair);
@@ -156,6 +159,7 @@ public class ImportBisq1AccountsParser {
             case "UPI" -> new ImportUpiAccountParser(accountNode).parse(dsaKeyPair);
             case "US_POSTAL_MONEY_ORDER" -> new ImportUSPostalMoneyOrderAccountParser(accountNode).parse(dsaKeyPair);
             case "VERSE" -> new ImportVerseAccountParser(accountNode).parse(dsaKeyPair);
+            case "WECHAT_PAY" -> new ImportWeChatPayAccountParser(accountNode).parse(dsaKeyPair);
 
             case "BLOCK_CHAINS" -> {
                 JsonNode selectedTradeCurrencyNode = ImportAccountParser.requireNode(accountNode, "selectedTradeCurrency");

--- a/account/src/main/java/bisq/account/bisq1_import/fiat/ImportAliPayAccountParser.java
+++ b/account/src/main/java/bisq/account/bisq1_import/fiat/ImportAliPayAccountParser.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.bisq1_import.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.AliPayAccount;
+import bisq.account.accounts.fiat.AliPayAccountPayload;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.timestamp.KeyAlgorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.KeyPair;
+
+@Slf4j
+public final class ImportAliPayAccountParser extends ImportFiatAccountParser<FiatPaymentMethod, AliPayAccountPayload> {
+
+    public ImportAliPayAccountParser(JsonNode accountNode) {
+        super(accountNode);
+    }
+
+    @Override
+    public AliPayAccount parse(KeyPair dsaKeyPair) {
+        String accountNr = requireText(paymentAccountPayloadNode, "accountNr");
+        AliPayAccountPayload accountPayload = new AliPayAccountPayload(
+                paymentAccountPayloadId,
+                salt,
+                accountNr);
+
+        return new AliPayAccount(id,
+                creationDate,
+                accountName,
+                accountPayload,
+                dsaKeyPair,
+                KeyAlgorithm.DSA,
+                AccountOrigin.BISQ1_IMPORTED);
+    }
+}

--- a/account/src/main/java/bisq/account/bisq1_import/fiat/ImportWeChatPayAccountParser.java
+++ b/account/src/main/java/bisq/account/bisq1_import/fiat/ImportWeChatPayAccountParser.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.bisq1_import.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.WeChatPayAccount;
+import bisq.account.accounts.fiat.WeChatPayAccountPayload;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.timestamp.KeyAlgorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.KeyPair;
+
+@Slf4j
+public final class ImportWeChatPayAccountParser extends ImportFiatAccountParser<FiatPaymentMethod, WeChatPayAccountPayload> {
+
+    public ImportWeChatPayAccountParser(JsonNode accountNode) {
+        super(accountNode);
+    }
+
+    @Override
+    public WeChatPayAccount parse(KeyPair dsaKeyPair) {
+        String accountNr = requireText(paymentAccountPayloadNode, "accountNr");
+        WeChatPayAccountPayload accountPayload = new WeChatPayAccountPayload(
+                paymentAccountPayloadId,
+                salt,
+                accountNr);
+
+        return new WeChatPayAccount(id,
+                creationDate,
+                accountName,
+                accountPayload,
+                dsaKeyPair,
+                KeyAlgorithm.DSA,
+                AccountOrigin.BISQ1_IMPORTED);
+    }
+}

--- a/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRail.java
@@ -76,7 +76,7 @@ public enum FiatPaymentRail implements PaymentRail {
             FiatCurrencyRepository.getCurrencyByCode("USD"),
             FiatPaymentMethodChargebackRisk.MODERATE),
 
-    // EUR
+    // EUR zone
     SEPA(FiatPaymentRailUtil.getAllSepaCountries(),
             FiatCurrencyRepository.getCurrencyByCode("EUR"),
             FiatPaymentMethodChargebackRisk.MODERATE),
@@ -128,7 +128,7 @@ public enum FiatPaymentRail implements PaymentRail {
             FiatCurrencyRepository.getCurrencyByCode("AUD"),
             FiatPaymentMethodChargebackRisk.LOW),
 
-    // Argentina
+    // Argentina (also other LA countries but not supported yet)
     MERCADO_PAGO(countryFromCode("AR"),
             FiatCurrencyRepository.getCurrencyByCode("ARS"),
             FiatPaymentMethodChargebackRisk.MODERATE),
@@ -139,9 +139,13 @@ public enum FiatPaymentRail implements PaymentRail {
             FiatPaymentMethodChargebackRisk.MODERATE),
 
     // China
-    // Not added yet due lack of language support and low usage
-    // ALI_PAY = new PaymentMethod(ALI_PAY_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
-    // WECHAT_PAY = new PaymentMethod(WECHAT_PAY_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
+    ALI_PAY(countryFromCode("CN"),
+            FiatCurrencyRepository.getCurrencyByCode("CNY"),
+            FiatPaymentMethodChargebackRisk.LOW),
+
+    WECHAT_PAY(countryFromCode("CN"),
+            FiatCurrencyRepository.getCurrencyByCode("CNY"),
+            FiatPaymentMethodChargebackRisk.LOW),
 
     // Thailand
     PROMPT_PAY(countryFromCode("TH"),
@@ -163,14 +167,12 @@ public enum FiatPaymentRail implements PaymentRail {
     NEFT(countryFromCode("IN"),
             FiatCurrencyRepository.getCurrencyByCode("INR"),
             FiatPaymentMethodChargebackRisk.MODERATE),
-    // NEFT = new PaymentMethod(NEFT_ID, DAY, Coin.parseCoin("0.02")),
-    // RTGS = new PaymentMethod(RTGS_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // IMPS = new PaymentMethod(IMPS_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // PAYTM = new PaymentMethod(PAYTM_ID, DAY, Coin.parseCoin("0.05")),
 
 
     // Global
-    // WESTERN_UNION = new PaymentMethod(WESTERN_UNION_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_MID_RISK), N
+    // Not added as low usage and expensive fees
+    // WESTERN_UNION = new PaymentMethod(WESTERN_UNION_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_MID_RISK),
+    // Not added as complex and low usage
     // SPECIFIC_BANKS = new PaymentMethod(SPECIFIC_BANKS_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
 
     CUSTOM(allCountries(),
@@ -254,21 +256,6 @@ public enum FiatPaymentRail implements PaymentRail {
     MONEY_GRAM(FiatPaymentRailUtil.getMoneyGramCountries(),
             FiatPaymentRailUtil.getMoneyGramCurrencies(),
             FiatPaymentMethodChargebackRisk.MEDIUM);
-
-
-    // PERFECT_MONEY = new PaymentMethod(PERFECT_MONEY_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK),
-    // ADVANCED_CASH = new PaymentMethod(ADVANCED_CASH_ID, DAY, DEFAULT_TRADE_LIMIT_VERY_LOW_RISK),
-    // PAYSERA = new PaymentMethod(PAYSERA_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // PAXUM = new PaymentMethod(PAXUM_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-
-
-    // NEQUI = new PaymentMethod(NEQUI_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // CAPITUAL = new PaymentMethod(CAPITUAL_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // CELPAY = new PaymentMethod(CELPAY_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // MONESE = new PaymentMethod(MONESE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // SATISPAY = new PaymentMethod(SATISPAY_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
-    // TIKKIE = new PaymentMethod(TIKKIE_ID, DAY, Coin.parseCoin("0.05")),
-    // VERSE = new PaymentMethod(VERSE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK),
 
     private static List<FiatCurrency> allCurrencies() {
         return FiatCurrencyRepository.getAllCurrencies();
@@ -427,8 +414,10 @@ public enum FiatPaymentRail implements PaymentRail {
             case WISE -> DAYS_4;
             case UPHOLD -> HOURS_24;
             case AMAZON_GIFT_CARD -> DAYS_4;
+            case ALI_PAY -> HOURS_24;
             case MONEY_GRAM -> DAYS_4;
             case HAL_CASH -> HOURS_24;
+            case WECHAT_PAY -> HOURS_24;
         };
     }
 

--- a/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRailUtil.java
+++ b/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRailUtil.java
@@ -532,6 +532,8 @@ public class FiatPaymentRailUtil {
                 Map.entry(FiatPaymentRail.PERFECT_MONEY, 2),
                 Map.entry(FiatPaymentRail.ADVANCED_CASH, 2),
                 Map.entry(FiatPaymentRail.PIN_4, 1), // not in bisq 1, polish version of halcash
+                Map.entry(FiatPaymentRail.ALI_PAY, 1),
+                Map.entry(FiatPaymentRail.WECHAT_PAY, 1),
                 Map.entry(FiatPaymentRail.SATISPAY, 1),
                 Map.entry(FiatPaymentRail.SBP, 1),
                 Map.entry(FiatPaymentRail.MERCADO_PAGO, 1),

--- a/account/src/main/proto/account.proto
+++ b/account/src/main/proto/account.proto
@@ -186,6 +186,8 @@ message CountryBasedAccountPayload {
     SbpAccountPayload sbpAccountPayload = 42;
     ImpsAccountPayload impsAccountPayload = 43;
     NeftAccountPayload neftAccountPayload = 44;
+    AliPayAccountPayload aliPayAccountPayload = 45;
+    WeChatPayAccountPayload weChatPayAccountPayload = 46;
   }
 }
 
@@ -300,6 +302,14 @@ message PixAccountPayload {
 
 message PromptPayAccountPayload {
   string promptPayId = 1;
+}
+
+message AliPayAccountPayload {
+  string accountNr = 1;
+}
+
+message WeChatPayAccountPayload {
+  string accountNr = 1;
 }
 
 message SwishAccountPayload {
@@ -495,6 +505,8 @@ message CountryBasedAccount {
     FasterPaymentsAccount fasterPaymentsAccount = 42;
     ImpsAccount impsAccount = 43;
     NeftAccount neftAccount = 44;
+    AliPayAccount aliPayAccount = 45;
+    WeChatPayAccount weChatPayAccount = 46;
   }
 }
 message HalCashAccount {
@@ -560,6 +572,12 @@ message ImpsAccount {
 }
 
 message NeftAccount {
+}
+
+message AliPayAccount {
+}
+
+message WeChatPayAccount {
 }
 
 message PayIdAccount {

--- a/account/src/test/java/bisq/account/accounts/AccountPayloadFingerprintTest.java
+++ b/account/src/test/java/bisq/account/accounts/AccountPayloadFingerprintTest.java
@@ -4,6 +4,7 @@ import bisq.account.accounts.crypto.MoneroAccountPayload;
 import bisq.account.accounts.crypto.OtherCryptoAssetAccountPayload;
 import bisq.account.accounts.fiat.AchTransferAccountPayload;
 import bisq.account.accounts.fiat.AdvancedCashAccountPayload;
+import bisq.account.accounts.fiat.AliPayAccountPayload;
 import bisq.account.accounts.fiat.AmazonGiftCardAccountPayload;
 import bisq.account.accounts.fiat.BankAccountPayload;
 import bisq.account.accounts.fiat.BankAccountType;
@@ -41,6 +42,7 @@ import bisq.account.accounts.fiat.UpholdAccountPayload;
 import bisq.account.accounts.fiat.UpiAccountPayload;
 import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
 import bisq.account.accounts.fiat.VerseAccountPayload;
+import bisq.account.accounts.fiat.WeChatPayAccountPayload;
 import bisq.account.accounts.fiat.WiseAccountPayload;
 import bisq.account.accounts.fiat.WiseUsdAccountPayload;
 import bisq.account.accounts.fiat.ZelleAccountPayload;
@@ -113,6 +115,20 @@ public class AccountPayloadFingerprintTest {
         // Bisq 1 compatibility: SBP uses mobile number and bank name without country code.
         SbpAccountPayload payload = new SbpAccountPayload("id", SALT, "Alice", "+79161234567", "Sberbank");
         assertArrayEquals(expected("SBP", "+79161234567", "Sberbank"), payload.getFingerprint());
+    }
+
+    @Test
+    void aliPayFingerprintMatchesBisq1() {
+        // Bisq 1 compatibility: AliPay uses account number without country code.
+        AliPayAccountPayload payload = new AliPayAccountPayload("id", SALT, "alipay-123");
+        assertArrayEquals(expected("ALI_PAY", "alipay-123"), payload.getFingerprint());
+    }
+
+    @Test
+    void weChatPayFingerprintMatchesBisq1() {
+        // Bisq 1 compatibility: WeChat Pay uses account number without country code.
+        WeChatPayAccountPayload payload = new WeChatPayAccountPayload("id", SALT, "wechat-456");
+        assertArrayEquals(expected("WECHAT_PAY", "wechat-456"), payload.getFingerprint());
     }
 
     @Test

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/FiatPaymentAccountsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/FiatPaymentAccountsController.java
@@ -290,6 +290,7 @@ public class FiatPaymentAccountsController implements Controller {
         return switch (fiatPaymentRail) {
             case ACH_TRANSFER -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case ADVANCED_CASH -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
+            case ALI_PAY -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case AMAZON_GIFT_CARD -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case BIZUM -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case CASH_APP -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
@@ -329,6 +330,7 @@ public class FiatPaymentAccountsController implements Controller {
             case UPI -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case US_POSTAL_MONEY_ORDER -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case VERSE -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
+            case WECHAT_PAY -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case WISE -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case WISE_USD -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case ZELLE -> new ZelleAccountDetails((ZelleAccount) account, accountTimestampService);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/data/PaymentDataController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/data/PaymentDataController.java
@@ -112,6 +112,7 @@ public class PaymentDataController implements Controller {
         return switch (fiatPaymentRail) {
             case ACH_TRANSFER -> throw new UnsupportedOperationException("Not implemented yet");
             case ADVANCED_CASH -> throw new UnsupportedOperationException("Not implemented yet");
+            case ALI_PAY -> throw new UnsupportedOperationException("Not implemented yet");
             case AMAZON_GIFT_CARD -> throw new UnsupportedOperationException("Not implemented yet");
             case BIZUM -> throw new UnsupportedOperationException("Not implemented yet");
             case CASH_APP -> throw new UnsupportedOperationException("Not implemented yet");
@@ -149,6 +150,7 @@ public class PaymentDataController implements Controller {
             case UPI -> throw new UnsupportedOperationException("Not implemented yet");
             case US_POSTAL_MONEY_ORDER -> throw new UnsupportedOperationException("Not implemented yet");
             case VERSE -> throw new UnsupportedOperationException("Not implemented yet");
+            case WECHAT_PAY -> throw new UnsupportedOperationException("Not implemented yet");
             case WISE -> throw new UnsupportedOperationException("Not implemented yet");
             case WISE_USD -> throw new UnsupportedOperationException("Not implemented yet");
             case ZELLE -> new ZelleFormController(serviceProvider);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/summary/PaymentSummaryController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/summary/PaymentSummaryController.java
@@ -151,6 +151,7 @@ public class PaymentSummaryController implements Controller {
         return switch (fiatPaymentRail) {
             case ACH_TRANSFER -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case ADVANCED_CASH -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
+            case ALI_PAY -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case AMAZON_GIFT_CARD -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case BIZUM -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case CASH_APP -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
@@ -190,6 +191,7 @@ public class PaymentSummaryController implements Controller {
             case UPI -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case US_POSTAL_MONEY_ORDER -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case VERSE -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
+            case WECHAT_PAY -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case WISE -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case WISE_USD -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
             case ZELLE -> new ZelleAccountDetailsGridPane((ZelleAccountPayload) accountPayload, fiatPaymentRail);
@@ -204,6 +206,7 @@ public class PaymentSummaryController implements Controller {
             return switch (fiatPaymentRail) {
                 case ACH_TRANSFER -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case ADVANCED_CASH -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
+                case ALI_PAY -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case AMAZON_GIFT_CARD -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case BIZUM -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case CASH_APP -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
@@ -283,6 +286,7 @@ public class PaymentSummaryController implements Controller {
                 case UPI -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case US_POSTAL_MONEY_ORDER -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case VERSE -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
+                case WECHAT_PAY -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case WISE -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case WISE_USD -> throw new UnsupportedOperationException("Not yet implemented:  " + fiatPaymentRail);
                 case ZELLE ->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added AliPay and WeChat Pay as payment method options supporting Chinese Yuan
- Enabled import of existing AliPay and WeChat Pay accounts from Bisq 1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->