### PR TITLE
Add remaining time to trade process UI

### DIFF
--- a/account/src/main/java/bisq/account/payment_method/BitcoinPaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/BitcoinPaymentRail.java
@@ -25,4 +25,9 @@ public enum BitcoinPaymentRail implements PaymentRail {
     RBTC,               // BTC wrapped on the RSK blockchain
     WBTC,               // BTC wrapped on ETH
     OTHER;
+
+    @Override
+    public TradeDuration getTradeDuration() {
+        return TradeDuration.HOURS_24;
+    }
 }

--- a/account/src/main/java/bisq/account/payment_method/PaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/PaymentRail.java
@@ -28,8 +28,5 @@ public interface PaymentRail {
         return "10000 USD";
     }
 
-    //todo
-    default String getTradeDuration() {
-        return "24 hours";
-    }
+    TradeDuration getTradeDuration();
 }

--- a/account/src/main/java/bisq/account/payment_method/TradeDuration.java
+++ b/account/src/main/java/bisq/account/payment_method/TradeDuration.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.account.payment_method;
+
+import bisq.i18n.Res;
+import lombok.Getter;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+public enum TradeDuration {
+    HOURS_24(24, TimeUnit.HOURS),
+    DAYS_2(2, TimeUnit.DAYS),
+    DAYS_3(3, TimeUnit.DAYS),
+    DAYS_4(4, TimeUnit.DAYS),
+    DAYS_5(5, TimeUnit.DAYS),
+    DAYS_6(6, TimeUnit.DAYS),
+    DAYS_7(7, TimeUnit.DAYS),
+    DAYS_8(8, TimeUnit.DAYS);
+
+    private final long time;
+    private final String displayString;
+
+    TradeDuration(long duration, TimeUnit unit) {
+        this.time = unit.toMillis(duration);
+        if (unit == TimeUnit.HOURS) {
+            this.displayString = Res.get("temporal.hour.*", (int) duration);
+        } else {
+            this.displayString = Res.get("temporal.day.*", (int) duration);
+        }
+    }
+}

--- a/account/src/main/java/bisq/account/payment_method/cbdc/CbdcPaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/cbdc/CbdcPaymentRail.java
@@ -18,6 +18,7 @@
 package bisq.account.payment_method.cbdc;
 
 import bisq.account.payment_method.PaymentRail;
+import bisq.account.payment_method.TradeDuration;
 import bisq.common.asset.Cbdc;
 import bisq.common.asset.CbdcRepository;
 import lombok.Getter;
@@ -42,5 +43,10 @@ public enum CbdcPaymentRail implements PaymentRail {
 
     CbdcPaymentRail(Cbdc cbdc) {
         this.cbdc = cbdc;
+    }
+
+    @Override
+    public TradeDuration getTradeDuration() {
+        return TradeDuration.HOURS_24;
     }
 }

--- a/account/src/main/java/bisq/account/payment_method/crypto/CryptoPaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/crypto/CryptoPaymentRail.java
@@ -18,6 +18,7 @@
 package bisq.account.payment_method.crypto;
 
 import bisq.account.payment_method.PaymentRail;
+import bisq.account.payment_method.TradeDuration;
 
 /**
  * Currently for musig it has no usage, but we still support it for potential future protocols or usage in Bisq Easy.
@@ -33,4 +34,10 @@ public enum CryptoPaymentRail implements PaymentRail {
     CUSTODIAL,               // Off-chain/internal ledger (CEX transfers, PayPal USD)
     CBDC,                    // CBDC
     OTHER                    // Catch-all
+    ;
+
+    @Override
+    public TradeDuration getTradeDuration() {
+        return TradeDuration.HOURS_24;
+    }
 }

--- a/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRail.java
@@ -18,6 +18,7 @@
 package bisq.account.payment_method.fiat;
 
 import bisq.account.payment_method.PaymentRail;
+import bisq.account.payment_method.TradeDuration;
 import bisq.common.asset.Asset;
 import bisq.common.asset.FiatCurrency;
 import bisq.common.asset.FiatCurrencyRepository;
@@ -330,61 +331,53 @@ public enum FiatPaymentRail implements PaymentRail {
     }
 
     //todo add duration as enum field, use Duration not string (add method to get display string)
-    private static final String HOURS_24 = Res.get("temporal.hour.*", 24);
-    private static final String DAYS_2 = Res.get("temporal.day.*", 2);
-    private static final String DAYS_3 = Res.get("temporal.day.*", 3);
-    private static final String DAYS_4 = Res.get("temporal.day.*", 4);
-    private static final String DAYS_5 = Res.get("temporal.day.*", 5);
-    private static final String DAYS_6 = Res.get("temporal.day.*", 6);
-    private static final String DAYS_7 = Res.get("temporal.day.*", 7);
-    private static final String DAYS_8 = Res.get("temporal.day.*", 8);
 
     @Override
-    public String getTradeDuration() {
+    public TradeDuration getTradeDuration() {
         return switch (this) {
-            case ACH_TRANSFER -> DAYS_5;
-            case ADVANCED_CASH -> HOURS_24;
-            case ALI_PAY -> HOURS_24;
-            case AMAZON_GIFT_CARD -> DAYS_4;
-            case BIZUM -> DAYS_4;
-            case CASH_APP -> DAYS_4;
-            case CASH_BY_MAIL -> DAYS_8;
-            case CASH_DEPOSIT -> DAYS_4;
-            case CUSTOM -> DAYS_4;
-            case DOMESTIC_WIRE_TRANSFER -> DAYS_3;
-            case F2F -> DAYS_4;
-            case FASTER_PAYMENTS -> HOURS_24;
-            case HAL_CASH -> HOURS_24;
-            case IMPS -> HOURS_24;
-            case INTERAC_E_TRANSFER -> HOURS_24;
-            case MERCADO_PAGO -> HOURS_24;
-            case MONESE -> HOURS_24;
-            case MONEY_BEAM -> HOURS_24;
-            case MONEY_GRAM -> DAYS_4;
-            case NATIONAL_BANK -> DAYS_4;
-            case NEFT -> HOURS_24;
-            case PAY_ID -> DAYS_4;
-            case PAYSERA -> HOURS_24;
-            case PERFECT_MONEY -> HOURS_24;
-            case PIN_4 -> HOURS_24;
-            case PIX -> HOURS_24;
-            case PROMPT_PAY -> HOURS_24;
-            case REVOLUT -> HOURS_24;
-            case SAME_BANK -> HOURS_24;
-            case SATISPAY -> HOURS_24;
-            case SBP -> HOURS_24;
-            case SEPA -> DAYS_6;
-            case SEPA_INSTANT -> HOURS_24;
-            case STRIKE -> DAYS_4;
-            case SWIFT -> DAYS_4;
-            case SWISH -> HOURS_24;
-            case UPHOLD -> HOURS_24;
-            case UPI -> DAYS_4;
-            case US_POSTAL_MONEY_ORDER -> DAYS_4;
-            case WECHAT_PAY -> HOURS_24;
-            case WISE -> DAYS_4;
-            case WISE_USD -> DAYS_4;
-            case ZELLE -> DAYS_4;
+            case ACH_TRANSFER -> TradeDuration.DAYS_5;
+            case ADVANCED_CASH -> TradeDuration.HOURS_24;
+            case ALI_PAY -> TradeDuration.HOURS_24;
+            case AMAZON_GIFT_CARD -> TradeDuration.DAYS_4;
+            case BIZUM -> TradeDuration.DAYS_4;
+            case CASH_APP -> TradeDuration.DAYS_4;
+            case CASH_BY_MAIL -> TradeDuration.DAYS_8;
+            case CASH_DEPOSIT -> TradeDuration.DAYS_4;
+            case CUSTOM -> TradeDuration.DAYS_4;
+            case DOMESTIC_WIRE_TRANSFER -> TradeDuration.DAYS_3;
+            case F2F -> TradeDuration.DAYS_4;
+            case FASTER_PAYMENTS -> TradeDuration.HOURS_24;
+            case HAL_CASH -> TradeDuration.HOURS_24;
+            case IMPS -> TradeDuration.HOURS_24;
+            case INTERAC_E_TRANSFER -> TradeDuration.HOURS_24;
+            case MERCADO_PAGO -> TradeDuration.HOURS_24;
+            case MONESE -> TradeDuration.HOURS_24;
+            case MONEY_BEAM -> TradeDuration.HOURS_24;
+            case MONEY_GRAM -> TradeDuration.DAYS_4;
+            case NATIONAL_BANK -> TradeDuration.DAYS_4;
+            case NEFT -> TradeDuration.HOURS_24;
+            case PAY_ID -> TradeDuration.DAYS_4;
+            case PAYSERA -> TradeDuration.HOURS_24;
+            case PERFECT_MONEY -> TradeDuration.HOURS_24;
+            case PIN_4 -> TradeDuration.HOURS_24;
+            case PIX -> TradeDuration.HOURS_24;
+            case PROMPT_PAY -> TradeDuration.HOURS_24;
+            case REVOLUT -> TradeDuration.HOURS_24;
+            case SAME_BANK -> TradeDuration.HOURS_24;
+            case SATISPAY -> TradeDuration.HOURS_24;
+            case SBP -> TradeDuration.HOURS_24;
+            case SEPA -> TradeDuration.DAYS_6;
+            case SEPA_INSTANT -> TradeDuration.HOURS_24;
+            case STRIKE -> TradeDuration.DAYS_4;
+            case SWIFT -> TradeDuration.DAYS_4;
+            case SWISH -> TradeDuration.HOURS_24;
+            case UPHOLD -> TradeDuration.HOURS_24;
+            case UPI -> TradeDuration.DAYS_4;
+            case US_POSTAL_MONEY_ORDER -> TradeDuration.DAYS_4;
+            case WECHAT_PAY -> TradeDuration.HOURS_24;
+            case WISE -> TradeDuration.DAYS_4;
+            case WISE_USD -> TradeDuration.DAYS_4;
+            case ZELLE -> TradeDuration.DAYS_4;
         };
     }
 

--- a/account/src/main/java/bisq/account/payment_method/stable_coin/StableCoinPaymentRail.java
+++ b/account/src/main/java/bisq/account/payment_method/stable_coin/StableCoinPaymentRail.java
@@ -18,6 +18,7 @@
 package bisq.account.payment_method.stable_coin;
 
 import bisq.account.payment_method.PaymentRail;
+import bisq.account.payment_method.TradeDuration;
 import bisq.common.asset.StableCoin;
 import bisq.common.asset.StableCoinRepository;
 import lombok.Getter;
@@ -40,6 +41,11 @@ public enum StableCoinPaymentRail implements PaymentRail {
 
     StableCoinPaymentRail(StableCoin stableCoin) {
         this.stableCoin = stableCoin;
+    }
+
+    @Override
+    public TradeDuration getTradeDuration() {
+        return TradeDuration.HOURS_24;
     }
 }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/threading/UIClock.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/threading/UIClock.java
@@ -17,6 +17,8 @@
 
 package bisq.desktop.common.threading;
 
+import bisq.common.observable.Pin;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -49,19 +51,25 @@ public class UIClock {
         onMinuteTickListeners.clear();
     }
 
-    public static void addOnSecondTickListener(Runnable listener) {
+    public static Pin addOnSecondTickListener(Runnable listener) {
         onSecondTickListeners.add(listener);
+        listener.run();
+        return () -> removeOnSecondTickListener(listener);
     }
+
 
     public static void removeOnSecondTickListener(Runnable listener) {
         onSecondTickListeners.remove(listener);
     }
 
-    public static void addOnMinuteTickListener(Runnable listener) {
+    public static Pin addOnMinuteTickListener(Runnable listener) {
         onMinuteTickListeners.add(listener);
+        listener.run();
+        return () -> removeOnMinuteTickListener(listener);
     }
 
     public static void removeOnMinuteTickListener(Runnable listener) {
         onMinuteTickListeners.remove(listener);
+
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/AccountDetails.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/AccountDetails.java
@@ -165,7 +165,7 @@ public abstract class AccountDetails<A extends Account<?, ?>, R extends PaymentR
 
     protected Label addTradeDuration() {
         return addDescriptionAndValue(Res.get("paymentAccounts.tradeDuration"),
-                account.getPaymentMethod().getPaymentRail().getTradeDuration());
+                account.getPaymentMethod().getPaymentRail().getTradeDuration().getDisplayString());
     }
 
     protected void addCurrencyDisplay() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/crypto_accounts/create/summary/details/SummaryDetails.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/crypto_accounts/create/summary/details/SummaryDetails.java
@@ -79,7 +79,7 @@ public class SummaryDetails<P extends CryptoAssetAccountPayload> extends GridPan
     protected void addRestrictions(P accountPayload) {
         CryptoPaymentRail paymentRail = accountPayload.getPaymentMethod().getPaymentRail();
         String restrictions = Res.get("paymentAccounts.summary.tradeLimit", paymentRail.getTradeLimit()) + " / " +
-                Res.get("paymentAccounts.summary.tradeDuration", paymentRail.getTradeDuration());
+                Res.get("paymentAccounts.summary.tradeDuration", paymentRail.getTradeDuration().getDisplayString());
         addDescriptionAndValue(Res.get("paymentAccounts.restrictions"), restrictions);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/summary/details/AccountDetailsGridPane.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/summary/details/AccountDetailsGridPane.java
@@ -59,7 +59,7 @@ public abstract class AccountDetailsGridPane<A extends AccountPayload<?>, R exte
 
     protected void addRestrictions(R fiatPaymentRail) {
         String restrictions = Res.get("paymentAccounts.summary.tradeLimit", fiatPaymentRail.getTradeLimit()) + " / " +
-                Res.get("paymentAccounts.summary.tradeDuration", fiatPaymentRail.getTradeDuration());
+                Res.get("paymentAccounts.summary.tradeDuration", fiatPaymentRail.getTradeDuration().getDisplayString());
         addDescriptionAndValue(Res.get("paymentAccounts.restrictions"), restrictions);
     }
 

--- a/apps/desktop/desktop/src/main/resources/css/mu_sig.css
+++ b/apps/desktop/desktop/src/main/resources/css/mu_sig.css
@@ -155,3 +155,15 @@
 .mu-sig-my-offers-table .table-row-cell:selected .quote-currency-market-logo {
     -fx-fill: -bisq-dark-grey-40 !important;
 }
+
+
+/*******************************************************************************
+ *                                                                             *
+ * Remaining trade time ProgressBar                                                                *
+ *                                                                             *
+ ******************************************************************************/
+
+.time-progress-bar > .bar,
+.time-progress-bar:indeterminate > .bar {
+    -fx-background-color: -bisq2-yellow;
+}

--- a/apps/desktop/desktop/src/main/resources/css/text.css
+++ b/apps/desktop/desktop/src/main/resources/css/text.css
@@ -618,13 +618,6 @@
     -fx-font-size: 1em;
 }
 
-.dimmed-text {
-    -fx-fill: -fx-mid-text-color;
-    -fx-text-fill: -fx-mid-text-color;
-    -fx-font-family: "IBM Plex Sans Light";
-    -fx-font-size: 1em;
-}
-
 .code-block {
     -fx-fill: -fx-mid-text-color;
     -fx-text-fill: -fx-mid-text-color;

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -186,6 +186,11 @@ muSig.tradeState.phase2=Start Fiat payment
 muSig.tradeState.phase3=Await Fiat payment receipt
 muSig.tradeState.phase4=Trade completed
 
+muSig.tradeState.maxPeriod=Max. trade period: {0}
+muSig.tradeState.remainingTime=Remaining time: {0}
+muSig.tradeState.remainingTime.notStarted=Trade has not started yet
+muSig.tradeState.remainingTime.exceeded=Trade exceeded the max. trade period
+
 muSig.tradeState.info.phase1a.headline=Setup deposit transaction
 muSig.tradeState.info.phase1a.info=The MuSig deposit transaction is being created cooperatively with your peer.
 

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -224,7 +224,8 @@ message MuSigTradeParty {
 
 message MuSigTrade {
   optional string depositTxId = 1;
-  optional sint64 tradeCompletedDate = 2;
+  optional sint64 tradeStartedDate = 2;
+  optional sint64 tradeCompletedDate = 3;
 }
 
 message MuSigTradeStore {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/4146


<img width="2046" height="1486" alt="Screenshot 2026-02-18 at 18 52 51" src="https://github.com/user-attachments/assets/790dbdbe-22df-4861-808a-d5990c67eff4" />

@axpoems If you have a better idea for the layout/design feel free to improve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade start date is now recorded for MuSig trades.
  * Standardized trade duration values across payment methods.

* **UI/UX Improvements**
  * Real-time remaining trade time with formatted countdown and progress bar in MuSig views.
  * Trade duration displayed using localized, user-friendly labels.
  * Added localized strings for max period and remaining time messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->