### PR TITLE
Verify peer account payload against hash in contract

### DIFF
--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeUtils.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeUtils.java
@@ -17,9 +17,16 @@
 
 package bisq.trade.mu_sig;
 
+import bisq.account.accounts.AccountPayload;
 import bisq.common.monetary.Monetary;
 import bisq.common.monetary.PriceQuote;
+import bisq.contract.Party;
 import bisq.contract.mu_sig.MuSigContract;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static bisq.offer.options.OfferOptionUtil.createSaltedAccountPayloadHash;
 
 public final class MuSigTradeUtils {
     public static Monetary getBaseSideMonetary(MuSigTrade trade) {
@@ -60,5 +67,21 @@ public final class MuSigTradeUtils {
 
     public static PriceQuote getPriceQuote(MuSigContract contract) {
         return PriceQuote.from(getBaseSideMonetary(contract), getQuoteSideMonetary(contract));
+    }
+
+    public static boolean doesPeerAccountPayloadMatchContract(MuSigTrade trade, AccountPayload<?> accountPayload) {
+        return findPeersContractSaltedAccountPayloadHash(trade)
+                .map(expectedHash -> Arrays.equals(expectedHash,
+                        createSaltedAccountPayloadHash(accountPayload, trade.getOffer().getId())))
+                .orElse(false);
+    }
+
+    public static Optional<byte[]> findPeersContractSaltedAccountPayloadHash(MuSigTrade trade) {
+        return getPeersContractParty(trade).getSaltedAccountPayloadHash();
+    }
+
+    private static Party getPeersContractParty(MuSigTrade trade) {
+        MuSigContract contract = trade.getContract();
+        return trade.isTaker() ? contract.getMaker() : contract.getTaker();
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSendAccountPayloadAndDepositTxMessage_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSendAccountPayloadAndDepositTxMessage_Handler.java
@@ -24,10 +24,13 @@ import bisq.common.util.StringUtils;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
+import bisq.trade.mu_sig.MuSigTradeUtils;
 import bisq.trade.mu_sig.handler.MuSigTradeMessageHandlerAsMessageSender;
 import bisq.trade.mu_sig.messages.network.SendAccountPayloadAndDepositTxMessage;
 import bisq.trade.mu_sig.messages.network.SendAccountPayloadMessage;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 public abstract class BaseSendAccountPayloadAndDepositTxMessage_Handler extends MuSigTradeMessageHandlerAsMessageSender<MuSigTrade, SendAccountPayloadAndDepositTxMessage> {
@@ -41,7 +44,10 @@ public abstract class BaseSendAccountPayloadAndDepositTxMessage_Handler extends 
 
     @Override
     protected void verify(SendAccountPayloadAndDepositTxMessage message) {
-        // todo
+        checkArgument(MuSigTradeUtils.findPeersContractSaltedAccountPayloadHash(trade).isPresent(),
+                "Peer salted account payload hash must be present in contract");
+        checkArgument(MuSigTradeUtils.doesPeerAccountPayloadMatchContract(trade, message.getAccountPayload()),
+                "Peer account payload does not match the salted account payload hash from the contract");
     }
 
     @Override

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSendAccountPayloadMessage_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSendAccountPayloadMessage_Handler.java
@@ -20,9 +20,12 @@ package bisq.trade.mu_sig.messages.network.handler.taker;
 import bisq.account.accounts.AccountPayload;
 import bisq.trade.ServiceProvider;
 import bisq.trade.mu_sig.MuSigTrade;
+import bisq.trade.mu_sig.MuSigTradeUtils;
 import bisq.trade.mu_sig.handler.MuSigTradeMessageHandler;
 import bisq.trade.mu_sig.messages.network.SendAccountPayloadMessage;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 public abstract class BaseSendAccountPayloadMessage_Handler extends MuSigTradeMessageHandler<MuSigTrade, SendAccountPayloadMessage> {
@@ -34,6 +37,10 @@ public abstract class BaseSendAccountPayloadMessage_Handler extends MuSigTradeMe
 
     @Override
     protected void verify(SendAccountPayloadMessage message) {
+        checkArgument(MuSigTradeUtils.findPeersContractSaltedAccountPayloadHash(trade).isPresent(),
+                "Peer salted account payload hash must be present in contract");
+        checkArgument(MuSigTradeUtils.doesPeerAccountPayloadMatchContract(trade, message.getAccountPayload()),
+                "Peer account payload does not match the salted account payload hash from the contract");
     }
 
     @Override

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeUtilsTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeUtilsTest.java
@@ -17,25 +17,42 @@
 
 package bisq.trade.mu_sig;
 
+import bisq.account.accounts.AccountPayload;
 import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.account.payment_method.PaymentMethodSpecUtil;
 import bisq.account.protocol_type.TradeProtocolType;
 import bisq.account.payment_method.crypto.CryptoPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.account.payment_method.PaymentMethod;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.ClearnetAddress;
+import bisq.common.network.TransportType;
 import bisq.common.market.Market;
 import bisq.common.monetary.Monetary;
 import bisq.contract.Party;
 import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
+import bisq.identity.Identity;
+import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.security.keys.I2PKeyGeneration;
+import bisq.security.keys.KeyBundle;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.keys.TorKeyGeneration;
+import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static bisq.offer.options.OfferOptionUtil.createSaltedAccountPayloadHash;
 
 class MuSigTradeUtilsTest {
     @Test
@@ -62,6 +79,55 @@ class MuSigTradeUtilsTest {
         assertEquals("BTC", btcSideMonetary.getCode());
         assertEquals(111L, nonBtcSideMonetary.getValue());
         assertEquals("XMR", nonBtcSideMonetary.getCode());
+    }
+
+    @Test
+    void matchesMakersSaltedAccountPayloadHashWhenTakerReceivesPeersAccountPayload() {
+        TestAccountPayload accountPayload = new TestAccountPayload(new byte[]{1, 2, 3});
+        MuSigContract contract = createContractWithPeerHashes(
+                createBtcFiatMarket(),
+                createSaltedAccountPayloadHash(accountPayload, "test-id"),
+                createSaltedAccountPayloadHash(new TestAccountPayload(new byte[]{9, 9, 9}), "test-id"));
+        MuSigTrade trade = createTrade(contract, true);
+
+        assertTrue(MuSigTradeUtils.doesPeerAccountPayloadMatchContract(trade, accountPayload));
+    }
+
+    @Test
+    void matchesTakersSaltedAccountPayloadHashWhenMakerReceivesPeersAccountPayload() {
+        TestAccountPayload accountPayload = new TestAccountPayload(new byte[]{4, 5, 6});
+        MuSigContract contract = createContractWithPeerHashes(
+                createBtcFiatMarket(),
+                createSaltedAccountPayloadHash(new TestAccountPayload(new byte[]{9, 9, 9}), "test-id"),
+                createSaltedAccountPayloadHash(accountPayload, "test-id"));
+        MuSigTrade trade = createTrade(contract, false);
+
+        assertTrue(MuSigTradeUtils.doesPeerAccountPayloadMatchContract(trade, accountPayload));
+    }
+
+    @Test
+    void returnsFalseWhenPeerAccountPayloadHashDoesNotMatchContract() {
+        TestAccountPayload accountPayload = new TestAccountPayload(new byte[]{1, 2, 3});
+        MuSigContract contract = createContractWithPeerHashes(
+                createBtcFiatMarket(),
+                createSaltedAccountPayloadHash(new TestAccountPayload(new byte[]{9, 9, 9}), "test-id"),
+                createSaltedAccountPayloadHash(new TestAccountPayload(new byte[]{8, 8, 8}), "test-id"));
+        MuSigTrade trade = createTrade(contract, true);
+
+        assertFalse(MuSigTradeUtils.doesPeerAccountPayloadMatchContract(trade, accountPayload));
+    }
+
+    @Test
+    void returnsEmptyAndFalseWhenPeersContractSaltedAccountPayloadHashIsMissing() {
+        TestAccountPayload accountPayload = new TestAccountPayload(new byte[]{1, 2, 3});
+        MuSigContract contract = createContractWithPeerHashes(
+                createBtcFiatMarket(),
+                Optional.empty(),
+                Optional.of(createSaltedAccountPayloadHash(new TestAccountPayload(new byte[]{9, 9, 9}), "test-id")));
+        MuSigTrade trade = createTrade(contract, true);
+
+        assertFalse(MuSigTradeUtils.findPeersContractSaltedAccountPayloadHash(trade).isPresent());
+        assertFalse(MuSigTradeUtils.doesPeerAccountPayloadMatchContract(trade, accountPayload));
     }
 
     private MuSigContract createContract(Market market, long baseSideAmount, long quoteSideAmount) {
@@ -94,11 +160,110 @@ class MuSigTradeUtilsTest {
                 0);
     }
 
+    private MuSigContract createContractWithPeerHashes(Market market, byte[] makerHash, byte[] takerHash) {
+        return createContractWithPeerHashes(market, Optional.of(makerHash), Optional.of(takerHash));
+    }
+
+    private MuSigContract createContractWithPeerHashes(Market market,
+                                                       Optional<byte[]> makerHash,
+                                                       Optional<byte[]> takerHash) {
+        MuSigOffer offer = new MuSigOffer("test-id",
+                null,
+                Direction.BUY,
+                market,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                "1.0.0");
+        PaymentMethodSpec<?> baseSpec = PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0);
+        PaymentMethodSpec<?> quoteSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER),
+                "USD");
+        return new MuSigContract(System.currentTimeMillis(),
+                offer,
+                TradeProtocolType.MU_SIG,
+                new Party(Role.MAKER, createNetworkId("maker", 9998), makerHash),
+                new Party(Role.TAKER, createNetworkId("taker", 9999), takerHash),
+                111L,
+                222L,
+                baseSpec,
+                quoteSpec,
+                Optional.empty(),
+                null,
+                0);
+    }
+
+    private MuSigTrade createTrade(MuSigContract contract, boolean isTaker) {
+        Identity myIdentity = createIdentity(isTaker ? contract.getTaker().getNetworkId() : contract.getMaker().getNetworkId());
+        return new MuSigTrade(contract,
+                true,
+                isTaker,
+                myIdentity,
+                contract.getOffer(),
+                contract.getTaker().getNetworkId(),
+                contract.getMaker().getNetworkId());
+    }
+
+    private Identity createIdentity(NetworkId networkId) {
+        KeyBundle keyBundle = new KeyBundle("test-key-bundle",
+                KeyGeneration.generateDefaultEcKeyPair(),
+                TorKeyGeneration.generateKeyPair(),
+                I2PKeyGeneration.generateKeyPair());
+        return new Identity("test-id", networkId, keyBundle);
+    }
+
+    private NetworkId createNetworkId(String keyIdSuffix, int port) {
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(Map.of(
+                TransportType.CLEAR, new ClearnetAddress("127.0.0.1", port)));
+        PubKey pubKey = new PubKey(KeyGeneration.generateDefaultEcKeyPair().getPublic(), "test-key-" + keyIdSuffix);
+        return new NetworkId(addresses, pubKey);
+    }
+
     private Market createBtcFiatMarket() {
         return new Market("BTC", "USD", "Bitcoin", "US Dollar");
     }
 
     private Market createCryptoBtcMarket() {
         return new Market("XMR", "BTC", "Monero", "Bitcoin");
+    }
+
+    private static final class TestAccountPayload extends AccountPayload<PaymentMethod<?>> {
+        private final byte[] serializedForHash;
+
+        private TestAccountPayload(byte[] serializedForHash) {
+            super("test-account-id", new byte[32]);
+            this.serializedForHash = serializedForHash;
+        }
+
+        @Override
+        public byte[] serializeForHash() {
+            return serializedForHash;
+        }
+
+        @Override
+        public Message.Builder getBuilder(boolean serializeForHash) {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public byte[] getBisq1CompatibleFingerprint() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        protected byte[] getBisq2Fingerprint() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public PaymentMethod<?> getPaymentMethod() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
+
+        @Override
+        public String getAccountDataDisplayString() {
+            throw new UnsupportedOperationException("Not required for this test");
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added validation checks to ensure account payloads in trade messages match contract requirements, improving security and data integrity for peer-to-peer trades

* **Tests**
  * Added tests verifying account payload validation across different trade participant roles and mismatch scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->