### PR TITLE
Calculate security deposit as BTC independent of market.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseDetailSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseDetailSection.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.authorized_role.mediator.mu_sig.components;
 
+import bisq.common.market.Market;
 import bisq.common.monetary.Monetary;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.desktop.ServiceProvider;
@@ -110,7 +111,7 @@ public class MuSigMediationCaseDetailSection {
                 double securityDeposit = collateralOption.get().getBuyerSecurityDeposit();
                 model.setSecurityDepositInfo(Optional.of(new Model.SecurityDepositInfo(
                         securityDeposit,
-                        calculateSecurityDeposit(MuSigTradeUtils.getBaseSideMonetary(contract), securityDeposit),
+                        calculateSecurityDeposit(offer.getMarket(), contract, securityDeposit),
                         PercentageFormatter.formatToPercentWithSymbol(securityDeposit, 0),
                         true)));
             }
@@ -138,8 +139,12 @@ public class MuSigMediationCaseDetailSection {
             model.setSecurityDepositInfo(Optional.empty());
         }
 
-        private static String calculateSecurityDeposit(Monetary monetary, double securityDepositAsPercent) {
-            Monetary securityDeposit = OfferAmountUtil.calculateSecurityDeposit(monetary, securityDepositAsPercent);
+        private static String calculateSecurityDeposit(Market market,
+                                                       MuSigContract contract,
+                                                       double securityDepositAsPercent) {
+            Monetary baseSideMonetary = MuSigTradeUtils.getBaseSideMonetary(contract);
+            Monetary quoteSideMonetary = MuSigTradeUtils.getQuoteSideMonetary(contract);
+            Monetary securityDeposit = OfferAmountUtil.calculateSecurityDepositAsBTC(market, baseSideMonetary, quoteSideMonetary, securityDepositAsPercent);
             return OfferAmountFormatter.formatDepositAmountAsBTC(securityDeposit);
         }
     }
@@ -160,7 +165,8 @@ public class MuSigMediationCaseDetailSection {
 
         private Optional<SecurityDepositInfo> securityDepositInfo = Optional.empty();
 
-        private record SecurityDepositInfo(double percentValue, String amountText, String percentText, boolean isMatching) {
+        private record SecurityDepositInfo(double percentValue, String amountText, String percentText,
+                                           boolean isMatching) {
         }
 
         private String buyerNetworkAddress;

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountFormatter.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountFormatter.java
@@ -18,6 +18,7 @@
 package bisq.offer.amount;
 
 import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.common.asset.Asset;
 import bisq.common.market.Market;
 import bisq.common.monetary.Coin;
 import bisq.common.monetary.Monetary;
@@ -326,7 +327,7 @@ public class OfferAmountFormatter {
     /* --------------------------------------------------------------------- */
 
     public static String formatDepositAmountAsBTC(Monetary monetary) {
-        checkArgument(monetary.getCode().equals("BTC"));
+        checkArgument(Asset.isBtc(monetary.getCode()));
         return formatAmountWithCode(Coin.asBtcFromValue(monetary.getValue()), false);
     }
 

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
@@ -37,6 +37,8 @@ import bisq.offer.price.spec.PriceSpec;
 
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * Public APIs for getting different types of amounts:
  * - Base side / quote side
@@ -98,7 +100,8 @@ public class OfferAmountUtil {
     }
 
     // Combinations
-    public static Optional<Monetary> findBaseSideMinOrFixedAmount(MarketPriceService marketPriceService, Offer<?, ?> offer) {
+    public static Optional<Monetary> findBaseSideMinOrFixedAmount(MarketPriceService marketPriceService,
+                                                                  Offer<?, ?> offer) {
         return findBaseSideMinOrFixedAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket());
     }
 
@@ -113,7 +116,8 @@ public class OfferAmountUtil {
                         ));
     }
 
-    public static Optional<Monetary> findBaseSideMaxOrFixedAmount(MarketPriceService marketPriceService, Offer<?, ?> offer) {
+    public static Optional<Monetary> findBaseSideMaxOrFixedAmount(MarketPriceService marketPriceService,
+                                                                  Offer<?, ?> offer) {
         return findBaseSideMaxOrFixedAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket());
     }
 
@@ -134,7 +138,8 @@ public class OfferAmountUtil {
     /* --------------------------------------------------------------------- */
 
     // Fixed
-    public static Optional<Monetary> findQuoteSideFixedAmount(MarketPriceService marketPriceService, Offer<?, ?> offer) {
+    public static Optional<Monetary> findQuoteSideFixedAmount(MarketPriceService marketPriceService,
+                                                              Offer<?, ?> offer) {
         return findQuoteSideFixedAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket());
     }
 
@@ -182,7 +187,8 @@ public class OfferAmountUtil {
     }
 
     // Combinations
-    public static Optional<Monetary> findQuoteSideMinOrFixedAmount(MarketPriceService marketPriceService, Offer<?, ?> offer) {
+    public static Optional<Monetary> findQuoteSideMinOrFixedAmount(MarketPriceService marketPriceService,
+                                                                   Offer<?, ?> offer) {
         return findQuoteSideMinOrFixedAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket());
     }
 
@@ -197,7 +203,8 @@ public class OfferAmountUtil {
                         ));
     }
 
-    public static Optional<Monetary> findQuoteSideMaxOrFixedAmount(MarketPriceService marketPriceService, Offer<?, ?> offer) {
+    public static Optional<Monetary> findQuoteSideMaxOrFixedAmount(MarketPriceService marketPriceService,
+                                                                   Offer<?, ?> offer) {
         return findQuoteSideMaxOrFixedAmount(marketPriceService, offer.getAmountSpec(), offer.getPriceSpec(), offer.getMarket());
     }
 
@@ -276,5 +283,18 @@ public class OfferAmountUtil {
 
     public static Monetary calculateSecurityDeposit(Monetary monetary, double securityDeposit) {
         return Monetary.from(MathUtils.roundDoubleToLong(monetary.getValue() * securityDeposit), monetary.getCode());
+    }
+
+    public static Monetary calculateSecurityDepositAsBTC(Market market,
+                                                         Monetary baseSideMonetary,
+                                                         Monetary quoteSideMonetary,
+                                                         double securityDeposit) {
+        if (market.isBtcFiatMarket()) {
+            checkArgument(market.isBaseCurrencyBitcoin());
+            return calculateSecurityDeposit(baseSideMonetary, securityDeposit);
+        } else {
+            checkArgument(!market.isBaseCurrencyBitcoin());
+            return calculateSecurityDeposit(quoteSideMonetary, securityDeposit);
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated security-deposit calculation into a market-aware utility used by mediation and offer-review screens.
  * Centralized BTC detection and deposit formatting for consistent asset handling and display.
  * Updated deposit validation and call sites to use market-aware base/quote logic, reducing duplication and improving correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->