### PR TITLE
Fix MuSig BTC and non-BTC side mapping in open trades.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradeListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradeListItem.java
@@ -102,12 +102,8 @@ class MuSigOpenTradeListItem implements DateTableItem {
         );
         basePaymentRail = contract.getBaseSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
         quotePaymentRail = contract.getQuoteSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
-        paymentMethodDisplayName = isBaseCurrencyBitcoin
-                ? contract.getQuoteSidePaymentMethodSpec().getShortDisplayString()
-                : contract.getBaseSidePaymentMethodSpec().getShortDisplayString();
-        paymentMethod = isBaseCurrencyBitcoin
-                ? contract.getQuoteSidePaymentMethodSpec().getPaymentMethod()
-                : contract.getBaseSidePaymentMethodSpec().getPaymentMethod();
+        paymentMethodDisplayName = contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString();
+        paymentMethod = contract.getNonBtcSidePaymentMethodSpec().getPaymentMethod();
 
         myRole = MuSigTradeFormatter.getMakerTakerRole(trade);
         reputationScore = reputationService.getReputationScore(peersUserProfile);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_details/MuSigTradeDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_details/MuSigTradeDetailsController.java
@@ -111,10 +111,7 @@ public class MuSigTradeDetailsController extends NavigationController implements
                 ? ""
                 : String.format("(%s)", PriceSpecFormatter.getFormattedPriceSpec(trade.getOffer().getPriceSpec(), true)));
 
-
-        if (isBaseCurrencyBitcoin) {
-            model.setPaymentMethod(contract.getQuoteSidePaymentMethodSpec().getShortDisplayString());
-        }
+        model.setPaymentMethod(contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString());
         model.setPaymentMethodsBoxVisible(isBaseCurrencyBitcoin);
 
         model.setTradeId(trade.getId());

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigTradePhaseBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/MuSigTradePhaseBox.java
@@ -130,7 +130,7 @@ class MuSigTradePhaseBox {
             }
 
             TradeDuration tradeDuration = trade.getContract()
-                    .getQuoteSidePaymentMethodSpec()
+                    .getNonBtcSidePaymentMethodSpec()
                     .getPaymentMethod()
                     .getPaymentRail()
                     .getTradeDuration();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State1bWaitForDepositTxConfirmation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State1bWaitForDepositTxConfirmation.java
@@ -21,7 +21,6 @@ import bisq.bonded_roles.explorer.ExplorerService;
 import bisq.bonded_roles.explorer.dto.Output;
 import bisq.bonded_roles.explorer.dto.Tx;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
-import bisq.common.monetary.Coin;
 import bisq.common.util.ExceptionUtil;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Browser;
@@ -33,7 +32,6 @@ import bisq.desktop.components.controls.validator.BitcoinTransactionValidator;
 import bisq.desktop.main.content.mu_sig.components.MuSigWaitingAnimation;
 import bisq.desktop.main.content.mu_sig.components.MuSigWaitingState;
 import bisq.i18n.Res;
-import bisq.presentation.formatters.AmountFormatter;
 import bisq.trade.mu_sig.MuSigTrade;
 import de.jensd.fx.fontawesome.AwesomeIcon;
 import javafx.beans.property.BooleanProperty;
@@ -200,10 +198,6 @@ public class State1bWaitForDepositTxConfirmation extends BaseState {
                                     ExceptionUtil.getRootCauseMessage(rootCause)));
                         }
                     }));
-        }
-
-        private static String getFormattedBaseAmount(long value) {
-            return AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(value));
         }
 
         private List<Long> findTxOutputValuesForAddress(Tx tx, String address) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State2BuyerSendPayment.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State2BuyerSendPayment.java
@@ -88,8 +88,6 @@ public class State2BuyerSendPayment extends BaseState {
 
             MuSigTrade trade = model.getTrade();
 
-            String paymentMethodName = trade.getContract().getQuoteSidePaymentMethodSpec().getShortDisplayString();
-            model.setPaymentMethodName(paymentMethodName);
             AccountPayload<?> peersAccountPayload = trade.getPeer().getAccountPayload().orElseThrow();
             if (muSigService.isAccountDataBanned(peersAccountPayload)) {
                 model.getConfirmFiatSentButtonDisabled().set(true);
@@ -129,6 +127,7 @@ public class State2BuyerSendPayment extends BaseState {
 
             String formattedNonBtcAmount = model.getFormattedNonBtcAmount();
             if (model.getMarket().isBaseCurrencyBitcoin()) {
+                String paymentMethodName = trade.getContract().getNonBtcSidePaymentMethodSpec().getShortDisplayString();
                 model.setHeadline(Res.get("muSig.tradeState.info.fiat.phase2a.headline",
                         formattedNonBtcAmount, paymentMethodName));
                 model.setPeersAccountDataDescription(Res.get("muSig.tradeState.info.fiat.phase2a.sellersAccount"));
@@ -157,8 +156,6 @@ public class State2BuyerSendPayment extends BaseState {
     private static class Model extends BaseState.Model {
         private final BooleanProperty confirmFiatSentButtonDisabled = new SimpleBooleanProperty();
         private final SettableErrorValidator accountDataBannedValidator = new SettableErrorValidator(Res.get("bisqEasy.tradeState.info.buyer.phase2a.accountDataBannedError"));
-        @Setter
-        private String paymentMethodName;
         @Setter
         private String sellersAccountData;
         @Setter

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State4TradeClosed.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/trade_state/states/State4TradeClosed.java
@@ -107,7 +107,7 @@ public class State4TradeClosed extends BaseState {
             model.setTradePeer(tradePeer);
             model.setBuyer(trade.isBuyerInDisplayContext());
             model.setQuoteCurrency(trade.getOffer().getMarket().getQuoteCurrencyCode());
-            model.setPaymentMethod(contract.getQuoteSidePaymentMethodSpec().getShortDisplayString());
+            model.setPaymentMethod(contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString());
             model.setTradeId(trade.getShortId());
             long takeOfferDate = contract.getTakeOfferDate();
             model.setTradeDate(DateFormatter.formatDateTime(takeOfferDate));

--- a/contract/src/main/java/bisq/contract/mu_sig/MuSigContract.java
+++ b/contract/src/main/java/bisq/contract/mu_sig/MuSigContract.java
@@ -176,4 +176,12 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
             return offer.getQuoteSidePaymentMethodSpecs().get(0);
         }
     }
+
+    public PaymentMethodSpec<?> getBtcSidePaymentMethodSpec() {
+        return offer.getMarket().isBaseCurrencyBitcoin() ? baseSidePaymentMethodSpec : quoteSidePaymentMethodSpec;
+    }
+
+    public PaymentMethodSpec<?> getNonBtcSidePaymentMethodSpec() {
+        return offer.getMarket().isBaseCurrencyBitcoin() ? quoteSidePaymentMethodSpec : baseSidePaymentMethodSpec;
+    }
 }

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
@@ -289,11 +289,11 @@ public class OfferAmountUtil {
                                                          Monetary baseSideMonetary,
                                                          Monetary quoteSideMonetary,
                                                          double securityDeposit) {
-        if (market.isBtcFiatMarket()) {
-            checkArgument(market.isBaseCurrencyBitcoin());
+        if (market.isBaseCurrencyBitcoin()) {
+            checkArgument(baseSideMonetary.getCode().equals("BTC"));
             return calculateSecurityDeposit(baseSideMonetary, securityDeposit);
         } else {
-            checkArgument(!market.isBaseCurrencyBitcoin());
+            checkArgument(quoteSideMonetary.getCode().equals("BTC"));
             return calculateSecurityDeposit(quoteSideMonetary, securityDeposit);
         }
     }

--- a/offer/src/main/java/bisq/offer/mu_sig/MuSigOffer.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MuSigOffer.java
@@ -64,10 +64,10 @@ public final class MuSigOffer extends Offer<PaymentMethodSpec<?>, PaymentMethodS
                 amountSpec,
                 priceSpec,
                 List.of(TradeProtocolType.MU_SIG),
-                market.isBtcFiatMarket()
+                market.isBaseCurrencyBitcoin()
                         ? createBitcoinMainChainPaymentMethodSpec()
                         : PaymentMethodSpecUtil.createPaymentMethodSpecs(paymentMethods, market.getBaseCurrencyCode()),
-                market.isBtcFiatMarket()
+                market.isBaseCurrencyBitcoin()
                         ? PaymentMethodSpecUtil.createPaymentMethodSpecs(paymentMethods, market.getQuoteCurrencyCode())
                         : createBitcoinMainChainPaymentMethodSpec(),
                 offerOptions,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected payment method shown across trade details, open-trade list, phase views and closed trades so the Non‑BTC side payment method is used when Bitcoin is the base currency.
  * Aligned trade duration and related displays with the corrected payment method source.

* **Refactor**
  * Added contract-level accessors to explicitly expose BTC-side and Non‑BTC-side payment method specs for consistent UI sourcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->