### PR TITLE
Apply unified calculation of security deposit as BTC to all areas.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/create_offer/review/MuSigCreateOfferReviewController.java
@@ -48,7 +48,6 @@ import bisq.offer.amount.OfferAmountFormatter;
 import bisq.offer.amount.OfferAmountUtil;
 import bisq.offer.amount.spec.AmountSpec;
 import bisq.offer.amount.spec.RangeAmountSpec;
-import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.offer.options.AccountOption;
 import bisq.offer.options.CollateralOption;
@@ -109,12 +108,6 @@ public class MuSigCreateOfferReviewController implements Controller {
         if (paymentMethods != null) {
             resetSelectedPaymentMethod();
             model.setPaymentMethods(paymentMethods);
-        }
-    }
-
-    public void setSelectedBisqEasyOffer(BisqEasyOffer selectedBisqEasyOffer) {
-        if (selectedBisqEasyOffer != null) {
-            resetSelectedPaymentMethod();
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security deposit calculation to use both takers' base and quote side amounts with market context, ensuring accurate BTC-based deposit display across offer review flows.
  * Removed an extra setter that could trigger unintended payment-method resets, preventing unexpected changes to the selected payment method during offer creation review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->