### PR TITLE
fix: min value for signed account age witness

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessScoreSimulation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/reputation/build_reputation/signedAccount/tab2/SignedWitnessScoreSimulation.java
@@ -56,8 +56,8 @@ public class SignedWitnessScoreSimulation {
             model = new Model();
             view = new View(model, this);
 
-            model.getAge().set(0);
-            model.getAgeAsString().set("0");
+            model.getAge().set((int) SignedWitnessService.MIN_DAYS_AGE_SCORE);
+            model.getAgeAsString().set(String.valueOf(SignedWitnessService.MIN_DAYS_AGE_SCORE));
         }
 
         @Override
@@ -83,7 +83,7 @@ public class SignedWitnessScoreSimulation {
 
         private String calculateSimScore(Number age) {
             try {
-                long ageInDays = Math.max(0, age.intValue());
+                long ageInDays = Math.max(SignedWitnessService.MIN_DAYS_AGE_SCORE, age.longValue());
                 long totalScore = SignedWitnessService.doCalculateScore(ageInDays);
                 return String.valueOf(totalScore);
             } catch (Exception e) {
@@ -113,7 +113,7 @@ public class SignedWitnessScoreSimulation {
             Label simHeadline = new Label(Res.get("reputation.sim.headline"));
             simHeadline.getStyleClass().addAll("bisq-text-1");
             ageField = getInputField("reputation.sim.age");
-            simAgeSlider = new AgeSlider(0, (int) SignedWitnessService.MAX_DAYS_AGE_SCORE, 0);
+            simAgeSlider = new AgeSlider((int) SignedWitnessService.MIN_DAYS_AGE_SCORE, (int) SignedWitnessService.MAX_DAYS_AGE_SCORE, (int) SignedWitnessService.MIN_DAYS_AGE_SCORE);
             simScore = getField(Res.get("reputation.sim.score"));
             VBox.setMargin(simAgeSlider.getView().getRoot(), new Insets(15, 0, 0, 0));
             root.getChildren().addAll(simHeadline,

--- a/user/src/main/java/bisq/user/reputation/SignedWitnessService.java
+++ b/user/src/main/java/bisq/user/reputation/SignedWitnessService.java
@@ -56,6 +56,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class SignedWitnessService extends SourceReputationService<AuthorizedSignedWitnessData> implements PersistenceClient<SignedWitnessStore> {
     public static final double WEIGHT = 10;
     public static final long MAX_DAYS_AGE_SCORE = 2000;
+    public static final long MIN_DAYS_AGE_SCORE = 61;
 
     // Has to be in sync with Bisq1 class
     @Getter
@@ -149,16 +150,6 @@ public class SignedWitnessService extends SourceReputationService<AuthorizedSign
         return userProfile.getSignedWitnessKey();
     }
 
-  /*  @Override
-    public long calculateScore(AuthorizedSignedWitnessData data) {
-        long age = getAgeInDays(data.getWitnessSignDate());
-        if (age <= 60) {
-            return 0;
-        }
-        return Math.min(365, age) * WEIGHT;
-    }*/
-
-
     @Override
     public long calculateScore(AuthorizedSignedWitnessData data) {
         return doCalculateScore(getAgeInDays(data.getWitnessSignDate()));
@@ -166,7 +157,7 @@ public class SignedWitnessService extends SourceReputationService<AuthorizedSign
 
     public static long doCalculateScore(long ageInDays) {
         checkArgument(ageInDays >= 0);
-        if (ageInDays <= 60) {
+        if (ageInDays < MIN_DAYS_AGE_SCORE) {
             return 0;
         }
         long boundedAgeInDays = Math.min(MAX_DAYS_AGE_SCORE, ageInDays);
@@ -180,8 +171,8 @@ public class SignedWitnessService extends SourceReputationService<AuthorizedSign
             SignedWitnessDto dto = new Gson().fromJson(json, SignedWitnessDto.class);
             long witnessSignDate = dto.getWitnessSignDate();
             long age = getAgeInDays(witnessSignDate);
-            if (age < 61) {
-                log.error("witnessSignDate has to be at least 61 days. witnessSignDate={}", witnessSignDate);
+            if (age < MIN_DAYS_AGE_SCORE) {
+                log.error("witnessSignDate has to be at least {} days. witnessSignDate={}", MIN_DAYS_AGE_SCORE, witnessSignDate);
                 return false;
             }
             String profileId = dto.getProfileId();


### PR DESCRIPTION
fixes #4157 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signed witness score simulation enforces a minimum age of 61: the age slider now starts at 61 and score calculations treat any age below 61 as 61 for consistent results.

* **Refactor**
  * The 61-day threshold was centralized into a single constant and applied consistently across authorization and scoring logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->