### PR TITLE
Use price nodes instead of mempool for reference time.

### DIFF
--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -364,28 +364,28 @@ application {
             providers=[
                 {
                     // Production node, bonded role
-                    url="http://runbtcx3wfygbq2wdde6qzjnpyrqn3gvbks7t5jdymmunxttdvvttpyd.onion"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://runbtcpn7gmbj5rgqeyfyvepqokrijem6rbw7o5wgqbguimuoxrmcdyd.onion"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 },
                 {
                     // Production node, bonded role
-                    url="http://44naenfnp6foaegpmujdn4pmhtgo52tjkgs2d3ir2wo7d7mfbufq.b32.i2p"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://3ncpabphuixvd45yfekeugsz57voiqij7cf3goudmcyfekti7t6a.b32.i2p"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 }
             ]
             fallbackProviders=[
                 {
-                    url="https://mempool.emzy.de"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
+                   url="http://172.86.75.7:8080"
+                   operator="runbtc",
+                   apiPath="getAllMarketPrices",
                 },
                 {
-                    url="http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
-                }
+                    url="http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion"
+                    operator="alexej996",
+                    apiPath="getAllMarketPrices",
+                },
             ]
         }
     }

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -343,28 +343,28 @@ application {
             providers=[
                 {
                     // Production node, bonded role
-                    url="http://runbtcx3wfygbq2wdde6qzjnpyrqn3gvbks7t5jdymmunxttdvvttpyd.onion"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://runbtcpn7gmbj5rgqeyfyvepqokrijem6rbw7o5wgqbguimuoxrmcdyd.onion"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 },
                 {
                     // Production node, bonded role
-                    url="http://44naenfnp6foaegpmujdn4pmhtgo52tjkgs2d3ir2wo7d7mfbufq.b32.i2p"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://3ncpabphuixvd45yfekeugsz57voiqij7cf3goudmcyfekti7t6a.b32.i2p"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 }
             ]
             fallbackProviders=[
                 {
-                    url="https://mempool.emzy.de"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
+                   url="http://172.86.75.7:8080"
+                   operator="runbtc",
+                   apiPath="getAllMarketPrices",
                 },
                 {
-                    url="http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
-                }
+                    url="http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion"
+                    operator="alexej996",
+                    apiPath="getAllMarketPrices",
+                },
             ]
         }
     }

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -343,28 +343,28 @@ application {
             providers=[
                 {
                     // Production node, bonded role
-                    url="http://runbtcx3wfygbq2wdde6qzjnpyrqn3gvbks7t5jdymmunxttdvvttpyd.onion"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://runbtcpn7gmbj5rgqeyfyvepqokrijem6rbw7o5wgqbguimuoxrmcdyd.onion"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 },
                 {
                     // Production node, bonded role
-                    url="http://44naenfnp6foaegpmujdn4pmhtgo52tjkgs2d3ir2wo7d7mfbufq.b32.i2p"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://3ncpabphuixvd45yfekeugsz57voiqij7cf3goudmcyfekti7t6a.b32.i2p"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 }
             ]
             fallbackProviders=[
                 {
-                    url="https://mempool.emzy.de"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
+                   url="http://172.86.75.7:8080"
+                   operator="runbtc",
+                   apiPath="getAllMarketPrices",
                 },
                 {
-                    url="http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
-                }
+                    url="http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion"
+                    operator="alexej996",
+                    apiPath="getAllMarketPrices",
+                },
             ]
         }
     }

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -343,28 +343,28 @@ application {
             providers=[
                 {
                     // Production node, bonded role
-                    url="http://runbtcx3wfygbq2wdde6qzjnpyrqn3gvbks7t5jdymmunxttdvvttpyd.onion"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://runbtcpn7gmbj5rgqeyfyvepqokrijem6rbw7o5wgqbguimuoxrmcdyd.onion"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 },
                 {
                     // Production node, bonded role
-                    url="http://44naenfnp6foaegpmujdn4pmhtgo52tjkgs2d3ir2wo7d7mfbufq.b32.i2p"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://3ncpabphuixvd45yfekeugsz57voiqij7cf3goudmcyfekti7t6a.b32.i2p"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 }
             ]
             fallbackProviders=[
                 {
-                    url="https://mempool.emzy.de"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
+                   url="http://172.86.75.7:8080"
+                   operator="runbtc",
+                   apiPath="getAllMarketPrices",
                 },
                 {
-                    url="http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
-                }
+                    url="http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion"
+                    operator="alexej996",
+                    apiPath="getAllMarketPrices",
+                },
             ]
         }
     }

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -346,28 +346,28 @@ application {
             providers=[
                 {
                     // Production node, bonded role
-                    url="http://runbtcx3wfygbq2wdde6qzjnpyrqn3gvbks7t5jdymmunxttdvvttpyd.onion"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://runbtcpn7gmbj5rgqeyfyvepqokrijem6rbw7o5wgqbguimuoxrmcdyd.onion"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 },
                 {
                     // Production node, bonded role
-                    url="http://44naenfnp6foaegpmujdn4pmhtgo52tjkgs2d3ir2wo7d7mfbufq.b32.i2p"
-                    operator="RunBTC",
-                    apiPath="api/v1/prices",
+                    url="http://3ncpabphuixvd45yfekeugsz57voiqij7cf3goudmcyfekti7t6a.b32.i2p"
+                    operator="runbtc",
+                    apiPath="getAllMarketPrices",
                 }
             ]
             fallbackProviders=[
                 {
-                    url="https://mempool.emzy.de"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
+                   url="http://172.86.75.7:8080"
+                   operator="runbtc",
+                   apiPath="getAllMarketPrices",
                 },
                 {
-                    url="http://mempool4t6mypeemozyterviq3i5de4kpoua65r3qkn5i3kknu5l2cad.onion"
-                    operator="emzy",
-                    apiPath="api/v1/prices",
-                }
+                    url="http://ro7nv73awqs3ga2qtqeqawrjpbxwarsazznszvr6whv7tes5ehffopid.onion"
+                    operator="alexej996",
+                    apiPath="getAllMarketPrices",
+                },
             ]
         }
     }

--- a/network/network/src/main/java/bisq/network/http/ReferenceTimeService.java
+++ b/network/network/src/main/java/bisq/network/http/ReferenceTimeService.java
@@ -19,17 +19,38 @@ package bisq.network.http;
 
 import bisq.common.json.JsonMapperProvider;
 import bisq.common.threading.ExecutorFactory;
+import bisq.common.util.MathUtils;
 import bisq.network.NetworkService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
 @Slf4j
 public class ReferenceTimeService extends HttpRequestService<Void, Long> {
+    // coinmarketcapTs and btcAverageTs are excluded as we use longer request time intervals for those.
+    // coinbaseproTs has a timestamp of 0. independentreserveTs has a ts with 1 hour in future
+    private static final List<String> TIMESTAMP_KEYS = List.of(
+            "bitstampTs",
+            "btcmarketsTs",
+            "coingeckoTs",
+            "binanceTs",
+            "poloniexTs",
+            "krakenTs",
+            "bitflyerTs",
+            "cryptoyaTs",
+            "paribuTs",
+            "bitfinexTs",
+            "lunoTs",
+            "yadioTs",
+            "coinoneTs",
+            "mercadobitcoinTs"
+    );
+
     private static ExecutorService getExecutorService() {
         return ExecutorFactory.newCachedThreadPool(ReferenceTimeService.class.getSimpleName(),
                 1,
@@ -45,13 +66,37 @@ public class ReferenceTimeService extends HttpRequestService<Void, Long> {
 
     @Override
     protected Long parseResult(String json) throws JsonProcessingException {
-        JsonNode timeNode = JsonMapperProvider.get().readTree(json).get("time");
-        if (timeNode == null || timeNode.isNull() || !timeNode.isNumber()) {
+        JsonNode jsonNode = JsonMapperProvider.get().readTree(json);
+
+        // We drop the 3 outliers on both ends and take the average of the rest.
+        double averageTimestamp = TIMESTAMP_KEYS.stream()
+                .mapToLong(key -> {
+                    try {
+                        return parseTimestamp(jsonNode, key);
+                    } catch (JsonProcessingException ignore) {
+                        return 0;
+                    }
+                })
+                .filter(ts -> ts > 0)
+                .sorted()
+                .limit(TIMESTAMP_KEYS.size() - 3)
+                .skip(3)
+                .average()
+                .orElse(0d);
+
+        long referenceTime = MathUtils.roundDoubleToLong(averageTimestamp);
+        log.info("Reference time from {}: {} ({})", selectedProvider.get().getBaseUrl(), new Date(referenceTime), referenceTime);
+        return referenceTime;
+    }
+
+    private Long parseTimestamp(JsonNode jsonNode, String key) throws JsonProcessingException {
+        JsonNode timestampNode = jsonNode.get(key);
+        if (timestampNode == null || timestampNode.isNull() || !timestampNode.isNumber()) {
             throw new RuntimeException("Response JSON missing 'time' field");
         }
-        long referenceTime = timeNode.asLong() * 1000;
-        log.info("Reference time from {}: {} (epoche time in seconds: {})",
-                selectedProvider.get().getBaseUrl(),
+        long referenceTime = timestampNode.asLong();
+        log.debug("Timestamp from latest price request from {}: {} (epoche time in seconds: {})",
+                key.replace("Ts", ""),
                 new Date(referenceTime),
                 referenceTime);
         return referenceTime;


### PR DESCRIPTION
Mempool provided timestamp from their latest update of the prices, but that seemed unreliable.

Now we use the time stamps of the requests to our price providers which have a 1 min interval. We remove outliers and take the average.