### PR TITLE
Fix cancel trade flow in rest api

### DIFF
--- a/http-api/src/main/java/bisq/http_api/rest_api/domain/trades/TradeRestApi.java
+++ b/http-api/src/main/java/bisq/http_api/rest_api/domain/trades/TradeRestApi.java
@@ -284,7 +284,6 @@ public class TradeRestApi extends RestApiBase {
         String encoded = Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).get();
         bisqEasyTradeService.cancelTrade(trade);
-        leavePrivateChatManager.leaveChannel(channel);
     }
 
     private void handleCloseTrade(BisqEasyOpenTradeChannel channel, BisqEasyTrade trade) throws Exception {


### PR DESCRIPTION
Fixes: https://github.com/bisq-network/bisq-mobile/issues/1143

Fixed an issue where closing a trade after cancellation failed with the error: Open trade channel not found. The TradeID was being cleared during the cancellation process; I've updated the logic to match the desktop app, ensuring the ID is retained until the trade is fully closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where canceling a trade would unexpectedly remove you from the private chat channel. You can now remain in the chat after canceling a trade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->