### PR TITLE
Add trade limit to reputation score sources

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab2/AccountAgeScoreSimulation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab2/AccountAgeScoreSimulation.java
@@ -71,7 +71,16 @@ public class AccountAgeScoreSimulation {
                 }
             });
 
-            scorePin = EasyBind.subscribe(model.getAge(), age -> model.getScore().set(calculateSimScore(age)));
+            scorePin = EasyBind.subscribe(model.getAge(), age -> {
+                String score = calculateSimScore(age);
+                model.getScore().set(score);
+                try {
+                    long s = Long.parseLong(score);
+                    model.getTradeLimit().set(String.valueOf(s / 200));
+                } catch (Exception ignore) {
+                    model.getTradeLimit().set("");
+                }
+            });
         }
 
         @Override
@@ -97,6 +106,7 @@ public class AccountAgeScoreSimulation {
         private final IntegerProperty age = new SimpleIntegerProperty();
         private final StringProperty ageAsString = new SimpleStringProperty();
         private final StringProperty score = new SimpleStringProperty();
+        private final StringProperty tradeLimit = new SimpleStringProperty();
     }
 
     private static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
@@ -104,6 +114,7 @@ public class AccountAgeScoreSimulation {
 
         private final AgeSlider simAgeSlider;
         private final MaterialTextField simScore;
+        private final MaterialTextField simTradeLimit;
         private final MaterialTextField ageField;
 
         private View(Model model, Controller controller) {
@@ -114,11 +125,13 @@ public class AccountAgeScoreSimulation {
             ageField = getInputField("reputation.sim.age");
             simAgeSlider = new AgeSlider(0, (int) AccountAgeService.MAX_DAYS_AGE_SCORE, 0);
             simScore = getField(Res.get("reputation.sim.score"));
+            simTradeLimit = getField(Res.get("reputation.sim.tradeLimit"));
             VBox.setMargin(simAgeSlider.getView().getRoot(), new Insets(15, 0, 0, 0));
             root.getChildren().addAll(simHeadline,
                     ageField,
                     simAgeSlider.getView().getRoot(),
-                    simScore);
+                    simScore,
+                    simTradeLimit);
         }
 
         @Override
@@ -126,6 +139,7 @@ public class AccountAgeScoreSimulation {
             simAgeSlider.valueProperty().bindBidirectional(model.getAge());
             ageField.textProperty().bindBidirectional(model.getAgeAsString());
             simScore.textProperty().bind(model.getScore());
+            simTradeLimit.textProperty().bind(model.getTradeLimit());
         }
 
         @Override
@@ -133,6 +147,7 @@ public class AccountAgeScoreSimulation {
             simAgeSlider.valueProperty().unbindBidirectional(model.getAge());
             ageField.textProperty().unbindBidirectional(model.getAgeAsString());
             simScore.textProperty().unbind();
+            simTradeLimit.textProperty().unbind();
         }
 
         private MaterialTextField getField(String description) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab2/AccountAgeTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/accountAge/tab2/AccountAgeTab2View.java
@@ -50,7 +50,11 @@ public class AccountAgeTab2View extends View<VBox, AccountAgeTab2Model, AccountA
 
         Label formulaHeadline = new Label(Res.get("reputation.score.formulaHeadline"));
         formulaHeadline.getStyleClass().addAll("bisq-text-1");
-        VBox formulaBox = new VBox(10, formulaHeadline, getField("weight", String.valueOf(AccountAgeService.WEIGHT)), getField("totalScore"));
+        VBox formulaBox = new VBox(10,
+                formulaHeadline,
+                getField("weight", String.valueOf(AccountAgeService.WEIGHT)),
+                getField("totalScore"),
+                getField("tradeLimit", Res.get("reputation.tradeLimit.formula")));
 
         HBox hBox = new HBox(20, formulaBox, simulation);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab2/BondScoreSimulation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab2/BondScoreSimulation.java
@@ -96,6 +96,7 @@ public class BondScoreSimulation {
                 long totalScore = BondedReputationService.doCalculateScore(amountAsLong, blockTime);
                 String score = String.valueOf(totalScore);
                 model.getScore().set(score);
+                model.getTradeLimit().set(String.valueOf(totalScore / 200));
             } catch (Exception e) {
                 log.error("Failed to calculate simScore", e);
             }
@@ -108,6 +109,7 @@ public class BondScoreSimulation {
         private final IntegerProperty age = new SimpleIntegerProperty();
         private final StringProperty ageAsString = new SimpleStringProperty();
         private final StringProperty score = new SimpleStringProperty();
+        private final StringProperty tradeLimit = new SimpleStringProperty();
     }
 
     private static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
@@ -115,6 +117,7 @@ public class BondScoreSimulation {
 
         private final MaterialTextField amount;
         private final MaterialTextField score;
+        private final MaterialTextField tradeLimit;
         private final AgeSlider simAgeSlider;
         private final MaterialTextField ageField;
 
@@ -125,6 +128,7 @@ public class BondScoreSimulation {
             simHeadline.getStyleClass().addAll("bisq-text-1");
             amount = getInputField("reputation.sim.burnAmount");
             score = getField(Res.get("reputation.sim.score"));
+            tradeLimit = getField(Res.get("reputation.sim.tradeLimit"));
             ageField = getInputField("reputation.sim.age");
             simAgeSlider = new AgeSlider(0, ProofOfBurnService.MAX_AGE_BOOST_DAYS, 0);
             VBox.setMargin(simAgeSlider.getView().getRoot(), new Insets(15, 0, 0, 0));
@@ -132,7 +136,8 @@ public class BondScoreSimulation {
                     amount,
                     ageField,
                     simAgeSlider.getView().getRoot(),
-                    score);
+                    score,
+                    tradeLimit);
         }
 
         @Override
@@ -141,6 +146,7 @@ public class BondScoreSimulation {
             ageField.textProperty().bindBidirectional(model.getAgeAsString());
             amount.textProperty().bindBidirectional(model.getAmount());
             score.textProperty().bind(model.getScore());
+            tradeLimit.textProperty().bind(model.getTradeLimit());
         }
 
         @Override
@@ -149,6 +155,7 @@ public class BondScoreSimulation {
             ageField.textProperty().unbindBidirectional(model.getAgeAsString());
             amount.textProperty().unbindBidirectional(model.getAmount());
             score.textProperty().unbind();
+            tradeLimit.textProperty().unbind();
         }
 
         private MaterialTextField getField(String description) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab2/BondedReputationTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/bond/tab2/BondedReputationTab2View.java
@@ -54,7 +54,8 @@ public class BondedReputationTab2View extends View<VBox, BondedReputationTab2Mod
         formulaHeadline.getStyleClass().addAll("bisq-text-1");
         VBox formulaBox = new VBox(10, formulaHeadline,
                 getField("weight", String.valueOf(BondedReputationService.WEIGHT)),
-                getField("totalScore"));
+                getField("totalScore"),
+                getField("tradeLimit", Res.get("reputation.tradeLimit.formula")));
 
         HBox hBox = new HBox(20, formulaBox, simulation);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab2/BurnBsqTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab2/BurnBsqTab2View.java
@@ -52,7 +52,8 @@ public class BurnBsqTab2View extends View<VBox, BurnBsqTab2Model, BurnBsqTab2Con
         formulaHeadline.getStyleClass().addAll("bisq-text-1");
         VBox formulaBox = new VBox(10, formulaHeadline,
                 getField(Res.get("reputation.weight"), String.valueOf(ProofOfBurnService.WEIGHT)),
-                getFormulaField("totalScore"));
+                getFormulaField("totalScore"),
+                getField(Res.get("reputation.tradeLimit"), Res.get("reputation.tradeLimit.formula")));
 
         HBox hBox = new HBox(20, formulaBox, simulation);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab2/BurnScoreSimulation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/burn/tab2/BurnScoreSimulation.java
@@ -95,6 +95,7 @@ public class BurnScoreSimulation {
                 long totalScore = ProofOfBurnService.doCalculateScore(amountAsLong, blockTime);
                 String score = String.valueOf(totalScore);
                 model.getScore().set(score);
+                model.getTradeLimit().set(String.valueOf(totalScore / 200));
             } catch (Exception e) {
                 log.error("Failed to calculate simScore", e);
             }
@@ -107,6 +108,7 @@ public class BurnScoreSimulation {
         private final IntegerProperty age = new SimpleIntegerProperty();
         private final StringProperty ageAsString = new SimpleStringProperty();
         private final StringProperty score = new SimpleStringProperty();
+        private final StringProperty tradeLimit = new SimpleStringProperty();
     }
 
     private static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
@@ -114,6 +116,7 @@ public class BurnScoreSimulation {
 
         private final MaterialTextField amount;
         private final MaterialTextField score;
+        private final MaterialTextField tradeLimit;
         private final AgeSlider simAgeSlider;
         private final MaterialTextField ageField;
 
@@ -124,6 +127,7 @@ public class BurnScoreSimulation {
             simHeadline.getStyleClass().addAll("bisq-text-1");
             amount = getInputField("reputation.sim.burnAmount");
             score = getField(Res.get("reputation.sim.score"));
+            tradeLimit = getField(Res.get("reputation.sim.tradeLimit"));
             ageField = getInputField("reputation.sim.age");
             simAgeSlider = new AgeSlider(0, ProofOfBurnService.MAX_AGE_BOOST_DAYS, 0);
             VBox.setMargin(simAgeSlider.getView().getRoot(), new Insets(15, 0, 0, 0));
@@ -131,7 +135,8 @@ public class BurnScoreSimulation {
                     amount,
                     ageField,
                     simAgeSlider.getView().getRoot(),
-                    score);
+                    score,
+                    tradeLimit);
         }
 
         @Override
@@ -140,6 +145,7 @@ public class BurnScoreSimulation {
             ageField.textProperty().bindBidirectional(model.getAgeAsString());
             amount.textProperty().bindBidirectional(model.getAmount());
             score.textProperty().bind(model.getScore());
+            tradeLimit.textProperty().bind(model.getTradeLimit());
         }
 
         @Override
@@ -148,6 +154,7 @@ public class BurnScoreSimulation {
             ageField.textProperty().unbindBidirectional(model.getAgeAsString());
             amount.textProperty().unbindBidirectional(model.getAmount());
             score.textProperty().unbind();
+            tradeLimit.textProperty().unbind();
         }
 
         private MaterialTextField getField(String description) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessScoreSimulation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessScoreSimulation.java
@@ -71,8 +71,16 @@ public class SignedWitnessScoreSimulation {
                 }
             });
 
-            scorePin = EasyBind.subscribe(model.getAge(), age -> model.getScore().set(calculateSimScore(age)));
-        }
+            scorePin = EasyBind.subscribe(model.getAge(), age -> {
+                String score = calculateSimScore(age);
+                model.getScore().set(score);
+                try {
+                    long s = Long.parseLong(score);
+                    model.getTradeLimit().set(String.valueOf(s / 200));
+                } catch (Exception ignore) {
+                    model.getTradeLimit().set("");
+                }
+            });}
 
         @Override
         public void onDeactivate() {
@@ -97,6 +105,7 @@ public class SignedWitnessScoreSimulation {
         private final IntegerProperty age = new SimpleIntegerProperty();
         private final StringProperty ageAsString = new SimpleStringProperty();
         private final StringProperty score = new SimpleStringProperty();
+        private final StringProperty tradeLimit = new SimpleStringProperty();
     }
 
     private static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
@@ -104,6 +113,7 @@ public class SignedWitnessScoreSimulation {
 
         private final AgeSlider simAgeSlider;
         private final MaterialTextField simScore;
+        private final MaterialTextField simTradeLimit;
         private final MaterialTextField ageField;
 
         private View(Model model,
@@ -115,11 +125,13 @@ public class SignedWitnessScoreSimulation {
             ageField = getInputField("reputation.sim.age");
             simAgeSlider = new AgeSlider(0, (int) SignedWitnessService.MAX_DAYS_AGE_SCORE, 0);
             simScore = getField(Res.get("reputation.sim.score"));
+            simTradeLimit = getField(Res.get("reputation.sim.tradeLimit"));
             VBox.setMargin(simAgeSlider.getView().getRoot(), new Insets(15, 0, 0, 0));
             root.getChildren().addAll(simHeadline,
                     ageField,
                     simAgeSlider.getView().getRoot(),
-                    simScore);
+                    simScore,
+                    simTradeLimit);
         }
 
         @Override
@@ -127,6 +139,7 @@ public class SignedWitnessScoreSimulation {
             simAgeSlider.valueProperty().bindBidirectional(model.getAge());
             ageField.textProperty().bindBidirectional(model.getAgeAsString());
             simScore.textProperty().bind(model.getScore());
+            simTradeLimit.textProperty().bind(model.getTradeLimit());
         }
 
         @Override
@@ -134,6 +147,7 @@ public class SignedWitnessScoreSimulation {
             simAgeSlider.valueProperty().unbindBidirectional(model.getAge());
             ageField.textProperty().unbindBidirectional(model.getAgeAsString());
             simScore.textProperty().unbind();
+            simTradeLimit.textProperty().unbind();
         }
 
         private MaterialTextField getField(String description) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessTab2View.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessTab2View.java
@@ -52,7 +52,11 @@ public class SignedWitnessTab2View extends View<VBox, SignedWitnessTab2Model, Si
 
         Label formulaHeadline = new Label(Res.get("reputation.score.formulaHeadline"));
         formulaHeadline.getStyleClass().addAll("bisq-text-1");
-        VBox formulaBox = new VBox(10, formulaHeadline, getField("weight", String.valueOf(SignedWitnessService.WEIGHT)), getField("totalScore"));
+        VBox formulaBox = new VBox(10,
+                formulaHeadline,
+                getField("weight", String.valueOf(SignedWitnessService.WEIGHT)),
+                getField("totalScore"),
+                getField("tradeLimit", Res.get("reputation.tradeLimit.formula")));
 
         HBox hBox = new HBox(20, formulaBox, simulation);
 

--- a/i18n/src/main/resources/reputation.properties
+++ b/i18n/src/main/resources/reputation.properties
@@ -48,9 +48,11 @@ reputation.pubKeyHash=Profile ID
 reputation.weight=Weight
 reputation.score=Reputation score
 reputation.totalScore=Total score
+reputation.tradeLimit=Trade limit
 reputation.ranking=Ranking
 reputation.score.formulaHeadline=The reputation score is calculated as follows:
 reputation.score.tooltip=Score: {0}\nRanking: {1}
+reputation.tradeLimit.formula=Reputation score / 200
 
 reputation.score.BSQ_BOND.score.unlockedBond=0 (bond unlocked)
 
@@ -89,6 +91,7 @@ reputation.sim.age=Age in days
 # suppress inspection "UnusedProperty"
 reputation.sim.age.prompt=Enter the age in days
 reputation.sim.score=Total score
+reputation.sim.tradeLimit=Trade limit
 
 reputation.burnedBsq.howToHeadline=Process for burning BSQ
 reputation.burnedBsq.howTo=1. Select the user profile for which you want to attach the reputation.\n\


### PR DESCRIPTION
fixes #4156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade limit is now displayed across the reputation-building UI (account age, bonded reputation, burn BSQ, signed witness).
  * Trade limits are calculated from reputation scores and update in real time in the simulation and formula views.
  * New localized labels added for trade limit fields and formula display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->