### PR TITLE
Add mediation result accept/reject flow and wire banner actions

### DIFF
--- a/application/src/main/java/bisq/application/ResolverConfig.java
+++ b/application/src/main/java/bisq/application/ResolverConfig.java
@@ -49,6 +49,7 @@ import bisq.offer.mu_sig.MuSigOfferMessage;
 import bisq.support.mediation.bisq_easy.BisqEasyMediationRequest;
 import bisq.support.mediation.bisq_easy.BisqEasyMediatorsResponse;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
+import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.support.mediation.mu_sig.MuSigMediatorsResponse;
 import bisq.support.moderator.ReportToModeratorMessage;
@@ -130,6 +131,7 @@ public class ResolverConfig {
         NetworkMessageResolver.addResolver("support.MuSigMediationRequest", MuSigMediationRequest.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigMediatorsResponse", MuSigMediatorsResponse.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigMediationStateChangeMessage", MuSigMediationStateChangeMessage.getNetworkMessageResolver());
+        NetworkMessageResolver.addResolver("support.MuSigMediationResultAcceptanceMessage", MuSigMediationResultAcceptanceMessage.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.ReportToModeratorMessage", ReportToModeratorMessage.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("account.AuthorizeAccountTimestampRequest", AuthorizeAccountTimestampRequest.getNetworkMessageResolver());
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateController.java
@@ -77,7 +77,7 @@ public class MuSigTradeStateController implements Controller {
     private final DontShowAgainService dontShowAgainService;
     private final Optional<ResendMessageService> resendMessageService;
     private Pin tradeStatePin, errorMessagePin, peersErrorMessagePin, isInMediationPin,
-            requestMediationDeliveryStatusPin, messageDeliveryStatusByMessageIdPin;
+            requestMediationDeliveryStatusPin, messageDeliveryStatusByMessageIdPin, mediationResultAcceptancePin;
     private Subscription channelPin;
 
     public MuSigTradeStateController(ServiceProvider serviceProvider) {
@@ -126,9 +126,12 @@ public class MuSigTradeStateController implements Controller {
 
             MuSigTrade trade = optionalMuSigTrade.get();
             model.getTrade().set(trade);
+            model.getMyMediationResultAcceptance().set(trade.getMyself().getMediationResultAcceptance());
 
             isInMediationPin = trade.disputeStateObservable().addObserver(disputeState ->
                     UIThread.run(() -> model.getIsInMediation().set(shouldShowMediationBanner(disputeState))));
+            mediationResultAcceptancePin = trade.getMyself().mediationResultAcceptanceObservable().addObserver(acceptance ->
+                    UIThread.run(() -> model.getMyMediationResultAcceptance().set(acceptance)));
 
             muSigTradePhaseBox.setMuSigTrade(trade);
 
@@ -254,6 +257,20 @@ public class MuSigTradeStateController implements Controller {
         }
     }
 
+    public void onAcceptMediationResult() {
+        MuSigTrade trade = model.getTrade().get();
+        if (trade != null) {
+            muSigService.acceptMediationResult(trade);
+        }
+    }
+
+    public void onRejectMediationResult() {
+        MuSigTrade trade = model.getTrade().get();
+        if (trade != null) {
+            muSigService.rejectMediationResult(trade);
+        }
+    }
+
     public boolean canManuallyResendMessage(String messageId) {
         return resendMessageService.map(service -> service.canManuallyResendMessage(messageId)).orElse(false);
     }
@@ -375,6 +392,10 @@ public class MuSigTradeStateController implements Controller {
         if (isInMediationPin != null) {
             isInMediationPin.unbind();
             isInMediationPin = null;
+        }
+        if (mediationResultAcceptancePin != null) {
+            mediationResultAcceptancePin.unbind();
+            mediationResultAcceptancePin = null;
         }
         if (messageDeliveryStatusByMessageIdPin != null) {
             messageDeliveryStatusByMessageIdPin.unbind();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateModel.java
@@ -31,6 +31,8 @@ import javafx.scene.layout.VBox;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
+
 @Slf4j
 @Getter
 public class MuSigTradeStateModel implements Model {
@@ -45,6 +47,7 @@ public class MuSigTradeStateModel implements Model {
     private final BooleanProperty isTradeCompleted = new SimpleBooleanProperty();
     private final ObjectProperty<MessageDeliveryStatus> requestMediationDeliveryStatus = new SimpleObjectProperty<>();
     private final BooleanProperty shouldShowTryRequestMediationAgain = new SimpleBooleanProperty();
+    private final ObjectProperty<Optional<Boolean>> myMediationResultAcceptance = new SimpleObjectProperty<>(Optional.empty());
 
     void resetAll() {
         reset();
@@ -62,5 +65,6 @@ public class MuSigTradeStateModel implements Model {
         isTradeCompleted.set(false);
         requestMediationDeliveryStatus.set(null);
         shouldShowTryRequestMediationAgain.set(false);
+        myMediationResultAcceptance.set(Optional.empty());
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateView.java
@@ -48,13 +48,13 @@ import org.fxmisc.easybind.Subscription;
 public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigTradeStateController> {
     private final HBox phaseAndInfoHBox, errorHBox, isInMediationHBox;
     private final Button closeTradeButton, exportButton, reportToMediatorButton,
-            tradeDetailsButton;
+            tradeDetailsButton, acceptMediationResultButton, rejectMediationResultButton;
     private final Label errorMessage, mediationBannerLabel;
     private final VBox tradePhaseBox, tradeDataHeaderBox;
     private final BisqMenuItem tryAgainMenuItem;
     private Pin disputeStatePin;
     private Subscription stateInfoVBoxPin, requestMediationDeliveryStatusPin,
-            shouldShowTryRequestMediationAgainPin, tradePin;
+            shouldShowTryRequestMediationAgainPin, tradePin, mediationResultAcceptancePin;
 
     public MuSigTradeStateView(MuSigTradeStateModel model,
                                MuSigTradeStateController controller,
@@ -77,14 +77,36 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
 
         mediationBannerLabel = new Label();
         mediationBannerLabel.getStyleClass().add("bisq-easy-trade-isInMediation-headline");
+        mediationBannerLabel.setWrapText(true);
 
         tryAgainMenuItem = new BisqMenuItem("try-again-dark", "try-again-white");
         tryAgainMenuItem.useIconOnly(22);
         tryAgainMenuItem.setTooltip(new BisqTooltip(Res.get("muSig.trade.requestMediation.resendRequest.tooltip")));
         isInMediationIcon.getStyleClass().add("bisq-easy-trade-isInMediation-headline");
 
-        isInMediationHBox = new HBox(10, isInMediationIcon, mediationBannerLabel, tryAgainMenuItem);
-        isInMediationHBox.setAlignment(Pos.CENTER_LEFT);
+        acceptMediationResultButton = new Button(Res.get("muSig.mediation.result.accept"));
+        acceptMediationResultButton.getStyleClass().add("accept-button");
+        acceptMediationResultButton.setVisible(false);
+        acceptMediationResultButton.setManaged(false);
+        acceptMediationResultButton.setMinWidth(90);
+
+        rejectMediationResultButton = new Button(Res.get("muSig.mediation.result.reject"));
+        rejectMediationResultButton.getStyleClass().add("reject-button");
+        rejectMediationResultButton.setVisible(false);
+        rejectMediationResultButton.setManaged(false);
+        rejectMediationResultButton.setMinWidth(90);
+
+        HBox mediationResultActionsHBox = new HBox(10, acceptMediationResultButton, rejectMediationResultButton);
+        mediationResultActionsHBox.setAlignment(Pos.CENTER_LEFT);
+        VBox.setMargin(mediationResultActionsHBox, new Insets(4, 0, 0, 0));
+        VBox mediationBannerContentVBox = new VBox(6, mediationBannerLabel, mediationResultActionsHBox);
+        HBox.setHgrow(mediationBannerContentVBox, Priority.ALWAYS);
+
+        isInMediationHBox = new HBox(10,
+                isInMediationIcon,
+                mediationBannerContentVBox,
+                tryAgainMenuItem);
+        isInMediationHBox.setAlignment(Pos.TOP_LEFT);
         isInMediationHBox.setPadding(new Insets(10));
         isInMediationHBox.getStyleClass().add("bisq-easy-trade-isInMediation-bg");
 
@@ -154,6 +176,8 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
 
         requestMediationDeliveryStatusPin = EasyBind.subscribe(model.getRequestMediationDeliveryStatus(),
                 this::updateMediationBannerLabel);
+        mediationResultAcceptancePin = EasyBind.subscribe(model.getMyMediationResultAcceptance(),
+                update -> updateMediationBannerLabel(model.getRequestMediationDeliveryStatus().get()));
         tradePin = EasyBind.subscribe(model.getTrade(), trade -> {
             if (disputeStatePin != null) {
                 disputeStatePin.unbind();
@@ -173,6 +197,8 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
         exportButton.setOnAction(e -> controller.onExportTrade());
         reportToMediatorButton.setOnAction(e -> controller.onRequestMediation());
         tryAgainMenuItem.setOnAction(e -> controller.onResendMediationRequest());
+        acceptMediationResultButton.setOnAction(e -> controller.onAcceptMediationResult());
+        rejectMediationResultButton.setOnAction(e -> controller.onRejectMediationResult());
     }
 
     @Override
@@ -196,6 +222,7 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
         requestMediationDeliveryStatusPin.unsubscribe();
         shouldShowTryRequestMediationAgainPin.unsubscribe();
         tradePin.unsubscribe();
+        mediationResultAcceptancePin.unsubscribe();
         if (disputeStatePin != null) {
             disputeStatePin.unbind();
             disputeStatePin = null;
@@ -206,6 +233,8 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
         exportButton.setOnAction(null);
         reportToMediatorButton.setOnAction(null);
         tryAgainMenuItem.setOnAction(null);
+        acceptMediationResultButton.setOnAction(null);
+        rejectMediationResultButton.setOnAction(null);
 
         if (phaseAndInfoHBox.getChildren().size() == 2) {
             phaseAndInfoHBox.getChildren().remove(1);
@@ -226,6 +255,7 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
 
     private void updateMediationBannerLabel(MessageDeliveryStatus status) {
         MuSigTrade trade = model.getTrade().get();
+        updateMediationResultDecisionControls(trade);
         if (trade != null) {
             MuSigDisputeState disputeState = trade.getDisputeState();
             if (disputeState == MuSigDisputeState.MEDIATION_CLOSED) {
@@ -266,6 +296,24 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
                 mediationBannerLabel.setText(Res.get("muSig.trade.pending.inMediation.requestSent", deliveryStatus));
             }
         }
+    }
+
+    private void updateMediationResultDecisionControls(MuSigTrade trade) {
+        boolean showDecisionControls = false;
+        if (trade != null) {
+            MuSigDisputeState disputeState = trade.getDisputeState();
+            showDecisionControls = disputeState == MuSigDisputeState.MEDIATION_CLOSED ||
+                    disputeState == MuSigDisputeState.MEDIATION_RE_OPENED;
+        }
+        boolean myDecisionKnown = model.getMyMediationResultAcceptance().get().isPresent();
+
+        boolean showDecisionButtons = showDecisionControls && !myDecisionKnown;
+        acceptMediationResultButton.setVisible(showDecisionButtons);
+        acceptMediationResultButton.setManaged(showDecisionButtons);
+        rejectMediationResultButton.setVisible(showDecisionButtons);
+        rejectMediationResultButton.setManaged(showDecisionButtons);
+        acceptMediationResultButton.setDisable(false);
+        rejectMediationResultButton.setDisable(false);
     }
 
     private static String getMediationResultDetailsText(MuSigTrade trade, MuSigMediationResult result) {

--- a/apps/desktop/desktop/src/main/resources/css/controls.css
+++ b/apps/desktop/desktop/src/main/resources/css/controls.css
@@ -147,6 +147,30 @@
     -fx-background-color: -bisq-green-pressed;
 }
 
+.accept-button {
+    -fx-background-color: -fx-default-button;
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-border-color: transparent;
+}
+
+.accept-button > .text {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+}
+
+.accept-button:hover {
+    -fx-background-color: -bisq-green-hover;
+}
+
+.accept-button:pressed {
+    -fx-background-color: -bisq-green-pressed;
+}
+
+.accept-button:disabled {
+    -fx-background-color: -bisq-green-pressed;
+}
+
 .sell-button {
     -fx-background-color: -bisq2-red-dim-20;
     -fx-fill: -fx-light-text-color;
@@ -168,6 +192,30 @@
 }
 
 .sell-button:disabled {
+    -fx-background-color: -bisq2-red-dim-30;
+}
+
+.reject-button {
+    -fx-background-color: -bisq2-red-dim-20;
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+    -fx-border-color: transparent;
+}
+
+.reject-button > .text {
+    -fx-fill: -fx-light-text-color;
+    -fx-text-fill: -fx-light-text-color;
+}
+
+.reject-button:hover {
+    -fx-background-color: -bisq2-red-dim-10;
+}
+
+.reject-button:pressed {
+    -fx-background-color: -bisq2-red-dim-30;
+}
+
+.reject-button:disabled {
     -fx-background-color: -bisq2-red-dim-30;
 }
 

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -721,6 +721,10 @@ muSig.mediation.request.feedback.msg=A request to the registered mediators has b
   Please have patience until a mediator is online to join the trade chat and help to resolve any problems.
 muSig.mediation.request.feedback.noMediatorAvailable=There is no mediator available. Please use the support chat instead.
 muSig.mediation.requester.tradeLogMessage={0} requested mediation
+muSig.mediation.result.accept=Accept
+muSig.mediation.result.reject=Reject
+muSig.mediation.result.accepted.tradeLogMessage={0} accepted the mediation result
+muSig.mediation.result.rejected.tradeLogMessage={0} rejected the mediation result
 
 
 ######################################################

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
@@ -41,6 +41,7 @@ import bisq.common.util.CompletableFutureUtils;
 import bisq.contract.ContractService;
 import bisq.identity.Identity;
 import bisq.identity.IdentityService;
+import bisq.i18n.Res;
 import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
 import bisq.network.p2p.services.data.BroadcastResult;
@@ -360,6 +361,24 @@ public class MuSigService extends LifecycleService {
         leavePrivateChatManager.leaveChannel(channel);
     }
 
+    public boolean acceptMediationResult(MuSigTrade muSigTrade) {
+        checkArgument(isActivated());
+        if (muSigTradeService.acceptMediationResult(muSigTrade, true)) {
+            addMediationResultTradeLogMessage(muSigTrade, true);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean rejectMediationResult(MuSigTrade muSigTrade) {
+        checkArgument(isActivated());
+        if (muSigTradeService.acceptMediationResult(muSigTrade, false)) {
+            addMediationResultTradeLogMessage(muSigTrade, false);
+            return true;
+        }
+        return false;
+    }
+
 
     /* --------------------------------------------------------------------- */
     // Markets API
@@ -388,6 +407,16 @@ public class MuSigService extends LifecycleService {
         if (bannedUserService.isRateLimitExceeding(userProfileId)) {
             throw new RateLimitExceededException(userProfileId);
         }
+    }
+
+    private void addMediationResultTradeLogMessage(MuSigTrade muSigTrade, boolean mediationResultAccepted) {
+        muSigOpenTradeChannelService.findChannelByTradeId(muSigTrade.getId()).ifPresent(channel -> {
+            String key = mediationResultAccepted
+                    ? "muSig.mediation.result.accepted.tradeLogMessage"
+                    : "muSig.mediation.result.rejected.tradeLogMessage";
+            String encoded = Res.encode(key, channel.getMyUserIdentity().getUserName());
+            muSigOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
+        });
     }
 
     public boolean isAccountDataBanned(AccountPayload<?> accountPayload) {

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultAcceptanceMessage.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultAcceptanceMessage.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.common.proto.ProtoResolver;
+import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
+import bisq.network.p2p.message.ExternalNetworkMessage;
+import bisq.network.p2p.services.data.storage.MetaData;
+import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+
+@Slf4j
+@Getter
+@ToString
+@EqualsAndHashCode
+public final class MuSigMediationResultAcceptanceMessage implements MailboxMessage, ExternalNetworkMessage {
+    private transient final MetaData metaData = new MetaData(TTL_10_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
+    private final String tradeId;
+    private final boolean mediationResultAccepted;
+    private final String senderUserProfileId;
+
+    public MuSigMediationResultAcceptanceMessage(String tradeId, boolean mediationResultAccepted, String senderUserProfileId) {
+        this.tradeId = tradeId;
+        this.mediationResultAccepted = mediationResultAccepted;
+        this.senderUserProfileId = senderUserProfileId;
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateTradeId(tradeId);
+        NetworkDataValidation.validateProfileId(senderUserProfileId);
+    }
+
+    @Override
+    public bisq.support.protobuf.MuSigMediationResultAcceptanceMessage.Builder getValueBuilder(boolean serializeForHash) {
+        return bisq.support.protobuf.MuSigMediationResultAcceptanceMessage.newBuilder()
+                .setTradeId(tradeId)
+                .setMediationResultAccepted(mediationResultAccepted)
+                .setSenderUserProfileId(senderUserProfileId);
+    }
+
+    public static MuSigMediationResultAcceptanceMessage fromProto(bisq.support.protobuf.MuSigMediationResultAcceptanceMessage proto) {
+        return new MuSigMediationResultAcceptanceMessage(
+                proto.getTradeId(),
+                proto.getMediationResultAccepted(),
+                proto.getSenderUserProfileId()
+        );
+    }
+
+    public static ProtoResolver<ExternalNetworkMessage> getNetworkMessageResolver() {
+        return any -> {
+            try {
+                bisq.support.protobuf.MuSigMediationResultAcceptanceMessage proto = any.unpack(bisq.support.protobuf.MuSigMediationResultAcceptanceMessage.class);
+                return MuSigMediationResultAcceptanceMessage.fromProto(proto);
+            } catch (InvalidProtocolBufferException e) {
+                throw new UnresolvableProtobufMessageException(e);
+            }
+        };
+    }
+
+    @Override
+    public double getCostFactor() {
+        return getCostFactor(0.1, 0.2);
+    }
+}

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -94,6 +94,12 @@ message MuSigMediationStateChangeMessage {
   optional MuSigMediationResult muSigMediationResult = 4;
 }
 
+message MuSigMediationResultAcceptanceMessage {
+  string tradeId = 1;
+  bool mediationResultAccepted = 2;
+  string senderUserProfileId = 3;
+}
+
 message MuSigMediationCase {
   MuSigMediationRequest muSigMediationRequest = 1;
   sint64 requestDate = 2;

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
@@ -18,6 +18,8 @@
 package bisq.trade.mu_sig;
 
 import bisq.account.accounts.AccountPayload;
+import bisq.common.observable.Observable;
+import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.data.ByteArray;
 import bisq.network.identity.NetworkId;
 import bisq.trade.TradeParty;
@@ -54,6 +56,7 @@ public final class MuSigTradeParty extends TradeParty {
     private Optional<CloseTradeResponse> myCloseTradeResponse = Optional.empty();
     private Optional<ByteArray> peersOutputPrvKeyShare = Optional.empty();
     private Optional<AccountPayload<?>> accountPayload = Optional.empty();
+    private final transient Observable<Optional<Boolean>> mediationResultAcceptanceObservable = new Observable<>(Optional.empty());
 
     public MuSigTradeParty(NetworkId networkId) {
         super(networkId);
@@ -72,7 +75,8 @@ public final class MuSigTradeParty extends TradeParty {
                            Optional<SwapTxSignature> peersSwapTxSignature,
                            Optional<CloseTradeResponse> myCloseTradeResponse,
                            Optional<ByteArray> peersOutputPrvKeyShare,
-                           Optional<AccountPayload<?>> accountPayload) {
+                           Optional<AccountPayload<?>> accountPayload,
+                           Optional<Boolean> mediationResultAcceptance) {
         super(networkId);
 
         this.myPubKeySharesResponse = myPubKeySharesResponse;
@@ -88,6 +92,7 @@ public final class MuSigTradeParty extends TradeParty {
         this.myCloseTradeResponse = myCloseTradeResponse;
         this.peersOutputPrvKeyShare = peersOutputPrvKeyShare;
         this.accountPayload = accountPayload;
+        mediationResultAcceptanceObservable.set(mediationResultAcceptance);
     }
 
     @Override
@@ -106,6 +111,7 @@ public final class MuSigTradeParty extends TradeParty {
         myCloseTradeResponse.ifPresent(e -> builder.setMyCloseTradeResponse(e.toProto(serializeForHash)));
         peersOutputPrvKeyShare.ifPresent(e -> builder.setPeersOutputPrvKeyShare(e.toProto(serializeForHash)));
         accountPayload.ifPresent(e -> builder.setAccountPayload(e.toProto(serializeForHash)));
+        mediationResultAcceptanceObservable.get().ifPresent(builder::setMediationResultAcceptance);
         return getTradePartyBuilder(serializeForHash).setMuSigTradeParty(builder);
     }
 
@@ -151,6 +157,9 @@ public final class MuSigTradeParty extends TradeParty {
                         : Optional.empty(),
                 muSigTradePartyProto.hasAccountPayload()
                         ? Optional.of(AccountPayload.fromProto(muSigTradePartyProto.getAccountPayload()))
+                        : Optional.empty(),
+                muSigTradePartyProto.hasMediationResultAcceptance()
+                        ? Optional.of(muSigTradePartyProto.getMediationResultAcceptance())
                         : Optional.empty()
         );
     }
@@ -205,5 +214,21 @@ public final class MuSigTradeParty extends TradeParty {
 
     public void setAccountPayload(AccountPayload<?> accountPayload) {
         this.accountPayload = Optional.of(accountPayload);
+    }
+
+    public boolean setMediationResultAcceptance(boolean mediationResultAccepted) {
+        if (mediationResultAcceptanceObservable.get().isPresent()) {
+            return false;
+        }
+        mediationResultAcceptanceObservable.set(Optional.of(mediationResultAccepted));
+        return true;
+    }
+
+    public Optional<Boolean> getMediationResultAcceptance() {
+        return mediationResultAcceptanceObservable.get();
+    }
+
+    public ReadOnlyObservable<Optional<Boolean>> mediationResultAcceptanceObservable() {
+        return mediationResultAcceptanceObservable;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -54,6 +54,7 @@ import bisq.persistence.RateLimitedPersistenceClient;
 import bisq.settings.SettingsService;
 import bisq.support.mediation.MediationCaseState;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
+import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.support.mediation.mu_sig.MuSigMediatorsResponse;
 import bisq.trade.MuSigDisputeState;
@@ -292,6 +293,8 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             maybeApplyDisputeStateFromMediationOpenSignal(muSigMediatorsResponse.getTradeId());
         } else if (envelopePayloadMessage instanceof MuSigMediationStateChangeMessage message) {
             maybeApplyDisputeStateFromMediationStateChangeMessage(message);
+        } else if (envelopePayloadMessage instanceof MuSigMediationResultAcceptanceMessage message) {
+            maybeApplyMediationResultAcceptanceMessage(message);
         }
     }
 
@@ -362,6 +365,25 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     public void closeTrade(MuSigTrade trade) {
         //todo: just temp, we will move it to closed trades in future
         removeTrade(trade);
+    }
+
+    public boolean acceptMediationResult(MuSigTrade trade, boolean mediationResultAccepted) {
+        if (trade.getMuSigMediationResult().isEmpty()) {
+            log.warn("Cannot set MuSig mediation result acceptance for trade {} because MuSigMediationResult is missing.",
+                    trade.getId());
+            return false;
+        }
+        if (!trade.getMyself().setMediationResultAcceptance(mediationResultAccepted)) {
+            return false;
+        }
+
+        networkService.confidentialSend(new MuSigMediationResultAcceptanceMessage(trade.getId(),
+                        mediationResultAccepted,
+                        trade.getMyIdentity().getId()),
+                trade.getPeer().getNetworkId(),
+                trade.getMyIdentity().getNetworkIdWithKeyPair());
+        persist();
+        return true;
     }
 
     public void maybeApplyDisputeStateFromMediationRequest(String tradeId) {
@@ -718,6 +740,25 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
 
             if (next != current || resultChanged) {
                 trade.setDisputeState(next);
+                persist();
+            }
+        });
+    }
+
+    private void maybeApplyMediationResultAcceptanceMessage(MuSigMediationResultAcceptanceMessage message) {
+        findTrade(message.getTradeId()).ifPresent(trade -> {
+            if (trade.getMuSigMediationResult().isEmpty()) {
+                log.warn("Ignoring MuSigMediationResultAcceptanceMessage for trade {} because MuSigMediationResult is missing.",
+                        message.getTradeId());
+                return;
+            }
+            if (!trade.getPeer().getNetworkId().getId().equals(message.getSenderUserProfileId())) {
+                log.warn("Ignoring MuSigMediationResultAcceptanceMessage with unexpected senderUserProfileId {} for trade {}.",
+                        message.getSenderUserProfileId(), message.getTradeId());
+                return;
+            }
+
+            if (trade.getPeer().setMediationResultAcceptance(message.isMediationResultAccepted())) {
                 persist();
             }
         });

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -221,6 +221,7 @@ message MuSigTradeParty {
   optional musigrpc.CloseTradeResponse myCloseTradeResponse = 11;
   optional common.ByteArray peersOutputPrvKeyShare = 12;
   optional account.AccountPayload accountPayload = 13;
+  optional bool mediationResultAcceptance = 14;
 }
 
 enum MuSigDisputeState {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now accept or reject mediation results in MuSig trades via new action buttons
  * Mediation result decisions are communicated to the trading peer
  * Trade history logs mediation result acceptance and rejection actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->