### PR TITLE
Show security deposit on MuSig mediation details view.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/close/MuSigMediationCaseCloseController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/close/MuSigMediationCaseCloseController.java
@@ -95,10 +95,12 @@ public class MuSigMediationCaseCloseController extends NavigationController impl
 
     @Override
     public void onActivate() {
+        model.getCloseCaseButtonDisabled().bind(muSigMediationResultSection.hasRequiredSelectionsProperty().not());
     }
 
     @Override
     public void onDeactivate() {
+        model.getCloseCaseButtonDisabled().unbind();
     }
 
     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/close/MuSigMediationCaseCloseModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/close/MuSigMediationCaseCloseModel.java
@@ -20,6 +20,8 @@ package bisq.desktop.main.content.authorized_role.mediator.mu_sig.close;
 import bisq.desktop.common.view.NavigationModel;
 import bisq.desktop.main.content.authorized_role.mediator.mu_sig.MuSigMediationCaseListItem;
 import bisq.desktop.navigation.NavigationTarget;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MuSigMediationCaseCloseModel extends NavigationModel {
 
     private MuSigMediationCaseListItem muSigMediationCaseListItem;
+    private final BooleanProperty closeCaseButtonDisabled = new SimpleBooleanProperty(true);
 
     @Override
     public NavigationTarget getDefaultNavigationTarget() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/close/MuSigMediationCaseCloseView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/close/MuSigMediationCaseCloseView.java
@@ -90,12 +90,14 @@ public class MuSigMediationCaseCloseView extends NavigationView<VBox, MuSigMedia
 
     @Override
     protected void onViewAttached() {
+        closeCaseButton.disableProperty().bind(model.getCloseCaseButtonDisabled());
         closeButton.setOnAction(e -> controller.onClose());
         closeCaseButton.setOnAction(e -> controller.onCloseCase());
     }
 
     @Override
     protected void onViewDetached() {
+        closeCaseButton.disableProperty().unbind();
         closeButton.setOnAction(null);
         closeCaseButton.setOnAction(null);
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationResultSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationResultSection.java
@@ -27,7 +27,10 @@ import bisq.support.mediation.MediationResultReason;
 import bisq.support.mediation.mu_sig.MuSigMediationCase;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.support.mediation.mu_sig.MuSigMediatorService;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -64,6 +67,10 @@ public class MuSigMediationResultSection {
         controller.closeCase();
     }
 
+    public ReadOnlyBooleanProperty hasRequiredSelectionsProperty() {
+        return controller.getHasRequiredSelections();
+    }
+
     @Slf4j
     private static class Controller implements bisq.desktop.common.view.Controller {
 
@@ -77,10 +84,15 @@ public class MuSigMediationResultSection {
             model = new Model();
             view = new View(new VBox(), model, this);
             muSigMediatorService = serviceProvider.getSupportService().getMuSigMediatorService();
+            model.getHasRequiredSelections().bind(model.getSelectedReason().isNotNull());
         }
 
         private void setMediationCaseListItem(MuSigMediationCaseListItem item) {
             model.setMuSigMediationCaseListItem(item);
+        }
+
+        private ReadOnlyBooleanProperty getHasRequiredSelections() {
+            return model.getHasRequiredSelections();
         }
 
         @Override
@@ -91,6 +103,7 @@ public class MuSigMediationResultSection {
             model.getPayoutTypes().setAll(Model.PayoutType.values());
             model.getReasons().setAll(MediationResultReason.values());
 
+            model.getSelectedPayoutType().set(null);
             model.getSelectedReason().set(null);
 
             model.getSelectedReason().set(
@@ -138,6 +151,7 @@ public class MuSigMediationResultSection {
         private final ObservableList<MediationResultReason> reasons = FXCollections.observableArrayList();
 
         private final StringProperty summaryNotes = new SimpleStringProperty("");
+        private final BooleanProperty hasRequiredSelections = new SimpleBooleanProperty(false);
 
         enum PayoutType {
             CUSTOM_PAYOUT,

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -80,6 +80,7 @@ authorizedRole.mediator.mediationCaseDetails.sellerUserName=Seller's username
 authorizedRole.mediator.mediationCaseDetails.buyerUserName.copy=Copy buyer's username
 authorizedRole.mediator.mediationCaseDetails.sellerUserName.copy=Copy seller's username
 authorizedRole.mediator.mediationCaseDetails.securityDeposit=Security deposit
+authorizedRole.mediator.mediationCaseDetails.securityDepositMismatch=Buyer and seller amounts are not matching
 authorizedRole.mediator.caseCounts.tooltip=Bot ID: {0}\nUser ID: {1}\nNr. open cases: {2}\nNr. closed cases: {3}
 
 authorizedRole.mediator.mediationCaseClose.headline=Close mediation case

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountFormatter.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountFormatter.java
@@ -19,6 +19,7 @@ package bisq.offer.amount;
 
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.market.Market;
+import bisq.common.monetary.Coin;
 import bisq.common.monetary.Monetary;
 import bisq.i18n.Res;
 import bisq.offer.Offer;
@@ -29,6 +30,9 @@ import bisq.presentation.formatters.AmountFormatter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.function.BiFunction;
+
+import static bisq.presentation.formatters.AmountFormatter.formatAmountWithCode;
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 public class OfferAmountFormatter {
@@ -46,7 +50,10 @@ public class OfferAmountFormatter {
         return formatBaseAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket(), offer.hasAmountRange(), withCode, true);
     }
 
-    public static String formatBaseAmount(MarketPriceService marketPriceService, Offer<?, ?> offer, boolean withCode, boolean useLowPrecision) {
+    public static String formatBaseAmount(MarketPriceService marketPriceService,
+                                          Offer<?, ?> offer,
+                                          boolean withCode,
+                                          boolean useLowPrecision) {
         return formatBaseAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket(), offer.hasAmountRange(), withCode, useLowPrecision);
     }
 
@@ -314,6 +321,14 @@ public class OfferAmountFormatter {
                 formatQuoteSideMaxAmount(marketPriceService, amountSpec, priceSpec, market, withCode);
     }
 
+    /* --------------------------------------------------------------------- */
+    // Deposit Amount
+    /* --------------------------------------------------------------------- */
+
+    public static String formatDepositAmountAsBTC(Monetary monetary) {
+        checkArgument(monetary.getCode().equals("BTC"));
+        return formatAmountWithCode(Coin.asBtcFromValue(monetary.getValue()), false);
+    }
 
     /* --------------------------------------------------------------------- */
     // Private

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
@@ -20,8 +20,18 @@ package bisq.offer.amount;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.market.Market;
 import bisq.common.monetary.Monetary;
+import bisq.common.util.MathUtils;
 import bisq.offer.Offer;
-import bisq.offer.amount.spec.*;
+import bisq.offer.amount.spec.AmountSpec;
+import bisq.offer.amount.spec.AmountSpecUtil;
+import bisq.offer.amount.spec.BaseSideAmountSpec;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.amount.spec.BaseSideRangeAmountSpec;
+import bisq.offer.amount.spec.FixedAmountSpec;
+import bisq.offer.amount.spec.QuoteSideAmountSpec;
+import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
+import bisq.offer.amount.spec.QuoteSideRangeAmountSpec;
+import bisq.offer.amount.spec.RangeAmountSpec;
 import bisq.offer.price.PriceUtil;
 import bisq.offer.price.spec.PriceSpec;
 
@@ -258,5 +268,13 @@ public class OfferAmountUtil {
         } else {
             throw new RuntimeException("Unsupported amountSpec: {}" + amountSpec);
         }
+    }
+
+    /* --------------------------------------------------------------------- */
+    // Deposit Amount
+    /* --------------------------------------------------------------------- */
+
+    public static Monetary calculateSecurityDeposit(Monetary monetary, double securityDeposit) {
+        return Monetary.from(MathUtils.roundDoubleToLong(monetary.getValue() * securityDeposit), monetary.getCode());
     }
 }

--- a/offer/src/test/java/bisq/offer/amount/OfferAmountFormatterTest.java
+++ b/offer/src/test/java/bisq/offer/amount/OfferAmountFormatterTest.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.amount;
+
+import bisq.common.locale.LocaleRepository;
+import bisq.common.monetary.Coin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class OfferAmountFormatterTest {
+
+    @BeforeEach
+    void setUp() {
+        LocaleRepository.setDefaultLocale(Locale.US);
+    }
+
+    @Test
+    void formatDepositAmountAsBtcFormatsWithCode() {
+        String formatted = OfferAmountFormatter.formatDepositAmountAsBTC(Coin.asBtcFromValue(123_456_789L));
+        assertEquals("1.23456789 BTC", formatted);
+    }
+
+    @Test
+    void formatDepositAmountAsBtcRejectsNonBtc() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OfferAmountFormatter.formatDepositAmountAsBTC(Coin.asXmrFromValue(1)));
+    }
+}

--- a/offer/src/test/java/bisq/offer/amount/OfferAmountUtilTest.java
+++ b/offer/src/test/java/bisq/offer/amount/OfferAmountUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.amount;
+
+import bisq.common.monetary.Coin;
+import bisq.common.monetary.Monetary;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OfferAmountUtilTest {
+
+    @Test
+    void calculateSecurityDepositUsesPercentageAndCode() {
+        Monetary input = Coin.asBtcFromValue(100_000_000L);
+        Monetary deposit = OfferAmountUtil.calculateSecurityDeposit(input, 0.25);
+        assertEquals("BTC", deposit.getCode());
+        assertEquals(25_000_000L, deposit.getValue());
+    }
+
+    @Test
+    void calculateSecurityDepositRoundsHalfUp() {
+        Monetary input = Coin.asBtcFromValue(3L);
+        Monetary deposit = OfferAmountUtil.calculateSecurityDeposit(input, 0.5);
+        assertEquals(2L, deposit.getValue());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security deposit now shows both BTC amount and percent together in mediation details.

* **Bug Fixes**
  * Close Case button enablement now reflects required selections.
  * Mediation required-selection validation improved.

* **Tests**
  * Added unit tests for deposit formatting and security-deposit calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->