### PR TITLE
Add show trade details in history

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryController.java
@@ -22,6 +22,9 @@ import bisq.common.observable.Pin;
 import bisq.common.observable.collection.CollectionObserver;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.view.Controller;
+import bisq.desktop.common.view.Navigation;
+import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
+import bisq.desktop.navigation.NavigationTarget;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyClosedTrade;
@@ -93,6 +96,12 @@ public class BisqEasyHistoryController implements Controller {
 //                        || item.getPrice().contains(string)
 //                        || item.getPaymentMethodsAsString().toLowerCase().contains(string));
         applyPredicates();
+    }
+
+    void onShowTradeDetails(BisqEasyTradeHistoryListItem item) {
+        Navigation.navigateTo(NavigationTarget.BISQ_EASY_TRADE_DETAILS,
+                new TradeDetailsController.InitData(item.getTrade(), item.getMyUserProfile(), item.getPeerProfile(),
+                        item.getTrade().getContract().getMediator()));
     }
 
     private void applyPredicates() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryView.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.bisq_easy.history;
 import bisq.common.data.Pair;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
+import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.RichTableView;
@@ -29,11 +30,13 @@ import bisq.desktop.main.content.components.UserProfileDisplay;
 import bisq.i18n.Res;
 import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
+import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
@@ -159,10 +162,17 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
         bisqEasyTradeHistoryListView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
                 .title(Res.get("bisqEasy.history.table.myRole"))
                 .left()
-                .minWidth(140)
+                .minWidth(100)
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getMyRole))
                 .valueSupplier(BisqEasyTradeHistoryListItem::getMyRole)
                 .tooltipSupplier(BisqEasyTradeHistoryListItem::getMyRole)
+                .build());
+
+        bisqEasyTradeHistoryListView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
+                .setCellFactory(getActionButtonsCellFactory())
+                .left()
+                .minWidth(50)
+                .includeForCsv(false)
                 .build());
     }
 
@@ -302,6 +312,95 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 } else {
                     setGraphic(null);
                 }
+            }
+        };
+    }
+
+    private Callback<TableColumn<BisqEasyTradeHistoryListItem, BisqEasyTradeHistoryListItem>,
+            TableCell<BisqEasyTradeHistoryListItem, BisqEasyTradeHistoryListItem>> getActionButtonsCellFactory() {
+        return column -> new TableCell<>() {
+            private static final double PREF_WIDTH = 30;
+            private static final double PREF_HEIGHT = 26;
+
+            private final HBox tradeMainBox = new HBox();
+            private final HBox tradeActionsMenuBox = new HBox(5);
+            private final BisqMenuItem showTradeDetailsMenuItem = new BisqMenuItem("icon-info-grey", "icon-info-white");
+            private final ChangeListener<Boolean> selectedListener = (observable, oldValue, newValue) -> {
+                boolean shouldShow = newValue || getTableRow().isHover();
+                tradeActionsMenuBox.setVisible(shouldShow);
+                tradeActionsMenuBox.setManaged(shouldShow);
+            };
+
+            {
+                tradeMainBox.setMinWidth(PREF_WIDTH);
+                tradeMainBox.setPrefWidth(PREF_WIDTH);
+                tradeMainBox.setMaxWidth(PREF_WIDTH);
+                tradeMainBox.setMinHeight(PREF_HEIGHT);
+                tradeMainBox.setPrefHeight(PREF_HEIGHT);
+                tradeMainBox.setMaxHeight(PREF_HEIGHT);
+                tradeMainBox.getChildren().addAll(tradeActionsMenuBox);
+
+                tradeActionsMenuBox.setMinWidth(PREF_WIDTH);
+                tradeActionsMenuBox.setPrefWidth(PREF_WIDTH);
+                tradeActionsMenuBox.setMaxWidth(PREF_WIDTH);
+                tradeActionsMenuBox.setMinHeight(PREF_HEIGHT);
+                tradeActionsMenuBox.setPrefHeight(PREF_HEIGHT);
+                tradeActionsMenuBox.setMaxHeight(PREF_HEIGHT);
+                tradeActionsMenuBox.getChildren().addAll(showTradeDetailsMenuItem);
+                tradeActionsMenuBox.setAlignment(Pos.CENTER);
+
+                showTradeDetailsMenuItem.useIconOnly();
+                showTradeDetailsMenuItem.setTooltip(Res.get("bisqEasy.history.table.actionButtons.showTradeDetails.tooltip"));
+            }
+
+            @Override
+            protected void updateItem(BisqEasyTradeHistoryListItem item, boolean empty) {
+                super.updateItem(item, empty);
+
+                resetRowEventHandlersAndListeners();
+                resetVisibilities();
+
+                if (item != null && !empty) {
+                    setUpRowEventHandlersAndListeners();
+                    setGraphic(tradeMainBox);
+                    showTradeDetailsMenuItem.setOnAction(e -> controller.onShowTradeDetails(item));
+                } else {
+                    resetRowEventHandlersAndListeners();
+                    resetVisibilities();
+                    showTradeDetailsMenuItem.setOnAction(null);
+                    setGraphic(null);
+                }
+            }
+
+            private void setUpRowEventHandlersAndListeners() {
+                TableRow<?> row = getTableRow();
+                if (row != null) {
+                    row.setOnMouseEntered(e -> {
+                        boolean shouldShow = row.isSelected() || row.isHover();
+                        tradeActionsMenuBox.setVisible(shouldShow);
+                        tradeActionsMenuBox.setManaged(shouldShow);
+                    });
+                    row.setOnMouseExited(e -> {
+                        boolean shouldShow = row.isSelected();
+                        tradeActionsMenuBox.setVisible(shouldShow);
+                        tradeActionsMenuBox.setManaged(shouldShow);
+                    });
+                    row.selectedProperty().addListener(selectedListener);
+                }
+            }
+
+            private void resetRowEventHandlersAndListeners() {
+                TableRow<?> row = getTableRow();
+                if (row != null) {
+                    row.setOnMouseEntered(null);
+                    row.setOnMouseExited(null);
+                    row.selectedProperty().removeListener(selectedListener);
+                }
+            }
+
+            private void resetVisibilities() {
+                tradeActionsMenuBox.setVisible(false);
+                tradeActionsMenuBox.setManaged(false);
             }
         };
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsController.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_details;
 
 import bisq.account.payment_method.BitcoinPaymentRail;
 import bisq.desktop.navigation.NavigationTarget;
-import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.contract.bisq_easy.BisqEasyContract;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.view.Controller;
@@ -50,11 +49,17 @@ public class TradeDetailsController extends NavigationController implements Init
     @ToString
     public static class InitData {
         private final BisqEasyTrade bisqEasyTrade;
-        private final BisqEasyOpenTradeChannel channel;
+        private final UserProfile myUserProfile, peerProfile;
+        private final Optional<UserProfile> mediator;
 
-        public InitData(BisqEasyTrade bisqEasyTrade, BisqEasyOpenTradeChannel channel) {
+        public InitData(BisqEasyTrade bisqEasyTrade,
+                        UserProfile myUserProfile,
+                        UserProfile peerProfile,
+                        Optional<UserProfile> mediator) {
             this.bisqEasyTrade = bisqEasyTrade;
-            this.channel = channel;
+            this.myUserProfile = myUserProfile;
+            this.peerProfile = peerProfile;
+            this.mediator = mediator;
         }
     }
 
@@ -74,13 +79,14 @@ public class TradeDetailsController extends NavigationController implements Init
     @Override
     public void initWithData(InitData initData) {
         model.setTrade(initData.bisqEasyTrade);
-        model.setChannel(initData.channel);
+        model.setMyUserProfile(initData.myUserProfile);
+        model.setPeerProfile(initData.peerProfile);
+        model.setMediator(initData.mediator);
     }
 
     @Override
     public void onActivate() {
         BisqEasyTrade trade = model.getTrade();
-        BisqEasyOpenTradeChannel channel = model.getChannel();
         BisqEasyContract contract = trade.getContract();
 
         model.setTradeDate(DateFormatter.formatDateTime(contract.getTakeOfferDate()));
@@ -90,8 +96,8 @@ public class TradeDetailsController extends NavigationController implements Init
                 .map(TimeFormatter::formatAge);
         model.setTradeDuration(tradeDuration);
 
-        model.setMe(String.format("%s (%s)", channel.getMyUserIdentity().getNickName(), BisqEasyTradeFormatter.getMakerTakerRole(trade).toLowerCase()));
-        model.setPeer(channel.getPeer().getUserName());
+        model.setMe(String.format("%s (%s)", model.getMyUserProfile().getNickName(), BisqEasyTradeFormatter.getMakerTakerRole(trade).toLowerCase()));
+        model.setPeer(model.getPeerProfile().getUserName());
         model.setOfferType(trade.getOffer().getDirection().isBuy()
                 ? Res.get("bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.buyOffer")
                 : Res.get("bisqEasy.openTrades.tradeDetails.offerTypeAndMarket.sellOffer"));
@@ -108,11 +114,11 @@ public class TradeDetailsController extends NavigationController implements Init
         model.setPaymentMethod(contract.getQuoteSidePaymentMethodSpec().getShortDisplayString());
         model.setSettlementMethod(contract.getBaseSidePaymentMethodSpec().getShortDisplayString());
         model.setTradeId(trade.getId());
-        model.setPeerNetworkAddress(channel.getPeer().getAddressByTransportDisplayString(50));
+        model.setPeerNetworkAddress(model.getPeerProfile().getAddressByTransportDisplayString(50));
 
         model.setPaymentAccountDataEmpty(trade.getPaymentAccountData().get() == null);
-        model.setAssignedMediator(channel.getMediator().map(UserProfile::getUserName).orElse(""));
-        model.setHasMediatorBeenAssigned(channel.getMediator().isPresent());
+        model.setAssignedMediator(model.getMediator().map(UserProfile::getUserName).orElse(""));
+        model.setHasMediatorBeenAssigned(model.getMediator().isPresent());
 
         model.setPaymentAccountData(trade.getPaymentAccountData().get() == null
                 ? Res.get("bisqEasy.openTrades.tradeDetails.dataNotYetProvided")

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_details/TradeDetailsModel.java
@@ -18,9 +18,9 @@
 package bisq.desktop.main.content.bisq_easy.open_trades.trade_details;
 
 import bisq.desktop.navigation.NavigationTarget;
-import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.desktop.common.view.NavigationModel;
 import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.user.profile.UserProfile;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,9 @@ import java.util.Optional;
 @Setter
 public class TradeDetailsModel extends NavigationModel {
     private BisqEasyTrade trade;
-    private BisqEasyOpenTradeChannel channel;
+    private UserProfile myUserProfile;
+    private UserProfile peerProfile;
+    private Optional<UserProfile> mediator;
     private String tradeDate;
     private Optional<String> tradeDuration = Optional.empty();
     private String me;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -262,7 +262,7 @@ public class TradeStateController implements Controller {
 
         BisqEasyTrade bisqEasyTrade = optionalBisqEasyTrade.get();
         Navigation.navigateTo(NavigationTarget.BISQ_EASY_TRADE_DETAILS,
-                new TradeDetailsController.InitData(bisqEasyTrade, channel));
+                new TradeDetailsController.InitData(bisqEasyTrade, channel.getMyUserIdentity().getUserProfile(), channel.getPeer(), channel.getMediator()));
     }
 
     void onRejectPrice() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/State4.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/State4.java
@@ -134,8 +134,9 @@ public abstract class State4<C extends State4.Controller<?, ?>> extends BaseStat
         }
 
         protected void onShowDetails() {
+            BisqEasyOpenTradeChannel channel = model.getChannel();
             Navigation.navigateTo(NavigationTarget.BISQ_EASY_TRADE_DETAILS,
-                    new TradeDetailsController.InitData(model.getTrade(), model.getChannel()));
+                    new TradeDetailsController.InitData(model.getTrade(), channel.getMyUserIdentity().getUserProfile(), channel.getPeer(), channel.getMediator()));
         }
 
         protected void onExportTrade() {

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -698,6 +698,7 @@ bisqEasy.history.table.payment=Payment
 bisqEasy.history.table.myRole=My role
 bisqEasy.history.table.myRole.buyer=Buyer
 bisqEasy.history.table.myRole.seller=Seller
+bisqEasy.history.table.actionButtons.showTradeDetails.tooltip=Show trade details
 
 
 ######################################################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Show Trade Details" action button to trade history rows (visible on hover) to open a detailed trade view.
  * Trade details now display participant usernames and mediator information more directly.

* **UI**
  * Slight column width adjustment for improved layout.
  * Added tooltip text for the new action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->