### PR TITLE
Ensure the minRangeValue is not larger as maxAmount

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
@@ -180,6 +180,7 @@ public class TakeOfferAmountController implements Controller {
         Monetary maxAmount = reputationBasedQuoteSideAmount.isLessThan(offersQuoteSideMaxOrFixedAmount)
                 ? reputationBasedQuoteSideAmount
                 : offersQuoteSideMaxOrFixedAmount;
+
         amountSelectionController.setMaxAllowedLimitation(offersQuoteSideMaxOrFixedAmount);
         amountSelectionController.setRightMarkerQuoteSideValue(maxAmount);
         amountSelectionController.setMinMaxRange(minRangeValue, maxAmount);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/amount/MuSigTakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/take_offer/amount/MuSigTakeOfferAmountController.java
@@ -186,6 +186,7 @@ public class MuSigTakeOfferAmountController implements Controller {
         Monetary maxAmount = reputationBasedQuoteSideAmount.isLessThan(offersQuoteSideMaxOrFixedAmount)
                 ? reputationBasedQuoteSideAmount
                 : offersQuoteSideMaxOrFixedAmount;
+
         amountSelectionController.setMaxAllowedLimitation(offersQuoteSideMaxOrFixedAmount);
         amountSelectionController.setRightMarkerQuoteSideValue(maxAmount);
         amountSelectionController.setMinMaxRange(minRangeValue, maxAmount);


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/4407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved validation of minimum and maximum amount ranges in offer workflows to prevent invalid configurations and ensure consistent behavior when selecting offer amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->