### PR TITLE
Replace BisqEasy WaitingAnimation with MuSigWaitingAnimation inside MuSig.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/components/MuSigWaitingAnimation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/components/MuSigWaitingAnimation.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.mu_sig.components;
+
+import bisq.desktop.common.ManagedDuration;
+import bisq.desktop.common.threading.UIScheduler;
+import bisq.desktop.common.utils.ImageUtil;
+import javafx.animation.FadeTransition;
+import javafx.animation.RotateTransition;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.StackPane;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class MuSigWaitingAnimation extends StackPane {
+    public static final int INTERVAL = 1000;
+
+    private final ImageView spinningCircle;
+    private ImageView waitingStateIcon;
+    private MuSigWaitingState waitingState;
+    private final RotateTransition rotate;
+    private final FadeTransition fadeTransition;
+    private Scene scene;
+    private ChangeListener<Scene> sceneListener;
+    private ChangeListener<Boolean> focusListener;
+    private UIScheduler uiScheduler;
+
+    public MuSigWaitingAnimation(MuSigWaitingState waitingState) {
+        setState(waitingState);
+
+        setAlignment(Pos.CENTER);
+
+        spinningCircle = ImageUtil.getImageViewById(getSpinningCircleIconId(waitingState));
+        spinningCircle.setFitHeight(78);
+        spinningCircle.setFitWidth(78);
+        spinningCircle.setPreserveRatio(true);
+
+        getChildren().add(spinningCircle);
+
+        fadeTransition = new FadeTransition(ManagedDuration.millis(INTERVAL), spinningCircle);
+        fadeTransition.setFromValue(0);
+        fadeTransition.setToValue(1);
+
+        rotate = new RotateTransition(ManagedDuration.millis(INTERVAL), spinningCircle);
+        rotate.setByAngle(360);
+
+        sceneListener = (observable, oldValue, newValue) -> {
+            if (newValue != null) {
+                focusListener = new ChangeListener<>() {
+                    @Override
+                    public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) {
+                        if (newValue) {
+                            rotate.playFromStart();
+                            spinningCircle.setOpacity(0);
+                            fadeTransition.playFromStart();
+                        }
+                    }
+                };
+                scene = getScene();
+                scene.getWindow().focusedProperty().addListener(focusListener);
+            } else {
+                if (scene != null) {
+                    scene.getWindow().focusedProperty().removeListener(focusListener);
+                    scene = null;
+                }
+                sceneProperty().removeListener(sceneListener);
+            }
+        };
+        sceneProperty().addListener(sceneListener);
+    }
+
+    public void setState(MuSigWaitingState state) {
+        if (waitingState != state) {
+            waitingState = state;
+            updateWaitingStateIcon();
+            if (spinningCircle != null) {
+                spinningCircle.setImage(ImageUtil.getImageViewById(getSpinningCircleIconId(state)).getImage());
+            }
+        }
+    }
+
+    private void updateWaitingStateIcon() {
+        if (waitingStateIcon != null) {
+            getChildren().remove(waitingStateIcon);
+            waitingStateIcon = null;
+        }
+
+        if (waitingState != null) {
+            waitingStateIcon = ImageUtil.getImageViewById(getWaitingStateIconId(waitingState));
+            getChildren().add(waitingStateIcon);
+        }
+    }
+
+    private String getWaitingStateIconId(MuSigWaitingState waitingState) {
+        return switch (waitingState) {
+            case FIAT_PAYMENT -> "fiat-payment";
+            case FIAT_PAYMENT_CONFIRMATION -> "fiat-payment-confirmation";
+            case BITCOIN_CONFIRMATION -> "bitcoin-confirmation";
+            case SCAN_WITH_CAMERA -> "scan-with-camera";
+            case TRADE_COMPLETED -> "take-bisq-easy-offer";
+        };
+    }
+
+    private String getSpinningCircleIconId(MuSigWaitingState state) {
+        return "spinning-circle";
+    }
+
+    public void play() {
+        rotate.play();
+        fadeTransition.play();
+    }
+
+    public void playIndefinitely() {
+        playRepeated(0, 4 * INTERVAL, TimeUnit.MILLISECONDS, Long.MAX_VALUE);
+    }
+
+    public void playRepeated(long initialDelay, long delay, TimeUnit timeUnit, long cycles) {
+        stop();
+        uiScheduler = UIScheduler.run((this::play)).repeated(initialDelay, delay, timeUnit, cycles);
+    }
+
+    public void stop() {
+        rotate.stop();
+        fadeTransition.stop();
+        if (uiScheduler != null) {
+            uiScheduler.stop();
+            uiScheduler = null;
+        }
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/components/MuSigWaitingState.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/components/MuSigWaitingState.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.mu_sig.components;
+
+public enum MuSigWaitingState {
+    FIAT_PAYMENT,
+    FIAT_PAYMENT_CONFIRMATION,
+    BITCOIN_CONFIRMATION,
+    SCAN_WITH_CAMERA,
+    TRADE_COMPLETED
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/BaseState.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/BaseState.java
@@ -27,7 +27,7 @@ import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.components.controls.WrappingText;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
 import bisq.mu_sig.MuSigService;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.presentation.formatters.AmountFormatter;
@@ -123,7 +123,7 @@ public abstract class BaseState {
             this.trade = trade;
             this.channel = channel;
 
-            quoteCode=  trade.getContract().getOffer().getMarket().getQuoteCurrencyCode();
+            quoteCode = trade.getContract().getOffer().getMarket().getQuoteCurrencyCode();
         }
 
         protected MuSigOffer getMuSigOffer() {
@@ -146,7 +146,7 @@ public abstract class BaseState {
         protected void onViewDetached() {
         }
 
-        protected HBox createWaitingInfo(WaitingAnimation animation, WrappingText headline, WrappingText info) {
+        protected HBox createWaitingInfo(MuSigWaitingAnimation animation, WrappingText headline, WrappingText info) {
             animation.setAlignment(Pos.CENTER);
             VBox text = new VBox(headline, info);
             text.setAlignment(Pos.CENTER_LEFT);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/MuSigTradeCompletedTable.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/MuSigTradeCompletedTable.java
@@ -24,9 +24,9 @@ import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.controls.BitcoinAmountDisplay;
 import bisq.desktop.components.controls.WrappingText;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
-import bisq.desktop.main.content.bisq_easy.components.WaitingState;
 import bisq.desktop.main.content.components.UserProfileDisplay;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -47,11 +47,11 @@ public class MuSigTradeCompletedTable extends VBox {
     private final GridPane headerGridPane, bodyGridPane;
     @Getter
     private final BisqMenuItem copyTxIdButton, copyTxExplorerLinkButton, openTxExplorerButton;
-    private final WaitingAnimation waitingAnimation;
+    private final MuSigWaitingAnimation waitingAnimation;
     private final BitcoinAmountDisplay bitcoinAmountDisplay;
 
     public MuSigTradeCompletedTable() {
-        waitingAnimation = new WaitingAnimation(WaitingState.TRADE_COMPLETED);
+        waitingAnimation = new MuSigWaitingAnimation(MuSigWaitingState.TRADE_COMPLETED);
 
         WrappingText headline = MuSigFormUtils.getHeadline(Res.get("muSig.tradeCompleted.title"));
         WrappingText info = MuSigFormUtils.getInfo(Res.get("muSig.tradeCompleted.info"));
@@ -268,7 +268,7 @@ public class MuSigTradeCompletedTable extends VBox {
         return line;
     }
 
-    private HBox createWaitingInfo(WaitingAnimation animation, WrappingText headline, WrappingText info) {
+    private HBox createWaitingInfo(MuSigWaitingAnimation animation, WrappingText headline, WrappingText info) {
         animation.setAlignment(Pos.CENTER);
         VBox textBox = new VBox(10, headline, info);
         return new HBox(20, animation, textBox);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State1aSetupDepositTx.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State1aSetupDepositTx.java
@@ -20,8 +20,8 @@ package bisq.desktop.main.content.mu_sig.open_trades.trade_state.states;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.components.controls.WrappingText;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
-import bisq.desktop.main.content.bisq_easy.components.WaitingState;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
 import bisq.trade.mu_sig.MuSigTrade;
 import javafx.scene.layout.HBox;
@@ -79,14 +79,14 @@ public class State1aSetupDepositTx extends BaseState {
     }
 
     public static class View extends BaseState.View<Model, Controller> {
-        private final WaitingAnimation waitingAnimation;
+        private final MuSigWaitingAnimation waitingAnimation;
 
         private View(Model model, Controller controller) {
             super(model, controller);
 
             WrappingText headline = MuSigFormUtils.getHeadline(Res.get("muSig.tradeState.info.phase1a.headline"));
             WrappingText info = MuSigFormUtils.getInfo(Res.get("muSig.tradeState.info.phase1a.info"));
-            waitingAnimation = new WaitingAnimation(WaitingState.BITCOIN_CONFIRMATION);
+            waitingAnimation = new MuSigWaitingAnimation(MuSigWaitingState.BITCOIN_CONFIRMATION);
             HBox waitingInfo = createWaitingInfo(waitingAnimation, headline, info);
 
             root.getChildren().addAll(waitingInfo);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State1bWaitForDepositTxConfirmation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State1bWaitForDepositTxConfirmation.java
@@ -30,8 +30,8 @@ import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.desktop.components.controls.validator.BitcoinTransactionValidator;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
-import bisq.desktop.main.content.bisq_easy.components.WaitingState;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
 import bisq.presentation.formatters.AmountFormatter;
 import bisq.trade.mu_sig.MuSigTrade;
@@ -234,7 +234,7 @@ public class State1bWaitForDepositTxConfirmation extends BaseState {
     public static class View extends BaseState.View<Model, Controller> {
         private final Button button;
         private final MaterialTextField txId;
-        private final WaitingAnimation waitingAnimation;
+        private final MuSigWaitingAnimation waitingAnimation;
         private Subscription confirmationStatePin;
 
         private View(Model model, Controller controller) {
@@ -243,7 +243,7 @@ public class State1bWaitForDepositTxConfirmation extends BaseState {
             String role = model.getRole();
             WrappingText headline = MuSigFormUtils.getHeadline(Res.get("muSig.tradeState.info.phase1b.headline"));
             WrappingText info = MuSigFormUtils.getInfo(Res.get("muSig.tradeState.info.phase1b.info." + role, model.getQuoteCode()));
-            waitingAnimation = new WaitingAnimation(WaitingState.BITCOIN_CONFIRMATION);
+            waitingAnimation = new MuSigWaitingAnimation(MuSigWaitingState.BITCOIN_CONFIRMATION);
             HBox waitingInfo = createWaitingInfo(waitingAnimation, headline, info);
 
             txId = MuSigFormUtils.getTextField(Res.get("muSig.tradeState.info.phase1b.txId"), "", false);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State2SellerWaitForPayment.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State2SellerWaitForPayment.java
@@ -20,8 +20,8 @@ package bisq.desktop.main.content.mu_sig.open_trades.trade_state.states;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.components.controls.WrappingText;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
-import bisq.desktop.main.content.bisq_easy.components.WaitingState;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
 import bisq.trade.mu_sig.MuSigTrade;
 import javafx.scene.layout.HBox;
@@ -33,7 +33,9 @@ import lombok.extern.slf4j.Slf4j;
 public class State2SellerWaitForPayment extends BaseState {
     private final Controller controller;
 
-    public State2SellerWaitForPayment(ServiceProvider serviceProvider, MuSigTrade trade, MuSigOpenTradeChannel channel) {
+    public State2SellerWaitForPayment(ServiceProvider serviceProvider,
+                                      MuSigTrade trade,
+                                      MuSigOpenTradeChannel channel) {
         controller = new Controller(serviceProvider, trade, channel);
     }
 
@@ -76,12 +78,12 @@ public class State2SellerWaitForPayment extends BaseState {
 
     public static class View extends BaseState.View<Model, Controller> {
         private final WrappingText headline, info;
-        private final WaitingAnimation waitingAnimation;
+        private final MuSigWaitingAnimation waitingAnimation;
 
         private View(Model model, Controller controller) {
             super(model, controller);
 
-            waitingAnimation = new WaitingAnimation(WaitingState.FIAT_PAYMENT);
+            waitingAnimation = new MuSigWaitingAnimation(MuSigWaitingState.FIAT_PAYMENT);
             headline = MuSigFormUtils.getHeadline();
             info = MuSigFormUtils.getInfo();
             HBox waitingInfo = createWaitingInfo(waitingAnimation, headline, info);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State3BuyerWaitForSellersPaymentReceiptConfirmation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State3BuyerWaitForSellersPaymentReceiptConfirmation.java
@@ -20,8 +20,8 @@ package bisq.desktop.main.content.mu_sig.open_trades.trade_state.states;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.components.controls.WrappingText;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
-import bisq.desktop.main.content.bisq_easy.components.WaitingState;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
 import bisq.trade.mu_sig.MuSigTrade;
 import javafx.scene.layout.HBox;
@@ -33,7 +33,9 @@ import lombok.extern.slf4j.Slf4j;
 public class State3BuyerWaitForSellersPaymentReceiptConfirmation extends BaseState {
     private final Controller controller;
 
-    public State3BuyerWaitForSellersPaymentReceiptConfirmation(ServiceProvider serviceProvider, MuSigTrade trade, MuSigOpenTradeChannel channel) {
+    public State3BuyerWaitForSellersPaymentReceiptConfirmation(ServiceProvider serviceProvider,
+                                                               MuSigTrade trade,
+                                                               MuSigOpenTradeChannel channel) {
         controller = new Controller(serviceProvider, trade, channel);
     }
 
@@ -76,12 +78,12 @@ public class State3BuyerWaitForSellersPaymentReceiptConfirmation extends BaseSta
 
     public static class View extends BaseState.View<Model, Controller> {
         private final WrappingText headline, info;
-        private final WaitingAnimation waitingAnimation;
+        private final MuSigWaitingAnimation waitingAnimation;
 
         private View(Model model, Controller controller) {
             super(model, controller);
 
-            waitingAnimation = new WaitingAnimation(WaitingState.FIAT_PAYMENT_CONFIRMATION);
+            waitingAnimation = new MuSigWaitingAnimation(MuSigWaitingState.FIAT_PAYMENT_CONFIRMATION);
             headline = MuSigFormUtils.getHeadline();
             info = MuSigFormUtils.getInfo();
             HBox waitingInfo = createWaitingInfo(waitingAnimation, headline, info);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State3bSellerWaitForBuyerToCloseTrade.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State3bSellerWaitForBuyerToCloseTrade.java
@@ -20,8 +20,8 @@ package bisq.desktop.main.content.mu_sig.open_trades.trade_state.states;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.components.controls.WrappingText;
-import bisq.desktop.main.content.bisq_easy.components.WaitingAnimation;
-import bisq.desktop.main.content.bisq_easy.components.WaitingState;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
+import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
 import bisq.trade.mu_sig.MuSigTrade;
 import javafx.scene.layout.HBox;
@@ -33,7 +33,9 @@ import lombok.extern.slf4j.Slf4j;
 public class State3bSellerWaitForBuyerToCloseTrade extends BaseState {
     private final Controller controller;
 
-    public State3bSellerWaitForBuyerToCloseTrade(ServiceProvider serviceProvider, MuSigTrade trade, MuSigOpenTradeChannel channel) {
+    public State3bSellerWaitForBuyerToCloseTrade(ServiceProvider serviceProvider,
+                                                 MuSigTrade trade,
+                                                 MuSigOpenTradeChannel channel) {
         controller = new Controller(serviceProvider, trade, channel);
     }
 
@@ -76,12 +78,12 @@ public class State3bSellerWaitForBuyerToCloseTrade extends BaseState {
 
     public static class View extends BaseState.View<Model, Controller> {
         private final WrappingText headline, info;
-        private final WaitingAnimation waitingAnimation;
+        private final MuSigWaitingAnimation waitingAnimation;
 
         private View(Model model, Controller controller) {
             super(model, controller);
 
-            waitingAnimation = new WaitingAnimation(WaitingState.FIAT_PAYMENT);
+            waitingAnimation = new MuSigWaitingAnimation(MuSigWaitingState.FIAT_PAYMENT);
             headline = MuSigFormUtils.getHeadline();
             info = MuSigFormUtils.getInfo();
             HBox waitingInfo = createWaitingInfo(waitingAnimation, headline, info);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced waiting animation for multi-signature trade operations, displaying progress through deposit setup, confirmations, and payment states with visual feedback during key transaction phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->