### PR TITLE
Fix reactive close date updates in mediation case tables

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationCaseListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationCaseListItem.java
@@ -36,6 +36,8 @@ import bisq.trade.bisq_easy.BisqEasyTradeFormatter;
 import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -65,9 +67,10 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
     private final Badge makersBadge = new Badge();
     private final Badge takersBadge = new Badge();
     private Pin changedChatNotificationPin;
+    private Pin isClosedPin;
     private Long closeCaseDate = 0L;
-    private String closeCaseDateString = "";
-    private String closeCaseTimeString = "";
+    private final StringProperty closeCaseDateString = new SimpleStringProperty("");
+    private final StringProperty closeCaseTimeString = new SimpleStringProperty("");
 
     BisqEasyMediationCaseListItem(ServiceProvider serviceProvider,
                                   BisqEasyMediationCase bisqEasyMediationCase,
@@ -112,10 +115,8 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
 
     @Override
     public void onActivate() {
-        Optional<Long> optionalCloseCaseDate = bisqEasyMediationCase.getCloseCaseDate();
-        closeCaseDate = optionalCloseCaseDate.orElse(0L);
-        closeCaseDateString = optionalCloseCaseDate.map(DateFormatter::formatDate).orElse("");
-        closeCaseTimeString = optionalCloseCaseDate.map(DateFormatter::formatTime).orElse("");
+        isClosedPin = bisqEasyMediationCase.getIsClosed().addObserver(isClosed ->
+                UIThread.run(() -> applyCloseCaseDate(bisqEasyMediationCase.getCloseCaseDate())));
 
         chatNotificationService.getNotConsumedNotifications().forEach(this::handleNotification);
         changedChatNotificationPin = chatNotificationService.getChangedNotification().addObserver(this::handleNotification);
@@ -123,7 +124,33 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
 
     @Override
     public void onDeactivate() {
+        if (isClosedPin != null) {
+            isClosedPin.unbind();
+            isClosedPin = null;
+        }
         changedChatNotificationPin.unbind();
+    }
+
+    public String getCloseCaseDateString() {
+        return closeCaseDateString.get();
+    }
+
+    public StringProperty getCloseCaseDateStringProperty() {
+        return closeCaseDateString;
+    }
+
+    public String getCloseCaseTimeString() {
+        return closeCaseTimeString.get();
+    }
+
+    public StringProperty getCloseCaseTimeStringProperty() {
+        return closeCaseTimeString;
+    }
+
+    private void applyCloseCaseDate(Optional<Long> optionalCloseCaseDate) {
+        closeCaseDate = optionalCloseCaseDate.orElse(0L);
+        closeCaseDateString.set(optionalCloseCaseDate.map(DateFormatter::formatDate).orElse(""));
+        closeCaseTimeString.set(optionalCloseCaseDate.map(DateFormatter::formatTime).orElse(""));
     }
 
     private void handleNotification(ChatNotification notification) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationTableView.java
@@ -325,21 +325,27 @@ class BisqEasyMediationTableView extends VBox {
     private Callback<TableColumn<BisqEasyMediationCaseListItem, BisqEasyMediationCaseListItem>,
             TableCell<BisqEasyMediationCaseListItem, BisqEasyMediationCaseListItem>> getCloseDateCellFactory() {
         return column -> new TableCell<>() {
+            private final Label date = new Label();
+            private final Label time = new Label();
+            private final VBox vBox = new VBox(3, date, time);
 
-            private final Label label = new Label();
+            {
+                date.getStyleClass().add("table-view-date-column-date");
+                time.getStyleClass().add("table-view-date-column-time");
+                vBox.setAlignment(Pos.CENTER);
+                setAlignment(Pos.CENTER);
+            }
 
             @Override
             protected void updateItem(BisqEasyMediationCaseListItem item, boolean empty) {
                 super.updateItem(item, empty);
 
+                date.textProperty().unbind();
+                time.textProperty().unbind();
+
                 if (item != null && !empty) {
-                    Label date = new Label(item.getCloseCaseDateString());
-                    date.getStyleClass().add("table-view-date-column-date");
-                    Label time = new Label(item.getCloseCaseTimeString());
-                    time.getStyleClass().add("table-view-date-column-time");
-                    VBox vBox = new VBox(3, date, time);
-                    vBox.setAlignment(Pos.CENTER);
-                    setAlignment(Pos.CENTER);
+                    date.textProperty().bind(item.getCloseCaseDateStringProperty());
+                    time.textProperty().bind(item.getCloseCaseTimeStringProperty());
                     setGraphic(vBox);
                 } else {
                     setGraphic(null);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItem.java
@@ -39,6 +39,8 @@ import bisq.trade.mu_sig.MuSigTradeUtils;
 import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -68,9 +70,10 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
     private final Badge makersBadge = new Badge();
     private final Badge takersBadge = new Badge();
     private Pin changedChatNotificationPin;
+    private Pin muSigMediationResultPin;
     private Long closeCaseDate = 0L;
-    private String closeCaseDateString = "";
-    private String closeCaseTimeString = "";
+    private final StringProperty closeCaseDateString = new SimpleStringProperty("");
+    private final StringProperty closeCaseTimeString = new SimpleStringProperty("");
 
     MuSigMediationCaseListItem(ServiceProvider serviceProvider,
                                MuSigMediationCase muSigMediationCase,
@@ -115,10 +118,8 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
 
     @Override
     public void onActivate() {
-        Optional<Long> optionalCloseCaseDate = muSigMediationCase.getMuSigMediationResult().get().map(MuSigMediationResult::getDate);
-        closeCaseDate = optionalCloseCaseDate.orElse(0L);
-        closeCaseDateString = optionalCloseCaseDate.map(DateFormatter::formatDate).orElse("");
-        closeCaseTimeString = optionalCloseCaseDate.map(DateFormatter::formatTime).orElse("");
+        muSigMediationResultPin = muSigMediationCase.getMuSigMediationResult().addObserver(optionalResult ->
+                UIThread.run(() -> applyCloseCaseDate(optionalResult.map(MuSigMediationResult::getDate))));
 
         chatNotificationService.getNotConsumedNotifications().forEach(this::handleNotification);
         changedChatNotificationPin = chatNotificationService.getChangedNotification().addObserver(this::handleNotification);
@@ -126,7 +127,33 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
 
     @Override
     public void onDeactivate() {
+        if (muSigMediationResultPin != null) {
+            muSigMediationResultPin.unbind();
+            muSigMediationResultPin = null;
+        }
         changedChatNotificationPin.unbind();
+    }
+
+    public String getCloseCaseDateString() {
+        return closeCaseDateString.get();
+    }
+
+    public StringProperty getCloseCaseDateStringProperty() {
+        return closeCaseDateString;
+    }
+
+    public String getCloseCaseTimeString() {
+        return closeCaseTimeString.get();
+    }
+
+    public StringProperty getCloseCaseTimeStringProperty() {
+        return closeCaseTimeString;
+    }
+
+    private void applyCloseCaseDate(Optional<Long> optionalCloseCaseDate) {
+        closeCaseDate = optionalCloseCaseDate.orElse(0L);
+        closeCaseDateString.set(optionalCloseCaseDate.map(DateFormatter::formatDate).orElse(""));
+        closeCaseTimeString.set(optionalCloseCaseDate.map(DateFormatter::formatTime).orElse(""));
     }
 
     private void handleNotification(ChatNotification notification) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationTableView.java
@@ -325,21 +325,27 @@ class MuSigMediationTableView extends VBox {
     private Callback<TableColumn<MuSigMediationCaseListItem, MuSigMediationCaseListItem>,
             TableCell<MuSigMediationCaseListItem, MuSigMediationCaseListItem>> getCloseDateCellFactory() {
         return column -> new TableCell<>() {
+            private final Label date = new Label();
+            private final Label time = new Label();
+            private final VBox vBox = new VBox(3, date, time);
 
-            private final Label label = new Label();
+            {
+                date.getStyleClass().add("table-view-date-column-date");
+                time.getStyleClass().add("table-view-date-column-time");
+                vBox.setAlignment(Pos.CENTER);
+                setAlignment(Pos.CENTER);
+            }
 
             @Override
             protected void updateItem(MuSigMediationCaseListItem item, boolean empty) {
                 super.updateItem(item, empty);
 
+                date.textProperty().unbind();
+                time.textProperty().unbind();
+
                 if (item != null && !empty) {
-                    Label date = new Label(item.getCloseCaseDateString());
-                    date.getStyleClass().add("table-view-date-column-date");
-                    Label time = new Label(item.getCloseCaseTimeString());
-                    time.getStyleClass().add("table-view-date-column-time");
-                    VBox vBox = new VBox(3, date, time);
-                    vBox.setAlignment(Pos.CENTER);
-                    setAlignment(Pos.CENTER);
+                    date.textProperty().bind(item.getCloseCaseDateStringProperty());
+                    time.textProperty().bind(item.getCloseCaseTimeStringProperty());
                     setGraphic(vBox);
                 } else {
                     setGraphic(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Mediation case tables now display close case date and time as separate fields for improved readability.
  * Updates applied to both Bisq Easy and MuSig mediation case displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->