### PR TITLE
Add no-payout option to MuSig mediation results

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationPayoutDistributionCalculator.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationPayoutDistributionCalculator.java
@@ -78,6 +78,7 @@ final class MuSigMediationPayoutDistributionCalculator {
                                                     PayoutContext context,
                                                     Optional<Double> payoutAdjustmentPercentageValue) {
         return switch (payoutDistributionType) {
+            case NO_PAYOUT -> Optional.empty();
             case CUSTOM_PAYOUT -> Optional.empty();
             case BUYER_GETS_TRADE_AMOUNT -> Optional.of(new PayoutAmounts(
                     context.tradeAmount() + context.buyerSecurityDeposit(),

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationResultSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationResultSection.java
@@ -131,13 +131,25 @@ public class MuSigMediationResultSection {
                     muSigMediationResult
                             .map(i -> i.getSummaryNotes().orElse("")).orElse(""));
             model.getBuyerPayoutAmountAsCoin().set(
-                    muSigMediationResult.map(MuSigMediationResult::getProposedBuyerPayoutAmount).map(Coin::asBtcFromValue).orElse(null));
+                    muSigMediationResult
+                            .flatMap(MuSigMediationResult::getProposedBuyerPayoutAmount)
+                            .map(Coin::asBtcFromValue)
+                            .orElse(null));
             model.getSellerPayoutAmountAsCoin().set(
-                    muSigMediationResult.map(MuSigMediationResult::getProposedSellerPayoutAmount).map(Coin::asBtcFromValue).orElse(null));
+                    muSigMediationResult
+                            .flatMap(MuSigMediationResult::getProposedSellerPayoutAmount)
+                            .map(Coin::asBtcFromValue)
+                            .orElse(null));
             model.getBuyerPayoutAmount().set(
-                    muSigMediationResult.map(MuSigMediationResult::getProposedBuyerPayoutAmount).map(Controller::formatSatsAsBtc).orElse(""));
+                    muSigMediationResult
+                            .flatMap(MuSigMediationResult::getProposedBuyerPayoutAmount)
+                            .map(Controller::formatSatsAsBtc)
+                            .orElse(""));
             model.getSellerPayoutAmount().set(
-                    muSigMediationResult.map(MuSigMediationResult::getProposedSellerPayoutAmount).map(Controller::formatSatsAsBtc).orElse(""));
+                    muSigMediationResult
+                            .flatMap(MuSigMediationResult::getProposedSellerPayoutAmount)
+                            .map(Controller::formatSatsAsBtc)
+                            .orElse(""));
             model.getPayoutAdjustmentPercentageValue().set(
                     muSigMediationResult.flatMap(MuSigMediationResult::getPayoutAdjustmentPercentage).orElse(null));
             model.getPayoutAdjustmentPercentage().set(
@@ -146,8 +158,10 @@ public class MuSigMediationResultSection {
                             .map(value -> PercentageFormatter.formatToPercent(value, 0))
                             .orElse(""));
             MediationPayoutDistributionType payoutDistributionType = model.getSelectedPayoutDistributionType().get();
+            boolean showPayoutAmounts = payoutDistributionType != null && shouldShowPayoutAmounts(payoutDistributionType);
             boolean showPayoutAdjustmentPercentage = payoutDistributionType != null &&
                     shouldShowPayoutAdjustmentPercentage(payoutDistributionType);
+            model.getShowPayoutAmounts().set(showPayoutAmounts);
             model.getShowPayoutAdjustmentPercentage().set(showPayoutAdjustmentPercentage);
             model.getUsePenaltyDescription().set(
                     payoutDistributionType != null && shouldUsePenaltyDescription(payoutDistributionType));
@@ -207,9 +221,14 @@ public class MuSigMediationResultSection {
             }
 
             boolean showPayoutAdjustmentPercentage = shouldShowPayoutAdjustmentPercentage(payoutDistributionType);
+            boolean showPayoutAmounts = shouldShowPayoutAmounts(payoutDistributionType);
+            model.getShowPayoutAmounts().set(showPayoutAmounts);
             if (!showPayoutAdjustmentPercentage) {
                 model.getPayoutAdjustmentPercentageValue().set(null);
                 model.getPayoutAdjustmentPercentage().set("");
+            }
+            if (!showPayoutAmounts) {
+                clearPayoutAmounts();
             }
             model.getShowPayoutAdjustmentPercentage().set(showPayoutAdjustmentPercentage);
             model.getUsePenaltyDescription().set(shouldUsePenaltyDescription(payoutDistributionType));
@@ -250,6 +269,10 @@ public class MuSigMediationResultSection {
         }
 
         private void applyPayoutAmountsForType(MediationPayoutDistributionType payoutDistributionType) {
+            if (payoutDistributionType == MediationPayoutDistributionType.NO_PAYOUT) {
+                clearPayoutAmounts();
+                return;
+            }
             if (payoutDistributionType == MediationPayoutDistributionType.CUSTOM_PAYOUT) {
                 return;
             }
@@ -335,6 +358,10 @@ public class MuSigMediationResultSection {
             return payoutDistributionType == MediationPayoutDistributionType.CUSTOM_PAYOUT;
         }
 
+        private static boolean shouldShowPayoutAmounts(MediationPayoutDistributionType payoutDistributionType) {
+            return payoutDistributionType != MediationPayoutDistributionType.NO_PAYOUT;
+        }
+
         private boolean hasRequiredSelections() {
             MediationPayoutDistributionType payoutDistributionType = model.getSelectedPayoutDistributionType().get();
             return model.getSelectedReason().get() != null &&
@@ -352,6 +379,10 @@ public class MuSigMediationResultSection {
         private boolean hasValidPayoutAmounts(MediationPayoutDistributionType payoutDistributionType,
                                               Optional<Long> optionalBuyerPayoutAmount,
                                               Optional<Long> optionalSellerPayoutAmount) {
+            if (payoutDistributionType == MediationPayoutDistributionType.NO_PAYOUT) {
+                return optionalBuyerPayoutAmount.isEmpty() && optionalSellerPayoutAmount.isEmpty();
+            }
+
             if (optionalBuyerPayoutAmount.isEmpty() || optionalSellerPayoutAmount.isEmpty()) {
                 return false;
             }
@@ -416,8 +447,11 @@ public class MuSigMediationResultSection {
                         Optional.ofNullable(model.getBuyerPayoutAmountAsCoin().get()).map(Coin::getValue);
                 Optional<Long> optionalSellerPayoutAmount =
                         Optional.ofNullable(model.getSellerPayoutAmountAsCoin().get()).map(Coin::getValue);
+                boolean payoutAmountsRequired = selectedPayoutDistributionType != null &&
+                        shouldShowPayoutAmounts(selectedPayoutDistributionType);
                 if (selectedReason == null || selectedPayoutDistributionType == null ||
-                        optionalBuyerPayoutAmount.isEmpty() || optionalSellerPayoutAmount.isEmpty()) {
+                        (payoutAmountsRequired &&
+                                (optionalBuyerPayoutAmount.isEmpty() || optionalSellerPayoutAmount.isEmpty()))) {
                     log.warn("Cannot close MuSig mediation case because required fields are missing");
                     return;
                 }
@@ -425,9 +459,9 @@ public class MuSigMediationResultSection {
                 String summaryNotes = model.getSummaryNotes().get();
                 MuSigMediationResult muSigMediationResult = muSigMediatorService.createMuSigMediationResult(
                         selectedReason,
-                        optionalBuyerPayoutAmount.orElseThrow(),
-                        optionalSellerPayoutAmount.orElseThrow(),
                         selectedPayoutDistributionType,
+                        optionalBuyerPayoutAmount,
+                        optionalSellerPayoutAmount,
                         getPayoutAdjustmentPercentageValue(),
                         summaryNotes.isEmpty() ? Optional.empty() : Optional.of(summaryNotes));
                 muSigMediatorService.closeMediationCase(muSigMediationCase, muSigMediationResult);
@@ -454,6 +488,7 @@ public class MuSigMediationResultSection {
         private final ObjectProperty<Coin> sellerPayoutAmountAsCoin = new SimpleObjectProperty<>();
         private final StringProperty payoutAdjustmentPercentage = new SimpleStringProperty("");
         private final ObjectProperty<Double> payoutAdjustmentPercentageValue = new SimpleObjectProperty<>();
+        private final BooleanProperty showPayoutAmounts = new SimpleBooleanProperty(true);
         private final BooleanProperty showPayoutAdjustmentPercentage = new SimpleBooleanProperty(false);
         private final BooleanProperty usePenaltyDescription = new SimpleBooleanProperty(false);
         private final BooleanProperty payoutAmountsEditable = new SimpleBooleanProperty(false);
@@ -629,6 +664,10 @@ public class MuSigMediationResultSection {
             buyerPayoutAmount.textProperty().bindBidirectional(model.getBuyerPayoutAmount());
             sellerPayoutAmount.textProperty().bindBidirectional(model.getSellerPayoutAmount());
             payoutAdjustmentPercentage.textProperty().bindBidirectional(model.getPayoutAdjustmentPercentage());
+            buyerPayoutAmount.visibleProperty().bind(model.getShowPayoutAmounts());
+            buyerPayoutAmount.managedProperty().bind(model.getShowPayoutAmounts());
+            sellerPayoutAmount.visibleProperty().bind(model.getShowPayoutAmounts());
+            sellerPayoutAmount.managedProperty().bind(model.getShowPayoutAmounts());
             payoutAdjustmentPercentage.visibleProperty().bind(model.getShowPayoutAdjustmentPercentage());
             payoutAdjustmentPercentage.managedProperty().bind(model.getShowPayoutAdjustmentPercentage());
             applyPayoutAdjustmentPercentageDescription(model.getUsePenaltyDescription().get());
@@ -661,8 +700,16 @@ public class MuSigMediationResultSection {
             buyerPayoutAmount.textProperty().unbindBidirectional(model.getBuyerPayoutAmount());
             sellerPayoutAmount.textProperty().unbindBidirectional(model.getSellerPayoutAmount());
             payoutAdjustmentPercentage.textProperty().unbindBidirectional(model.getPayoutAdjustmentPercentage());
+            buyerPayoutAmount.visibleProperty().unbind();
+            buyerPayoutAmount.managedProperty().unbind();
+            sellerPayoutAmount.visibleProperty().unbind();
+            sellerPayoutAmount.managedProperty().unbind();
             payoutAdjustmentPercentage.visibleProperty().unbind();
             payoutAdjustmentPercentage.managedProperty().unbind();
+            buyerPayoutAmount.setVisible(true);
+            buyerPayoutAmount.setManaged(true);
+            sellerPayoutAmount.setVisible(true);
+            sellerPayoutAmount.setManaged(true);
             payoutDistributionTypeSelection.setVisible(true);
             payoutDistributionTypeSelection.setManaged(true);
             reasonSelection.setVisible(true);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/MuSigTradeStateView.java
@@ -29,6 +29,7 @@ import bisq.network.p2p.services.confidential.ack.MessageDeliveryStatus;
 import bisq.common.monetary.Coin;
 import bisq.common.observable.Pin;
 import bisq.presentation.formatters.AmountFormatter;
+import bisq.support.mediation.MediationPayoutDistributionType;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.trade.MuSigDisputeState;
 import bisq.trade.mu_sig.MuSigTrade;
@@ -317,12 +318,19 @@ public class MuSigTradeStateView extends View<VBox, MuSigTradeStateModel, MuSigT
     }
 
     private static String getMediationResultDetailsText(MuSigTrade trade, MuSigMediationResult result) {
+        if (result.getProposedBuyerPayoutAmount().isEmpty() || result.getProposedSellerPayoutAmount().isEmpty()) {
+            if (result.getMediationPayoutDistributionType() == MediationPayoutDistributionType.NO_PAYOUT) {
+                return Res.get("muSig.trade.pending.inMediation.resultDetails.noPayout");
+            }
+            return Res.get("muSig.trade.pending.inMediation.resultDetails", Res.get("data.na"), Res.get("data.na"));
+        }
+
         String myPayoutAmount = trade.isBuyer()
-                ? AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedBuyerPayoutAmount()))
-                : AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedSellerPayoutAmount()));
+                ? AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedBuyerPayoutAmount().orElseThrow()))
+                : AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedSellerPayoutAmount().orElseThrow()));
         String peerPayoutAmount = trade.isBuyer()
-                ? AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedSellerPayoutAmount()))
-                : AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedBuyerPayoutAmount()));
+                ? AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedSellerPayoutAmount().orElseThrow()))
+                : AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(result.getProposedBuyerPayoutAmount().orElseThrow()));
         return Res.get("muSig.trade.pending.inMediation.resultDetails",
                 myPayoutAmount,
                 peerPayoutAmount);

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationPayoutDistributionCalculatorTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationPayoutDistributionCalculatorTest.java
@@ -40,6 +40,16 @@ class MuSigMediationPayoutDistributionCalculatorTest {
                     TOTAL_PAYOUT_SATS);
 
     @Test
+    void calculateForTypeNoPayoutReturnsEmpty() {
+        Optional<MuSigMediationPayoutDistributionCalculator.PayoutAmounts> payoutAmounts = MuSigMediationPayoutDistributionCalculator.calculateForType(
+                MediationPayoutDistributionType.NO_PAYOUT,
+                CONTEXT,
+                Optional.empty());
+
+        assertTrue(payoutAmounts.isEmpty());
+    }
+
+    @Test
     void calculateForTypeBuyerGetsTradeAmount() {
         MuSigMediationPayoutDistributionCalculator.PayoutAmounts payoutAmounts = MuSigMediationPayoutDistributionCalculator.calculateForType(
                         MediationPayoutDistributionType.BUYER_GETS_TRADE_AMOUNT,

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -109,6 +109,8 @@ authorizedRole.mediator.mediationResult.payoutDistributionType.SELLER_GETS_TRADE
 authorizedRole.mediator.mediationResult.payoutDistributionType.SELLER_GETS_TRADE_AMOUNT_PLUS_COMPENSATION=Seller gets trade amount plus compensation
 # suppress inspection "UnusedProperty"
 authorizedRole.mediator.mediationResult.payoutDistributionType.SELLER_GETS_TRADE_AMOUNT_MINUS_PENALTY=Seller gets trade amount minus penalty
+# suppress inspection "UnusedProperty"
+authorizedRole.mediator.mediationResult.payoutDistributionType.NO_PAYOUT=No payout
 
 authorizedRole.mediator.mediationResult.selectReason=Select reason
 # suppress inspection "UnusedProperty"

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -486,6 +486,7 @@ muSig.trade.pending.inMediation.reOpened=The mediator re-opened the mediation ca
   {0}
 muSig.trade.pending.inMediation.resultDetails=You receive: {0}\n\
   Your trading peer receives: {1}
+muSig.trade.pending.inMediation.resultDetails.noPayout=No payout for either side.
 
 muSig.trade.pending.failed.errorMessage=The trade failed: ''{0}''
 muSig.trade.pending.failed.errorPopup.message=The trade failed: ''{0}''\n\n\

--- a/support/src/main/java/bisq/support/mediation/MediationPayoutDistributionType.java
+++ b/support/src/main/java/bisq/support/mediation/MediationPayoutDistributionType.java
@@ -27,7 +27,8 @@ public enum MediationPayoutDistributionType implements ProtoEnum {
     BUYER_GETS_TRADE_AMOUNT_MINUS_PENALTY,
     SELLER_GETS_TRADE_AMOUNT,
     SELLER_GETS_TRADE_AMOUNT_PLUS_COMPENSATION,
-    SELLER_GETS_TRADE_AMOUNT_MINUS_PENALTY;
+    SELLER_GETS_TRADE_AMOUNT_MINUS_PENALTY,
+    NO_PAYOUT;
 
     @Override
     public bisq.support.protobuf.MediationPayoutDistributionType toProtoEnum() {

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResult.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResult.java
@@ -27,8 +27,8 @@ import lombok.Getter;
 
 import java.util.Optional;
 
-import static java.lang.System.currentTimeMillis;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.System.currentTimeMillis;
 
 @Getter
 @EqualsAndHashCode
@@ -37,39 +37,39 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
 
     private final long date;
     private final MediationResultReason mediationResultReason;
-    private final long proposedBuyerPayoutAmount;
-    private final long proposedSellerPayoutAmount;
     private final MediationPayoutDistributionType mediationPayoutDistributionType;
+    private final Optional<Long> proposedBuyerPayoutAmount;
+    private final Optional<Long> proposedSellerPayoutAmount;
     private final Optional<Double> payoutAdjustmentPercentage;
     private final Optional<String> summaryNotes;
 
     public MuSigMediationResult(MediationResultReason mediationResultReason,
-                                long proposedBuyerPayoutAmount,
-                                long proposedSellerPayoutAmount,
                                 MediationPayoutDistributionType mediationPayoutDistributionType,
+                                Optional<Long> proposedBuyerPayoutAmount,
+                                Optional<Long> proposedSellerPayoutAmount,
                                 Optional<Double> payoutAdjustmentPercentage,
                                 Optional<String> summaryNotes) {
         this(currentTimeMillis(),
                 mediationResultReason,
+                mediationPayoutDistributionType,
                 proposedBuyerPayoutAmount,
                 proposedSellerPayoutAmount,
-                mediationPayoutDistributionType,
                 payoutAdjustmentPercentage,
                 summaryNotes);
     }
 
     private MuSigMediationResult(long date,
                                  MediationResultReason mediationResultReason,
-                                 long proposedBuyerPayoutAmount,
-                                 long proposedSellerPayoutAmount,
                                  MediationPayoutDistributionType mediationPayoutDistributionType,
+                                 Optional<Long> proposedBuyerPayoutAmount,
+                                 Optional<Long> proposedSellerPayoutAmount,
                                  Optional<Double> payoutAdjustmentPercentage,
                                  Optional<String> summaryNotes) {
         this.date = date;
         this.mediationResultReason = mediationResultReason;
+        this.mediationPayoutDistributionType = mediationPayoutDistributionType;
         this.proposedBuyerPayoutAmount = proposedBuyerPayoutAmount;
         this.proposedSellerPayoutAmount = proposedSellerPayoutAmount;
-        this.mediationPayoutDistributionType = mediationPayoutDistributionType;
         this.payoutAdjustmentPercentage = payoutAdjustmentPercentage;
         this.summaryNotes = summaryNotes;
 
@@ -81,8 +81,15 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
         NetworkDataValidation.validateDate(date);
         checkArgument(mediationResultReason != null, "mediationResultReason must not be null");
         checkArgument(mediationPayoutDistributionType != null, "mediationPayoutDistributionType must not be null");
-        checkArgument(proposedBuyerPayoutAmount >= 0, "proposedBuyerPayoutAmount must not be negative");
-        checkArgument(proposedSellerPayoutAmount >= 0, "proposedSellerPayoutAmount must not be negative");
+        boolean noPayout = mediationPayoutDistributionType == MediationPayoutDistributionType.NO_PAYOUT;
+        checkArgument(noPayout
+                ? proposedBuyerPayoutAmount.isEmpty() && proposedSellerPayoutAmount.isEmpty()
+                : proposedBuyerPayoutAmount.isPresent() && proposedSellerPayoutAmount.isPresent(),
+                "payout amounts must be present for payout distributions and absent for NO_PAYOUT");
+        proposedBuyerPayoutAmount.ifPresent(value ->
+                checkArgument(value >= 0, "proposedBuyerPayoutAmount must not be negative"));
+        proposedSellerPayoutAmount.ifPresent(value ->
+                checkArgument(value >= 0, "proposedSellerPayoutAmount must not be negative"));
         NetworkDataValidation.validateText(summaryNotes, MAX_SUMMARY_NOTES_LENGTH);
     }
 
@@ -91,9 +98,9 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
         var builder = bisq.support.protobuf.MuSigMediationResult.newBuilder()
                 .setDate(date)
                 .setMediationResultReason(mediationResultReason.toProtoEnum())
-                .setProposedBuyerPayoutAmount(proposedBuyerPayoutAmount)
-                .setProposedSellerPayoutAmount(proposedSellerPayoutAmount)
                 .setMediationPayoutDistributionType(mediationPayoutDistributionType.toProtoEnum());
+        proposedBuyerPayoutAmount.ifPresent(builder::setProposedBuyerPayoutAmount);
+        proposedSellerPayoutAmount.ifPresent(builder::setProposedSellerPayoutAmount);
         payoutAdjustmentPercentage.ifPresent(builder::setPayoutAdjustmentPercentage);
         summaryNotes.ifPresent(builder::setSummaryNotes);
         return builder;
@@ -109,9 +116,9 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
         return new MuSigMediationResult(
                 proto.getDate(),
                 MediationResultReason.fromProto(proto.getMediationResultReason()),
-                proto.getProposedBuyerPayoutAmount(),
-                proto.getProposedSellerPayoutAmount(),
                 MediationPayoutDistributionType.fromProto(proto.getMediationPayoutDistributionType()),
+                proto.hasProposedBuyerPayoutAmount() ? Optional.of(proto.getProposedBuyerPayoutAmount()) : Optional.empty(),
+                proto.hasProposedSellerPayoutAmount() ? Optional.of(proto.getProposedSellerPayoutAmount()) : Optional.empty(),
                 proto.hasPayoutAdjustmentPercentage() ? Optional.of(proto.getPayoutAdjustmentPercentage()) : Optional.empty(),
                 proto.hasSummaryNotes() ? Optional.of(proto.getSummaryNotes()) : Optional.empty());
     }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediatorService.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediatorService.java
@@ -118,13 +118,14 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
     /* --------------------------------------------------------------------- */
 
     public MuSigMediationResult createMuSigMediationResult(MediationResultReason mediationResultReason,
-                                                           long proposedBuyerPayoutAmount,
-                                                           long proposedSellerPayoutAmount,
                                                            MediationPayoutDistributionType mediationPayoutDistributionType,
+                                                           Optional<Long> proposedBuyerPayoutAmount,
+                                                           Optional<Long> proposedSellerPayoutAmount,
                                                            Optional<Double> payoutAdjustmentPercentage,
                                                            Optional<String> summaryNotes) {
-        return new MuSigMediationResult(mediationResultReason, proposedBuyerPayoutAmount, proposedSellerPayoutAmount,
-                mediationPayoutDistributionType, payoutAdjustmentPercentage, summaryNotes);
+        return new MuSigMediationResult(mediationResultReason, mediationPayoutDistributionType,
+                proposedBuyerPayoutAmount, proposedSellerPayoutAmount,
+                payoutAdjustmentPercentage, summaryNotes);
     }
 
     public void closeMediationCase(MuSigMediationCase muSigMediationCase, MuSigMediationResult muSigMediationResult) {

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -63,6 +63,7 @@ enum MediationPayoutDistributionType {
   MEDIATIONPAYOUTDISTRIBUTIONTYPE_SELLER_GETS_TRADE_AMOUNT = 5;
   MEDIATIONPAYOUTDISTRIBUTIONTYPE_SELLER_GETS_TRADE_AMOUNT_PLUS_COMPENSATION = 6;
   MEDIATIONPAYOUTDISTRIBUTIONTYPE_SELLER_GETS_TRADE_AMOUNT_MINUS_PENALTY = 7;
+  MEDIATIONPAYOUTDISTRIBUTIONTYPE_NO_PAYOUT = 8;
 }
 
 message MuSigMediationRequest {
@@ -81,11 +82,11 @@ message MuSigMediatorsResponse {
 message MuSigMediationResult {
   uint64 date = 1;
   MediationResultReason mediationResultReason = 2;
-  sint64 proposedBuyerPayoutAmount = 3;
-  sint64 proposedSellerPayoutAmount = 4;
-  optional string summaryNotes = 5;
-  MediationPayoutDistributionType mediationPayoutDistributionType = 6;
-  optional double payoutAdjustmentPercentage = 7;
+  MediationPayoutDistributionType mediationPayoutDistributionType = 3;
+  optional sint64 proposedBuyerPayoutAmount = 4;
+  optional sint64 proposedSellerPayoutAmount = 5;
+  optional double payoutAdjustmentPercentage = 6;
+  optional string summaryNotes = 7;
 }
 
 message MuSigMediationStateChangeMessage {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "No payout" mediation resolution option and a user-facing "No payout for either side." message.
  * UI now dynamically shows or hides payout input/display fields based on selected resolution type.

* **Bug Fixes / Validation**
  * Payout handling and validation updated so no-payout cases are accepted and payout fields are cleared when hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->