### PR TITLE
Centralize MuSig symmetric security deposit lookup

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/offer_details/MuSigOfferDetailsHelper.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/offer_details/MuSigOfferDetailsHelper.java
@@ -44,7 +44,6 @@ import bisq.offer.amount.spec.AmountSpec;
 import bisq.offer.amount.spec.FixedAmountSpec;
 import bisq.offer.amount.spec.RangeAmountSpec;
 import bisq.offer.mu_sig.MuSigOffer;
-import bisq.offer.options.CollateralOption;
 import bisq.offer.options.OfferOptionUtil;
 import bisq.offer.price.PriceUtil;
 import bisq.offer.price.spec.FixPriceSpec;
@@ -71,7 +70,8 @@ class MuSigOfferDetailsHelper {
     //
 
     static Optional<SecurityDepositInfo> createSecurityDepositInfo(MuSigOffer offer, Optional<OfferAmounts> offerAmounts) {
-        double securityDepositAsPercent = getSecurityDepositPercent(offer);
+        double securityDepositAsPercent = OfferOptionUtil.findSymmetricSecurityDepositPercent(offer.getOfferOptions())
+                .orElseThrow(() -> new IllegalArgumentException("CollateralOption must be present"));
         String formattedPercent = PercentageFormatter.formatToPercentWithSymbol(securityDepositAsPercent, 0);
         Optional<Amount> securityDepositAsBTC = offerAmounts.map(amounts ->
                 calculateSecurityDepositAsBTC(offer.getMarket(), amounts, securityDepositAsPercent));
@@ -103,16 +103,6 @@ class MuSigOfferDetailsHelper {
                     }
                     default -> throw new IllegalStateException("Unexpected amounts type: " + offerAmounts);
                 };
-    }
-
-    // From bisq.desktop.main.content.mu_sig.offer.take_offer.review.MuSigTakeOfferReviewController.init
-    static double getSecurityDepositPercent(MuSigOffer muSigOffer) {
-        Optional<CollateralOption> optionalCollateralOption = OfferOptionUtil.findCollateralOption(muSigOffer.getOfferOptions());
-        checkArgument(optionalCollateralOption.isPresent(), "CollateralOption must be present");
-        CollateralOption collateralOption = optionalCollateralOption.get();
-        checkArgument(Math.abs(collateralOption.getSellerSecurityDeposit() - collateralOption.getBuyerSecurityDeposit()) < 1e-9,
-                "SellerSecurityDeposit and BuyerSecurityDeposit are expected to be equal");
-        return collateralOption.getBuyerSecurityDeposit();
     }
 
     // From bisq.offer.amount.OfferAmountFormatter#formatDepositAmountAsBTC(Monetary)

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/take_offer/review/MuSigTakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/take_offer/review/MuSigTakeOfferReviewController.java
@@ -42,7 +42,6 @@ import bisq.offer.amount.OfferAmountFormatter;
 import bisq.offer.amount.OfferAmountUtil;
 import bisq.offer.amount.spec.FixedAmountSpec;
 import bisq.offer.mu_sig.MuSigOffer;
-import bisq.offer.options.CollateralOption;
 import bisq.offer.options.OfferOptionUtil;
 import bisq.offer.price.PriceUtil;
 import bisq.offer.price.spec.FloatPriceSpec;
@@ -122,14 +121,9 @@ public class MuSigTakeOfferReviewController implements Controller {
         applyPriceQuote(priceQuote);
         applyPriceDetails(muSigOffer.getPriceSpec(), market);
 
-        // DEFAULT_BUYER_SECURITY_DEPOSIT and DEFAULT_SELLER_SECURITY_DEPOSIT are the same
-        //double securityDeposit = MuSigOffer.DEFAULT_BUYER_SECURITY_DEPOSIT;
-        Optional<CollateralOption> optionalCollateralOption = OfferOptionUtil.findCollateralOption(muSigOffer.getOfferOptions());
-        checkArgument(optionalCollateralOption.isPresent(), "CollateralOption must be present");
-        CollateralOption collateralOption = optionalCollateralOption.get();
-        checkArgument(Double.compare(collateralOption.getSellerSecurityDeposit(), collateralOption.getBuyerSecurityDeposit()) == 0,
-                "SellerSecurityDeposit and BuyerSecurityDeposit are expected to be equal");
-        double securityDeposit = collateralOption.getBuyerSecurityDeposit();
+
+        double securityDeposit = OfferOptionUtil.findSymmetricSecurityDepositPercent(muSigOffer.getOfferOptions())
+                .orElseThrow(() -> new IllegalArgumentException("CollateralOption must be present"));
         model.setSecurityDepositAsPercent(securityDeposit);
         model.setFormattedSecurityDepositAsPercent(PercentageFormatter.formatToPercentWithSymbol(securityDeposit, 0));
 

--- a/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
+++ b/offer/src/main/java/bisq/offer/options/OfferOptionUtil.java
@@ -78,6 +78,17 @@ public class OfferOptionUtil {
                 .findAny();
     }
 
+    // DEFAULT_BUYER_SECURITY_DEPOSIT and DEFAULT_SELLER_SECURITY_DEPOSIT are the same
+    public static Optional<Double> findSymmetricSecurityDepositPercent(Collection<OfferOption> offerOptions) {
+        return findCollateralOption(offerOptions)
+                .map(collateralOption -> {
+                    checkArgument(Double.compare(collateralOption.getSellerSecurityDeposit(),
+                                    collateralOption.getBuyerSecurityDeposit()) == 0,
+                            "SellerSecurityDeposit and BuyerSecurityDeposit are expected to be equal");
+                    return collateralOption.getBuyerSecurityDeposit();
+                });
+    }
+
     public static Optional<FiatPaymentOption> findFiatPaymentOption(Collection<OfferOption> offerOptions) {
         return offerOptions.stream()
                 .filter(FiatPaymentOption.class::isInstance)

--- a/offer/src/test/java/bisq/offer/options/OfferOptionUtilTest.java
+++ b/offer/src/test/java/bisq/offer/options/OfferOptionUtilTest.java
@@ -26,11 +26,34 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OfferOptionUtilTest {
+
+    @Test
+    void findSymmetricSecurityDepositPercentReturnsEmptyWhenCollateralOptionIsMissing() {
+        assertTrue(OfferOptionUtil.findSymmetricSecurityDepositPercent(List.of()).isEmpty());
+    }
+
+    @Test
+    void findSymmetricSecurityDepositPercentReturnsBuyerDepositWhenBuyerAndSellerMatch() {
+        double result = OfferOptionUtil.findSymmetricSecurityDepositPercent(List.of(new CollateralOption(0.15, 0.15)))
+                .orElseThrow();
+
+        assertEquals(0.15, result);
+    }
+
+    @Test
+    void findSymmetricSecurityDepositPercentThrowsWhenBuyerAndSellerDoNotMatch() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OfferOptionUtil.findSymmetricSecurityDepositPercent(List.of(new CollateralOption(0.10, 0.15))));
+    }
 
     @Test
     void createSaltedAccountPayloadHashUsesSerializedPayloadForHashAndOfferId() {

--- a/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
+++ b/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
@@ -235,11 +235,12 @@ class MuSigMediatorServiceTest {
         AccountPayload<?> takerPayload = createNationalBankPayload("taker-account-5", "DE123");
         AccountPayload<?> makerPayloadOption1 = createNationalBankPayload("maker-account-4a", "DE124");
         AccountPayload<?> makerPayloadOption2 = createNationalBankPayload("maker-account-4b", "DE125");
-        MuSigContract contract = createContract(
+        MuSigContract contract = createContractWithExplicitMakerHash(
                 maker,
                 taker,
                 "offer-5",
                 takerPayload,
+                makerPayloadOption1,
                 List.of(makerPayloadOption1, makerPayloadOption2)
         );
         String tradeId = "trade-5";
@@ -406,9 +407,25 @@ class MuSigMediatorServiceTest {
                                          String offerId,
                                          AccountPayload<?> takerPayloadForHash,
                                          List<AccountPayload<?>> makerPayloadsForHash) {
+        return createContractWithExplicitMakerHash(
+                maker,
+                taker,
+                offerId,
+                takerPayloadForHash,
+                makerPayloadsForHash.getFirst(),
+                makerPayloadsForHash
+        );
+    }
+
+    private MuSigContract createContractWithExplicitMakerHash(UserProfile maker,
+                                                              UserProfile taker,
+                                                              String offerId,
+                                                              AccountPayload<?> takerPayloadForHash,
+                                                              AccountPayload<?> makerPayloadForHash,
+                                                              List<AccountPayload<?>> makerPayloadsForOfferOptions) {
         Market market = new Market("BTC", "EUR", "Bitcoin", "Euro");
         PaymentMethod<?> paymentMethod = FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK);
-        List<AccountOption> accountOptions = makerPayloadsForHash.stream()
+        List<AccountOption> accountOptions = makerPayloadsForOfferOptions.stream()
                 .map(payload -> new AccountOption(
                         paymentMethod,
                         "0123456789abcdef0123456789abcdef01234567",
@@ -432,14 +449,17 @@ class MuSigMediatorServiceTest {
         );
         PaymentMethodSpec<?> quoteSidePaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(paymentMethod, "EUR");
         byte[] takerSaltedAccountPayloadHash = OfferOptionUtil.createSaltedAccountPayloadHash(takerPayloadForHash, offerId);
+        byte[] makerSaltedAccountPayloadHash = OfferOptionUtil.createSaltedAccountPayloadHash(makerPayloadForHash, offerId);
         return new MuSigContract(
                 System.currentTimeMillis(),
                 offer,
-                taker.getNetworkId(),
+                TradeProtocolType.MU_SIG,
+                new Party(Role.MAKER, maker.getNetworkId(), Optional.of(makerSaltedAccountPayloadHash)),
+                new Party(Role.TAKER, taker.getNetworkId(), Optional.of(takerSaltedAccountPayloadHash)),
                 100_000L,
                 3_500_000L,
+                PaymentMethodSpecUtil.createBitcoinMainChainPaymentMethodSpec().get(0),
                 quoteSidePaymentMethodSpec,
-                takerSaltedAccountPayloadHash,
                 Optional.empty(),
                 createPriceSpec(),
                 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized security deposit percentage retrieval into a shared utility that enforces symmetric deposits.

* **Tests**
  * Added unit tests for security deposit symmetry: missing collateral, matching deposits, and mismatched deposits.
  * Updated MuSig mediation tests to build contracts with explicit maker and taker hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->