### PR TITLE
Verify payment account payload against contract during MuSig mediation

### DIFF
--- a/account/src/main/java/bisq/account/accounts/AccountPayload.java
+++ b/account/src/main/java/bisq/account/accounts/AccountPayload.java
@@ -126,7 +126,6 @@ public abstract class AccountPayload<M extends PaymentMethod<?>> implements Netw
         return DigestUtil.hash(getBisq2Fingerprint());
     }
 
-
     /**
      * Joins an array of strings into a single byte array, using a predefined separator
      * between non-null and non-empty strings. Strings are converted to bytes using UTF-8 encoding.

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseOverviewSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseOverviewSection.java
@@ -18,6 +18,8 @@
 package bisq.desktop.main.content.authorized_role.mediator.mu_sig.components;
 
 import bisq.account.accounts.AccountPayload;
+import bisq.common.observable.Pin;
+import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.threading.UIThread;
@@ -30,9 +32,10 @@ import bisq.offer.mu_sig.MuSigOffer;
 import bisq.offer.price.spec.FixPriceSpec;
 import bisq.offer.price.spec.PriceSpecFormatter;
 import bisq.presentation.formatters.PriceFormatter;
-import bisq.common.observable.Pin;
 import bisq.support.mediation.MediationCaseState;
 import bisq.support.mediation.mu_sig.MuSigMediationCase;
+import bisq.support.mediation.mu_sig.MuSigMediationIssue;
+import bisq.support.mediation.mu_sig.MuSigMediationIssueType;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
 import bisq.support.mediation.mu_sig.MuSigMediatorService;
 import bisq.trade.mu_sig.MuSigTradeFormatter;
@@ -44,6 +47,7 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
@@ -52,7 +56,12 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.createAndGetDescriptionAndValueBox;
 import static bisq.desktop.components.helpers.LabeledValueRowFactory.getCopyButton;
@@ -83,8 +92,7 @@ public class MuSigMediationCaseOverviewSection {
         private final Model model;
 
         private final MuSigMediatorService muSigMediatorService;
-        private Pin takerPaymentAccountDataPin;
-        private Pin makerPaymentAccountDataPin;
+        private final Set<Pin> pins = new HashSet<>();
 
         private Controller(ServiceProvider serviceProvider, boolean isCompactView) {
             model = new Model();
@@ -142,6 +150,10 @@ public class MuSigMediationCaseOverviewSection {
             model.getWaitingForPaymentAccountDataResponse().set(false);
             model.getTakerPaymentAccountData().set("");
             model.getMakerPaymentAccountData().set("");
+            model.getTakerPaymentAccountIssueVisible().set(false);
+            model.getMakerPaymentAccountIssueVisible().set(false);
+            model.getTakerPaymentAccountIssueTooltip().set("");
+            model.getMakerPaymentAccountIssueTooltip().set("");
             maybeAddPaymentAccountDataObservers();
 
             model.setDepositTxId(Res.get("bisqEasy.openTrades.tradeDetails.dataNotYetProvided"));
@@ -154,22 +166,13 @@ public class MuSigMediationCaseOverviewSection {
                 return;
             }
             model.getHasPaymentAccountData().set(false);
-            model.getTakerPaymentAccountData().set("");
-            model.getMakerPaymentAccountData().set("");
             boolean requestSent = muSigMediatorService.requestPaymentDetails(muSigMediationCaseListItem.getMuSigMediationCase());
             model.getWaitingForPaymentAccountDataResponse().set(requestSent);
         }
 
         @Override
         public void onDeactivate() {
-            if (takerPaymentAccountDataPin != null) {
-                takerPaymentAccountDataPin.unbind();
-                takerPaymentAccountDataPin = null;
-            }
-            if (makerPaymentAccountDataPin != null) {
-                makerPaymentAccountDataPin.unbind();
-                makerPaymentAccountDataPin = null;
-            }
+            clearPins();
         }
 
         private CaseCounts getCaseCounts(UserProfile userProfile) {
@@ -202,14 +205,7 @@ public class MuSigMediationCaseOverviewSection {
             if (model.isCompactView()) {
                 return;
             }
-            if (takerPaymentAccountDataPin != null) {
-                takerPaymentAccountDataPin.unbind();
-                takerPaymentAccountDataPin = null;
-            }
-            if (makerPaymentAccountDataPin != null) {
-                makerPaymentAccountDataPin.unbind();
-                makerPaymentAccountDataPin = null;
-            }
+            clearPins();
 
             MuSigMediationCaseListItem muSigMediationCaseListItem = model.getMuSigMediationCaseListItem();
             if (muSigMediationCaseListItem == null) {
@@ -217,14 +213,21 @@ public class MuSigMediationCaseOverviewSection {
             }
 
             MuSigMediationCase caseModel = muSigMediationCaseListItem.getMuSigMediationCase();
-            takerPaymentAccountDataPin = caseModel.getTakerAccountPayload().addObserver(payload -> UIThread.run(() -> {
+            pins.add(caseModel.getTakerAccountPayload().addObserver(payload -> UIThread.run(() -> {
                 model.getTakerPaymentAccountData().set(payload.map(AccountPayload::getAccountDataDisplayString).orElse(""));
                 applyHasPaymentAccountDataState(caseModel);
-            }));
-            makerPaymentAccountDataPin = caseModel.getMakerAccountPayload().addObserver(payload -> UIThread.run(() -> {
+            })));
+            pins.add(caseModel.getMakerAccountPayload().addObserver(payload -> UIThread.run(() -> {
                 model.getMakerPaymentAccountData().set(payload.map(AccountPayload::getAccountDataDisplayString).orElse(""));
                 applyHasPaymentAccountDataState(caseModel);
-            }));
+            })));
+            pins.add(caseModel.getIssues().addObserver(issues ->
+                    UIThread.run(() -> applyPaymentAccountIssueState(issues))));
+        }
+
+        private void clearPins() {
+            pins.forEach(Pin::unbind);
+            pins.clear();
         }
 
         private void applyHasPaymentAccountDataState(MuSigMediationCase muSigMediationCase) {
@@ -234,6 +237,46 @@ public class MuSigMediationCaseOverviewSection {
             if (hasBothPayloads) {
                 model.getWaitingForPaymentAccountDataResponse().set(false);
             }
+        }
+
+        private void applyPaymentAccountIssueState(List<MuSigMediationIssue> issues) {
+            List<MuSigMediationIssue> takerIssues = findFirstIssuesByTypeAndRole(issues, MuSigMediationIssueType.TAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH);
+            List<MuSigMediationIssue> makerIssues = findFirstIssuesByTypeAndRole(issues, MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH);
+            boolean hasIssue = !takerIssues.isEmpty() || !makerIssues.isEmpty();
+
+            model.getTakerPaymentAccountIssueVisible().set(!takerIssues.isEmpty());
+            model.getMakerPaymentAccountIssueVisible().set(!makerIssues.isEmpty());
+            model.getTakerPaymentAccountIssueTooltip().set(takerIssues.isEmpty() ? "" : toIssueTooltip(takerIssues));
+            model.getMakerPaymentAccountIssueTooltip().set(makerIssues.isEmpty() ? "" : toIssueTooltip(makerIssues));
+            if (hasIssue) {
+                model.getWaitingForPaymentAccountDataResponse().set(false);
+            }
+            if (!takerIssues.isEmpty() && model.getTakerPaymentAccountData().get().isEmpty()) {
+                model.getTakerPaymentAccountData().set(Res.get("data.na"));
+            }
+            if (!makerIssues.isEmpty() && model.getMakerPaymentAccountData().get().isEmpty()) {
+                model.getMakerPaymentAccountData().set(Res.get("data.na"));
+            }
+        }
+
+        private List<MuSigMediationIssue> findFirstIssuesByTypeAndRole(List<MuSigMediationIssue> issues,
+                                                                       MuSigMediationIssueType type) {
+            return Stream.of(Role.TAKER, Role.MAKER)
+                    .flatMap(role -> issues.stream()
+                            .filter(issue -> issue.getType() == type && issue.getReportingRole() == role)
+                            .findFirst()
+                            .stream())
+                    .toList();
+        }
+
+        private String toIssueTooltip(List<MuSigMediationIssue> issues) {
+            String key = "authorizedRole.mediator.mediationCaseDetails.paymentAccountData.issue.accountPayloadHashMismatch";
+            List<String> lines = new ArrayList<>();
+            for (MuSigMediationIssue issue : issues) {
+                String reportingRole = MuSigTradeFormatter.getMakerTakerRole(issue.getReportingRole() == Role.MAKER).toLowerCase();
+                lines.add(Res.get(key, reportingRole));
+            }
+            return String.join("\n", lines);
         }
     }
 
@@ -271,10 +314,13 @@ public class MuSigMediationCaseOverviewSection {
         private final BooleanProperty waitingForPaymentAccountDataResponse = new SimpleBooleanProperty(false);
         private final StringProperty takerPaymentAccountData = new SimpleStringProperty("");
         private final StringProperty makerPaymentAccountData = new SimpleStringProperty("");
+        private final BooleanProperty takerPaymentAccountIssueVisible = new SimpleBooleanProperty(false);
+        private final BooleanProperty makerPaymentAccountIssueVisible = new SimpleBooleanProperty(false);
+        private final StringProperty takerPaymentAccountIssueTooltip = new SimpleStringProperty("");
+        private final StringProperty makerPaymentAccountIssueTooltip = new SimpleStringProperty("");
 
         private String depositTxId;
         private boolean isDepositTxIdEmpty;
-
     }
 
     @Slf4j
@@ -284,6 +330,8 @@ public class MuSigMediationCaseOverviewSection {
                 priceCodesLabel, priceSpecLabel;
         private Label buyerUserNameLabel, sellerUserNameLabel, paymentMethodLabel, depositTxTitleLabel, depositTxDetailsLabel;
         private Label paymentAccountDataWaitingLabel, takerPaymentAccountDataLabel, makerPaymentAccountDataLabel;
+        private Button takerPaymentAccountIssueButton, makerPaymentAccountIssueButton;
+        private Tooltip takerPaymentAccountIssueTooltip, makerPaymentAccountIssueTooltip;
         private BisqMenuItem buyerUserNameCopyButton, sellerUserNameCopyButton, depositTxCopyButton,
                 paymentAccountDataRefreshButton;
         private HBox paymentMethodsBox, paymentAccountDataBox, takerPaymentAccountDataBox, makerPaymentAccountDataBox;
@@ -351,6 +399,8 @@ public class MuSigMediationCaseOverviewSection {
                 takerPaymentAccountDataLabel = getValueLabel();
                 paymentAccountDataRefreshButton = new BisqMenuItem("try-again-grey", "try-again-white");
                 paymentAccountDataRefreshButton.setTooltip(Res.get("authorizedRole.mediator.mediationCaseDetails.paymentAccountData.fetch"));
+                takerPaymentAccountIssueTooltip = new Tooltip();
+                makerPaymentAccountIssueTooltip = new Tooltip();
                 HBox paymentAccountDataDetailsBox = new HBox(8, paymentAccountDataRefreshButton, paymentAccountDataWaitingLabel);
                 paymentAccountDataDetailsBox.setAlignment(Pos.BASELINE_LEFT);
                 paymentAccountDataBox = createAndGetDescriptionAndValueBox(
@@ -359,12 +409,12 @@ public class MuSigMediationCaseOverviewSection {
                 );
                 takerPaymentAccountDataBox = createAndGetDescriptionAndValueBox(
                         "authorizedRole.mediator.mediationCaseDetails.paymentAccountData.taker",
-                        takerPaymentAccountDataLabel
+                        createPaymentAccountDataWithIssueBox(true)
                 );
                 makerPaymentAccountDataLabel = getValueLabel();
                 makerPaymentAccountDataBox = createAndGetDescriptionAndValueBox(
                         "authorizedRole.mediator.mediationCaseDetails.paymentAccountData.maker",
-                        makerPaymentAccountDataLabel
+                        createPaymentAccountDataWithIssueBox(false)
                 );
                 paymentAccountDataWaitingLabel.setText(Res.get("authorizedRole.mediator.mediationCaseDetails.paymentAccountData.waitingForResponse"));
                 paymentAccountDataWaitingLabel.getStyleClass().clear();
@@ -429,8 +479,16 @@ public class MuSigMediationCaseOverviewSection {
                         : "text-fill-white");
                 depositTxDetailsLabel.getStyleClass().add("normal-text");
                 depositTxCopyButton.setOnAction(e -> ClipboardUtil.copyToClipboard(model.getDepositTxId()));
-                paymentAccountDataBox.visibleProperty().bind(model.getHasPaymentAccountData().not());
-                paymentAccountDataBox.managedProperty().bind(model.getHasPaymentAccountData().not());
+                paymentAccountDataBox.visibleProperty().bind(
+                        model.getHasPaymentAccountData().not()
+                                .and(model.getTakerPaymentAccountIssueVisible().not())
+                                .and(model.getMakerPaymentAccountIssueVisible().not())
+                );
+                paymentAccountDataBox.managedProperty().bind(
+                        model.getHasPaymentAccountData().not()
+                                .and(model.getTakerPaymentAccountIssueVisible().not())
+                                .and(model.getMakerPaymentAccountIssueVisible().not())
+                );
                 paymentAccountDataRefreshButton.visibleProperty().bind(
                         model.getHasPaymentAccountData().not().and(model.getWaitingForPaymentAccountDataResponse().not())
                 );
@@ -443,12 +501,34 @@ public class MuSigMediationCaseOverviewSection {
                 paymentAccountDataWaitingLabel.managedProperty().bind(
                         model.getHasPaymentAccountData().not().and(model.getWaitingForPaymentAccountDataResponse())
                 );
-                takerPaymentAccountDataBox.visibleProperty().bind(model.getHasPaymentAccountData());
-                takerPaymentAccountDataBox.managedProperty().bind(model.getHasPaymentAccountData());
-                makerPaymentAccountDataBox.visibleProperty().bind(model.getHasPaymentAccountData());
-                makerPaymentAccountDataBox.managedProperty().bind(model.getHasPaymentAccountData());
+                takerPaymentAccountDataBox.visibleProperty().bind(
+                        model.getHasPaymentAccountData()
+                                .or(model.getTakerPaymentAccountIssueVisible())
+                                .or(model.getMakerPaymentAccountIssueVisible())
+                );
+                takerPaymentAccountDataBox.managedProperty().bind(
+                        model.getHasPaymentAccountData()
+                                .or(model.getTakerPaymentAccountIssueVisible())
+                                .or(model.getMakerPaymentAccountIssueVisible())
+                );
+                makerPaymentAccountDataBox.visibleProperty().bind(
+                        model.getHasPaymentAccountData()
+                                .or(model.getMakerPaymentAccountIssueVisible())
+                                .or(model.getTakerPaymentAccountIssueVisible())
+                );
+                makerPaymentAccountDataBox.managedProperty().bind(
+                        model.getHasPaymentAccountData()
+                                .or(model.getMakerPaymentAccountIssueVisible())
+                                .or(model.getTakerPaymentAccountIssueVisible())
+                );
                 takerPaymentAccountDataLabel.textProperty().bind(model.getTakerPaymentAccountData());
                 makerPaymentAccountDataLabel.textProperty().bind(model.getMakerPaymentAccountData());
+                takerPaymentAccountIssueButton.visibleProperty().bind(model.getTakerPaymentAccountIssueVisible());
+                takerPaymentAccountIssueButton.managedProperty().bind(model.getTakerPaymentAccountIssueVisible());
+                makerPaymentAccountIssueButton.visibleProperty().bind(model.getMakerPaymentAccountIssueVisible());
+                makerPaymentAccountIssueButton.managedProperty().bind(model.getMakerPaymentAccountIssueVisible());
+                takerPaymentAccountIssueTooltip.textProperty().bind(model.getTakerPaymentAccountIssueTooltip());
+                makerPaymentAccountIssueTooltip.textProperty().bind(model.getMakerPaymentAccountIssueTooltip());
                 paymentAccountDataRefreshButton.setOnAction(e -> controller.requestPaymentAccountData());
             }
 
@@ -479,7 +559,31 @@ public class MuSigMediationCaseOverviewSection {
                 makerPaymentAccountDataBox.managedProperty().unbind();
                 takerPaymentAccountDataLabel.textProperty().unbind();
                 makerPaymentAccountDataLabel.textProperty().unbind();
+                takerPaymentAccountIssueButton.visibleProperty().unbind();
+                takerPaymentAccountIssueButton.managedProperty().unbind();
+                makerPaymentAccountIssueButton.visibleProperty().unbind();
+                makerPaymentAccountIssueButton.managedProperty().unbind();
+                takerPaymentAccountIssueTooltip.textProperty().unbind();
+                makerPaymentAccountIssueTooltip.textProperty().unbind();
             }
+        }
+
+        private HBox createPaymentAccountDataWithIssueBox(boolean taker) {
+            Button issueButton = bisq.desktop.components.controls.BisqIconButton.createInfoIconButton();
+            issueButton.getGraphic().getStyleClass().add("error");
+            issueButton.setVisible(false);
+            issueButton.setManaged(false);
+            if (taker) {
+                takerPaymentAccountIssueButton = issueButton;
+                issueButton.setTooltip(takerPaymentAccountIssueTooltip);
+            } else {
+                makerPaymentAccountIssueButton = issueButton;
+                issueButton.setTooltip(makerPaymentAccountIssueTooltip);
+            }
+            Label valueLabel = taker ? takerPaymentAccountDataLabel : makerPaymentAccountDataLabel;
+            HBox box = new HBox(6, valueLabel, issueButton);
+            box.setAlignment(Pos.BASELINE_LEFT);
+            return box;
         }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/review/MuSigCreateOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/review/MuSigCreateOfferReviewController.java
@@ -162,7 +162,13 @@ public class MuSigCreateOfferReviewController implements Controller {
                     List<String> acceptedCountryCodes = AccountUtils.getAcceptedCountryCodes(accountPayload);
                     Optional<String> bankId = AccountUtils.getBankId(accountPayload);
                     List<String> acceptedBanks = AccountUtils.getAcceptedBanks(accountPayload);
-                    return new AccountOption(account.getPaymentMethod(), saltedAccountId, countryCode, acceptedCountryCodes, bankId, acceptedBanks);
+                    return new AccountOption(account.getPaymentMethod(),
+                            saltedAccountId,
+                            countryCode,
+                            acceptedCountryCodes,
+                            bankId,
+                            acceptedBanks,
+                            OfferOptionUtil.createSaltedAccountPayloadHash(accountPayload, offerId));
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
 

--- a/contract/src/main/java/bisq/contract/mu_sig/MuSigContract.java
+++ b/contract/src/main/java/bisq/contract/mu_sig/MuSigContract.java
@@ -20,6 +20,7 @@ package bisq.contract.mu_sig;
 import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.account.payment_method.PaymentMethodSpecUtil;
 import bisq.account.protocol_type.TradeProtocolType;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.common.market.Market;
 import bisq.contract.Party;
 import bisq.contract.Role;
@@ -28,17 +29,16 @@ import bisq.network.identity.NetworkId;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.offer.price.spec.PriceSpec;
 import bisq.user.profile.UserProfile;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 @ToString(callSuper = true)
 @Getter
-@EqualsAndHashCode(callSuper = true)
 public class MuSigContract extends TwoPartyContract<MuSigOffer> {
 
     private final long baseSideAmount;
@@ -48,6 +48,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
     private final Optional<UserProfile> mediator;
     private final PriceSpec priceSpec;
     private final long marketPrice;
+    private final byte[] takerSaltedAccountPayloadHash;
 
     public MuSigContract(long takeOfferDate,
                          MuSigOffer offer,
@@ -55,6 +56,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
                          long baseSideAmount,
                          long quoteSideAmount,
                          PaymentMethodSpec<?> paymentMethodSpec,
+                         byte[] takerSaltedAccountPayloadHash,
                          Optional<UserProfile> mediator,
                          PriceSpec priceSpec,
                          long marketPrice) {
@@ -66,6 +68,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
                 quoteSideAmount,
                 getBaseSidePaymentMethodSpec(offer, paymentMethodSpec),
                 getQuoteSidePaymentMethodSpec(offer, paymentMethodSpec),
+                takerSaltedAccountPayloadHash,
                 mediator,
                 priceSpec,
                 marketPrice);
@@ -79,6 +82,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
                          long quoteSideAmount,
                          PaymentMethodSpec<?> baseSidePaymentMethodSpec,
                          PaymentMethodSpec<?> quoteSidePaymentMethodSpec,
+                         byte[] takerSaltedAccountPayloadHash,
                          Optional<UserProfile> mediator,
                          PriceSpec priceSpec,
                          long marketPrice) {
@@ -87,6 +91,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
         this.quoteSideAmount = quoteSideAmount;
         this.baseSidePaymentMethodSpec = baseSidePaymentMethodSpec;
         this.quoteSidePaymentMethodSpec = quoteSidePaymentMethodSpec;
+        this.takerSaltedAccountPayloadHash = takerSaltedAccountPayloadHash.clone();
         this.mediator = mediator;
         this.priceSpec = priceSpec;
         this.marketPrice = marketPrice;
@@ -97,6 +102,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
     @Override
     public void verify() {
         super.verify();
+        NetworkDataValidation.validateHash(takerSaltedAccountPayloadHash);
     }
 
     @Override
@@ -121,7 +127,8 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
                 .setBaseSidePaymentMethodSpec(baseSidePaymentMethodSpec.toProto(serializeForHash))
                 .setQuoteSidePaymentMethodSpec(quoteSidePaymentMethodSpec.toProto(serializeForHash))
                 .setPriceSpec(priceSpec.toProto(serializeForHash))
-                .setMarketPrice(marketPrice);
+                .setMarketPrice(marketPrice)
+                .setTakerSaltedAccountPayloadHash(com.google.protobuf.ByteString.copyFrom(takerSaltedAccountPayloadHash));
         mediator.ifPresent(mediator -> builder.setMediator(mediator.toProto(serializeForHash)));
         return builder;
     }
@@ -148,6 +155,7 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
                 PaymentMethodSpec.fromProto(
                         muSigContractProto.getQuoteSidePaymentMethodSpec(),
                         PaymentMethodSpecUtil.getPaymentMethodSpecClassForQuoteSide(market)),
+                muSigContractProto.getTakerSaltedAccountPayloadHash().toByteArray(),
                 muSigContractProto.hasMediator() ?
                         Optional.of(UserProfile.fromProto(muSigContractProto.getMediator())) :
                         Optional.empty(),
@@ -191,5 +199,39 @@ public class MuSigContract extends TwoPartyContract<MuSigOffer> {
 
     public long getNonBtcSideAmount() {
         return offer.getMarket().isBaseCurrencyBitcoin() ? quoteSideAmount : baseSideAmount;
+    }
+
+    public byte[] getTakerSaltedAccountPayloadHash() {
+        return takerSaltedAccountPayloadHash.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MuSigContract that)) {
+            return false;
+        }
+        return super.equals(o) &&
+                baseSideAmount == that.baseSideAmount &&
+                quoteSideAmount == that.quoteSideAmount &&
+                marketPrice == that.marketPrice &&
+                baseSidePaymentMethodSpec.equals(that.baseSidePaymentMethodSpec) &&
+                quoteSidePaymentMethodSpec.equals(that.quoteSidePaymentMethodSpec) &&
+                mediator.equals(that.mediator) &&
+                priceSpec.equals(that.priceSpec) &&
+                Arrays.equals(takerSaltedAccountPayloadHash, that.takerSaltedAccountPayloadHash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Long.hashCode(baseSideAmount);
+        result = 31 * result + Long.hashCode(quoteSideAmount);
+        result = 31 * result + baseSidePaymentMethodSpec.hashCode();
+        result = 31 * result + quoteSidePaymentMethodSpec.hashCode();
+        result = 31 * result + mediator.hashCode();
+        result = 31 * result + priceSpec.hashCode();
+        result = 31 * result + Long.hashCode(marketPrice);
+        result = 31 * result + Arrays.hashCode(takerSaltedAccountPayloadHash);
+        return result;
     }
 }

--- a/contract/src/main/proto/contract.proto
+++ b/contract/src/main/proto/contract.proto
@@ -96,4 +96,5 @@ message MuSigContract {
   optional user.UserProfile mediator = 5;
   offer.PriceSpec priceSpec =6;
   sint64 marketPrice = 7;
+  bytes takerSaltedAccountPayloadHash = 8;
 }

--- a/contract/src/test/java/bisq/contract/mu_sig/MuSigContractTest.java
+++ b/contract/src/test/java/bisq/contract/mu_sig/MuSigContractTest.java
@@ -24,17 +24,29 @@ import bisq.account.payment_method.crypto.CryptoPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.common.market.Market;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.TransportType;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.contract.Party;
 import bisq.contract.Role;
+import bisq.network.identity.NetworkId;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
 import bisq.offer.Direction;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
 import org.junit.jupiter.api.Test;
 
+import java.security.KeyPair;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MuSigContractTest {
     @Test
@@ -62,31 +74,76 @@ class MuSigContractTest {
         assertSame(baseSpec, contract.getNonBtcSidePaymentMethodSpec());
     }
 
+    @Test
+    void keepsTakerSaltedAccountPayloadHashAtProtoRoundTrip() {
+        byte[] hash = new byte[20];
+        hash[0] = 1;
+        hash[19] = 2;
+        PaymentMethodSpec<?> baseSpec = PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        PaymentMethodSpec<?> quoteSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD");
+        MuSigContract contract = createContract(createBtcFiatMarket(), 111L, 222L, baseSpec, quoteSpec, hash);
+
+        MuSigContract fromProto = MuSigContract.fromProto(contract.toProto(false));
+        assertArrayEquals(hash, fromProto.getTakerSaltedAccountPayloadHash());
+    }
+
+    @Test
+    void rejectsNon20ByteTakerSaltedAccountPayloadHash() {
+        PaymentMethodSpec<?> baseSpec = PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        PaymentMethodSpec<?> quoteSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                createContract(createBtcFiatMarket(), 111L, 222L, baseSpec, quoteSpec, new byte[19]));
+    }
+
     private MuSigContract createContract(Market market,
                                          long baseSideAmount,
                                          long quoteSideAmount,
                                          PaymentMethodSpec<?> baseSpec,
                                          PaymentMethodSpec<?> quoteSpec) {
+        return createContract(market, baseSideAmount, quoteSideAmount, baseSpec, quoteSpec, new byte[20]);
+    }
+
+    private MuSigContract createContract(Market market,
+                                         long baseSideAmount,
+                                         long quoteSideAmount,
+                                         PaymentMethodSpec<?> baseSpec,
+                                         PaymentMethodSpec<?> quoteSpec,
+                                         byte[] takerSaltedAccountPayloadHash) {
+        NetworkId makerNetworkId = createNetworkId(18001);
+        NetworkId takerNetworkId = createNetworkId(18002);
         MuSigOffer offer = new MuSigOffer("test-id",
-                null,
+                makerNetworkId,
                 Direction.BUY,
                 market,
-                null,
-                null,
+                new BaseSideFixedAmountSpec(baseSideAmount),
+                new MarketPriceSpec(),
                 List.of(),
                 List.of(),
                 "1.0.0");
         return new MuSigContract(System.currentTimeMillis(),
                 offer,
                 TradeProtocolType.MU_SIG,
-                new Party(Role.TAKER, null),
+                new Party(Role.TAKER, takerNetworkId),
                 baseSideAmount,
                 quoteSideAmount,
                 baseSpec,
                 quoteSpec,
+                takerSaltedAccountPayloadHash,
                 Optional.empty(),
-                null,
+                new MarketPriceSpec(),
                 0);
+    }
+
+    private NetworkId createNetworkId(int port) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        PubKey pubKey = new PubKey(keyPair.getPublic(), "mu-sig-contract-test-key-" + port);
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(
+                Map.of(TransportType.CLEAR, LocalHostAddressTypeFacade.toLocalHostAddress(port))
+        );
+        return new NetworkId(addresses, pubKey);
     }
 
     private Market createBtcFiatMarket() {

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -88,6 +88,7 @@ authorizedRole.mediator.mediationCaseDetails.paymentAccountData.taker=Taker paym
 authorizedRole.mediator.mediationCaseDetails.paymentAccountData.maker=Maker payment account data
 authorizedRole.mediator.mediationCaseDetails.paymentAccountData.fetch=Fetch payment account data
 authorizedRole.mediator.mediationCaseDetails.paymentAccountData.waitingForResponse=Waiting for response
+authorizedRole.mediator.mediationCaseDetails.paymentAccountData.issue.accountPayloadHashMismatch=The payment account details shared by the {0} do not match the contract
 authorizedRole.mediator.mediationCaseDetails.mediationResult=Mediation result
 authorizedRole.mediator.caseCounts.tooltip=Bot ID: {0}\nUser ID: {1}\nNr. open cases: {2}\nNr. closed cases: {3}
 

--- a/offer/src/main/java/bisq/offer/options/AccountOption.java
+++ b/offer/src/main/java/bisq/offer/options/AccountOption.java
@@ -40,19 +40,22 @@ public final class AccountOption implements OfferOption {
     private final List<String> acceptedCountryCodes;
     private final Optional<String> bankId;
     private final List<String> acceptedBanks;
+    private final byte[] saltedAccountPayloadHash;
 
     public AccountOption(PaymentMethod<? extends PaymentRail> paymentMethod,
                          String saltedAccountId,
                          Optional<String> countryCode,
                          List<String> acceptedCountryCodes,
                          Optional<String> bankId,
-                         List<String> acceptedBanks) {
+                         List<String> acceptedBanks,
+                         byte[] saltedAccountPayloadHash) {
         this.paymentMethod = paymentMethod;
         this.saltedAccountId = saltedAccountId;
         this.countryCode = countryCode;
         this.acceptedCountryCodes = acceptedCountryCodes;
         this.bankId = bankId;
         this.acceptedBanks = acceptedBanks;
+        this.saltedAccountPayloadHash = saltedAccountPayloadHash.clone();
 
         verify();
     }
@@ -66,6 +69,7 @@ public final class AccountOption implements OfferOption {
         bankId.ifPresent(e -> NetworkDataValidation.validateText(e, BankAccountPayload.BANK_ID_MIN_LENGTH, BankAccountPayload.BANK_ID_MAX_LENGTH));
         checkArgument(acceptedBanks.size() < 10, "acceptedBanks must be < 100 items");
         checkArgument(acceptedBanks.toString().length() < 500, "Length of acceptedBanks must be < 500");
+        NetworkDataValidation.validateHash(saltedAccountPayloadHash);
     }
 
     public bisq.offer.protobuf.OfferOption.Builder getBuilder(boolean serializeForHash) {
@@ -73,7 +77,8 @@ public final class AccountOption implements OfferOption {
                 .setPaymentMethod(paymentMethod.toProto(serializeForHash))
                 .setSaltedAccountId(saltedAccountId)
                 .addAllAcceptedCountryCodes(acceptedCountryCodes)
-                .addAllAcceptedBanks(acceptedBanks);
+                .addAllAcceptedBanks(acceptedBanks)
+                .setSaltedAccountPayloadHash(com.google.protobuf.ByteString.copyFrom(saltedAccountPayloadHash));
         countryCode.ifPresent(builder::setCountryCode);
         bankId.ifPresent(builder::setBankId);
         return getOfferOptionBuilder(serializeForHash).setAccountOption(builder);
@@ -90,7 +95,12 @@ public final class AccountOption implements OfferOption {
                 proto.hasCountryCode() ? Optional.of(proto.getCountryCode()) : Optional.empty(),
                 proto.getAcceptedCountryCodesList(),
                 proto.hasBankId() ? Optional.of(proto.getBankId()) : Optional.empty(),
-                proto.getAcceptedBanksList()
+                proto.getAcceptedBanksList(),
+                proto.getSaltedAccountPayloadHash().toByteArray()
         );
+    }
+
+    public byte[] getSaltedAccountPayloadHash() {
+        return saltedAccountPayloadHash.clone();
     }
 }

--- a/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
+++ b/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
@@ -18,7 +18,9 @@
 package bisq.offer.options;
 
 import bisq.account.accounts.Account;
+import bisq.account.accounts.AccountPayload;
 import bisq.account.payment_method.PaymentMethod;
+import bisq.common.util.ByteArrayUtils;
 import bisq.common.encoding.Hex;
 import bisq.security.DigestUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -110,6 +112,12 @@ public class OfferOptionUtil {
         byte[] hash = DigestUtil.hash(input.getBytes(StandardCharsets.UTF_8));
         log.info("createdSaltedAccountId Hex.encode(hash)={}", Hex.encode(hash));
         return Hex.encode(hash);
+    }
+
+    public static byte[] createSaltedAccountPayloadHash(AccountPayload<?> accountPayload, String offerId) {
+        return DigestUtil.hash(ByteArrayUtils.concat(
+                accountPayload.serializeForHash(),
+                offerId.getBytes(StandardCharsets.UTF_8)));
     }
 
     public static Optional<Account<? extends PaymentMethod<?>, ?>> findAccountFromSaltedAccountId(Set<Account<? extends PaymentMethod<?>, ?>> accounts,

--- a/offer/src/main/proto/offer.proto
+++ b/offer/src/main/proto/offer.proto
@@ -102,6 +102,7 @@ message AccountOption {
   repeated string acceptedCountryCodes = 4;
   optional string bankId = 5;
   repeated string acceptedBanks = 6;
+  bytes saltedAccountPayloadHash = 7;
 }
 
 message OfferOption {
@@ -156,4 +157,3 @@ message MyMuSigOffersStore {
 message MuSigOfferMessage {
   Offer offer = 1;
 }
-

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationCase.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationCase.java
@@ -24,6 +24,8 @@ import bisq.support.mediation.MediationCaseState;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static java.lang.System.currentTimeMillis;
@@ -38,6 +40,7 @@ public class MuSigMediationCase implements PersistableProto {
     private final Observable<Optional<MuSigMediationResult>> muSigMediationResult = new Observable<>();
     private final Observable<Optional<AccountPayload<?>>> takerAccountPayload = new Observable<>(Optional.empty());
     private final Observable<Optional<AccountPayload<?>>> makerAccountPayload = new Observable<>(Optional.empty());
+    private final Observable<List<MuSigMediationIssue>> issues = new Observable<>(List.of());
 
 
     public MuSigMediationCase(MuSigMediationRequest muSigMediationRequest) {
@@ -46,7 +49,8 @@ public class MuSigMediationCase implements PersistableProto {
                 MediationCaseState.OPEN,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                List.of());
     }
 
     private MuSigMediationCase(MuSigMediationRequest muSigMediationRequest,
@@ -54,13 +58,15 @@ public class MuSigMediationCase implements PersistableProto {
                                MediationCaseState mediationCaseState,
                                Optional<MuSigMediationResult> muSigMediationResult,
                                Optional<AccountPayload<?>> takerAccountPayload,
-                               Optional<AccountPayload<?>> makerAccountPayload) {
+                               Optional<AccountPayload<?>> makerAccountPayload,
+                               List<MuSigMediationIssue> issues) {
         this.muSigMediationRequest = muSigMediationRequest;
         this.requestDate = requestDate;
         this.mediationCaseState.set(mediationCaseState);
         this.muSigMediationResult.set(muSigMediationResult);
         this.takerAccountPayload.set(takerAccountPayload);
         this.makerAccountPayload.set(makerAccountPayload);
+        this.issues.set(issues);
     }
 
     /**
@@ -77,6 +83,9 @@ public class MuSigMediationCase implements PersistableProto {
                 builder.setMuSigMediationResult(item.toProto(serializeForHash)));
         takerAccountPayload.get().ifPresent(item -> builder.setTakerAccountPayload(item.toProto(serializeForHash)));
         makerAccountPayload.get().ifPresent(item -> builder.setMakerAccountPayload(item.toProto(serializeForHash)));
+        builder.addAllIssues(issues.get().stream()
+                .map(item -> item.toProto(serializeForHash))
+                .toList());
         return builder;
     }
 
@@ -97,7 +106,10 @@ public class MuSigMediationCase implements PersistableProto {
                         Optional.empty(),
                 proto.hasMakerAccountPayload() ?
                         Optional.of(AccountPayload.fromProto(proto.getMakerAccountPayload())) :
-                        Optional.empty());
+                        Optional.empty(),
+                proto.getIssuesList().stream()
+                        .map(MuSigMediationIssue::fromProto)
+                        .toList());
     }
 
     public boolean setMediationCaseState(MediationCaseState state) {
@@ -121,7 +133,8 @@ public class MuSigMediationCase implements PersistableProto {
         return true;
     }
 
-    public boolean setPaymentAccountPayloads(AccountPayload<?> takerAccountPayload, AccountPayload<?> makerAccountPayload) {
+    public boolean setPaymentAccountPayloads(AccountPayload<?> takerAccountPayload,
+                                             AccountPayload<?> makerAccountPayload) {
         Optional<AccountPayload<?>> newTakerValue = Optional.of(takerAccountPayload);
         Optional<AccountPayload<?>> newMakerValue = Optional.of(makerAccountPayload);
         if (this.takerAccountPayload.get().equals(newTakerValue) && this.makerAccountPayload.get().equals(newMakerValue)) {
@@ -132,4 +145,39 @@ public class MuSigMediationCase implements PersistableProto {
         return true;
     }
 
+    public boolean setTakerPaymentAccountPayload(AccountPayload<?> takerAccountPayload) {
+        Optional<AccountPayload<?>> newValue = Optional.of(takerAccountPayload);
+        if (this.takerAccountPayload.get().equals(newValue)) {
+            return false;
+        }
+        this.takerAccountPayload.set(newValue);
+        return true;
+    }
+
+    public boolean setMakerPaymentAccountPayload(AccountPayload<?> makerAccountPayload) {
+        Optional<AccountPayload<?>> newValue = Optional.of(makerAccountPayload);
+        if (this.makerAccountPayload.get().equals(newValue)) {
+            return false;
+        }
+        this.makerAccountPayload.set(newValue);
+        return true;
+    }
+
+    public boolean addIssues(List<MuSigMediationIssue> newIssues) {
+        if (newIssues.isEmpty()) {
+            return false;
+        }
+        List<MuSigMediationIssue> updated = new ArrayList<>(issues.get());
+        boolean changed = false;
+        for (MuSigMediationIssue issue : newIssues) {
+            boolean alreadyPresent = updated.stream()
+                    .anyMatch(existing -> existing.getReportingRole() == issue.getReportingRole()
+                            && existing.getType() == issue.getType());
+            if (!alreadyPresent) {
+                updated.add(issue);
+                changed = true;
+            }
+        }
+        return changed && issues.set(List.copyOf(updated));
+    }
 }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationIssue.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationIssue.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.common.proto.PersistableProto;
+import bisq.common.validation.NetworkDataValidation;
+import bisq.contract.Role;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import static java.lang.System.currentTimeMillis;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class MuSigMediationIssue implements PersistableProto {
+    private final long date;
+    private final Role reportingRole;
+    private final MuSigMediationIssueType type;
+
+    public MuSigMediationIssue(Role reportingRole, MuSigMediationIssueType type) {
+        this(currentTimeMillis(), reportingRole, type);
+    }
+
+    private MuSigMediationIssue(long date, Role reportingRole, MuSigMediationIssueType type) {
+        this.date = date;
+        this.reportingRole = reportingRole;
+        this.type = type;
+        verify();
+    }
+
+    public void verify() {
+        NetworkDataValidation.validateDate(date);
+    }
+
+    @Override
+    public bisq.support.protobuf.MuSigMediationIssue.Builder getBuilder(boolean serializeForHash) {
+        return bisq.support.protobuf.MuSigMediationIssue.newBuilder()
+                .setDate(date)
+                .setReportingRole(reportingRole.toProtoEnum())
+                .setType(type.toProtoEnum());
+    }
+
+    @Override
+    public bisq.support.protobuf.MuSigMediationIssue toProto(boolean serializeForHash) {
+        return unsafeToProto(serializeForHash);
+    }
+
+    public static MuSigMediationIssue fromProto(bisq.support.protobuf.MuSigMediationIssue proto) {
+        return new MuSigMediationIssue(
+                proto.getDate(),
+                Role.fromProto(proto.getReportingRole()),
+                MuSigMediationIssueType.fromProto(proto.getType()));
+    }
+}

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationIssueType.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationIssueType.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.common.proto.ProtoEnum;
+import bisq.common.proto.ProtobufUtils;
+
+public enum MuSigMediationIssueType implements ProtoEnum {
+    UNSPECIFIED,
+    MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH,
+    TAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH;
+
+    @Override
+    public bisq.support.protobuf.MuSigMediationIssueType toProtoEnum() {
+        return bisq.support.protobuf.MuSigMediationIssueType.valueOf(getProtobufEnumPrefix() + name());
+    }
+
+    public static MuSigMediationIssueType fromProto(bisq.support.protobuf.MuSigMediationIssueType proto) {
+        return ProtobufUtils.enumFromProto(MuSigMediationIssueType.class, proto.name(), UNSPECIFIED);
+    }
+}

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediatorService.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediatorService.java
@@ -27,12 +27,15 @@ import bisq.chat.mu_sig.open_trades.MuSigOpenTradeMessage;
 import bisq.common.application.Service;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.util.StringUtils;
+import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.i18n.Res;
 import bisq.network.NetworkService;
 import bisq.network.identity.NetworkIdWithKeyPair;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.confidential.ConfidentialMessageService;
+import bisq.offer.options.AccountOption;
+import bisq.offer.options.OfferOptionUtil;
 import bisq.persistence.DbSubDirectory;
 import bisq.persistence.Persistence;
 import bisq.persistence.PersistenceService;
@@ -48,8 +51,11 @@ import bisq.user.profile.UserProfile;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -278,12 +284,76 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
                                 tradeId, senderUserProfileId);
                         return;
                     }
-                    if (mediationCase.setPaymentAccountPayloads(response.getTakerAccountPayload(),
-                            response.getMakerAccountPayload())) {
+                    Role reportingRole = resolveReportingRole(muSigMediationRequest.getContract(), senderUserProfileId);
+                    PaymentDetailsVerification verification = verifyPaymentDetails(muSigMediationRequest.getContract(),
+                            response,
+                            reportingRole);
+                    boolean changed = false;
+                    if (verification.takerAccountPayloadMatches()) {
+                        changed |= mediationCase.setTakerPaymentAccountPayload(response.getTakerAccountPayload());
+                    }
+                    if (verification.makerAccountPayloadMatches()) {
+                        changed |= mediationCase.setMakerPaymentAccountPayload(response.getMakerAccountPayload());
+                    }
+                    if (!verification.issues().isEmpty()) {
+                        changed |= mediationCase.addIssues(verification.issues());
+                        log.warn("MuSigPaymentDetailsResponse for trade {} has verification issues: {}",
+                                tradeId, verification.issues());
+                    }
+                    if (changed) {
                         persist();
                     }
                 },
                 () -> log.warn("Ignoring MuSigPaymentDetailsResponse for unknown trade {}.", tradeId));
+    }
+
+    private PaymentDetailsVerification verifyPaymentDetails(MuSigContract contract,
+                                                            MuSigPaymentDetailsResponse response,
+                                                            Role reportingRole) {
+        List<MuSigMediationIssue> issues = new ArrayList<>();
+        String offerId = contract.getOffer().getId();
+        boolean takerAccountPayloadMatches = true;
+        boolean makerAccountPayloadMatches = true;
+
+        byte[] takerSaltedAccountPayloadHash = OfferOptionUtil.createSaltedAccountPayloadHash(response.getTakerAccountPayload(), offerId);
+        if (!Arrays.equals(takerSaltedAccountPayloadHash, contract.getTakerSaltedAccountPayloadHash())) {
+            takerAccountPayloadMatches = false;
+            issues.add(new MuSigMediationIssue(
+                    reportingRole,
+                    MuSigMediationIssueType.TAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH));
+        }
+
+        Set<AccountOption> accountOptions = OfferOptionUtil.findAccountOptions(contract.getOffer().getOfferOptions());
+        var matchingAccountOptions = accountOptions.stream()
+                .filter(option -> option.getPaymentMethod().equals(contract.getNonBtcSidePaymentMethodSpec().getPaymentMethod()))
+                .toList();
+        if (matchingAccountOptions.isEmpty()) {
+            makerAccountPayloadMatches = false;
+            issues.add(new MuSigMediationIssue(
+                    reportingRole,
+                    MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH));
+            return new PaymentDetailsVerification(takerAccountPayloadMatches, makerAccountPayloadMatches, issues);
+        }
+
+        byte[] makerSaltedAccountPayloadHash = OfferOptionUtil.createSaltedAccountPayloadHash(response.getMakerAccountPayload(), offerId);
+        boolean makerPayloadMatchesAnyOption = matchingAccountOptions.stream()
+                .anyMatch(option -> Arrays.equals(makerSaltedAccountPayloadHash, option.getSaltedAccountPayloadHash()));
+        if (!makerPayloadMatchesAnyOption) {
+            makerAccountPayloadMatches = false;
+            issues.add(new MuSigMediationIssue(
+                    reportingRole,
+                    MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH));
+        }
+        return new PaymentDetailsVerification(takerAccountPayloadMatches, makerAccountPayloadMatches, issues);
+    }
+
+    private Role resolveReportingRole(MuSigContract contract, String senderUserProfileId) {
+        return senderUserProfileId.equals(contract.getOffer().getMakersUserProfileId()) ? Role.MAKER : Role.TAKER;
+    }
+
+    private record PaymentDetailsVerification(boolean takerAccountPayloadMatches,
+                                              boolean makerAccountPayloadMatches,
+                                              List<MuSigMediationIssue> issues) {
     }
 
     private Optional<MuSigMediationCase> findMediationCase(String tradeId) {

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -114,6 +114,18 @@ message MuSigPaymentDetailsResponse {
   string senderUserProfileId = 4;
 }
 
+enum MuSigMediationIssueType {
+  MUSIGMEDIATIONISSUETYPE_UNSPECIFIED = 0;
+  MUSIGMEDIATIONISSUETYPE_MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH = 1;
+  MUSIGMEDIATIONISSUETYPE_TAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH = 2;
+}
+
+message MuSigMediationIssue {
+  uint64 date = 1;
+  contract.Role reportingRole = 2;
+  MuSigMediationIssueType type = 3;
+}
+
 message MuSigMediationCase {
   MuSigMediationRequest muSigMediationRequest = 1;
   sint64 requestDate = 2;
@@ -121,6 +133,7 @@ message MuSigMediationCase {
   optional MuSigMediationResult muSigMediationResult = 4;
   optional account.AccountPayload takerAccountPayload = 5;
   optional account.AccountPayload makerAccountPayload = 6;
+  repeated MuSigMediationIssue issues = 7;
 }
 
 message MuSigMediatorStore {

--- a/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
+++ b/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
@@ -1,0 +1,448 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.account.accounts.AccountPayload;
+import bisq.account.accounts.fiat.NationalBankAccountPayload;
+import bisq.account.payment_method.PaymentMethod;
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.account.protocol_type.TradeProtocolType;
+import bisq.bonded_roles.BondedRolesService;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
+import bisq.chat.ChatService;
+import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannelService;
+import bisq.common.market.Market;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.TransportType;
+import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
+import bisq.contract.Party;
+import bisq.contract.Role;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.options.AccountOption;
+import bisq.offer.options.OfferOptionUtil;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.offer.price.spec.PriceSpec;
+import bisq.persistence.DbSubDirectory;
+import bisq.persistence.PersistableStore;
+import bisq.persistence.Persistence;
+import bisq.persistence.PersistenceClient;
+import bisq.persistence.PersistenceService;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.pow.ProofOfWork;
+import bisq.user.UserService;
+import bisq.user.banned.BannedUserService;
+import bisq.user.identity.UserIdentityService;
+import bisq.user.profile.UserProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MuSigMediatorServiceTest {
+    private MuSigMediatorService service;
+
+    @BeforeEach
+    void setUp() {
+        PersistenceService persistenceService = mock(PersistenceService.class);
+        @SuppressWarnings("unchecked")
+        Persistence<MuSigMediatorStore> persistence = mock(Persistence.class);
+        when(persistenceService.getOrCreatePersistence(any(PersistenceClient.class), any(DbSubDirectory.class), any(PersistableStore.class)))
+                .thenReturn(persistence);
+        when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(persistence.getStorePath()).thenReturn(Path.of("build/test/musig-mediator-service"));
+
+        NetworkService networkService = mock(NetworkService.class);
+
+        ChatService chatService = mock(ChatService.class);
+        MuSigOpenTradeChannelService openTradeChannelService = mock(MuSigOpenTradeChannelService.class);
+        when(chatService.getMuSigOpenTradeChannelService()).thenReturn(openTradeChannelService);
+
+        UserService userService = mock(UserService.class);
+        UserIdentityService userIdentityService = mock(UserIdentityService.class);
+        when(userService.getUserIdentityService()).thenReturn(userIdentityService);
+        BannedUserService bannedUserService = mock(BannedUserService.class);
+        when(userService.getBannedUserService()).thenReturn(bannedUserService);
+        when(bannedUserService.isUserProfileBanned(any(String.class))).thenReturn(false);
+        when(bannedUserService.isUserProfileBanned(any(UserProfile.class))).thenReturn(false);
+
+        BondedRolesService bondedRolesService = mock(BondedRolesService.class);
+        AuthorizedBondedRolesService authorizedBondedRolesService = mock(AuthorizedBondedRolesService.class);
+        when(bondedRolesService.getAuthorizedBondedRolesService()).thenReturn(authorizedBondedRolesService);
+
+        service = new MuSigMediatorService(
+                persistenceService,
+                networkService,
+                chatService,
+                userService,
+                bondedRolesService
+        );
+    }
+
+    @Test
+    void verifyPaymentDetails_returnsMatchesForValidTakerAndMakerPayloadsEvenWhenReportedByTaker() throws Exception {
+        UserProfile maker = createUserProfile(10001);
+        UserProfile taker = createUserProfile(10002);
+        AccountPayload<?> takerPayload = createNationalBankPayload("taker-account", "DE111");
+        AccountPayload<?> makerPayload = createNationalBankPayload("maker-account", "DE222");
+        MuSigContract contract = createContract(maker, taker, "offer-1", takerPayload, makerPayload);
+        MuSigPaymentDetailsResponse response = new MuSigPaymentDetailsResponse(
+                "trade-1",
+                takerPayload,
+                makerPayload,
+                taker.getId()
+        );
+
+        Object verification = invokeVerifyPaymentDetails(contract, response, Role.TAKER);
+
+        assertThat(invokeVerificationBoolean(verification, "takerAccountPayloadMatches")).isTrue();
+        assertThat(invokeVerificationBoolean(verification, "makerAccountPayloadMatches")).isTrue();
+        assertThat(invokeVerificationIssues(verification)).isEmpty();
+    }
+
+    @Test
+    void processPaymentDetailsResponse_storesBothPayloads_whenResponseHashesMatch() throws Exception {
+        UserProfile maker = createUserProfile(11001);
+        UserProfile taker = createUserProfile(11002);
+        AccountPayload<?> takerPayload = createNationalBankPayload("taker-account-2", "DE333");
+        AccountPayload<?> makerPayload = createNationalBankPayload("maker-account-2", "DE444");
+        MuSigContract contract = createContract(maker, taker, "offer-2", takerPayload, makerPayload);
+        String tradeId = "trade-2";
+        MuSigMediationCase mediationCase = createMediationCase(tradeId, contract, maker, taker);
+        service.getMediationCases().add(mediationCase);
+
+        MuSigPaymentDetailsResponse response = new MuSigPaymentDetailsResponse(
+                tradeId,
+                takerPayload,
+                makerPayload,
+                taker.getId()
+        );
+
+        invokeProcessPaymentDetailsResponse(response);
+
+        assertThat(mediationCase.getTakerAccountPayload().get()).containsSame(takerPayload);
+        assertThat(mediationCase.getMakerAccountPayload().get()).containsSame(makerPayload);
+        assertThat(mediationCase.getIssues().get()).isEmpty();
+    }
+
+    @Test
+    void processPaymentDetailsResponse_storesMatchingMakerPayloadAndAddsIssue_whenTakerHashMismatches() throws Exception {
+        UserProfile maker = createUserProfile(12001);
+        UserProfile taker = createUserProfile(12002);
+        AccountPayload<?> expectedTakerPayload = createNationalBankPayload("expected-taker-account", "DE555");
+        AccountPayload<?> wrongTakerPayload = createNationalBankPayload("wrong-taker-account", "DE666");
+        AccountPayload<?> makerPayload = createNationalBankPayload("maker-account-3", "DE777");
+        MuSigContract contract = createContract(maker, taker, "offer-3", expectedTakerPayload, makerPayload);
+        String tradeId = "trade-3";
+        MuSigMediationCase mediationCase = createMediationCase(tradeId, contract, maker, taker);
+        service.getMediationCases().add(mediationCase);
+
+        MuSigPaymentDetailsResponse response = new MuSigPaymentDetailsResponse(
+                tradeId,
+                wrongTakerPayload,
+                makerPayload,
+                maker.getId()
+        );
+
+        invokeProcessPaymentDetailsResponse(response);
+
+        assertThat(mediationCase.getTakerAccountPayload().get()).isEmpty();
+        assertThat(mediationCase.getMakerAccountPayload().get()).containsSame(makerPayload);
+        assertThat(mediationCase.getIssues().get()).hasSize(1);
+        MuSigMediationIssue issue = mediationCase.getIssues().get().getFirst();
+        assertThat(issue.getType()).isEqualTo(MuSigMediationIssueType.TAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH);
+        assertThat(issue.getReportingRole()).isEqualTo(Role.MAKER);
+    }
+
+    @Test
+    void processPaymentDetailsResponse_storesMatchingTakerPayloadAndAddsIssue_whenMakerHashMismatches() throws Exception {
+        UserProfile maker = createUserProfile(13001);
+        UserProfile taker = createUserProfile(13002);
+        AccountPayload<?> takerPayload = createNationalBankPayload("taker-account-4", "DE888");
+        AccountPayload<?> expectedMakerPayload = createNationalBankPayload("expected-maker-account", "DE999");
+        AccountPayload<?> wrongMakerPayload = createNationalBankPayload("wrong-maker-account", "DE000");
+        MuSigContract contract = createContract(maker, taker, "offer-4", takerPayload, expectedMakerPayload);
+        String tradeId = "trade-4";
+        MuSigMediationCase mediationCase = createMediationCase(tradeId, contract, maker, taker);
+        service.getMediationCases().add(mediationCase);
+
+        MuSigPaymentDetailsResponse response = new MuSigPaymentDetailsResponse(
+                tradeId,
+                takerPayload,
+                wrongMakerPayload,
+                taker.getId()
+        );
+
+        invokeProcessPaymentDetailsResponse(response);
+
+        assertThat(mediationCase.getTakerAccountPayload().get()).containsSame(takerPayload);
+        assertThat(mediationCase.getMakerAccountPayload().get()).isEmpty();
+        assertThat(mediationCase.getIssues().get()).hasSize(1);
+        MuSigMediationIssue issue = mediationCase.getIssues().get().getFirst();
+        assertThat(issue.getType()).isEqualTo(MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH);
+        assertThat(issue.getReportingRole()).isEqualTo(Role.TAKER);
+    }
+
+    @Test
+    void processPaymentDetailsResponse_acceptsMakerPayload_whenMatchingAnyMakerAccountOption() throws Exception {
+        UserProfile maker = createUserProfile(14001);
+        UserProfile taker = createUserProfile(14002);
+        AccountPayload<?> takerPayload = createNationalBankPayload("taker-account-5", "DE123");
+        AccountPayload<?> makerPayloadOption1 = createNationalBankPayload("maker-account-4a", "DE124");
+        AccountPayload<?> makerPayloadOption2 = createNationalBankPayload("maker-account-4b", "DE125");
+        MuSigContract contract = createContract(
+                maker,
+                taker,
+                "offer-5",
+                takerPayload,
+                List.of(makerPayloadOption1, makerPayloadOption2)
+        );
+        String tradeId = "trade-5";
+        MuSigMediationCase mediationCase = createMediationCase(tradeId, contract, maker, taker);
+        service.getMediationCases().add(mediationCase);
+
+        MuSigPaymentDetailsResponse response = new MuSigPaymentDetailsResponse(
+                tradeId,
+                takerPayload,
+                makerPayloadOption2,
+                taker.getId()
+        );
+
+        invokeProcessPaymentDetailsResponse(response);
+
+        assertThat(mediationCase.getTakerAccountPayload().get()).containsSame(takerPayload);
+        assertThat(mediationCase.getMakerAccountPayload().get()).containsSame(makerPayloadOption2);
+        assertThat(mediationCase.getIssues().get()).isEmpty();
+    }
+
+    @Test
+    void processPaymentDetailsResponse_doesNotDuplicateIssue_whenSameMismatchReportedTwice() throws Exception {
+        UserProfile maker = createUserProfile(15001);
+        UserProfile taker = createUserProfile(15002);
+        AccountPayload<?> takerPayload = createNationalBankPayload("taker-account-6", "DE901");
+        AccountPayload<?> expectedMakerPayload = createNationalBankPayload("expected-maker-account-2", "DE902");
+        AccountPayload<?> wrongMakerPayload = createNationalBankPayload("wrong-maker-account-2", "DE903");
+        MuSigContract contract = createContract(maker, taker, "offer-6", takerPayload, expectedMakerPayload);
+        String tradeId = "trade-6";
+        MuSigMediationCase mediationCase = createMediationCase(tradeId, contract, maker, taker);
+        service.getMediationCases().add(mediationCase);
+
+        MuSigPaymentDetailsResponse response = new MuSigPaymentDetailsResponse(
+                tradeId,
+                takerPayload,
+                wrongMakerPayload,
+                taker.getId()
+        );
+
+        invokeProcessPaymentDetailsResponse(response);
+        invokeProcessPaymentDetailsResponse(response);
+
+        assertThat(mediationCase.getIssues().get()).hasSize(1);
+        MuSigMediationIssue issue = mediationCase.getIssues().get().getFirst();
+        assertThat(issue.getType()).isEqualTo(MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH);
+        assertThat(issue.getReportingRole()).isEqualTo(Role.TAKER);
+    }
+
+    @Test
+    void processPaymentDetailsResponse_keepsSeparateIssues_whenSameMismatchReportedByDifferentRoles() throws Exception {
+        UserProfile maker = createUserProfile(16001);
+        UserProfile taker = createUserProfile(16002);
+        AccountPayload<?> takerPayload = createNationalBankPayload("taker-account-7", "DE911");
+        AccountPayload<?> expectedMakerPayload = createNationalBankPayload("expected-maker-account-3", "DE912");
+        AccountPayload<?> wrongMakerPayload = createNationalBankPayload("wrong-maker-account-3", "DE913");
+        MuSigContract contract = createContract(maker, taker, "offer-7", takerPayload, expectedMakerPayload);
+        String tradeId = "trade-7";
+        MuSigMediationCase mediationCase = createMediationCase(tradeId, contract, maker, taker);
+        service.getMediationCases().add(mediationCase);
+
+        MuSigPaymentDetailsResponse takerResponse = new MuSigPaymentDetailsResponse(
+                tradeId,
+                takerPayload,
+                wrongMakerPayload,
+                taker.getId()
+        );
+        MuSigPaymentDetailsResponse makerResponse = new MuSigPaymentDetailsResponse(
+                tradeId,
+                takerPayload,
+                wrongMakerPayload,
+                maker.getId()
+        );
+
+        invokeProcessPaymentDetailsResponse(takerResponse);
+        invokeProcessPaymentDetailsResponse(makerResponse);
+
+        assertThat(mediationCase.getIssues().get()).hasSize(2);
+        assertThat(mediationCase.getIssues().get())
+                .extracting(MuSigMediationIssue::getType, MuSigMediationIssue::getReportingRole)
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple(MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH, Role.TAKER),
+                        org.assertj.core.groups.Tuple.tuple(MuSigMediationIssueType.MAKER_ACCOUNT_PAYLOAD_HASH_MISMATCH, Role.MAKER)
+                );
+    }
+
+    private MuSigMediationCase createMediationCase(String tradeId,
+                                                   MuSigContract contract,
+                                                   UserProfile requester,
+                                                   UserProfile peer) {
+        MuSigMediationRequest request = new MuSigMediationRequest(
+                tradeId,
+                contract,
+                requester,
+                peer,
+                List.of(),
+                Optional.empty()
+        );
+        return new MuSigMediationCase(request);
+    }
+
+    private MuSigContract createContract(UserProfile maker,
+                                         UserProfile taker,
+                                         String offerId,
+                                         AccountPayload<?> takerPayloadForHash,
+                                         AccountPayload<?> makerPayloadForHash) {
+        return createContract(maker, taker, offerId, takerPayloadForHash, List.of(makerPayloadForHash));
+    }
+
+    private MuSigContract createContract(UserProfile maker,
+                                         UserProfile taker,
+                                         String offerId,
+                                         AccountPayload<?> takerPayloadForHash,
+                                         List<AccountPayload<?>> makerPayloadsForHash) {
+        Market market = new Market("BTC", "EUR", "Bitcoin", "Euro");
+        PaymentMethod<?> paymentMethod = FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK);
+        List<AccountOption> accountOptions = makerPayloadsForHash.stream()
+                .map(payload -> new AccountOption(
+                        paymentMethod,
+                        "0123456789abcdef0123456789abcdef01234567",
+                        Optional.empty(),
+                        List.of(),
+                        Optional.empty(),
+                        List.of(),
+                        OfferOptionUtil.createSaltedAccountPayloadHash(payload, offerId)
+                ))
+                .toList();
+        MuSigOffer offer = new MuSigOffer(
+                offerId,
+                maker.getNetworkId(),
+                Direction.BUY,
+                market,
+                new BaseSideFixedAmountSpec(100_000L),
+                new MarketPriceSpec(),
+                List.of(paymentMethod),
+                accountOptions,
+                "1.0.0"
+        );
+        PaymentMethodSpec<?> baseSidePaymentMethodSpec = PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        PaymentMethodSpec<?> quoteSidePaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(paymentMethod, "EUR");
+        byte[] takerSaltedAccountPayloadHash = OfferOptionUtil.createSaltedAccountPayloadHash(takerPayloadForHash, offerId);
+        return new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                TradeProtocolType.MU_SIG,
+                new Party(Role.TAKER, taker.getNetworkId()),
+                100_000L,
+                3_500_000L,
+                baseSidePaymentMethodSpec,
+                quoteSidePaymentMethodSpec,
+                takerSaltedAccountPayloadHash,
+                Optional.empty(),
+                createPriceSpec(),
+                0
+        );
+    }
+
+    private PriceSpec createPriceSpec() {
+        return new MarketPriceSpec();
+    }
+
+    private UserProfile createUserProfile(int port) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        PubKey pubKey = new PubKey(keyPair.getPublic(), "key-" + port);
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(
+                Map.of(TransportType.CLEAR, LocalHostAddressTypeFacade.toLocalHostAddress(port))
+        );
+        NetworkId networkId = new NetworkId(addresses, pubKey);
+        ProofOfWork proofOfWork = new ProofOfWork(pubKey.getHash(), 0, null, 1.0, new byte[72], 0);
+        return new UserProfile(1, "nick-" + port, proofOfWork, 0, networkId, "", "", "1.0.0");
+    }
+
+    private AccountPayload<?> createNationalBankPayload(String id, String accountNr) {
+        return new NationalBankAccountPayload(
+                id,
+                "DE",
+                "EUR",
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                accountNr,
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
+    private void invokeProcessPaymentDetailsResponse(MuSigPaymentDetailsResponse response) throws Exception {
+        Method method = MuSigMediatorService.class.getDeclaredMethod("processPaymentDetailsResponse", MuSigPaymentDetailsResponse.class);
+        method.setAccessible(true);
+        method.invoke(service, response);
+    }
+
+    private Object invokeVerifyPaymentDetails(MuSigContract contract,
+                                              MuSigPaymentDetailsResponse response,
+                                              Role reportingRole) throws Exception {
+        Method method = MuSigMediatorService.class.getDeclaredMethod("verifyPaymentDetails",
+                MuSigContract.class,
+                MuSigPaymentDetailsResponse.class,
+                Role.class);
+        method.setAccessible(true);
+        return method.invoke(service, contract, response, reportingRole);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<MuSigMediationIssue> invokeVerificationIssues(Object verification) throws Exception {
+        Method issues = verification.getClass().getDeclaredMethod("issues");
+        issues.setAccessible(true);
+        return (List<MuSigMediationIssue>) issues.invoke(verification);
+    }
+
+    private boolean invokeVerificationBoolean(Object verification, String accessorName) throws Exception {
+        Method accessor = verification.getClass().getDeclaredMethod(accessorName);
+        accessor.setAccessible(true);
+        return (boolean) accessor.invoke(verification);
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -458,6 +458,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                 baseSideAmount.getValue(),
                 quoteSideAmount.getValue(),
                 paymentMethodSpec,
+                OfferOptionUtil.createSaltedAccountPayloadHash(takersAccountPayload, muSigOffer.getId()),
                 mediator,
                 priceSpec,
                 marketPrice);

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeFormatterTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeFormatterTest.java
@@ -30,6 +30,7 @@ import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.offer.Direction;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -140,8 +141,9 @@ class MuSigTradeFormatterTest {
                 quoteSideAmount,
                 baseSpec,
                 quoteSpec,
+                new byte[20],
                 Optional.empty(),
-                null,
+                new MarketPriceSpec(),
                 0);
     }
 

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeUtilsTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeUtilsTest.java
@@ -30,6 +30,7 @@ import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.offer.Direction;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -88,8 +89,9 @@ class MuSigTradeUtilsTest {
                 quoteSideAmount,
                 baseSpec,
                 quoteSpec,
+                new byte[20],
                 Optional.empty(),
-                null,
+                new MarketPriceSpec(),
                 0);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mediator UI: payment-account issue indicators with localized tooltips to flag payload-hash mismatches and toggle visibility per party.
  * Data integrity: offers/contracts and account options now include salted payload hashes to enable per-side verification.

* **Mediation Flow**
  * Mediator processing records per-side issues, selectively updates stored payment payloads, and avoids duplicate issue entries.

* **Tests**
  * Added tests for mediation verification/processing and proto round-trip of salted payload hashes.

* **Documentation**
  * Added localization key for account-payload-hash mismatch message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->