### PR TITLE
Improve trade detail popup

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/helpers/LabeledValueRowFactory.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/helpers/LabeledValueRowFactory.java
@@ -27,9 +27,12 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 
+import java.util.List;
 import java.util.Optional;
 
 public class LabeledValueRowFactory {
+
+    public static final double DESCRIPTION_LABEL_WIDTH = 180;
 
     public static HBox createAndGetDescriptionAndValueBox(String descriptionKey, Node valueNode) {
         return createAndGetDescriptionAndValueBox(descriptionKey, valueNode, Optional.empty());
@@ -56,18 +59,24 @@ public class LabeledValueRowFactory {
     public static HBox createAndGetDescriptionAndValueBox(Label descriptionLabel,
                                                           Node detailsNode,
                                                           Optional<BisqMenuItem> button) {
-        double width = 180;
-        descriptionLabel.setMaxWidth(width);
-        descriptionLabel.setMinWidth(width);
-        descriptionLabel.setPrefWidth(width);
+        return createAndGetDescriptionAndValueBox(descriptionLabel, detailsNode, button.map(List::of).orElse(List.of()));
+    }
 
-        HBox hBox = new HBox(descriptionLabel, detailsNode);
-        hBox.setAlignment(Pos.BASELINE_LEFT);
+    public static HBox createAndGetDescriptionAndValueBox(Label descriptionLabel,
+                                                          Node detailsNode,
+                                                          List<BisqMenuItem> buttons) {
+        descriptionLabel.setMaxWidth(DESCRIPTION_LABEL_WIDTH);
+        descriptionLabel.setMinWidth(DESCRIPTION_LABEL_WIDTH);
+        descriptionLabel.setPrefWidth(DESCRIPTION_LABEL_WIDTH);
 
-        if (button.isPresent()) {
-            button.get().useIconOnly(17);
-            HBox.setMargin(button.get(), new Insets(0, 0, 0, 40));
-            hBox.getChildren().addAll(Spacer.fillHBox(), button.get());
+        HBox hBox = getValueBox(descriptionLabel, detailsNode);
+
+        if (!buttons.isEmpty()) {
+            HBox hBoxButtons = new HBox(5);
+            hBoxButtons.getChildren().addAll(buttons);
+            buttons.forEach(button -> button.useIconOnly(17));
+            HBox.setMargin(hBoxButtons, new Insets(0, 0, 0, 40));
+            hBox.getChildren().addAll(Spacer.fillHBox(), hBoxButtons);
         }
         return hBox;
     }
@@ -79,9 +88,25 @@ public class LabeledValueRowFactory {
     }
 
     public static Label getValueLabel() {
-        Label label = new Label();
-        label.getStyleClass().addAll("text-fill-white", "normal-text", "font-light");
+        return getValueLabel(ValueLabelStyle.NORMAL);
+    }
+
+    public static Label getValueLabel(ValueLabelStyle style, String text) {
+        Label label = getValueLabel(style);
+        label.setText(text);
         return label;
+    }
+
+    public static Label getValueLabel(ValueLabelStyle style) {
+        Label label = new Label();
+        label.getStyleClass().addAll(style.textColor, style.textSize, "font-light");
+        return label;
+    }
+
+    public static HBox getValueBox(Node... children) {
+        HBox box = new HBox(5, children);
+        box.setAlignment(Pos.BASELINE_LEFT);
+        return box;
     }
 
     public static BisqMenuItem getCopyButton(String tooltip) {
@@ -97,5 +122,24 @@ public class LabeledValueRowFactory {
         line.getStyleClass().add("separator-line");
         line.setPadding(new Insets(9, 0, 8, 0));
         return line;
+    }
+
+    //
+    // Style enums
+    //
+
+    public enum ValueLabelStyle {
+
+        NORMAL("normal-text", "text-fill-white"),
+        SMALL("small-text", "text-fill-white"),
+        DIMMED("normal-text", "text-fill-grey-dimmed"),
+        SMALL_DIMMED("small-text", "text-fill-grey-dimmed");
+
+        private final String textColor, textSize;
+
+        ValueLabelStyle(String textSize, String textColor) {
+            this.textColor = textColor;
+            this.textSize = textSize;
+        }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsController.java
@@ -18,19 +18,28 @@
 package bisq.desktop.main.content.mu_sig.trade.pending.trade_details;
 
 import bisq.account.accounts.AccountPayload;
+import bisq.bonded_roles.explorer.ExplorerService;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
+import bisq.common.monetary.Monetary;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.Browser;
+import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.InitWithDataController;
 import bisq.desktop.common.view.NavigationController;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayController;
 import bisq.i18n.Res;
+import bisq.offer.amount.OfferAmountFormatter;
+import bisq.offer.amount.OfferAmountUtil;
+import bisq.offer.options.OfferOptionUtil;
 import bisq.presentation.formatters.DateFormatter;
+import bisq.presentation.formatters.PercentageFormatter;
 import bisq.presentation.formatters.TimeFormatter;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeFormatter;
+import bisq.trade.mu_sig.MuSigTradeUtils;
 import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -59,9 +68,13 @@ public class MuSigTradeDetailsController extends NavigationController implements
     @Getter
     private final MuSigTradeDetailsView view;
 
+    private final ExplorerService explorerService;
+
 
     public MuSigTradeDetailsController(ServiceProvider serviceProvider) {
         super(NavigationTarget.MU_SIG_TRADE_DETAILS);
+
+        explorerService = serviceProvider.getBondedRolesService().getExplorerService();
 
         model = new MuSigTradeDetailsModel();
         view = new MuSigTradeDetailsView(model, this);
@@ -116,12 +129,22 @@ public class MuSigTradeDetailsController extends NavigationController implements
         model.setAssignedMediator(channel.getMediator().map(UserProfile::getUserName).orElse(""));
         model.setHasMediatorBeenAssigned(channel.getMediator().isPresent());
 
+        String depositTxId = trade.getDepositTxId();
+        boolean hasDepositTxId = depositTxId != null && !depositTxId.isBlank();
+        model.setDepositTxId(hasDepositTxId
+                ? depositTxId
+                : Res.get("muSig.trade.details.dataNotYetProvided"));
+        model.setDepositTxIdEmpty(!hasDepositTxId);
+        model.setDepositTxIdVisible(hasDepositTxId);
 
-        model.setDepositTxId(trade.getDepositTxId() == null
-                ? Res.get("muSig.trade.details.dataNotYetProvided")
-                : trade.getDepositTxId());
-        model.setDepositTxIdEmpty(trade.getDepositTxId() == null);
-        model.setDepositTxIdVisible(trade.getDepositTxId() != null);
+        boolean hasExplorerProvider = explorerService.getExplorerServiceProvider().isPresent();
+        model.setBlockExplorerLinkVisible(hasDepositTxId && hasExplorerProvider);
+
+        model.setSecurityDepositInfo(createSecurityDepositInfo(contract));
+
+        // todo: set real fee amount and percent once we have that information, for now we set it to N/A
+        model.setFeeAmount(Res.get("data.na"));
+        model.setFeePercent(Res.get("data.na"));
     }
 
     @Override
@@ -136,4 +159,32 @@ public class MuSigTradeDetailsController extends NavigationController implements
     void onClose() {
         OverlayController.hide();
     }
+
+    void openExplorer() {
+        Browser.open(getBlockExplorerUrl());
+    }
+
+    void onCopyExplorerLink() {
+        ClipboardUtil.copyToClipboard(getBlockExplorerUrl());
+    }
+
+    private String getBlockExplorerUrl() {
+        return getBlockExplorerUrl(explorerService, model.getDepositTxId());
+    }
+
+    private static String getBlockExplorerUrl(ExplorerService explorerService, String txId) {
+        return explorerService.getExplorerServiceProvider()
+                .map(provider -> provider.getBaseUrl() + "/" + provider.getTxPath() + "/" + txId)
+                .orElse(Res.get("data.na"));
+    }
+
+    private static MuSigTradeDetailsModel.SecurityDepositInfo createSecurityDepositInfo(MuSigContract contract) {
+        double percent = OfferOptionUtil.findSymmetricSecurityDepositPercent(contract.getOffer().getOfferOptions())
+                .orElseThrow(() -> new IllegalArgumentException("CollateralOption must be present"));
+        Monetary btcAmount = OfferAmountUtil.calculateSecurityDepositAsBTC(MuSigTradeUtils.getBtcSideMonetary(contract), percent);
+        return new MuSigTradeDetailsModel.SecurityDepositInfo(
+                PercentageFormatter.formatToPercentWithSymbol(percent, 0),
+                OfferAmountFormatter.formatDepositAmountAsBTC(btcAmount));
+    }
 }
+

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsModel.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 @Slf4j
 @Getter
 @Setter
-public class MuSigTradeDetailsModel extends NavigationModel {
+class MuSigTradeDetailsModel extends NavigationModel {
     private MuSigTrade trade;
     private MuSigOpenTradeChannel channel;
     private MuSigContract contract;
@@ -49,11 +49,18 @@ public class MuSigTradeDetailsModel extends NavigationModel {
     private String depositTxId;
     private boolean isDepositTxIdEmpty;
     private boolean isDepositTxIdVisible;
+    private boolean isBlockExplorerLinkVisible;
     private String peersPaymentAccountDataDescription;
     private String peersPaymentAccountData;
     private boolean isPaymentAccountDataEmpty;
     private String assignedMediator;
     private boolean hasMediatorBeenAssigned;
+    private SecurityDepositInfo securityDepositInfo;
+    private String feeAmount;
+    private String feePercent;
+
+    record SecurityDepositInfo(String percentAsString, String btcAmountAsString) {
+    }
 
     @Override
     public NavigationTarget getDefaultNavigationTarget() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsView.java
@@ -36,21 +36,26 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
+import static bisq.desktop.components.helpers.LabeledValueRowFactory.ValueLabelStyle.DIMMED;
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.createAndGetDescriptionAndValueBox;
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.createSeparatorLine;
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.getCopyButton;
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.getDescriptionLabel;
+import static bisq.desktop.components.helpers.LabeledValueRowFactory.getValueBox;
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.getValueLabel;
 
 @Slf4j
-public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetailsModel, MuSigTradeDetailsController> {
+class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetailsModel, MuSigTradeDetailsController> {
     private final Button closeButton;
     private final Label tradeDateLabel, tradeDurationLabel, meLabel, peerLabel, offerTypeLabel, marketLabel, paymentMethodValue,
+            securityDepositAmountLabel, securityDepositPercentLabel, feeAmountLabel, feePercentLabel,
             tradeIdLabel, peerNetworkAddressLabel,
             peersPaymentAccountData, depositTxDetailsLabel, peersAccountPayloadDescription,
             assignedMediatorLabel;
     private final BisqMenuItem tradersAndRoleCopyButton, tradeIdCopyButton, peerNetworkAddressCopyButton,
-            depositTxCopyButton, peersAccountDataCopyButton;
+            depositTxCopyButton, depositTxExplorerLinkButton, depositTxExplorerButton, peersAccountDataCopyButton;
     private final HBox assignedMediatorBox, depositTxBox, tradeDurationBox, paymentMethodsBox;
     private final MuSigAmountAndPriceDisplay amountAndPriceDisplay;
 
@@ -89,33 +94,42 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
         tradeDurationBox = createAndGetDescriptionAndValueBox("muSig.trade.details.tradeDuration", tradeDurationLabel);
 
         // Traders / Roles
-        Label mePrefixLabel = new Label(Res.get("muSig.trade.details.tradersAndRole.me"));
-        mePrefixLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        Label mePrefixLabel = getValueLabel(DIMMED, Res.get("muSig.trade.details.tradersAndRole.me"));
         meLabel = getValueLabel();
-        Label offerTypeAndRoleSlashLabel = new Label("/");
-        offerTypeAndRoleSlashLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-        Label peerPrefixLabel = new Label(Res.get("muSig.trade.details.tradersAndRole.peer"));
-        peerPrefixLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        Label offerTypeAndRoleSlashLabel = getValueLabel(DIMMED, "/");
+        Label peerPrefixLabel = getValueLabel(DIMMED, Res.get("muSig.trade.details.tradersAndRole.peer"));
         peerLabel = getValueLabel();
-        HBox tradersAndRoleDetailsHBox = new HBox(5, mePrefixLabel, meLabel, offerTypeAndRoleSlashLabel, peerPrefixLabel, peerLabel);
-        tradersAndRoleDetailsHBox.setAlignment(Pos.BASELINE_LEFT);
+        HBox tradersAndRoleDetailsHBox = getValueBox(mePrefixLabel, meLabel, offerTypeAndRoleSlashLabel, peerPrefixLabel, peerLabel);
         tradersAndRoleCopyButton = getCopyButton(Res.get("muSig.trade.details.tradersAndRole.copy"));
         HBox tradersAndRoleBox = createAndGetDescriptionAndValueBox("muSig.trade.details.tradersAndRole",
                 tradersAndRoleDetailsHBox, tradersAndRoleCopyButton);
 
         // Offer type and market
         offerTypeLabel = getValueLabel();
-        Label offerAndMarketslashLabel = new Label("/");
-        offerAndMarketslashLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        Label offerAndMarketslashLabel = getValueLabel(DIMMED, "/");
         marketLabel = getValueLabel();
-        HBox offerTypeAndMarketDetailsHBox = new HBox(5, offerTypeLabel, offerAndMarketslashLabel, marketLabel);
-        offerTypeAndMarketDetailsHBox.setAlignment(Pos.BASELINE_LEFT);
-        HBox offerTypeAndMarketBox = createAndGetDescriptionAndValueBox("muSig.trade.details.offerTypeAndMarket",
-                offerTypeAndMarketDetailsHBox);
+        HBox offerTypeAndMarketDetailsHBox = getValueBox(offerTypeLabel, offerAndMarketslashLabel, marketLabel);
+        HBox offerTypeAndMarketBox = createAndGetDescriptionAndValueBox( "muSig.trade.details.offerTypeAndMarket", offerTypeAndMarketDetailsHBox);
 
         // Amount and price
         amountAndPriceDisplay = new MuSigAmountAndPriceDisplay();
         HBox amountAndPriceBox = createAndGetDescriptionAndValueBox("muSig.trade.details.amountAndPrice", amountAndPriceDisplay);
+
+        // Security deposits
+        securityDepositAmountLabel = getValueLabel();
+        securityDepositPercentLabel = getValueLabel(DIMMED);
+        HBox securityDepositPercentBox = new HBox(getValueLabel(DIMMED, "("), securityDepositPercentLabel, getValueLabel(DIMMED, ")"));
+        securityDepositPercentBox.setAlignment(Pos.BASELINE_LEFT);
+        HBox securityDepositValueBox = getValueBox(securityDepositAmountLabel, securityDepositPercentBox);
+        HBox securityDepositBox = createAndGetDescriptionAndValueBox("muSig.trade.details.securityDeposit", securityDepositValueBox);
+
+        // Fee
+        feeAmountLabel = getValueLabel();
+        feePercentLabel = getValueLabel(DIMMED);
+        HBox feePercentBox = new HBox(getValueLabel(DIMMED, "("), feePercentLabel, getValueLabel(DIMMED, ")"));
+        feePercentBox.setAlignment(Pos.BASELINE_LEFT);
+        HBox feeValueBox = getValueBox(feeAmountLabel, feePercentBox);
+        HBox feeBox = createAndGetDescriptionAndValueBox("muSig.trade.details.feeDescription", feeValueBox);
 
         // Payment method
         paymentMethodValue = getValueLabel();
@@ -144,8 +158,12 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
         Label depositTxTitleLabel = getDescriptionLabel(Res.get("muSig.trade.details.depositTxId"));
         depositTxDetailsLabel = getValueLabel();
         depositTxCopyButton = getCopyButton(Res.get("muSig.trade.details.depositTxId.copy"));
-        depositTxBox = createAndGetDescriptionAndValueBox(depositTxTitleLabel,
-                depositTxDetailsLabel, depositTxCopyButton);
+        depositTxExplorerLinkButton = new BisqMenuItem("link-grey", "link-white");
+        depositTxExplorerLinkButton.setTooltip(Res.get("muSig.trade.details.depositTxId.copy.explorerLink.tooltip"));
+        depositTxExplorerButton = new BisqMenuItem("open-link-grey", "open-link-white");
+        depositTxExplorerButton.setTooltip(Res.get("muSig.trade.details.depositTxId.open.explorerLink.tooltip"));
+        depositTxBox = createAndGetDescriptionAndValueBox(depositTxTitleLabel, depositTxDetailsLabel,
+                List.of(depositTxCopyButton, depositTxExplorerLinkButton, depositTxExplorerButton));
 
         // Assigned mediator
         assignedMediatorLabel = getValueLabel();
@@ -174,6 +192,8 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
                 tradeIdBox,
                 tradeDateBox,
                 tradeDurationBox,
+                securityDepositBox,
+                feeBox,
                 offerTypeAndMarketBox,
                 peerNetworkAddressBox,
                 assignedMediatorBox
@@ -205,6 +225,7 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
         depositTxDetailsLabel.setText(model.getDepositTxId());
         depositTxBox.setVisible(model.isDepositTxIdVisible());
         depositTxBox.setManaged(model.isDepositTxIdVisible());
+        showBlockExplorerLink(model.isBlockExplorerLinkVisible());
 
         peersAccountPayloadDescription.setText(model.getPeersPaymentAccountDataDescription());
         peersPaymentAccountData.setText(model.getPeersPaymentAccountData());
@@ -214,7 +235,6 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
         assignedMediatorLabel.setText(model.getAssignedMediator());
         assignedMediatorBox.setVisible(model.isHasMediatorBeenAssigned());
         assignedMediatorBox.setManaged(model.isHasMediatorBeenAssigned());
-
 
         depositTxCopyButton.setVisible(!model.isDepositTxIdEmpty());
         depositTxCopyButton.setManaged(!model.isDepositTxIdEmpty());
@@ -231,12 +251,20 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
                 : "text-fill-white");
         depositTxDetailsLabel.getStyleClass().add("normal-text");
 
+        securityDepositAmountLabel.setText(model.getSecurityDepositInfo().btcAmountAsString());
+        securityDepositPercentLabel.setText(model.getSecurityDepositInfo().percentAsString());
+
+        feeAmountLabel.setText(model.getFeeAmount());
+        feePercentLabel.setText(model.getFeePercent());
+
         closeButton.setOnAction(e -> controller.onClose());
         tradersAndRoleCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getPeer()));
         tradeIdCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getTradeId()));
         peerNetworkAddressCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getPeerNetworkAddress()));
         peersAccountDataCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getPeersPaymentAccountData()));
         depositTxCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getDepositTxId()));
+        depositTxExplorerLinkButton.setOnAction(e -> controller.onCopyExplorerLink());
+        depositTxExplorerButton.setOnAction(e -> controller.openExplorer());
     }
 
     @Override
@@ -247,5 +275,14 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
         peerNetworkAddressCopyButton.setOnAction(null);
         peersAccountDataCopyButton.setOnAction(null);
         depositTxCopyButton.setOnAction(null);
+        depositTxExplorerLinkButton.setOnAction(null);
+        depositTxExplorerButton.setOnAction(null);
+    }
+
+    private void showBlockExplorerLink(boolean value) {
+        depositTxExplorerLinkButton.setVisible(value);
+        depositTxExplorerLinkButton.setManaged(value);
+        depositTxExplorerButton.setVisible(value);
+        depositTxExplorerButton.setManaged(value);
     }
 }

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -642,6 +642,10 @@ muSig.trade.details.paymentAccountData.fiat=Payment account data
 muSig.trade.details.paymentAccountData.crypto={0} address
 muSig.trade.details.depositTxId=Deposit transaction ID
 muSig.trade.details.depositTxId.copy=Copy deposit transaction ID
+muSig.trade.details.depositTxId.copy.explorerLink.tooltip=Copy block explorer transaction link
+muSig.trade.details.depositTxId.open.explorerLink.tooltip=Open deposit transaction in block explorer
+muSig.trade.details.securityDeposit=Security deposit
+muSig.trade.details.feeDescription=Fees
 
 
 ######################################################


### PR DESCRIPTION
resolves #4150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View, open and copy block-explorer links for deposit transactions; link visibility adapts to transaction and provider availability.
  * Display security deposit and trade-fee details in trade view, including matching indicators and formatted values.
  * Improved layout with consistent description/value rows and unified copy actions.

* **Documentation**
  * Added localized labels and tooltips for explorer links and security deposit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->