### PR TITLE
Do not use upper case in description text

### DIFF
--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -732,10 +732,10 @@ bisqEasy.offerDetails.headline=Offer details
 bisqEasy.offerDetails.directionDescription=Offer type
 bisqEasy.offerDetails.direction.buy=Offer for buying Bitcoin
 bisqEasy.offerDetails.direction.sell=Offer for selling Bitcoin
-bisqEasy.offerDetails.quoteSideAmountDescription={0} Amount
+bisqEasy.offerDetails.quoteSideAmountDescription={0} amount
 bisqEasy.offerDetails.quoteSideAmount={0} <{1} style=offer-details-code>
 bisqEasy.offerDetails.quoteSideRangeAmount={0} - {1} <{2} style=offer-details-code>
-bisqEasy.offerDetails.baseSideAmountDescription={0} Amount
+bisqEasy.offerDetails.baseSideAmountDescription={0} amount
 bisqEasy.offerDetails.baseSideAmount={0} <{1} style=offer-details-code>
 bisqEasy.offerDetails.baseSideRangeAmount={0} - {1} <{2} style=offer-details-code>
 

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -226,10 +226,10 @@ muSig.offer.details.headline=Offer details
 muSig.offer.details.directionDescription=Offer type
 muSig.offer.details.direction.buy=Offer for buying Bitcoin
 muSig.offer.details.direction.sell=Offer for selling Bitcoin
-muSig.offer.details.quoteSideAmountDescription={0} Amount
+muSig.offer.details.quoteSideAmountDescription={0} amount
 muSig.offer.details.quoteSideAmount={0} <{1} style=offer-details-code>
 muSig.offer.details.quoteSideRangeAmount={0} - {1} <{2} style=offer-details-code>
-muSig.offer.details.baseSideAmountDescription={0} Amount
+muSig.offer.details.baseSideAmountDescription={0} amount
 muSig.offer.details.baseSideAmount={0} <{1} style=offer-details-code>
 muSig.offer.details.baseSideRangeAmount={0} - {1} <{2} style=offer-details-code>
 
@@ -246,7 +246,7 @@ muSig.offer.details.details=Details
 muSig.offer.details.offerIdDescription=Offer ID
 muSig.offer.details.dateDescription=Creation date
 muSig.offer.details.makersTradeTermsDescription=Maker's trade terms
-muSig.offer.details.securityDeposit.description=Security Deposit
+muSig.offer.details.securityDeposit.description=Security deposit
 muSig.offer.details.securityDeposit.info=To ensure both traders follow the trade protocol, each trader must pay a security deposit.\n\
   This deposit is locked in the multisig escrow until the trade is successfully completed, after which it is refunded to you.
 muSig.offer.details.securityDeposit.fixedAmount={0} <({1} style=offer-details-details> <{2} style=offer-details-code><) style=offer-details-details>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized text capitalization in offer amount descriptions and security deposit labels across the interface for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->