### PR TITLE
Add salted account payload hash to account option

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/review/MuSigCreateOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/review/MuSigCreateOfferReviewController.java
@@ -162,7 +162,15 @@ public class MuSigCreateOfferReviewController implements Controller {
                     List<String> acceptedCountryCodes = AccountUtils.getAcceptedCountryCodes(accountPayload);
                     Optional<String> bankId = AccountUtils.getBankId(accountPayload);
                     List<String> acceptedBanks = AccountUtils.getAcceptedBanks(accountPayload);
-                    return new AccountOption(account.getPaymentMethod(), saltedAccountId, countryCode, acceptedCountryCodes, bankId, acceptedBanks);
+                    byte[] saltedAccountPayloadHash = OfferOptionUtil.createSaltedAccountPayloadHash(accountPayload, offerId);
+                    return new AccountOption(
+                            account.getPaymentMethod(),
+                            saltedAccountId,
+                            countryCode,
+                            acceptedCountryCodes,
+                            bankId,
+                            acceptedBanks,
+                            saltedAccountPayloadHash);
                 })
                 .collect(Collectors.toCollection(ArrayList::new));
 

--- a/offer/src/main/java/bisq/offer/options/AccountOption.java
+++ b/offer/src/main/java/bisq/offer/options/AccountOption.java
@@ -40,19 +40,22 @@ public final class AccountOption implements OfferOption {
     private final List<String> acceptedCountryCodes;
     private final Optional<String> bankId;
     private final List<String> acceptedBanks;
+    private final byte[] saltedAccountPayloadHash;
 
     public AccountOption(PaymentMethod<? extends PaymentRail> paymentMethod,
                          String saltedAccountId,
                          Optional<String> countryCode,
                          List<String> acceptedCountryCodes,
                          Optional<String> bankId,
-                         List<String> acceptedBanks) {
+                         List<String> acceptedBanks,
+                         byte[] saltedAccountPayloadHash) {
         this.paymentMethod = paymentMethod;
         this.saltedAccountId = saltedAccountId;
         this.countryCode = countryCode;
         this.acceptedCountryCodes = acceptedCountryCodes;
         this.bankId = bankId;
         this.acceptedBanks = acceptedBanks;
+        this.saltedAccountPayloadHash = saltedAccountPayloadHash.clone();
 
         verify();
     }
@@ -66,6 +69,7 @@ public final class AccountOption implements OfferOption {
         bankId.ifPresent(e -> NetworkDataValidation.validateText(e, BankAccountPayload.BANK_ID_MIN_LENGTH, BankAccountPayload.BANK_ID_MAX_LENGTH));
         checkArgument(acceptedBanks.size() < 10, "acceptedBanks must be < 100 items");
         checkArgument(acceptedBanks.toString().length() < 500, "Length of acceptedBanks must be < 500");
+        NetworkDataValidation.validateHash(saltedAccountPayloadHash);
     }
 
     public bisq.offer.protobuf.OfferOption.Builder getBuilder(boolean serializeForHash) {
@@ -73,7 +77,8 @@ public final class AccountOption implements OfferOption {
                 .setPaymentMethod(paymentMethod.toProto(serializeForHash))
                 .setSaltedAccountId(saltedAccountId)
                 .addAllAcceptedCountryCodes(acceptedCountryCodes)
-                .addAllAcceptedBanks(acceptedBanks);
+                .addAllAcceptedBanks(acceptedBanks)
+                .setSaltedAccountPayloadHash(com.google.protobuf.ByteString.copyFrom(saltedAccountPayloadHash));
         countryCode.ifPresent(builder::setCountryCode);
         bankId.ifPresent(builder::setBankId);
         return getOfferOptionBuilder(serializeForHash).setAccountOption(builder);
@@ -90,7 +95,12 @@ public final class AccountOption implements OfferOption {
                 proto.hasCountryCode() ? Optional.of(proto.getCountryCode()) : Optional.empty(),
                 proto.getAcceptedCountryCodesList(),
                 proto.hasBankId() ? Optional.of(proto.getBankId()) : Optional.empty(),
-                proto.getAcceptedBanksList()
+                proto.getAcceptedBanksList(),
+                proto.getSaltedAccountPayloadHash().toByteArray()
         );
+    }
+
+    public byte[] getSaltedAccountPayloadHash() {
+        return saltedAccountPayloadHash.clone();
     }
 }

--- a/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
+++ b/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
@@ -18,8 +18,10 @@
 package bisq.offer.options;
 
 import bisq.account.accounts.Account;
+import bisq.account.accounts.AccountPayload;
 import bisq.account.payment_method.PaymentMethod;
 import bisq.common.encoding.Hex;
+import bisq.common.util.ByteArrayUtils;
 import bisq.security.DigestUtil;
 import lombok.extern.slf4j.Slf4j;
 
@@ -110,6 +112,12 @@ public class OfferOptionUtil {
         byte[] hash = DigestUtil.hash(input.getBytes(StandardCharsets.UTF_8));
         log.info("createdSaltedAccountId Hex.encode(hash)={}", Hex.encode(hash));
         return Hex.encode(hash);
+    }
+
+    public static byte[] createSaltedAccountPayloadHash(AccountPayload<?> accountPayload, String offerId) {
+        return DigestUtil.hash(ByteArrayUtils.concat(
+                accountPayload.serializeForHash(),
+                offerId.getBytes(StandardCharsets.UTF_8)));
     }
 
     public static Optional<Account<? extends PaymentMethod<?>, ?>> findAccountFromSaltedAccountId(Set<Account<? extends PaymentMethod<?>, ?>> accounts,

--- a/offer/src/main/proto/offer.proto
+++ b/offer/src/main/proto/offer.proto
@@ -102,6 +102,7 @@ message AccountOption {
   repeated string acceptedCountryCodes = 4;
   optional string bankId = 5;
   repeated string acceptedBanks = 6;
+  bytes saltedAccountPayloadHash = 7;
 }
 
 message OfferOption {

--- a/offer/src/test/java/bisq/offer/options/OfferOptionUtilTest.java
+++ b/offer/src/test/java/bisq/offer/options/OfferOptionUtilTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.options;
+
+import bisq.account.accounts.AccountPayload;
+import bisq.account.payment_method.PaymentMethod;
+import bisq.common.util.ByteArrayUtils;
+import bisq.security.DigestUtil;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class OfferOptionUtilTest {
+
+    @Test
+    void createSaltedAccountPayloadHashUsesSerializedPayloadForHashAndOfferId() {
+        byte[] serializedForHash = new byte[]{1, 2, 3, 4};
+        TestAccountPayload accountPayload = new TestAccountPayload(serializedForHash);
+        String offerId = "offer-123";
+
+        byte[] result = OfferOptionUtil.createSaltedAccountPayloadHash(accountPayload, offerId);
+
+        byte[] expected = DigestUtil.hash(ByteArrayUtils.concat(
+                serializedForHash,
+                offerId.getBytes(StandardCharsets.UTF_8)));
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void createSaltedAccountPayloadHashChangesWhenOfferIdChanges() {
+        TestAccountPayload accountPayload = new TestAccountPayload(new byte[]{9, 8, 7});
+
+        byte[] first = OfferOptionUtil.createSaltedAccountPayloadHash(accountPayload, "offer-1");
+        byte[] second = OfferOptionUtil.createSaltedAccountPayloadHash(accountPayload, "offer-2");
+
+        assertFalse(Arrays.equals(first, second));
+    }
+
+    @Test
+    void createSaltedAccountPayloadHashChangesWhenSerializedPayloadForHashChanges() {
+        String offerId = "offer-123";
+
+        byte[] first = OfferOptionUtil.createSaltedAccountPayloadHash(
+                new TestAccountPayload(new byte[]{1, 2, 3}),
+                offerId);
+        byte[] second = OfferOptionUtil.createSaltedAccountPayloadHash(
+                new TestAccountPayload(new byte[]{1, 2, 4}),
+                offerId);
+
+        assertFalse(Arrays.equals(first, second));
+    }
+
+    private static final class TestAccountPayload extends AccountPayload<PaymentMethod<?>> {
+        private final byte[] serializedForHash;
+
+        private TestAccountPayload(byte[] serializedForHash) {
+            super("test-account-id", new byte[32]);
+            this.serializedForHash = serializedForHash;
+        }
+
+        @Override
+        public byte[] serializeForHash() {
+            return serializedForHash;
+        }
+
+        @Override
+        public Message.Builder getBuilder(boolean serializeForHash) {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public byte[] getBisq1CompatibleFingerprint() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        protected byte[] getBisq2Fingerprint() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public PaymentMethod<?> getPaymentMethod() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public String getAccountDataDisplayString() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced account option validation with hash-based integrity verification for offer creation.

* **Tests**
  * Added comprehensive test coverage for the new account validation mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->