### PR TITLE
Add buyer payment data to seller screen

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState3aSellerConfirmPaymentReceipt.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState3aSellerConfirmPaymentReceipt.java
@@ -23,6 +23,7 @@ import bisq.account.accounts.crypto.CryptoAssetAccountPayload;
 import bisq.account.payment_method.PaymentMethod;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.i18n.Res;
 import bisq.trade.mu_sig.MuSigTrade;
@@ -76,11 +77,15 @@ public class MuSigState3aSellerConfirmPaymentReceipt extends MuSigBaseState {
             if (peersAccountPayload instanceof CryptoAssetAccountPayload cryptoAssetAccountPayload) {
                 model.setInfo(Res.get("muSig.trade.state.phase3a.verifyReceipt.account.crypto",
                         model.getNonBtcCurrencyCode(), cryptoAssetAccountPayload.getAddress()));
+                model.setPeersAccountDataDescription("");
+                model.setBuyersAccountData("");
             } else {
                 String accountName = account
                         .map(Account::getAccountName)
                         .orElse(Res.get("data.na"));
                 model.setInfo(Res.get("muSig.trade.state.phase3a.verifyReceipt.account.fiat", accountName));
+                model.setPeersAccountDataDescription(Res.get("muSig.trade.state.phase3a.buyersAccount.fiat"));
+                model.setBuyersAccountData(peersAccountPayload.getAccountDataDisplayString());
             }
         }
 
@@ -100,6 +105,10 @@ public class MuSigState3aSellerConfirmPaymentReceipt extends MuSigBaseState {
     private static class Model extends MuSigBaseState.Model {
         @Setter
         private String info;
+        @Setter
+        private String buyersAccountData;
+        @Setter
+        private String peersAccountDataDescription;
 
         protected Model(MuSigTrade trade, MuSigOpenTradeChannel channel) {
             super(trade, channel);
@@ -110,24 +119,31 @@ public class MuSigState3aSellerConfirmPaymentReceipt extends MuSigBaseState {
         private final WrappingText headline;
         private final Button confirmPaymentReceiptButton;
         private final WrappingText info;
+        private final MaterialTextArea buyersAccountData;
 
         private View(Model model, Controller controller) {
             super(model, controller);
 
             headline = MuSigFormUtils.getHeadline();
             info = MuSigFormUtils.getInfo();
+            buyersAccountData = MuSigFormUtils.addTextArea("", "", false);
             confirmPaymentReceiptButton = new Button();
             confirmPaymentReceiptButton.setDefaultButton(true);
             VBox.setMargin(confirmPaymentReceiptButton, new Insets(5, 0, 10, 0));
-            root.getChildren().addAll(headline, info, confirmPaymentReceiptButton);
+            root.getChildren().addAll(headline, buyersAccountData, info, confirmPaymentReceiptButton);
         }
 
         @Override
         protected void onViewAttached() {
             super.onViewAttached();
 
+            buyersAccountData.visibleProperty().bind(buyersAccountData.textProperty().isNotEmpty());
+            buyersAccountData.managedProperty().bind(buyersAccountData.visibleProperty());
+
             headline.setText(Res.get("muSig.trade.state.phase3a.headline", model.getFormattedNonBtcAmount()));
             info.setText(model.getInfo());
+            buyersAccountData.setText(model.getBuyersAccountData());
+            buyersAccountData.setDescription(model.getPeersAccountDataDescription());
             confirmPaymentReceiptButton.setText(Res.get("muSig.trade.state.phase3a.fiatReceivedButton"));
             confirmPaymentReceiptButton.setOnAction(e -> controller.onPaymentReceiptConfirmed());
         }
@@ -135,6 +151,9 @@ public class MuSigState3aSellerConfirmPaymentReceipt extends MuSigBaseState {
         @Override
         protected void onViewDetached() {
             super.onViewDetached();
+
+            buyersAccountData.visibleProperty().unbind();
+            buyersAccountData.managedProperty().unbind();
 
             confirmPaymentReceiptButton.setOnAction(null);
         }

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -552,6 +552,7 @@ muSig.trade.state.phase3.info.crypto=Once the buyer has received your payment of
 
 muSig.trade.state.phase3a.fiatReceivedButton=Confirm receipt
 muSig.trade.state.phase3a.headline=Check if you have received {0}
+muSig.trade.state.phase3a.buyersAccount.fiat=Payment account of buyer
 muSig.trade.state.phase3a.verifyReceipt.account.fiat=Have you received the buyer''s payment at your ''{0}'' payment account?
 muSig.trade.state.phase3a.verifyReceipt.account.crypto=Have you received the seller''s payment to your ''{0}'' address ''{1}''?
 muSig.trade.state.phase3a.logMessage={0} has confirmed the receipt of {1}


### PR DESCRIPTION
fixes #4418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buyers' fiat payment account details are now shown during the seller payment-confirmation step in a dedicated, scrollable text area (hidden for crypto payments).
* **Documentation**
  * Added a localized label for the buyer's payment account in phase 3a to support translation and proper display across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->