### PR TITLE
bugfix/bring_pairing_bugfixing_for_qr_code_and_sync

### DIFF
--- a/api/src/main/java/bisq/api/ApiConfig.java
+++ b/api/src/main/java/bisq/api/ApiConfig.java
@@ -148,6 +148,10 @@ public final class ApiConfig {
         return getWebSocketProtocol() + "://" + bindHost + ":" + bindPort;
     }
 
+    public static boolean isLoopbackHost(String host) {
+        return "127.0.0.1".equals(host) || "localhost".equals(host) || "::1".equals(host);
+    }
+
     public String getRestProtocol() {
         return tlsRequired ? "https" : "http";
     }

--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -52,13 +52,14 @@ import bisq.chat.ChatService;
 import bisq.common.application.Service;
 import bisq.common.network.Address;
 import bisq.common.observable.Observable;
+import bisq.common.observable.Pin;
 import bisq.common.observable.ReadOnlyObservable;
+import bisq.common.timer.Scheduler;
 import bisq.common.util.CompletableFutureUtils;
 import bisq.network.NetworkService;
 import bisq.notifications.mobile.registration.DeviceRegistrationService;
 import bisq.persistence.PersistenceService;
 import bisq.security.SecurityService;
-import bisq.security.tls.TlsException;
 import bisq.settings.SettingsService;
 import bisq.support.SupportService;
 import bisq.trade.TradeService;
@@ -74,9 +75,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * Swagger docs at: http://localhost:8090/doc/v1/index.html if rest is enabled
@@ -108,6 +108,10 @@ public class ApiService implements Service {
     @Getter
     private final TlsContextService tlsContextService;
     private final Observable<State> state = new Observable<>(State.NEW);
+    private final Object pairingQrCodeLock = new Object();
+    @Nullable
+    private Pin pairingCodePin;
+    private Optional<Scheduler> pairingCodeScheduler = Optional.empty();
 
     public ApiService(ApiConfig apiConfig,
                       Path appDataDirPath,
@@ -170,7 +174,9 @@ public class ApiService implements Service {
         DevicesRestApi devicesRestApi= new DevicesRestApi(deviceRegistrationService);
 
         ResourceConfig resourceConfig;
-        if (apiConfig.isRestEnabled()) {
+        if (apiConfig.isRestEnabled() || apiConfig.isWebsocketEnabled()) {
+            // WebSocket REST bridge forwards requests to the local HTTP server,
+            // so all endpoints must be registered when WebSocket is enabled.
             resourceConfig = new RestApiResourceConfig(apiConfig,
                     permissionService,
                     sessionAuthenticationService,
@@ -251,6 +257,7 @@ public class ApiService implements Service {
                     } else {
                         try {
                             createPairingQrCode();
+                            setupPairingCodeAutoRegeneration();
                             return CompletableFuture.completedFuture(true);
                         } catch (Exception e) {
                             return CompletableFuture.failedFuture(e);
@@ -267,6 +274,12 @@ public class ApiService implements Service {
         }
 
         setState(State.STOPPING);
+        pairingCodeScheduler.ifPresent(Scheduler::stop);
+        pairingCodeScheduler = Optional.empty();
+        if (pairingCodePin != null) {
+            pairingCodePin.unbind();
+            pairingCodePin = null;
+        }
         List<CompletableFuture<Boolean>> futures = new ArrayList<>();
         futures.add(apiAccessTransportService.shutdown());
         futures.add(httpServerBootstrapService.shutdown());
@@ -277,27 +290,81 @@ public class ApiService implements Service {
                 });
     }
 
-    public void createPairingQrCode() throws TlsException {
-        checkArgument(webSocketService.isPresent(),
-                "webSocketService must be present");
+    public void createPairingQrCode() {
+        synchronized (pairingQrCodeLock) {
+            if (webSocketService.isEmpty()) {
+                log.warn("Cannot create pairing QR code: WebSocket service not initialized");
+                return;
+            }
 
-        checkArgument(webSocketService.get().getState().get() == WebSocketService.State.RUNNING,
-                "webSocketServiceState must be RUNNING");
+            WebSocketService.State wsState = webSocketService.get().getState().get();
+            if (wsState != WebSocketService.State.RUNNING) {
+                log.warn("Cannot create pairing QR code: WebSocket service state is {} (expected RUNNING)", wsState);
+                return;
+            }
 
-        String webSocketUrl;
-        if (apiConfig.useTor()) {
-            Address onionAddress = apiAccessTransportService.getOnionAddress().get();
-            checkNotNull(onionAddress, "OnionAddress must not be null");
-            webSocketUrl = apiConfig.getWebSocketProtocol() + "://" + onionAddress.getHost() + ":" + onionAddress.getPort();
-        } else {
-            webSocketUrl = apiConfig.getWebSocketServerUrl();
+            pairingService.cleanupExpiredPairingCodes();
+
+            String webSocketUrl;
+            if (apiConfig.useTor()) {
+                Address onionAddress = apiAccessTransportService.getOnionAddress().get();
+                if (onionAddress == null) {
+                    log.warn("Cannot create pairing QR code: onion address not available yet");
+                    return;
+                }
+                webSocketUrl = apiConfig.getWebSocketProtocol() + "://" + onionAddress.getHost() + ":" + onionAddress.getPort();
+            } else {
+                String host = apiConfig.getBindHost();
+                if ("0.0.0.0".equals(host)) {
+                    // 0.0.0.0 is not a reachable address — attempt auto-detection for the QR code.
+                    Address lanAddress = apiAccessTransportService.findLanAddress();
+                    webSocketUrl = apiConfig.getWebSocketProtocol() + "://" + lanAddress.getHost() + ":" + lanAddress.getPort();
+                    log.warn("CLEAR mode: bind host is 0.0.0.0, using auto-detected LAN address {} for pairing QR code. " +
+                            "For reliable pairing, set bind.host to a specific IP.", lanAddress);
+                } else {
+                    // Use the configured bind host directly — whether it's a specific LAN IP
+                    // or loopback (loopback only works for emulators, warned at startup).
+                    webSocketUrl = apiConfig.getWebSocketServerUrl();
+                }
+            }
+
+            Set<Permission> grantedPermissions = apiConfig.getGrantedPermissions();
+            PairingCode pairingCode = pairingService.createPairingCode(grantedPermissions);
+            pairingService.createPairingQrCode(pairingCode,
+                    webSocketUrl,
+                    tlsContextService.getTlsContext(),
+                    apiAccessTransportService.getTorContext());
+
+            if (pairingService.getPairingQrCode().get() != null) {
+                log.info("Pairing QR code created. Code ID: {} (expires at: {})",
+                        pairingCode.getId(), pairingCode.getExpiresAt());
+            } else {
+                log.warn("Failed to create pairing QR code for Code ID: {}", pairingCode.getId());
+            }
         }
-        Set<Permission> grantedPermissions = apiConfig.getGrantedPermissions();
-        PairingCode pairingCode = pairingService.createPairingCode(grantedPermissions);
-        pairingService.createPairingQrCode(pairingCode,
-                webSocketUrl,
-                tlsContextService.getOrCreateTlsContext(),
-                apiAccessTransportService.getTorContext());
+    }
+
+    private void setupPairingCodeAutoRegeneration() {
+        // Schedule periodic regeneration before TTL expires.
+        // Use at most 5 minutes interval so headless users get fresh codes promptly.
+        int ttlMinutes = pairingService.getPairingCodeTtlInSeconds() / 60;
+        int regenerationIntervalMinutes = Math.max(1, Math.min(ttlMinutes - 1, 5));
+        pairingCodeScheduler = Optional.of(Scheduler.run(this::createPairingQrCode)
+                .host(this)
+                .runnableName("regeneratePairingCode")
+                .periodically(regenerationIntervalMinutes, TimeUnit.MINUTES));
+        log.info("Pairing code auto-regeneration scheduled every {} minutes (TTL: {} minutes)",
+                regenerationIntervalMinutes, ttlMinutes);
+
+        // Regenerate immediately when a pairing code is consumed
+        pairingCodePin = pairingService.getPairingCode().addObserver(pairingCode -> {
+            if (pairingCode == null && state.get() == State.RUNNING) {
+                log.info("Pairing code was consumed, regenerating immediately");
+                createPairingQrCode();
+            } else if (pairingCode == null) {
+                log.warn("Pairing code was consumed but ApiService state is {} — skipping regeneration", state.get());
+            }
+        });
     }
 
     public ReadOnlyObservable<State> getState() {

--- a/api/src/main/java/bisq/api/HttpServerBootstrapService.java
+++ b/api/src/main/java/bisq/api/HttpServerBootstrapService.java
@@ -93,9 +93,30 @@ public class HttpServerBootstrapService implements Service {
 
         setState(State.STARTING);
 
+        String bindHost = apiConfig.getBindHost();
+
+        if (ApiConfig.isLoopbackHost(bindHost) && !apiConfig.useTor()) {
+            log.warn("NETWORK: Bind host is set to {} (loopback). " +
+                    "In clearnet mode this will only be reachable from emulators on the same machine. " +
+                    "To allow real devices on your LAN, set bind.host to your LAN IP " +
+                    "(e.g. 192.168.x.x) and enable tls.required=true.", bindHost);
+        } else if ("0.0.0.0".equals(bindHost)) {
+            log.warn("NETWORK: Bind host is set to 0.0.0.0 — the server will listen on ALL network interfaces. " +
+                    "For better security, set bind.host to the specific LAN IP you want to expose " +
+                    "(e.g. 192.168.x.x) so only that interface is bound.");
+        }
+
+        // Warn about cleartext binding on non-loopback interfaces when not using Tor.
+        // Tor encrypts traffic via the onion service, so cleartext on loopback is fine.
+        if (!apiConfig.useTor() && !ApiConfig.isLoopbackHost(bindHost) && !apiConfig.isTlsRequired()) {
+            log.warn("SECURITY WARNING: Binding to {} without TLS. " +
+                    "Pairing tokens and session credentials will be transmitted in cleartext, " +
+                    "exposing them to interception on shared networks. " +
+                    "Consider setting tls.required=true or binding to 127.0.0.1.", bindHost);
+        }
+
         return CompletableFuture.supplyAsync(() -> {
                     String webSocketProtocol = apiConfig.getWebSocketProtocol();
-                    String bindHost = apiConfig.getBindHost();
                     int bindPort = apiConfig.getBindPort();
 
                     URI baseUri = UriBuilder
@@ -145,13 +166,16 @@ public class HttpServerBootstrapService implements Service {
 
                     try {
                         server.start();
-                        log.info("Server started at {}", baseUri);
-                        log.info("WebSocket endpoint available at '{}://{}:{}/websocket'", apiConfig.getWebSocketProtocol(), bindHost, bindPort);
+                        log.info("Server started at {} (advertised as {})", baseUri, bindHost);
+                        if (websocketEnabled) {
+                            log.info("WebSocket endpoint available at '{}://{}:{}/websocket'", apiConfig.getWebSocketProtocol(), bindHost, bindPort);
+                        }
                         if (apiConfig.isRestEnabled()) {
-                            log.info("Rest API endpoints available at '{}'", apiConfig.getRestServerApiBasePath());
+                            log.info("REST API endpoints available at '{}'", apiConfig.getRestServerApiBasePath());
+                        } else if (websocketEnabled) {
+                            log.info("REST API registered for WebSocket bridge (direct REST access disabled)");
                         } else {
-                            log.info("Rest API is disabled but pairing endpoint is available at '{}/pairing'",
-                                    apiConfig.getRestServerApiBasePath());
+                            log.info("Only pairing resources registered");
                         }
                         return true;
                     } catch (IOException e) {

--- a/api/src/main/java/bisq/api/access/filter/authn/SessionAuthenticationService.java
+++ b/api/src/main/java/bisq/api/access/filter/authn/SessionAuthenticationService.java
@@ -45,12 +45,9 @@ public final class SessionAuthenticationService {
             checkNotNull(sessionId, "Missing sessionId");
             checkNotNull(clientId, "Missing clientId");
 
-            SessionToken sessionToken = sessionService.find(sessionId)
+            // find() atomically evicts expired tokens, so a returned token is guaranteed valid
+            SessionToken sessionToken = sessionService.findNotExpiredToken(sessionId)
                     .orElseThrow(() -> new AuthenticationException("Invalid session"));
-
-            if (sessionToken.isExpired()) {
-                throw new AuthenticationException("Session expired");
-            }
 
             checkArgument(clientId.equals(sessionToken.getClientId()),
                     "ClientId from header not matching client ID from session");

--- a/api/src/main/java/bisq/api/access/identity/ClientProfile.java
+++ b/api/src/main/java/bisq/api/access/identity/ClientProfile.java
@@ -21,6 +21,19 @@ import bisq.common.proto.PersistableProto;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+/**
+ * Represents a client profile for API access pairing.
+ *
+ * <p><b>Security Note:</b> The clientSecret is currently stored in plaintext and serialized via protobuf.
+ * This creates exposure risk if the persistence store is compromised.
+ * Future enhancement should implement encryption for the persistence layer and document/enforce
+ * strict file-level protections and rotation policies.
+ *
+ * <p><b>Authentication:</b> Constant-time secret comparison is performed at authentication using
+ * {@link java.security.MessageDigest#isEqual(byte[], byte[])} in
+ * {@link bisq.api.access.ApiAccessService#requestSession(String, String)}.
+ * See that method for the secure comparison implementation.
+ */
 @Getter
 @EqualsAndHashCode
 public final class ClientProfile implements PersistableProto {

--- a/api/src/main/java/bisq/api/access/pairing/PairingCodeDecoder.java
+++ b/api/src/main/java/bisq/api/access/pairing/PairingCodeDecoder.java
@@ -51,7 +51,12 @@ public final class PairingCodeDecoder {
             }
             Set<Permission> permissions = EnumSet.noneOf(Permission.class);
             for (int i = 0; i < numPermissions; i++) {
-                permissions.add(Permission.fromId(BinaryDecodingUtils.readInt(in)));
+                try {
+                    permissions.add(Permission.fromId(BinaryDecodingUtils.readInt(in)));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(
+                        "Invalid permission at index " + i + " in pairing code", e);
+                }
             }
 
             return new PairingCode(id, expiresAt, permissions);

--- a/api/src/main/java/bisq/api/access/pairing/PairingService.java
+++ b/api/src/main/java/bisq/api/access/pairing/PairingService.java
@@ -89,18 +89,20 @@ public class PairingService {
         if (version != VERSION) {
             throw new InvalidPairingRequestException("Unsupported pairing protocol version: " + version);
         }
-        PairingCode pairingCode = pairingCodeByIdMap.get(pairingCodeId);
+
+        // Atomic remove to prevent race conditions - ensures only one request can use the code
+        PairingCode pairingCode = pairingCodeByIdMap.remove(pairingCodeId);
         if (pairingCode == null) {
             throw new InvalidPairingRequestException("Pairing code not found or already used");
         }
 
         if (isExpired(pairingCode)) {
-            pairingCodeByIdMap.remove(pairingCodeId, pairingCode);
             throw new InvalidPairingRequestException("Pairing code is expired");
         }
 
-        // Mark used by removing it
-        pairingCodeByIdMap.remove(pairingCodeId, pairingCode);
+        // Signal that the active code was consumed so observers can regenerate
+        log.info("Pairing code {} consumed, signalling observers for regeneration", pairingCodeId);
+        this.pairingCode.set(null);
 
         String clientId = UUID.randomUUID().toString();
         byte[] secret = ByteArrayUtils.getRandomBytes(32);
@@ -127,6 +129,23 @@ public class PairingService {
         return Instant.now().isAfter(pairingCode.getExpiresAt());
     }
 
+    /**
+     * Removes all expired pairing codes from the map.
+     * Should be called periodically or when creating new pairing codes.
+     */
+    public void cleanupExpiredPairingCodes() {
+        int removed = 0;
+        for (Map.Entry<String, PairingCode> entry : pairingCodeByIdMap.entrySet()) {
+            if (isExpired(entry.getValue())) {
+                pairingCodeByIdMap.remove(entry.getKey());
+                removed++;
+            }
+        }
+        if (removed > 0) {
+            log.debug("Cleaned up {} expired pairing codes", removed);
+        }
+    }
+
     public void createPairingQrCode(PairingCode pairingCode,
                                     String webSocketUrl,
                                     Optional<TlsContext> tlsContext,
@@ -150,8 +169,9 @@ public class PairingService {
         try {
             Path path = appDataDirPath.resolve("pairing_qr_code.txt");
             FileMutatorUtils.writeToPath(pairingQrCode, path);
+            log.info("Pairing QR code written to {}", path);
         } catch (IOException e) {
-            log.error("Error at write pairing QR code to disk", e);
+            log.error("Error at write pairing QR code to disk at {}", appDataDirPath.resolve("pairing_qr_code.txt"), e);
         }
     }
 }

--- a/api/src/main/java/bisq/api/access/session/SessionService.java
+++ b/api/src/main/java/bisq/api/access/session/SessionService.java
@@ -38,7 +38,23 @@ public class SessionService {
         return token;
     }
 
-    public Optional<SessionToken> find(String sessionId) {
-        return Optional.ofNullable(sessionTokenBySessionIdMap.get(sessionId));
+    public Optional<SessionToken> findNotExpiredToken(String sessionId) {
+        // Use computeIfPresent for atomic check-and-evict of expired tokens (prevents TOCTOU race)
+        SessionToken result = sessionTokenBySessionIdMap.computeIfPresent(sessionId, (key, token) -> {
+            if (token.isExpired()) {
+                return null; // Evict expired token
+            }
+            return token; // Keep valid token
+        });
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * Explicitly removes a session (e.g., for logout functionality).
+     *
+     * @param sessionId The session ID to remove
+     */
+    public void remove(String sessionId) {
+        sessionTokenBySessionIdMap.remove(sessionId);
     }
 }

--- a/api/src/main/java/bisq/api/access/session/SessionToken.java
+++ b/api/src/main/java/bisq/api/access/session/SessionToken.java
@@ -38,10 +38,10 @@ public class SessionToken {
         this.ttlInMinutes = ttlInMinutes;
         this.sessionId = UUID.randomUUID().toString();
         this.clientId = clientId;
-        this.expiresAt = Instant.now().plusSeconds(ttlInMinutes * 60L);
+        this.expiresAt = ttlInMinutes < 0 ? Instant.MAX : Instant.now().plusSeconds(ttlInMinutes * 60L);
     }
 
     public boolean isExpired() {
-        return Instant.now().isAfter(expiresAt);
+        return ttlInMinutes >= 0 && Instant.now().isAfter(expiresAt);
     }
 }

--- a/api/src/main/java/bisq/api/access/transport/ApiAccessTransportService.java
+++ b/api/src/main/java/bisq/api/access/transport/ApiAccessTransportService.java
@@ -93,6 +93,7 @@ public class ApiAccessTransportService implements Service {
 
     public CompletableFuture<Address> publishAndGetTorAddress() {
         if (networkService.findServiceNode(TransportType.TOR).isEmpty()) {
+            log.error("TOR ServiceNode not found in NetworkService. Check that network.supportedTransportTypes includes TOR in the config.");
             return CompletableFuture.failedFuture(new IllegalStateException("ApiAccessTorTransportService is initialized without TOR set as TransportType"));
         }
 

--- a/api/src/main/java/bisq/api/access/transport/TlsContextService.java
+++ b/api/src/main/java/bisq/api/access/transport/TlsContextService.java
@@ -36,8 +36,11 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -74,14 +77,15 @@ public class TlsContextService {
                     "TLS password does not have required min. length of " + MIN_PASSWORD_LENGTH);
             char[] password = tlsKeyStorePassword.toCharArray();
 
-            List<String> tlsKeyStoreSan = apiConfig.getTlsKeyStoreSan();
-            checkNotNull(tlsKeyStoreSan, "tlsKeyStoreSan must not be null");
-            checkArgument(!tlsKeyStoreSan.isEmpty(), "tlsKeyStoreSan must have at least one entry.");
+            List<String> configuredSans = apiConfig.getTlsKeyStoreSan();
+            checkNotNull(configuredSans, "tlsKeyStoreSan must not be null");
+            checkArgument(!configuredSans.isEmpty(), "tlsKeyStoreSan must have at least one entry.");
+            List<String> tlsKeyStoreSan = augmentSansWithBindHost(configuredSans);
 
             KeyStore keyStore;
             Optional<KeyStore> optionalKeyStore;
             try {
-                optionalKeyStore = TlsKeyStore.readKeyStore(keyStorePath, password, tlsKeyStoreSan);
+                optionalKeyStore = TlsKeyStore.readKeyStore(keyStorePath, password);
                 if (optionalKeyStore.isPresent()) {
                     keyStore = optionalKeyStore.get();
                     if (!SanUtils.isMatchingPersistedSan(keyStore, tlsKeyStoreSan)) {
@@ -103,6 +107,26 @@ public class TlsContextService {
         } catch (Exception e) {
             throw new TlsException(e);
         }
+    }
+
+    /**
+     * Augments the configured SANs with the bind host from config so the TLS certificate
+     * is valid for connections to the admin's chosen bind address.
+     * <p>
+     * Does not auto-detect LAN IPs — admins should add any extra SANs they need
+     * to the certificate.san config. For 0.0.0.0, a warning is logged suggesting
+     * the admin add the target IP to the san list manually.
+     */
+    private List<String> augmentSansWithBindHost(List<String> configuredSans) {
+        Set<String> sans = new LinkedHashSet<>(configuredSans);
+        String bindHost = apiConfig.getBindHost();
+        if ("0.0.0.0".equals(bindHost)) {
+            log.warn("Bind host is 0.0.0.0 — cannot add wildcard to TLS certificate SANs. " +
+                    "Add the specific IP(s) clients will connect to in the certificate.san config.");
+        } else if (sans.add(bindHost)) {
+            log.info("Added configured bind host {} to TLS certificate SANs", bindHost);
+        }
+        return new ArrayList<>(sans);
     }
 
     private KeyStore createNewKeyStore(List<String> tlsKeyStoreSan, char[] password) throws TlsException {

--- a/api/src/main/java/bisq/api/dto/presentation/offerbook/OfferItemPresentationDtoFactory.java
+++ b/api/src/main/java/bisq/api/dto/presentation/offerbook/OfferItemPresentationDtoFactory.java
@@ -44,24 +44,32 @@ import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class OfferItemPresentationDtoFactory {
-    public static OfferItemPresentationDto create(UserProfileService userProfileService,
-                                                  UserIdentityService userIdentityService,
-                                                  ReputationService reputationService,
-                                                  MarketPriceService marketPriceService,
-                                                  BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
+    public static Optional<OfferItemPresentationDto> create(UserProfileService userProfileService,
+                                                            UserIdentityService userIdentityService,
+                                                            ReputationService reputationService,
+                                                            MarketPriceService marketPriceService,
+                                                            BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
         BisqEasyOffer bisqEasyOffer = bisqEasyOfferbookMessage.getBisqEasyOffer().orElseThrow();
-        boolean isMyOffer = bisqEasyOfferbookMessage.isMyMessage(userIdentityService);
-        Direction direction = bisqEasyOffer.getDirection();
-        String messageId = bisqEasyOfferbookMessage.getId();
-        String offerId = bisqEasyOffer.getId();
-        BisqEasyOfferDto bisqEasyOfferDto = DtoMappings.BisqEasyOfferMapping.fromBisq2Model(bisqEasyOffer);
         String authorUserProfileId = bisqEasyOfferbookMessage.getAuthorUserProfileId();
+
+        Optional<UserProfile> userProfileOpt = userProfileService.findUserProfile(authorUserProfileId);
+        if (userProfileOpt.isEmpty()) {
+            log.debug("User profile not found for authorUserProfileId={}, skipping offer creation", authorUserProfileId);
+            return Optional.empty();
+        }
+
+        boolean isMyOffer = bisqEasyOfferbookMessage.isMyMessage(userIdentityService);
+        BisqEasyOfferDto bisqEasyOfferDto = DtoMappings.BisqEasyOfferMapping.fromBisq2Model(bisqEasyOffer);
 
         // For now, we send also the formatted values as we have not the complex formatters in mobile impl. yet.
         // We might need to replicate the formatters anyway later and then those fields could be removed
@@ -102,11 +110,10 @@ public class OfferItemPresentationDtoFactory {
                 .map(PaymentMethod::getPaymentRailName)
                 .collect(Collectors.toList());
 
-        UserProfile userProfile = userProfileService.findUserProfile(authorUserProfileId).orElseThrow();
-        UserProfileDto userProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(userProfile);
+        UserProfileDto userProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(userProfileOpt.get());
         ReputationScore reputationScore = reputationService.getReputationScore(authorUserProfileId);
         ReputationScoreDto reputationScoreDto = DtoMappings.ReputationScoreMapping.fromBisq2Model(reputationScore);
-        return new OfferItemPresentationDto(bisqEasyOfferDto,
+        return Optional.of(new OfferItemPresentationDto(bisqEasyOfferDto,
                 isMyOffer,
                 userProfileDto,
                 formattedDate,
@@ -116,6 +123,6 @@ public class OfferItemPresentationDtoFactory {
                 formattedPriceSpec,
                 quoteSidePaymentMethods,
                 baseSidePaymentMethods,
-                reputationScoreDto);
+                reputationScoreDto));
     }
 }

--- a/api/src/main/java/bisq/api/rest_api/PairingApiResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/PairingApiResourceConfig.java
@@ -4,10 +4,12 @@ import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.api.rest_api.error.CustomExceptionMapper;
 import bisq.api.rest_api.error.RestApiException;
 import bisq.common.json.JsonMapperProvider;
+import jakarta.ws.rs.ApplicationPath;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import org.glassfish.jersey.server.ResourceConfig;
 
+@ApplicationPath("/api/v1")
 public class PairingApiResourceConfig extends ResourceConfig {
     public PairingApiResourceConfig(AccessApi accessApi) {
         super();

--- a/api/src/main/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApi.java
@@ -325,12 +325,14 @@ public class OfferbookRestApi extends RestApiBase {
                                 .stream()
                                 .filter(BisqEasyOfferbookMessage::hasBisqEasyOffer)
                                 .map(this::createOfferListItemDto)
+                                .filter(Optional::isPresent)
+                                .map(Optional::get)
                                 .collect(Collectors.toList())
                         )
                 );
     }
 
-    private OfferItemPresentationDto createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
+    private Optional<OfferItemPresentationDto> createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
         return OfferItemPresentationDtoFactory.create(userProfileService,
                 userIdentityService,
                 reputationService,

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
@@ -284,7 +284,6 @@ public class TradeRestApi extends RestApiBase {
         String encoded = Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).get();
         bisqEasyTradeService.cancelTrade(trade);
-        leavePrivateChatManager.leaveChannel(channel);
     }
 
     private void handleCloseTrade(BisqEasyOpenTradeChannel channel, BisqEasyTrade trade) throws Exception {

--- a/api/src/main/java/bisq/api/web_socket/domain/offers/OffersWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/offers/OffersWebSocketService.java
@@ -121,7 +121,7 @@ public class OffersWebSocketService extends BaseWebSocketService {
                                 .filter(BisqEasyOfferbookMessage::hasBisqEasyOffer)
                                 .map(message -> {
                                     try {
-                                        return createOfferListItemDto(message);
+                                        return createOfferListItemDto(message).orElse(null);
                                     } catch (Exception e) {
                                         log.error("Failed to create OfferListItemDto", e);
                                         return null;
@@ -135,17 +135,23 @@ public class OffersWebSocketService extends BaseWebSocketService {
     private void send(String quoteCurrencyCode,
                       BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                       ModificationType modificationType) {
-        OfferItemPresentationDto item = createOfferListItemDto(bisqEasyOfferbookMessage);
-        // The payload is defined as a list to support batch data delivery at subscribe.
-        ArrayList<OfferItemPresentationDto> payload = new ArrayList<>(List.of(item));
-        toJson(payload).ifPresent(json -> {
-            subscriberRepository.findSubscribers(topic, quoteCurrencyCode)
-                    .ifPresent(subscribers -> subscribers
-                            .forEach(subscriber -> send(json, subscriber, modificationType)));
-        });
+        try {
+            createOfferListItemDto(bisqEasyOfferbookMessage).ifPresentOrElse(item -> {
+                // The payload is defined as a list to support batch data delivery at subscribe.
+                ArrayList<OfferItemPresentationDto> payload = new ArrayList<>(List.of(item));
+                toJson(payload).ifPresent(json -> {
+                    subscriberRepository.findSubscribers(topic, quoteCurrencyCode)
+                            .ifPresent(subscribers -> subscribers
+                                    .forEach(subscriber -> send(json, subscriber, modificationType)));
+                });
+            }, () -> log.debug("Skipping websocket send for offer from authorUserProfileId={}: user profile not yet available",
+                    bisqEasyOfferbookMessage.getAuthorUserProfileId()));
+        } catch (Exception e) {
+            log.error("Failed to send OfferListItemDto update for quoteCurrencyCode={}", quoteCurrencyCode, e);
+        }
     }
 
-    private OfferItemPresentationDto createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
+    private Optional<OfferItemPresentationDto> createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
         return OfferItemPresentationDtoFactory.create(userProfileService,
                 userIdentityService,
                 reputationService,

--- a/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiService.java
+++ b/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiService.java
@@ -58,7 +58,7 @@ public class WebSocketRestApiService implements Service {
 
     public WebSocketRestApiService(ApiConfig apiConfig, TlsContextService tlsContextService) {
         this.apiConfig = apiConfig;
-        this.restServerUrl = apiConfig.getRestServerUrl();
+        this.restServerUrl = apiConfig.getRestProtocol() + "://" + apiConfig.getBindHost() + ":" + apiConfig.getBindPort();
         this.tlsContextService = tlsContextService;
     }
 
@@ -108,6 +108,8 @@ public class WebSocketRestApiService implements Service {
         try {
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(url))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
                     .method(method, body == null
                             ? HttpRequest.BodyPublishers.noBody()
                             : HttpRequest.BodyPublishers.ofString(body));

--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -17,37 +17,55 @@ application {
     }
 
     api={
-        accessTransportType="CLEAR"   # One of: CLEAR | TOR | I2P
+        accessTransportType="TOR"   # One of: CLEAR | TOR | I2P
 
         pairing={
-            ttlInSeconds=3600
-            writePairingQrCodeToDisk=true
+            ttlInSeconds=3600           # Pairing code time-to-live (default: 1 hour)
+            writePairingQrCodeToDisk=true  # Write pairing QR code to pairing_qr_code.txt in data dir
         }
 
         server={
             restEnabled=false
-            websocketEnabled=false
+            websocketEnabled=true
             # grpcEnabled=false
 
             bind={
+                # The network interface the API server binds to.
+                #
+                # TOR mode:
+                #   Keep "127.0.0.1" (default). The Tor onion service forwards
+                #   traffic to loopback automatically. Do NOT use a LAN IP here —
+                #   the onion service always connects to 127.0.0.1.
+                #
+                # CLEAR mode (LAN):
+                #   Change to your server's LAN IP (e.g. "192.168.1.50") so real
+                #   mobile devices on the same network can connect.
+                #   "127.0.0.1" only works for emulators on the same machine.
+                #   Avoid "0.0.0.0" as it binds ALL interfaces — prefer a specific IP.
+                #   Enable tls.required=true below to prevent cleartext interception
+                #   of pairing tokens and session credentials on the network.
                 host="127.0.0.1"
                 port=8090
             }
 
             tor={
-                onionServicePort=80    # external virtual port
+                onionServicePort=80    # external virtual port exposed to Tor network
                 clientAuthRequired=false
             }
 
             tls={
-                required=false
+                required=false          # Set to true to enable HTTPS/WSS
 
                 keystore={
-                    password=""
+                    password=""         # Min 8 chars when tls.required=true
                 }
 
                 certificate={
-                    san=["127.0.0.1" ]
+                    # Subject Alternative Names for the self-signed TLS cert.
+                    # The configured bind.host is auto-added at runtime.
+                    # For CLEAR mode, include your LAN IP here if different from bind.host.
+                    # For TOR mode, SANs are not relevant (fingerprint-based trust is used).
+                    san=["127.0.0.1"]
                 }
             }
 
@@ -177,6 +195,7 @@ application {
             timeoutInSeconds=60
             providers=[
                         {
+                            // Production relay node
                             url="http://6be5uu6ldm3mim2xiyov2m6owzhdlicfobqho5mbpglzio6qt5etyhid.onion:8021"
                             operator="FSW LLC",
                             apiPath="relay",
@@ -184,6 +203,8 @@ application {
             ]
             fallbackProviders=[
             ]
+            // For development, you can host your own relay and use it as a provider
+            // Local example: url="http://localhost:8080", apiPath="relay"
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,7 @@ tasks.register("publishAll") {
             ":identity:publishToMavenLocal",
             ":network:publishToMavenLocal",
             ":network:tor:publishToMavenLocal",
+            ":notifications:publishToMavenLocal",
             ":offer:publishToMavenLocal",
             ":persistence:publishToMavenLocal",
             ":platform:publishToMavenLocal",

--- a/common/src/main/java/bisq/common/util/BinaryDecodingUtils.java
+++ b/common/src/main/java/bisq/common/util/BinaryDecodingUtils.java
@@ -22,8 +22,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public final class BinaryDecodingUtils {
+    // Actual maximum length is 65535 (unsigned short max value from readUnsignedShort)
+    private static final int MAX_UNSIGNED_SHORT_VALUE = 65535;
+
     public static byte[] readBytes(DataInputStream in) throws IOException {
-        return readBytes(in, Integer.MAX_VALUE);
+        return readBytes(in, MAX_UNSIGNED_SHORT_VALUE);
     }
 
     public static byte[] readBytes(DataInputStream in, int maxLength) throws IOException {
@@ -38,7 +41,7 @@ public final class BinaryDecodingUtils {
     }
 
     public static String readString(DataInputStream in) throws IOException {
-        return readString(in, Integer.MAX_VALUE);
+        return readString(in, MAX_UNSIGNED_SHORT_VALUE);
     }
 
     public static String readString(DataInputStream in, int maxLength) throws IOException {

--- a/common/src/main/java/bisq/common/util/ByteArrayUtils.java
+++ b/common/src/main/java/bisq/common/util/ByteArrayUtils.java
@@ -24,6 +24,8 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 
 public class ByteArrayUtils {
+    // Shared SecureRandom instance to avoid initialization overhead on every call
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public static byte[] concat(byte[]... bytes) {
         int length = 0;
@@ -87,8 +89,11 @@ public class ByteArrayUtils {
     }
 
     public static byte[] getRandomBytes(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("size must be >= 0");
+        }
         byte[] bytes = new byte[size];
-        new SecureRandom().nextBytes(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
         return bytes;
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ apache-httpcomponents-httpclient-lib = { strictly = '5.4.1' }
 apache-tomcat-annotations-api = { strictly = '6.0.53' }
 
 assertj-core-lib = { strictly = '3.22.0' }
-bouncycastle-lib = { strictly = '1.78.1' }
+bouncycastle-lib = { strictly = '1.79' }
 
 commons-codec = { strictly = '1.17.1' }
 

--- a/security/src/main/java/bisq/security/tls/TlsKeyStore.java
+++ b/security/src/main/java/bisq/security/tls/TlsKeyStore.java
@@ -32,12 +32,10 @@ import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -86,8 +84,7 @@ public class TlsKeyStore {
     }
 
     public static Optional<KeyStore> readKeyStore(Path keyStorePath,
-                                                  char[] password,
-                                                  List<String> tlsKeyStoreSan) throws TlsException, TlsPasswordException {
+                                                  char[] password) throws TlsException, TlsPasswordException {
         try {
             if (!Files.exists(keyStorePath)) {
                 return Optional.empty();
@@ -99,7 +96,7 @@ public class TlsKeyStore {
             }
             return Optional.of(keyStore);
         } catch (IOException e) {
-            if (e.getCause() instanceof UnrecoverableKeyException) {
+            if (isPasswordRelated(e)) {
                 throw new TlsPasswordException("Could not decrypt key store with given password.", e);
             } else {
                 throw new TlsException("Failed to read TLS key store", e);
@@ -122,16 +119,29 @@ public class TlsKeyStore {
         }
     }
 
-    private static PrivateKey loadPrivateKey(KeyStore keyStore, char[] password) throws TlsException {
-        try {
-            return (PrivateKey) keyStore.getKey(KEY_ALIAS, password);
-        } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
-            throw new TlsException("Failed to load private key", e);
-        }
-    }
-
     private static X509Certificate loadCertificate(KeyStore keyStore) throws KeyStoreException {
         return (X509Certificate) keyStore.getCertificate(KEY_ALIAS);
     }
 
+    private static boolean isPasswordRelated(IOException e) {
+        if (e.getCause() instanceof UnrecoverableKeyException) {
+            return true;
+        }
+        // Different JDK implementations may surface password errors differently
+        String message = e.getMessage();
+        if (message != null) {
+            String lower = message.toLowerCase();
+            if (lower.contains("password") || lower.contains("unrecoverable")) {
+                return true;
+            }
+        }
+        Throwable cause = e.getCause();
+        if (cause != null && cause.getMessage() != null) {
+            String causeLower = cause.getMessage().toLowerCase();
+            if (causeLower.contains("password") || causeLower.contains("unrecoverable")) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/security/src/main/java/bisq/security/tls/TlsTrustManager.java
+++ b/security/src/main/java/bisq/security/tls/TlsTrustManager.java
@@ -33,7 +33,13 @@ public final class TlsTrustManager implements X509TrustManager {
         if (fingerprintBase64 == null || fingerprintBase64.isEmpty()) {
             throw new IllegalArgumentException("tlsFingerprint must be a non-empty Base64 string");
         }
-        byte[] fingerprintBytes = Base64.decode(fingerprintBase64);
+        byte[] fingerprintBytes;
+        try {
+            fingerprintBytes = Base64.decode(fingerprintBase64);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "tlsFingerprint must be a valid Base64-encoded SHA-256 hash", e);
+        }
         if (fingerprintBytes.length != 32) {
             throw new IllegalArgumentException("tlsFingerprint must be a SHA-256 hash (32 bytes)");
         }


### PR DESCRIPTION
## Brief

This PR syncs all the bugfixing work made in mobile branch `for-moblie-based-on-2.1.8` to make all the security setups effectively work for both mobile platforms, in both supported transports CLEAR and TOR. It also brings other minor work needed to be brought to main.

This PR has been tested in all scenarios, with devices (including real and emulators) and also QR Pairing with Desktop as well (desktop launch from the 2.1.10-snapshot). For the Desktop pairing its delighful to see how a change in one client immediately impacts the other (except for minor cases like language change which requires a restart in Bisq Desktop)

## How to test this PR

All security configs have been ported to the new `api_app.conf` with cases C1-5 for Clearnet and cases T1-5 for Tor.
Please refer to [this comment](https://github.com/bisq-network/bisq-mobile/issues/1192#issuecomment-3995668384) in the associated bisq mobile issue.

## Code management after merging this PR

Given the critically of this PR and the incoming Bisq 2 `2.1.10` release, my proposal is:

 - After this PR gets merged, generate a new branch `for-mobile-based-on-2.1.10` -> this is a exceptional mobile branch from a main snapshot
 - Once Bisq2 2.1.10 gets released (expected for mid march), simply rebase the branch against the release branch to get any differences - leaving a clean from release

In this way we can also merge the mobile side of this PR (very small changes) and migrate to 2.1.10-based day to day work. 

### Dev commits log

 - sync non-security/privacy related changes in for-mobile-based-on-2.1.8 to main first
 - bring common and security fixes/improvement done whilst fixing pairing work for-mobile-based-on-2.1.8
 - ~~uplift bouncy castle lib to a avoid vulnerability issue (CRAI suggestion)~~ --> reverted, left TODO
 - apply security fixes usages to new api module (from for-mobile-based-on-2.1.8)
 - Fix clearnet pairing (bind to all interfaces but requiring TLS for security purposes)
 - Auto-regenerates QR code when pairing consumed
 - configure api defaults to help users of bisq2 headless as trusted node (T1)
 - revert strictly unnecessary changes
 - fix 404 for pairing api when rest api is disabled
 - bring for-mobile dev comments on api_app.conf useful for headless trusted node admins as well as devs
 - fix 404 pairing errors
 - add missing headers causing exceptions on rest api forwarding
 - allow 0.0.0.0 binding address for LAN real device pairing ONLY if TLS is enabled
 - fix issues on CLEARNET TLS pairing
 - always forward to loopback when forwarding to rest api server
 - support ttlInMinutes negative meaning no expiry
 - 0.0.0.0 binding check only applies to CLEARNET + improve logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket API enabled with automatic pairing QR regeneration and internal REST proxy constrained to loopback; TOR transport activated.

* **Bug Fixes**
  * Hardened pairing lifecycle (single-consumer consumption, expiry cleanup, auto-regen); session logout/removal and atomic expiry eviction; negative TTL now treated as non-expiring; offer broadcasts skip missing profiles and log errors.

* **Security**
  * Startup/network warnings for unsafe bindings; TLS/keystore handling and SANs improved.

* **Documentation**
  * Expanded configuration and client-profile guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->