### PR TITLE
Fix OfferItemPresentationDtoFactory crash when user profile not yet available

### DIFF
--- a/http-api/src/main/java/bisq/dto/presentation/offerbook/OfferItemPresentationDtoFactory.java
+++ b/http-api/src/main/java/bisq/dto/presentation/offerbook/OfferItemPresentationDtoFactory.java
@@ -44,24 +44,54 @@ import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class OfferItemPresentationDtoFactory {
-    public static OfferItemPresentationDto create(UserProfileService userProfileService,
-                                                  UserIdentityService userIdentityService,
-                                                  ReputationService reputationService,
-                                                  MarketPriceService marketPriceService,
-                                                  BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
+    /**
+     * Attempts to create an {@link OfferItemPresentationDto} for the given offerbook message.
+     *
+     * <p>Returns {@link Optional#empty()} when required data is transiently unavailable — most
+     * commonly when the author's {@link UserProfile} has not yet been received via the P2P gossip
+     * layer.  Callers must not treat an empty result as an error; they should simply skip the
+     * offer for the current snapshot.  Note: {@code OffersWebSocketService} only observes
+     * {@code channel.getChatMessages()} — there is no listener on {@code UserProfileService}
+     * that re-emits skipped offers when profiles arrive, so the offer will only appear on the
+     * next full subscription (REPLACE) or when the client re-subscribes.</p>
+     *
+     * @param userProfileService     service used to resolve the offer author's user profile
+     * @param userIdentityService    service used to determine whether the offer is the local user's own offer
+     * @param reputationService      service used to look up the offer author's reputation score
+     * @param marketPriceService     service used to format price-related fields
+     * @param bisqEasyOfferbookMessage the offerbook message carrying the offer
+     * @return an {@link Optional} containing the presentation DTO, or empty if a required
+     *         dependency (e.g. the author's user profile) is not yet available
+     */
+    public static Optional<OfferItemPresentationDto> create(UserProfileService userProfileService,
+                                                            UserIdentityService userIdentityService,
+                                                            ReputationService reputationService,
+                                                            MarketPriceService marketPriceService,
+                                                            BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
         BisqEasyOffer bisqEasyOffer = bisqEasyOfferbookMessage.getBisqEasyOffer().orElseThrow();
-        boolean isMyOffer = bisqEasyOfferbookMessage.isMyMessage(userIdentityService);
-        Direction direction = bisqEasyOffer.getDirection();
-        String messageId = bisqEasyOfferbookMessage.getId();
-        String offerId = bisqEasyOffer.getId();
-        BisqEasyOfferDto bisqEasyOfferDto = DtoMappings.BisqEasyOfferMapping.fromBisq2Model(bisqEasyOffer);
         String authorUserProfileId = bisqEasyOfferbookMessage.getAuthorUserProfileId();
+
+        // The author's UserProfile may not yet be available if the P2P gossip network has not
+        // delivered the profile data.  Returning empty rather than throwing allows callers to
+        // skip this offer gracefully and serve the remaining valid offers to subscribers.
+        Optional<UserProfile> userProfileOpt = userProfileService.findUserProfile(authorUserProfileId);
+        if (userProfileOpt.isEmpty()) {
+            log.debug("User profile not found for authorUserProfileId={}, skipping offer creation", authorUserProfileId);
+            return Optional.empty();
+        }
+
+        boolean isMyOffer = bisqEasyOfferbookMessage.isMyMessage(userIdentityService);
+        BisqEasyOfferDto bisqEasyOfferDto = DtoMappings.BisqEasyOfferMapping.fromBisq2Model(bisqEasyOffer);
 
         // For now, we send also the formatted values as we have not the complex formatters in mobile impl. yet.
         // We might need to replicate the formatters anyway later and then those fields could be removed
@@ -102,11 +132,10 @@ public class OfferItemPresentationDtoFactory {
                 .map(PaymentMethod::getPaymentRailName)
                 .collect(Collectors.toList());
 
-        UserProfile userProfile = userProfileService.findUserProfile(authorUserProfileId).orElseThrow();
-        UserProfileDto userProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(userProfile);
+        UserProfileDto userProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(userProfileOpt.get());
         ReputationScore reputationScore = reputationService.getReputationScore(authorUserProfileId);
         ReputationScoreDto reputationScoreDto = DtoMappings.ReputationScoreMapping.fromBisq2Model(reputationScore);
-        return new OfferItemPresentationDto(bisqEasyOfferDto,
+        return Optional.of(new OfferItemPresentationDto(bisqEasyOfferDto,
                 isMyOffer,
                 userProfileDto,
                 formattedDate,
@@ -116,6 +145,6 @@ public class OfferItemPresentationDtoFactory {
                 formattedPriceSpec,
                 quoteSidePaymentMethods,
                 baseSidePaymentMethods,
-                reputationScoreDto);
+                reputationScoreDto));
     }
 }

--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/offers/OfferbookRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/offers/OfferbookRestApi.java
@@ -326,12 +326,14 @@ public class OfferbookRestApi extends RestApiBase {
                                 .stream()
                                 .filter(BisqEasyOfferbookMessage::hasBisqEasyOffer)
                                 .map(this::createOfferListItemDto)
+                                .filter(Optional::isPresent)
+                                .map(Optional::get)
                                 .collect(Collectors.toList())
                         )
                 );
     }
 
-    private OfferItemPresentationDto createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
+    private Optional<OfferItemPresentationDto> createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
         return OfferItemPresentationDtoFactory.create(userProfileService,
                 userIdentityService,
                 reputationService,


### PR DESCRIPTION
Found this issue whilst working on [testing in all different clearnet](https://github.com/bisq-network/bisq-mobile/pull/1166) scenarios with local data. This change fixes a bug where none of the offers would get returned (not even the associated with valid ones, see exceptions below)

 - OfferItemPresentationDtoFactory.create() threw NoSuchElementException via Optional.orElseThrow() when the offer author's user profile hadn't arrived via P2P gossip yet. Changed return type to Optional and skip offers with missing profiles gracefully. Updated both WebSocket and REST callers to filter out empty results instead of crashing the entire subscription
 - added docs to API header


```
14:01:39.070 ERROR [WebSocketConnectionHandler-9] b.h.w.d.o.OffersWebSocketService: Failed to create OfferListItemDto java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.orElseThrow(Optional.java:377)
	at bisq.dto.presentation.offerbook.OfferItemPresentationDtoFactory.create(OfferItemPresentationDtoFactory.java:105)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.createOfferListItemDto(OffersWebSocketService.java:146)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.lambda$getJsonPayload$1(OffersWebSocketService.java:121)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:212)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:194)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:611)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:291)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:702)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.getJsonPayload(OffersWebSocketService.java:128)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.getJsonPayload(OffersWebSocketService.java:111)
	at java.base/java.util.Optional.flatMap(Optional.java:289)
	at bisq.http_api.web_socket.subscription.SubscriptionService.subscribe(SubscriptionService.java:132)
	at bisq.http_api.web_socket.subscription.SubscriptionService.lambda$onMessage$16(SubscriptionService.java:125)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at bisq.http_api.web_socket.subscription.SubscriptionService.onMessage(SubscriptionService.java:124)
	at bisq.http_api.web_socket.WebSocketConnectionHandler.lambda$onMessage$0(WebSocketConnectionHandler.java:88)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)

java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.orElseThrow(Optional.java:377)
	at bisq.dto.presentation.offerbook.OfferItemPresentationDtoFactory.create(OfferItemPresentationDtoFactory.java:105)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.createOfferListItemDto(OffersWebSocketService.java:146)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.lambda$getJsonPayload$1(OffersWebSocketService.java:121)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:212)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:194)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:611)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:291)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:702)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.getJsonPayload(OffersWebSocketService.java:128)
	at bisq.http_api.web_socket.domain.offers.OffersWebSocketService.getJsonPayload(OffersWebSocketService.java:111)
	at java.base/java.util.Optional.flatMap(Optional.java:289)
	at bisq.http_api.web_socket.subscription.SubscriptionService.subscribe(SubscriptionService.java:132)
	at bisq.http_api.web_socket.subscription.SubscriptionService.lambda$onMessage$16(SubscriptionService.java:125)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at bisq.http_api.web_socket.subscription.SubscriptionService.onMessage(SubscriptionService.java:124)
	at bisq.http_api.web_socket.WebSocketConnectionHandler.lambda$onMessage$0(WebSocketConnectionHandler.java:88)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when author profile data is temporarily missing — offer items are now skipped instead of causing failures, reducing errors and noisy logs.
  * Prevents broadcasting incomplete offer updates to subscribers when required profile info isn't available, improving stability and reliability of real-time offer feeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->