### PR TITLE
Make base side payment method dynamic for MuSig offer and contract.

### DIFF
--- a/account/src/main/java/bisq/account/payment_method/PaymentMethodSpecUtil.java
+++ b/account/src/main/java/bisq/account/payment_method/PaymentMethodSpecUtil.java
@@ -80,12 +80,6 @@ public class PaymentMethodSpecUtil {
     }
 
     public static List<PaymentMethodSpec<?>> createPaymentMethodSpecs(List<PaymentMethod<?>> paymentMethods,
-                                                                      Market market) {
-        String currencyCode = market.isCrypto() ? market.getBaseCurrencyCode() : market.getQuoteCurrencyCode();
-        return createPaymentMethodSpecs(paymentMethods, currencyCode);
-    }
-
-    public static List<PaymentMethodSpec<?>> createPaymentMethodSpecs(List<PaymentMethod<?>> paymentMethods,
                                                                       String currencyCode) {
         if (Asset.isFiat(currencyCode)) {
             return paymentMethods.stream()
@@ -115,11 +109,21 @@ public class PaymentMethodSpecUtil {
         }
     }
 
-    public static Class<? extends PaymentMethodSpec<?>> getPaymentMethodSpecClass(Market market) {
+    public static Class<? extends PaymentMethodSpec<?>> getPaymentMethodSpecClassForBaseSide(Market market) {
+        if (market.isBtcFiatMarket()) {
+            return BitcoinPaymentMethodSpec.class;
+        } else if (market.isCrypto()) {
+            return CryptoPaymentMethodSpec.class;
+        } else {
+            throw new IllegalArgumentException("Unsupported market type: " + market);
+        }
+    }
+
+    public static Class<? extends PaymentMethodSpec<?>> getPaymentMethodSpecClassForQuoteSide(Market market) {
         if (market.isBtcFiatMarket()) {
             return FiatPaymentMethodSpec.class;
         } else if (market.isCrypto()) {
-            return CryptoPaymentMethodSpec.class;
+            return BitcoinPaymentMethodSpec.class;
         } else {
             throw new IllegalArgumentException("Unsupported market type: " + market);
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradeListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradeListItem.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.content.mu_sig.open_trades;
 
-import bisq.account.payment_method.BitcoinPaymentRail;
 import bisq.account.payment_method.PaymentMethod;
 import bisq.account.payment_method.PaymentRail;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
@@ -59,8 +58,8 @@ class MuSigOpenTradeListItem implements DateTableItem {
     private final StringProperty peerNumNotificationsProperty = new SimpleStringProperty();
     private final StringProperty mediatorNumNotificationsProperty = new SimpleStringProperty();
     private final Pin changedChatNotificationPin, isInMediationPin;
-    private final BitcoinPaymentRail bitcoinPaymentRail;
-    private final PaymentRail paymentRail;
+    private final PaymentRail basePaymentRail;
+    private final PaymentRail quotePaymentRail;
     private final PaymentMethod<?> paymentMethod;
 
     private long peerNumNotifications, mediatorNumNotifications;
@@ -96,8 +95,8 @@ class MuSigOpenTradeListItem implements DateTableItem {
         baseAmountString = MuSigTradeFormatter.formatBaseSideAmount(trade);
         quoteAmount = contract.getQuoteSideAmount();
         quoteAmountString = MuSigTradeFormatter.formatQuoteSideAmountWithCode(trade);
-        bitcoinPaymentRail = contract.getBaseSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
-        paymentRail = contract.getQuoteSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
+        basePaymentRail = contract.getBaseSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
+        quotePaymentRail = contract.getQuoteSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
         paymentMethodDisplayName = contract.getQuoteSidePaymentMethodSpec().getShortDisplayString();
         paymentMethod = contract.getQuoteSidePaymentMethodSpec().getPaymentMethod();
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/MuSigTradeCompletedTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/MuSigTradeCompletedTable.java
@@ -107,9 +107,9 @@ public class MuSigTradeCompletedTable extends VBox {
 
     public void initialize(UserProfileDisplay tradeWithValue,
                            boolean isBuyer,
-                           String btcAmount,
-                           String fiatAmount,
-                           String fiatCurrency,
+                           String baseAmount,
+                           String quoteAmount,
+                           String quoteCurrency,
                            String paymentMethod,
                            String tradeId,
                            String tradeDate,
@@ -135,7 +135,7 @@ public class MuSigTradeCompletedTable extends VBox {
                 : new Label(Res.get("bisqEasy.tradeCompleted.header.myDirection.seller").toUpperCase());
         myDirection.getStyleClass().addAll("dimmed-text");
 
-        bitcoinAmountDisplay.setBtcAmount(btcAmount);
+        bitcoinAmountDisplay.setBtcAmount(baseAmount);
 
         HBox btcBox = new HBox(5, bitcoinAmountDisplay);
         btcBox.setAlignment(Pos.BASELINE_LEFT);
@@ -149,9 +149,9 @@ public class MuSigTradeCompletedTable extends VBox {
                 ? new Label(Res.get("bisqEasy.tradeCompleted.header.myOutcome.buyer").toUpperCase())
                 : new Label(Res.get("bisqEasy.tradeCompleted.header.myOutcome.seller").toUpperCase());
         myOutcome.getStyleClass().addAll("dimmed-text");
-        Label myOutcomeValue = new Label(fiatAmount);
+        Label myOutcomeValue = new Label(quoteAmount);
         myOutcomeValue.getStyleClass().add("medium-text");
-        Label fiat = new Label(fiatCurrency.toUpperCase());
+        Label fiat = new Label(quoteCurrency.toUpperCase());
         fiat.getStyleClass().addAll("small-text", "text-fill-grey-dimmed");
         HBox fiatBox = new HBox(5, myOutcomeValue, fiat);
         fiatBox.setAlignment(Pos.BASELINE_LEFT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State4TradeClosed.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State4TradeClosed.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.content.mu_sig.open_trades.trade_state.states;
 
 import bisq.account.payment_method.BitcoinPaymentRail;
+import bisq.account.payment_method.PaymentRail;
 import bisq.bonded_roles.explorer.ExplorerService;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.common.data.Pair;
@@ -97,17 +98,17 @@ public class State4TradeClosed extends BaseState {
 
             MuSigTrade trade = model.getTrade();
             MuSigContract contract = trade.getContract();
-            BitcoinPaymentRail paymentRail = contract.getBaseSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
-            String name = paymentRail.name();
+            PaymentRail basePaymentRail = contract.getBaseSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
+            String name = basePaymentRail.name();
             model.setPaymentProofDescription(Res.get("bisqEasy.tradeState.paymentProof." + name));
-            model.setBlockExplorerLinkVisible(paymentRail.equals(BitcoinPaymentRail.MAIN_CHAIN));
+            model.setBlockExplorerLinkVisible(basePaymentRail.equals(BitcoinPaymentRail.MAIN_CHAIN));
             String paymentProof = trade.getDepositTxId();
             model.setPaymentProof(paymentProof);
             model.setPaymentProofVisible(paymentProof != null);
             UserProfile tradePeer = model.getChannel().getPeer();
             model.setTradePeer(tradePeer);
             model.setBuyer(trade.isBuyer());
-            model.setFiatCurrency(trade.getOffer().getMarket().getQuoteCurrencyCode());
+            model.setQuoteCurrency(trade.getOffer().getMarket().getQuoteCurrencyCode());
             model.setPaymentMethod(contract.getQuoteSidePaymentMethodSpec().getShortDisplayString());
             model.setTradeId(trade.getShortId());
             long takeOfferDate = contract.getTakeOfferDate();
@@ -182,7 +183,7 @@ public class State4TradeClosed extends BaseState {
         protected boolean paymentProofVisible;
         protected UserProfile tradePeer;
         protected boolean isBuyer;
-        protected String fiatCurrency;
+        protected String quoteCurrency;
         protected String paymentMethod;
         protected String tradeId;
         protected String tradeDate;
@@ -233,7 +234,7 @@ public class State4TradeClosed extends BaseState {
             peerProfileDisplay.setUserProfile(model.getTradePeer());
             peerProfileDisplay.setReputationScore(model.getTradePeerReputationScore());
             muSigTradeCompletedTable.initialize(peerProfileDisplay, model.isBuyer(), model.getBaseAmount(),
-                    model.getQuoteAmount(), model.getFiatCurrency(), model.getPaymentMethod(), model.getTradeId(),
+                    model.getQuoteAmount(), model.getQuoteCurrency(), model.getPaymentMethod(), model.getTradeId(),
                     model.getTradeDate(), model.getTradeDuration(), model.getPrice(), model.getPriceSymbol(), txIdDescriptionAndValue);
             if (model.isBlockExplorerLinkVisible()) {
                 muSigTradeCompletedTable.showBlockExplorerLink();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/MuSigTakeOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/MuSigTakeOfferController.java
@@ -19,8 +19,8 @@ package bisq.desktop.main.content.mu_sig.take_offer;
 
 import bisq.account.AccountService;
 import bisq.account.accounts.Account;
-import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.account.payment_method.PaymentMethod;
+import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.Controller;
@@ -34,7 +34,6 @@ import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayController;
 import bisq.i18n.Res;
 import bisq.offer.mu_sig.MuSigOffer;
-import bisq.account.payment_method.BitcoinPaymentMethodSpec;
 import javafx.event.EventHandler;
 import javafx.scene.input.KeyEvent;
 import lombok.EqualsAndHashCode;
@@ -105,7 +104,7 @@ public class MuSigTakeOfferController extends NavigationController implements In
         muSigTakeOfferReviewController.init(muSigOffer);
 
         model.setAmountVisible(muSigOffer.hasAmountRange());
-        List<BitcoinPaymentMethodSpec> baseSidePaymentMethodSpecs = muSigOffer.getBaseSidePaymentMethodSpecs();
+        List<PaymentMethodSpec<?>> baseSidePaymentMethodSpecs = muSigOffer.getBaseSidePaymentMethodSpecs();
         List<PaymentMethodSpec<?>> quoteSidePaymentMethodSpecs = muSigOffer.getQuoteSidePaymentMethodSpecs();
 
         boolean isSingleAccountForSinglePaymentMethod = false;

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
@@ -218,7 +218,7 @@ public class MuSigService extends LifecycleService {
                                              Market market,
                                              AmountSpec amountSpec,
                                              PriceSpec priceSpec,
-                                             List<PaymentMethod<?>> fiatPaymentMethods,
+                                             List<PaymentMethod<?>> paymentMethods,
                                              List<? extends OfferOption> offerOptions) {
         checkArgument(isActivated());
         NetworkId makerNetworkId = userIdentityService.getSelectedUserIdentity().getUserProfile().getNetworkId();
@@ -228,7 +228,7 @@ public class MuSigService extends LifecycleService {
                 market,
                 amountSpec,
                 priceSpec,
-                fiatPaymentMethods,
+                paymentMethods,
                 offerOptions,
                 MuSigProtocol.VERSION);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Payment method handling generalized for broader market types (including BTC) and renamed internal currency labels to base/quote for consistency.
* **Behavior**
  * Offer creation no longer queries external offerbook suggestions; pricing relies on market quotes and internal calculations.
* **UX**
  * Trade views and labels updated to use base/quote terminology for clearer currency semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->