### PR TITLE
Improve btc and non btc side mapping for mediation.

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/Badge.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/Badge.java
@@ -136,6 +136,9 @@ public class Badge extends StackPane {
 
     public void setControl(Node control) {
         if (control != null) {
+            if (this.control != null) {
+                getChildren().remove(this.control);
+            }
             this.control = control;
             getChildren().add(0, control);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationTableView.java
@@ -420,6 +420,7 @@ class BisqEasyMediationTableView extends VBox {
                                                              boolean isRequester,
                                                              BisqEasyMediationCaseListItem.Trader trader) {
         UserProfileDisplay userProfileDisplay = new UserProfileDisplay(trader.getUserProfile(), false);
+        userProfileDisplay.setReputationScore(trader.getReputationScore());
         if (isRequester) {
             userProfileDisplay.getStyleClass().add("mediator-table-requester");
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItem.java
@@ -29,6 +29,7 @@ import bisq.desktop.components.table.ActivatableTableItem;
 import bisq.desktop.components.table.DateTableItem;
 import bisq.i18n.Res;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.presentation.formatters.AmountFormatter;
 import bisq.presentation.formatters.DateFormatter;
 import bisq.presentation.formatters.TimeFormatter;
 import bisq.support.mediation.mu_sig.MuSigMediationCase;
@@ -60,9 +61,9 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
     private final ReputationService reputationService;
 
     private final Trader maker, taker;
-    private final long date, price, baseAmount, quoteAmount;
+    private final long date, price, btcAmount, nonBtcAmount;
     private final String dateString, timeString, tradeId, shortTradeId, directionalTitle, market,
-            priceString, baseAmountString, quoteAmountString, paymentMethod;
+            priceString, btcAmountString, nonBtcAmountString, paymentMethod;
     private final boolean isMakerRequester;
     private final Badge makersBadge = new Badge();
     private final Badge takersBadge = new Badge();
@@ -103,11 +104,11 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
         market = offer.getMarket().toString();
         price = MuSigTradeUtils.getPriceQuote(contract).getValue();
         priceString = MuSigTradeFormatter.formatPriceWithCode(contract);
-        baseAmount = contract.getBaseSideAmount();
-        baseAmountString = MuSigTradeFormatter.formatBaseSideAmount(contract);
-        quoteAmount = contract.getQuoteSideAmount();
-        quoteAmountString = MuSigTradeFormatter.formatQuoteSideAmountWithCode(contract);
-        paymentMethod = contract.getQuoteSidePaymentMethodSpec().getShortDisplayString();
+        btcAmount = contract.getBtcSideAmount();
+        btcAmountString = MuSigTradeFormatter.formatBtcSideAmount(contract);
+        nonBtcAmount = contract.getNonBtcSideAmount();
+        nonBtcAmountString = AmountFormatter.formatAmountWithCode(MuSigTradeUtils.getNonBtcSideMonetary(contract), true);
+        paymentMethod = offer.getMarket().isBaseCurrencyBitcoin() ? contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString() : "";
 
         onActivate();
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationTableView.java
@@ -214,8 +214,8 @@ class MuSigMediationTableView extends VBox {
                         item.getMarket().toLowerCase().contains(string) ||
                         item.getPaymentMethod().toLowerCase().contains(string) ||
                         item.getPriceString().toLowerCase().contains(string) ||
-                        item.getQuoteAmountString().toLowerCase().contains(string) ||
-                        item.getBaseAmountString().toLowerCase().contains(string) ||
+                        item.getNonBtcAmountString().toLowerCase().contains(string) ||
+                        item.getBtcAmountString().toLowerCase().contains(string) ||
                         item.getDateString().toLowerCase().contains(string) ||
                         item.getTimeString().toLowerCase().contains(string) ||
                         item.getCloseCaseDateString().toLowerCase().contains(string) ||
@@ -287,14 +287,14 @@ class MuSigMediationTableView extends VBox {
         tableView.getColumns().add(new BisqTableColumn.Builder<MuSigMediationCaseListItem>()
                 .title(Res.get("bisqEasy.openTrades.table.quoteAmount"))
                 .fixWidth(120)
-                .comparator(Comparator.comparing(MuSigMediationCaseListItem::getQuoteAmount))
-                .valueSupplier(MuSigMediationCaseListItem::getQuoteAmountString)
+                .comparator(Comparator.comparing(MuSigMediationCaseListItem::getNonBtcAmount))
+                .valueSupplier(MuSigMediationCaseListItem::getNonBtcAmountString)
                 .build());
         tableView.getColumns().add(new BisqTableColumn.Builder<MuSigMediationCaseListItem>()
                 .title(Res.get("bisqEasy.openTrades.table.baseAmount"))
                 .fixWidth(120)
-                .comparator(Comparator.comparing(MuSigMediationCaseListItem::getBaseAmount))
-                .valueSupplier(MuSigMediationCaseListItem::getBaseAmountString)
+                .comparator(Comparator.comparing(MuSigMediationCaseListItem::getBtcAmount))
+                .valueSupplier(MuSigMediationCaseListItem::getBtcAmountString)
                 .build());
         tableView.getColumns().add(new BisqTableColumn.Builder<MuSigMediationCaseListItem>()
                 .title(Res.get("bisqEasy.openTrades.table.price"))
@@ -420,6 +420,7 @@ class MuSigMediationTableView extends VBox {
                                                              boolean isRequester,
                                                              MuSigMediationCaseListItem.Trader trader) {
         UserProfileDisplay userProfileDisplay = new UserProfileDisplay(trader.getUserProfile(), false);
+        userProfileDisplay.setReputationScore(trader.getReputationScore());
         if (isRequester) {
             userProfileDisplay.getStyleClass().add("mediator-table-requester");
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseDetailSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseDetailSection.java
@@ -17,7 +17,6 @@
 
 package bisq.desktop.main.content.authorized_role.mediator.mu_sig.components;
 
-import bisq.common.market.Market;
 import bisq.common.monetary.Monetary;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.desktop.ServiceProvider;
@@ -112,7 +111,7 @@ public class MuSigMediationCaseDetailSection {
                 double securityDeposit = collateralOption.get().getBuyerSecurityDeposit();
                 model.setSecurityDepositInfo(Optional.of(new Model.SecurityDepositInfo(
                         securityDeposit,
-                        calculateSecurityDeposit(offer.getMarket(), contract, securityDeposit),
+                        calculateSecurityDeposit(contract, securityDeposit),
                         PercentageFormatter.formatToPercentWithSymbol(securityDeposit, 0),
                         true)));
             }
@@ -141,12 +140,10 @@ public class MuSigMediationCaseDetailSection {
             model.setSecurityDepositInfo(Optional.empty());
         }
 
-        private static String calculateSecurityDeposit(Market market,
-                                                       MuSigContract contract,
+        private static String calculateSecurityDeposit(MuSigContract contract,
                                                        double securityDepositAsPercent) {
-            Monetary baseSideMonetary = MuSigTradeUtils.getBaseSideMonetary(contract);
-            Monetary quoteSideMonetary = MuSigTradeUtils.getQuoteSideMonetary(contract);
-            Monetary securityDeposit = OfferAmountUtil.calculateSecurityDepositAsBTC(market, baseSideMonetary, quoteSideMonetary, securityDepositAsPercent);
+            Monetary securityDeposit = OfferAmountUtil.calculateSecurityDepositAsBTC(
+                    MuSigTradeUtils.getBtcSideMonetary(contract), securityDepositAsPercent);
             return OfferAmountFormatter.formatDepositAmountAsBTC(securityDeposit);
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradeListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/open_trades/MuSigOpenTradeListItem.java
@@ -92,14 +92,10 @@ class MuSigOpenTradeListItem implements DateTableItem {
         market = trade.getOffer().getMarket().toString();
         price = MuSigTradeUtils.getPriceQuote(trade).getValue();
         priceString = MuSigTradeFormatter.formatPriceWithCode(trade);
-        boolean isBaseCurrencyBitcoin = trade.getOffer().getMarket().isBaseCurrencyBitcoin();
-        btcAmount = isBaseCurrencyBitcoin ? contract.getBaseSideAmount() : contract.getQuoteSideAmount();
-        btcAmountString = isBaseCurrencyBitcoin ? MuSigTradeFormatter.formatBaseSideAmount(trade) : MuSigTradeFormatter.formatQuoteSideAmount(trade);
-        nonBtcAmount = isBaseCurrencyBitcoin ? contract.getQuoteSideAmount() : contract.getBaseSideAmount();
-        nonBtcAmountString = AmountFormatter.formatAmountWithCode(
-                isBaseCurrencyBitcoin ? MuSigTradeUtils.getQuoteSideMonetary(trade) : MuSigTradeUtils.getBaseSideMonetary(trade),
-                true
-        );
+        btcAmount = contract.getBtcSideAmount();
+        btcAmountString = MuSigTradeFormatter.formatBtcSideAmount(trade);
+        nonBtcAmount = contract.getNonBtcSideAmount();
+        nonBtcAmountString = AmountFormatter.formatAmountWithCode(MuSigTradeUtils.getNonBtcSideMonetary(trade), true);
         basePaymentRail = contract.getBaseSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
         quotePaymentRail = contract.getQuoteSidePaymentMethodSpec().getPaymentMethod().getPaymentRail();
         paymentMethodDisplayName = contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString();

--- a/contract/src/main/java/bisq/contract/mu_sig/MuSigContract.java
+++ b/contract/src/main/java/bisq/contract/mu_sig/MuSigContract.java
@@ -184,4 +184,12 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
     public PaymentMethodSpec<?> getNonBtcSidePaymentMethodSpec() {
         return offer.getMarket().isBaseCurrencyBitcoin() ? quoteSidePaymentMethodSpec : baseSidePaymentMethodSpec;
     }
+
+    public long getBtcSideAmount() {
+        return offer.getMarket().isBaseCurrencyBitcoin() ? baseSideAmount : quoteSideAmount;
+    }
+
+    public long getNonBtcSideAmount() {
+        return offer.getMarket().isBaseCurrencyBitcoin() ? quoteSideAmount : baseSideAmount;
+    }
 }

--- a/contract/src/test/java/bisq/contract/mu_sig/MuSigContractTest.java
+++ b/contract/src/test/java/bisq/contract/mu_sig/MuSigContractTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.contract.mu_sig;
+
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.protocol_type.TradeProtocolType;
+import bisq.account.payment_method.crypto.CryptoPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.market.Market;
+import bisq.contract.Party;
+import bisq.contract.Role;
+import bisq.offer.Direction;
+import bisq.offer.mu_sig.MuSigOffer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class MuSigContractTest {
+    @Test
+    void usesBaseAsBtcSideWhenBaseCurrencyIsBitcoin() {
+        PaymentMethodSpec<?> baseSpec = PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        PaymentMethodSpec<?> quoteSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD");
+        MuSigContract contract = createContract(createBtcFiatMarket(), 111L, 222L, baseSpec, quoteSpec);
+
+        assertEquals(111L, contract.getBtcSideAmount());
+        assertEquals(222L, contract.getNonBtcSideAmount());
+        assertSame(baseSpec, contract.getBtcSidePaymentMethodSpec());
+        assertSame(quoteSpec, contract.getNonBtcSidePaymentMethodSpec());
+    }
+
+    @Test
+    void usesQuoteAsBtcSideWhenBaseCurrencyIsNotBitcoin() {
+        PaymentMethodSpec<?> baseSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(new CryptoPaymentMethod("XMR"), "XMR");
+        PaymentMethodSpec<?> quoteSpec = PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        MuSigContract contract = createContract(createCryptoBtcMarket(), 111L, 222L, baseSpec, quoteSpec);
+
+        assertEquals(222L, contract.getBtcSideAmount());
+        assertEquals(111L, contract.getNonBtcSideAmount());
+        assertSame(quoteSpec, contract.getBtcSidePaymentMethodSpec());
+        assertSame(baseSpec, contract.getNonBtcSidePaymentMethodSpec());
+    }
+
+    private MuSigContract createContract(Market market,
+                                         long baseSideAmount,
+                                         long quoteSideAmount,
+                                         PaymentMethodSpec<?> baseSpec,
+                                         PaymentMethodSpec<?> quoteSpec) {
+        MuSigOffer offer = new MuSigOffer("test-id",
+                null,
+                Direction.BUY,
+                market,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                "1.0.0");
+        return new MuSigContract(System.currentTimeMillis(),
+                offer,
+                TradeProtocolType.MU_SIG,
+                new Party(Role.TAKER, null),
+                baseSideAmount,
+                quoteSideAmount,
+                baseSpec,
+                quoteSpec,
+                Optional.empty(),
+                null,
+                0);
+    }
+
+    private Market createBtcFiatMarket() {
+        return new Market("BTC", "USD", "Bitcoin", "US Dollar");
+    }
+
+    private Market createCryptoBtcMarket() {
+        return new Market("XMR", "BTC", "Monero", "Bitcoin");
+    }
+}

--- a/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
@@ -281,20 +281,19 @@ public class OfferAmountUtil {
     // Deposit Amount
     /* --------------------------------------------------------------------- */
 
-    public static Monetary calculateSecurityDeposit(Monetary monetary, double securityDeposit) {
-        return Monetary.from(MathUtils.roundDoubleToLong(monetary.getValue() * securityDeposit), monetary.getCode());
-    }
-
     public static Monetary calculateSecurityDepositAsBTC(Market market,
                                                          Monetary baseSideMonetary,
                                                          Monetary quoteSideMonetary,
                                                          double securityDeposit) {
-        if (market.isBaseCurrencyBitcoin()) {
-            checkArgument(baseSideMonetary.getCode().equals("BTC"));
-            return calculateSecurityDeposit(baseSideMonetary, securityDeposit);
-        } else {
-            checkArgument(quoteSideMonetary.getCode().equals("BTC"));
-            return calculateSecurityDeposit(quoteSideMonetary, securityDeposit);
-        }
+        Monetary btcSideMonetary = market.isBaseCurrencyBitcoin()
+                ? baseSideMonetary
+                : quoteSideMonetary;
+        return calculateSecurityDepositAsBTC(btcSideMonetary, securityDeposit);
+    }
+
+    public static Monetary calculateSecurityDepositAsBTC(Monetary btcSideMonetary,
+                                                         double securityDeposit) {
+        checkArgument(btcSideMonetary.getCode().equals("BTC"));
+        return Monetary.from(MathUtils.roundDoubleToLong(btcSideMonetary.getValue() * securityDeposit), btcSideMonetary.getCode());
     }
 }

--- a/presentation/src/main/java/bisq/presentation/formatters/AmountFormatter.java
+++ b/presentation/src/main/java/bisq/presentation/formatters/AmountFormatter.java
@@ -66,7 +66,6 @@ public class AmountFormatter {
                 .orElse("");
     }
 
-
     // Base amount
     public static String formatBaseAmount(Monetary amount) {
         return formatAmountByMonetaryType(amount);
@@ -85,11 +84,11 @@ public class AmountFormatter {
         return formatAmountWithCodeByMonetaryType(amount);
     }
 
-    private static String formatAmountByMonetaryType(Monetary amount) {
+    public static String formatAmountByMonetaryType(Monetary amount) {
         return formatAmount(amount, amount instanceof Fiat);
     }
 
-    private static String formatAmountWithCodeByMonetaryType(Monetary amount) {
+    public static String formatAmountWithCodeByMonetaryType(Monetary amount) {
         return formatAmountWithCode(amount, LocaleRepository.getDefaultLocale(), amount instanceof Fiat);
     }
 

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeFormatter.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeFormatter.java
@@ -41,15 +41,19 @@ public final class MuSigTradeFormatter {
     }
 
     public static String formatBtcSideAmount(MuSigTrade trade) {
-        return trade.getMarket().isBaseCurrencyBitcoin()
-                ? formatBaseSideAmount(trade)
-                : formatQuoteSideAmount(trade);
+        return formatBtcSideAmount(trade.getContract());
+    }
+
+    public static String formatBtcSideAmount(MuSigContract contract) {
+        return AmountFormatter.formatAmountByMonetaryType(MuSigTradeUtils.getBtcSideMonetary(contract));
     }
 
     public static String formatNonBtcSideAmount(MuSigTrade trade) {
-        return trade.getMarket().isBaseCurrencyBitcoin()
-                ? formatQuoteSideAmount(trade)
-                : formatBaseSideAmount(trade);
+        return formatNonBtcSideAmount(trade.getContract());
+    }
+
+    public static String formatNonBtcSideAmount(MuSigContract contract) {
+        return AmountFormatter.formatAmountByMonetaryType(MuSigTradeUtils.getNonBtcSideMonetary(contract));
     }
 
     public static String formatQuoteSideAmount(MuSigTrade trade) {

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -529,9 +529,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     public Optional<Account<? extends PaymentMethod<?>, ?>> findMyAccount(MuSigTrade trade) {
         MuSigContract contract = trade.getContract();
         MuSigOffer offer = contract.getOffer();
-        PaymentMethod<?> selectedPaymentMethod = offer.getMarket().isBaseCurrencyBitcoin()
-                ? contract.getQuoteSidePaymentMethodSpec().getPaymentMethod()
-                : contract.getBaseSidePaymentMethodSpec().getPaymentMethod();
+        PaymentMethod<?> selectedPaymentMethod = contract.getNonBtcSidePaymentMethodSpec().getPaymentMethod();
         Set<Account<? extends PaymentMethod<?>, ?>> matchingAccounts = serviceProvider.getAccountService().getAccounts(selectedPaymentMethod);
         Set<AccountOption> accountOptions = OfferOptionUtil.findAccountOptions(offer.getOfferOptions());
         return accountOptions.stream()

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeUtils.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeUtils.java
@@ -38,6 +38,22 @@ public final class MuSigTradeUtils {
         return Monetary.from(contract.getQuoteSideAmount(), contract.getOffer().getMarket().getQuoteCurrencyCode());
     }
 
+    public static Monetary getBtcSideMonetary(MuSigTrade trade) {
+        return getBtcSideMonetary(trade.getContract());
+    }
+
+    public static Monetary getBtcSideMonetary(MuSigContract contract) {
+        return contract.getOffer().getMarket().isBaseCurrencyBitcoin() ? getBaseSideMonetary(contract) : getQuoteSideMonetary(contract);
+    }
+
+    public static Monetary getNonBtcSideMonetary(MuSigTrade trade) {
+        return getNonBtcSideMonetary(trade.getContract());
+    }
+
+    public static Monetary getNonBtcSideMonetary(MuSigContract contract) {
+        return contract.getOffer().getMarket().isBaseCurrencyBitcoin() ? getQuoteSideMonetary(contract) : getBaseSideMonetary(contract);
+    }
+
     public static PriceQuote getPriceQuote(MuSigTrade trade) {
         return PriceQuote.from(getBaseSideMonetary(trade), getQuoteSideMonetary(trade));
     }

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeFormatterTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeFormatterTest.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.protocol_type.TradeProtocolType;
+import bisq.account.payment_method.crypto.CryptoPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.locale.LocaleRepository;
+import bisq.common.market.Market;
+import bisq.contract.Party;
+import bisq.contract.Role;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.offer.Direction;
+import bisq.offer.mu_sig.MuSigOffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MuSigTradeFormatterTest {
+    private Locale previousLocale;
+
+    @BeforeEach
+    void setUp() {
+        previousLocale = LocaleRepository.getDefaultLocale();
+        LocaleRepository.setDefaultLocale(Locale.US);
+    }
+
+    @AfterEach
+    void tearDown() {
+        LocaleRepository.setDefaultLocale(previousLocale);
+    }
+
+    @Test
+    void formatBtcSideAmountMatchesBaseForBtcFiatMarket() {
+        MuSigContract contract = createContract(createBtcFiatMarket(), 100_000_000L, 12_345_000L);
+
+        assertEquals("1.00000000", MuSigTradeFormatter.formatBtcSideAmount(contract));
+    }
+
+    @Test
+    void formatBtcSideAmountMatchesQuoteForCryptoBtcMarket() {
+        MuSigContract contract = createContract(createCryptoBtcMarket(), 12_345_000_000L, 100_000_000L);
+
+        assertEquals("1.00000000", MuSigTradeFormatter.formatBtcSideAmount(contract));
+    }
+
+    @Test
+    void formatNonBtcSideAmountMatchesQuoteForBtcFiatMarket() {
+        MuSigContract contract = createContract(createBtcFiatMarket(), 100_000_000L, 12_345_000L);
+
+        assertEquals("1234.50", MuSigTradeFormatter.formatNonBtcSideAmount(contract));
+    }
+
+    @Test
+    void formatNonBtcSideAmountMatchesBaseForCryptoBtcMarket() {
+        MuSigContract contract = createContract(createCryptoBtcMarket(), 12_345_000_000L, 100_000_000L);
+
+        assertEquals("0.012345000000", MuSigTradeFormatter.formatNonBtcSideAmount(contract));
+    }
+
+    @Test
+    void formatBaseAndQuoteAmountsForBtcFiatMarket() {
+        MuSigContract contract = createContract(createBtcFiatMarket(), 100_000_000L, 12_345_000L);
+
+        assertEquals("1.00000000", MuSigTradeFormatter.formatBaseSideAmount(contract));
+        assertEquals("1234.50", MuSigTradeFormatter.formatQuoteSideAmount(contract));
+        assertEquals("1.00000000 BTC", MuSigTradeFormatter.formatBaseSideAmountWithCode(contract));
+        assertEquals("1234.50 USD", MuSigTradeFormatter.formatQuoteSideAmountWithCode(contract));
+    }
+
+    @Test
+    void formatBaseAndQuoteAmountsForCryptoBtcMarket() {
+        MuSigContract contract = createContract(createCryptoBtcMarket(), 12_345_000_000L, 100_000_000L);
+
+        assertEquals("0.012345000000", MuSigTradeFormatter.formatBaseSideAmount(contract));
+        assertEquals("1.00000000", MuSigTradeFormatter.formatQuoteSideAmount(contract));
+        assertEquals("0.012345000000 XMR", MuSigTradeFormatter.formatBaseSideAmountWithCode(contract));
+        assertEquals("1.00000000 BTC", MuSigTradeFormatter.formatQuoteSideAmountWithCode(contract));
+    }
+
+    @Test
+    void formatPriceWithCodeForBtcFiatMarket() {
+        MuSigContract contract = createContract(createBtcFiatMarket(), 100_000_000L, 12_345_000L);
+
+        assertEquals("1234.50 BTC/USD", MuSigTradeFormatter.formatPriceWithCode(contract));
+    }
+
+    @Test
+    void formatPriceWithCodeForCryptoBtcMarket() {
+        MuSigContract contract = createContract(createCryptoBtcMarket(), 12_345_000_000L, 100_000_000L);
+
+        assertEquals("81.0045 XMR/BTC", MuSigTradeFormatter.formatPriceWithCode(contract));
+    }
+
+    private MuSigContract createContract(Market market, long baseSideAmount, long quoteSideAmount) {
+        MuSigOffer offer = new MuSigOffer("test-id",
+                null,
+                Direction.BUY,
+                market,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                "1.0.0");
+        PaymentMethodSpec<?> baseSpec = market.isBaseCurrencyBitcoin()
+                ? PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0)
+                : PaymentMethodSpecUtil.createPaymentMethodSpec(new CryptoPaymentMethod("XMR"), "XMR");
+        PaymentMethodSpec<?> quoteSpec = market.isBaseCurrencyBitcoin()
+                ? PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD")
+                : PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        return new MuSigContract(System.currentTimeMillis(),
+                offer,
+                TradeProtocolType.MU_SIG,
+                new Party(Role.TAKER, null),
+                baseSideAmount,
+                quoteSideAmount,
+                baseSpec,
+                quoteSpec,
+                Optional.empty(),
+                null,
+                0);
+    }
+
+    private Market createBtcFiatMarket() {
+        return new Market("BTC", "USD", "Bitcoin", "US Dollar");
+    }
+
+    private Market createCryptoBtcMarket() {
+        return new Market("XMR", "BTC", "Monero", "Bitcoin");
+    }
+}

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeUtilsTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeUtilsTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.protocol_type.TradeProtocolType;
+import bisq.account.payment_method.crypto.CryptoPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.market.Market;
+import bisq.common.monetary.Monetary;
+import bisq.contract.Party;
+import bisq.contract.Role;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.offer.Direction;
+import bisq.offer.mu_sig.MuSigOffer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MuSigTradeUtilsTest {
+    @Test
+    void returnsBaseAsBtcSideForBtcFiatMarket() {
+        MuSigContract contract = createContract(createBtcFiatMarket(), 111L, 222L);
+
+        Monetary btcSideMonetary = MuSigTradeUtils.getBtcSideMonetary(contract);
+        Monetary nonBtcSideMonetary = MuSigTradeUtils.getNonBtcSideMonetary(contract);
+
+        assertEquals(111L, btcSideMonetary.getValue());
+        assertEquals("BTC", btcSideMonetary.getCode());
+        assertEquals(222L, nonBtcSideMonetary.getValue());
+        assertEquals("USD", nonBtcSideMonetary.getCode());
+    }
+
+    @Test
+    void returnsQuoteAsBtcSideForCryptoBtcMarket() {
+        MuSigContract contract = createContract(createCryptoBtcMarket(), 111L, 222L);
+
+        Monetary btcSideMonetary = MuSigTradeUtils.getBtcSideMonetary(contract);
+        Monetary nonBtcSideMonetary = MuSigTradeUtils.getNonBtcSideMonetary(contract);
+
+        assertEquals(222L, btcSideMonetary.getValue());
+        assertEquals("BTC", btcSideMonetary.getCode());
+        assertEquals(111L, nonBtcSideMonetary.getValue());
+        assertEquals("XMR", nonBtcSideMonetary.getCode());
+    }
+
+    private MuSigContract createContract(Market market, long baseSideAmount, long quoteSideAmount) {
+        MuSigOffer offer = new MuSigOffer("test-id",
+                null,
+                Direction.BUY,
+                market,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                "1.0.0");
+        PaymentMethodSpec<?> baseSpec = market.isBaseCurrencyBitcoin()
+                ? PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0)
+                : PaymentMethodSpecUtil.createPaymentMethodSpec(new CryptoPaymentMethod("XMR"), "XMR");
+        PaymentMethodSpec<?> quoteSpec = market.isBaseCurrencyBitcoin()
+                ? PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD")
+                : PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        return new MuSigContract(System.currentTimeMillis(),
+                offer,
+                TradeProtocolType.MU_SIG,
+                new Party(Role.TAKER, null),
+                baseSideAmount,
+                quoteSideAmount,
+                baseSpec,
+                quoteSpec,
+                Optional.empty(),
+                null,
+                0);
+    }
+
+    private Market createBtcFiatMarket() {
+        return new Market("BTC", "USD", "Bitcoin", "US Dollar");
+    }
+
+    private Market createCryptoBtcMarket() {
+        return new Market("XMR", "BTC", "Monero", "Bitcoin");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reputation score now shown for traders in mediator tables.
  * Payment methods box introduced to clarify non-BTC payment options.

* **Refactor**
  * Amounts renamed and presented as BTC / non‑BTC sides for clearer multi-asset displays.
  * Security deposit and amount formatting flows simplified to use BTC/non‑BTC side semantics.
  * Two formatting helpers are now public for broader reuse.

* **Bug Fixes**
  * UI control handling corrected so only the latest badge/control is attached.

* **Tests**
  * New unit tests added covering contract side-amounts, formatting, and utility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->