### PR TITLE
Extract MuSig amount/price component and reuse it in trade details and mediation overview

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseOverviewSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationCaseOverviewSection.java
@@ -26,12 +26,10 @@ import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.components.controls.BisqMenuItem;
 import bisq.desktop.main.content.authorized_role.mediator.mu_sig.MuSigMediationCaseListItem;
+import bisq.desktop.main.content.mu_sig.trade.components.MuSigAmountAndPriceDisplay;
 import bisq.i18n.Res;
 import bisq.offer.Direction;
 import bisq.offer.mu_sig.MuSigOffer;
-import bisq.offer.price.spec.FixPriceSpec;
-import bisq.offer.price.spec.PriceSpecFormatter;
-import bisq.presentation.formatters.PriceFormatter;
 import bisq.support.mediation.MediationCaseState;
 import bisq.support.mediation.mu_sig.MuSigMediationCase;
 import bisq.support.mediation.mu_sig.MuSigMediationIssue;
@@ -39,13 +37,11 @@ import bisq.support.mediation.mu_sig.MuSigMediationIssueType;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
 import bisq.support.mediation.mu_sig.MuSigMediatorService;
 import bisq.trade.mu_sig.MuSigTradeFormatter;
-import bisq.trade.mu_sig.MuSigTradeUtils;
 import bisq.user.profile.UserProfile;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -111,6 +107,7 @@ public class MuSigMediationCaseOverviewSection {
             MuSigMediationCase muSigMediationCase = muSigMediationCaseListItem.getMuSigMediationCase();
             MuSigMediationRequest muSigMediationRequest = muSigMediationCase.getMuSigMediationRequest();
             MuSigContract contract = muSigMediationRequest.getContract();
+            model.setContract(contract);
             MuSigOffer offer = contract.getOffer();
 
             MuSigMediationCaseListItem.Trader maker = muSigMediationCaseListItem.getMaker();
@@ -136,14 +133,6 @@ public class MuSigMediationCaseOverviewSection {
             model.setSellerCaseCountOpen(sellerCaseCounts.open());
             model.setSellerCaseCountClosed(sellerCaseCounts.closed());
 
-            model.setNonBtcAmount(MuSigTradeFormatter.formatNonBtcSideAmount(contract));
-            model.setNonBtcCurrency(offer.getMarket().getNonBtcCurrencyCode());
-            model.setBtcAmount(MuSigTradeFormatter.formatBtcSideAmount(contract));
-            model.setPrice(PriceFormatter.format(MuSigTradeUtils.getPriceQuote(contract)));
-            model.setPriceCodes(offer.getMarket().getMarketCodes());
-            model.setPriceSpec(offer.getPriceSpec() instanceof FixPriceSpec
-                    ? ""
-                    : String.format("(%s)", PriceSpecFormatter.getFormattedPriceSpec(offer.getPriceSpec(), true)));
             model.setPaymentMethod(contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString());
             model.setPaymentMethodsBoxVisible(offer.getMarket().isBaseCurrencyBitcoin());
             model.getHasPaymentAccountData().set(false);
@@ -156,7 +145,7 @@ public class MuSigMediationCaseOverviewSection {
             model.getMakerPaymentAccountIssueTooltip().set("");
             maybeAddPaymentAccountDataObservers();
 
-            model.setDepositTxId(Res.get("bisqEasy.openTrades.tradeDetails.dataNotYetProvided"));
+            model.setDepositTxId(Res.get("muSig.trade.details.dataNotYetProvided"));
             model.setDepositTxIdEmpty(true);
         }
 
@@ -302,13 +291,7 @@ public class MuSigMediationCaseOverviewSection {
         private int sellerCaseCountTotal;
         private int sellerCaseCountOpen;
         private int sellerCaseCountClosed;
-
-        private String nonBtcAmount;
-        private String nonBtcCurrency;
-        private String btcAmount;
-        private String price;
-        private String priceCodes;
-        private String priceSpec;
+        private MuSigContract contract;
 
         private String paymentMethod;
         private boolean isPaymentMethodsBoxVisible;
@@ -328,8 +311,7 @@ public class MuSigMediationCaseOverviewSection {
     @Slf4j
     private static class View extends bisq.desktop.common.view.View<VBox, Model, Controller> {
 
-        private final Label nonBtcAmountLabel, nonBtcCurrencyLabel, btcAmountLabel, priceLabel,
-                priceCodesLabel, priceSpecLabel;
+        private final MuSigAmountAndPriceDisplay amountAndPriceDisplay;
         private Label buyerUserNameLabel, sellerUserNameLabel, paymentMethodLabel, depositTxTitleLabel, depositTxDetailsLabel;
         private Label paymentAccountDataWaitingLabel, takerPaymentAccountDataLabel, makerPaymentAccountDataLabel;
         private Button takerPaymentAccountIssueButton, makerPaymentAccountIssueButton;
@@ -342,32 +324,8 @@ public class MuSigMediationCaseOverviewSection {
             super(root, model, controller);
 
             // Amount and price
-            nonBtcAmountLabel = getValueLabel();
-            nonBtcCurrencyLabel = new Label();
-            nonBtcCurrencyLabel.getStyleClass().addAll("text-fill-white", "small-text");
-
-            Label openParenthesisLabel = new Label("(");
-            openParenthesisLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-            btcAmountLabel = getValueLabel();
-            btcAmountLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-            btcAmountLabel.setPadding(new Insets(0, 5, 0, 0));
-            Label btcLabel = new Label("BTC");
-            btcLabel.getStyleClass().addAll("text-fill-grey-dimmed", "small-text");
-            Label closingParenthesisLabel = new Label(")");
-            closingParenthesisLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-            HBox btcAmountHBox = new HBox(openParenthesisLabel, btcAmountLabel, btcLabel, closingParenthesisLabel);
-            btcAmountHBox.setAlignment(Pos.BASELINE_LEFT);
-            Label atLabel = new Label("@");
-            atLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-            priceLabel = getValueLabel();
-            priceCodesLabel = new Label();
-            priceCodesLabel.getStyleClass().addAll("text-fill-white", "small-text");
-            priceSpecLabel = new Label();
-            priceSpecLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-            HBox amountAndPriceDetailsHBox = new HBox(5, nonBtcAmountLabel, nonBtcCurrencyLabel, btcAmountHBox,
-                    atLabel, priceLabel, priceCodesLabel, priceSpecLabel);
-            amountAndPriceDetailsHBox.setAlignment(Pos.BASELINE_LEFT);
-            HBox amountAndPriceBox = createAndGetDescriptionAndValueBox("bisqEasy.openTrades.tradeDetails.amountAndPrice", amountAndPriceDetailsHBox);
+            amountAndPriceDisplay = new MuSigAmountAndPriceDisplay();
+            HBox amountAndPriceBox = createAndGetDescriptionAndValueBox("muSig.trade.details.amountAndPrice", amountAndPriceDisplay);
 
             VBox content;
 
@@ -387,7 +345,7 @@ public class MuSigMediationCaseOverviewSection {
                 paymentMethodLabel = getValueLabel();
                 HBox paymentMethodsDetailsHBox = new HBox(5, paymentMethodLabel);
                 paymentMethodsDetailsHBox.setAlignment(Pos.BASELINE_LEFT);
-                paymentMethodsBox = createAndGetDescriptionAndValueBox("bisqEasy.openTrades.tradeDetails.paymentAndSettlementMethods",
+                paymentMethodsBox = createAndGetDescriptionAndValueBox("muSig.trade.details.paymentAndSettlementMethod",
                         paymentMethodsDetailsHBox);
 
                 // Deposit transaction ID
@@ -471,8 +429,8 @@ public class MuSigMediationCaseOverviewSection {
                 paymentMethodsBox.setManaged(model.isPaymentMethodsBoxVisible());
 
                 depositTxDetailsLabel.setText(model.getDepositTxId());
-                depositTxTitleLabel.setText(Res.get("bisqEasy.openTrades.tradeDetails.txId"));
-                depositTxCopyButton.setTooltip(Res.get("bisqEasy.openTrades.tradeDetails.txId.copy"));
+                depositTxTitleLabel.setText(Res.get("muSig.trade.details.depositTxId"));
+                depositTxCopyButton.setTooltip(Res.get("muSig.trade.details.depositTxId.copy"));
                 depositTxCopyButton.setVisible(!model.isDepositTxIdEmpty());
                 depositTxCopyButton.setManaged(!model.isDepositTxIdEmpty());
                 depositTxDetailsLabel.getStyleClass().clear();
@@ -530,12 +488,7 @@ public class MuSigMediationCaseOverviewSection {
                 paymentAccountDataRefreshButton.setOnAction(e -> controller.requestPaymentAccountData());
             }
 
-            nonBtcAmountLabel.setText(model.getNonBtcAmount());
-            nonBtcCurrencyLabel.setText(model.getNonBtcCurrency());
-            btcAmountLabel.setText(model.getBtcAmount());
-            priceLabel.setText(model.getPrice());
-            priceCodesLabel.setText(model.getPriceCodes());
-            priceSpecLabel.setText(model.getPriceSpec());
+            amountAndPriceDisplay.setContract(model.getContract());
         }
 
         @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/components/MuSigAmountAndPriceDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/components/MuSigAmountAndPriceDisplay.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.mu_sig.trade.components;
+
+import bisq.common.market.Market;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.offer.mu_sig.MuSigOffer;
+import bisq.presentation.formatters.PriceFormatter;
+import bisq.trade.mu_sig.MuSigTradeFormatter;
+import bisq.trade.mu_sig.MuSigTradeUtils;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+
+import static bisq.desktop.components.helpers.LabeledValueRowFactory.getValueLabel;
+
+public class MuSigAmountAndPriceDisplay extends HBox {
+    private final Label nonBtcAmountLabel;
+    private final Label nonBtcCurrencyLabel;
+    private final Label btcAmountLabel;
+    private final Label priceLabel;
+    private final Label priceCodesLabel;
+
+    public MuSigAmountAndPriceDisplay() {
+        super(5);
+        setAlignment(Pos.BASELINE_LEFT);
+
+        nonBtcAmountLabel = getValueLabel();
+        nonBtcCurrencyLabel = new Label();
+        nonBtcCurrencyLabel.getStyleClass().addAll("text-fill-white", "small-text");
+
+        Label openParenthesisLabel = new Label("(");
+        openParenthesisLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        btcAmountLabel = getValueLabel();
+        btcAmountLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        btcAmountLabel.setPadding(new Insets(0, 5, 0, 0));
+        Label btcLabel = new Label("BTC");
+        btcLabel.getStyleClass().addAll("text-fill-grey-dimmed", "small-text");
+        Label closingParenthesisLabel = new Label(")");
+        closingParenthesisLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        HBox btcAmountBox = new HBox(openParenthesisLabel, btcAmountLabel, btcLabel, closingParenthesisLabel);
+        btcAmountBox.setAlignment(Pos.BASELINE_LEFT);
+
+        Label atLabel = new Label("@");
+        atLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
+        priceLabel = getValueLabel();
+        priceCodesLabel = new Label();
+        priceCodesLabel.getStyleClass().addAll("text-fill-white", "small-text");
+
+        getChildren().addAll(nonBtcAmountLabel, nonBtcCurrencyLabel, btcAmountBox, atLabel, priceLabel, priceCodesLabel);
+    }
+
+    public void setContract(MuSigContract contract) {
+        MuSigOffer offer = contract.getOffer();
+        Market market = offer.getMarket();
+        boolean isBaseCurrencyBitcoin = market.isBaseCurrencyBitcoin();
+
+        nonBtcAmountLabel.setText(MuSigTradeFormatter.formatNonBtcSideAmount(contract));
+        nonBtcCurrencyLabel.setText(market.getNonBtcCurrencyCode());
+        btcAmountLabel.setText(MuSigTradeFormatter.formatBtcSideAmount(contract));
+        priceLabel.setText(PriceFormatter.format(MuSigTradeUtils.getPriceQuote(contract), isBaseCurrencyBitcoin));
+        priceCodesLabel.setText(market.getMarketCodes());
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsController.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.mu_sig.trade.pending.trade_details;
 
 import bisq.account.accounts.AccountPayload;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
-import bisq.common.market.Market;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.view.Controller;
@@ -28,14 +27,10 @@ import bisq.desktop.common.view.NavigationController;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.overlay.OverlayController;
 import bisq.i18n.Res;
-import bisq.offer.price.spec.FixPriceSpec;
-import bisq.offer.price.spec.PriceSpecFormatter;
 import bisq.presentation.formatters.DateFormatter;
-import bisq.presentation.formatters.PriceFormatter;
 import bisq.presentation.formatters.TimeFormatter;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.MuSigTradeFormatter;
-import bisq.trade.mu_sig.MuSigTradeUtils;
 import bisq.user.profile.UserProfile;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -83,8 +78,8 @@ public class MuSigTradeDetailsController extends NavigationController implements
         MuSigTrade trade = model.getTrade();
         MuSigOpenTradeChannel channel = model.getChannel();
         MuSigContract contract = trade.getContract();
-        Market market = trade.getMarket();
-        boolean isBaseCurrencyBitcoin = market.isBaseCurrencyBitcoin();
+        model.setContract(contract);
+        boolean isBaseCurrencyBitcoin = trade.getMarket().isBaseCurrencyBitcoin();
 
         model.setTradeDate(DateFormatter.formatDateTime(contract.getTakeOfferDate()));
 
@@ -101,16 +96,6 @@ public class MuSigTradeDetailsController extends NavigationController implements
         model.setMarket(Res.get("muSig.trade.details.offerTypeAndMarket.nonBtcMarket",
                 trade.getOffer().getMarket().getNonBtcCurrencyCode()));
 
-        model.setNonBtcAmount(MuSigTradeFormatter.formatNonBtcSideAmount(trade));
-        model.setNonBtcCurrency(trade.getOffer().getMarket().getNonBtcCurrencyCode());
-        model.setBtcAmount(MuSigTradeFormatter.formatBtcSideAmount(trade));
-
-        model.setPrice(PriceFormatter.format(MuSigTradeUtils.getPriceQuote(contract), isBaseCurrencyBitcoin));
-        model.setPriceCodes(trade.getOffer().getMarket().getMarketCodes());
-        model.setPriceSpec(trade.getOffer().getPriceSpec() instanceof FixPriceSpec
-                ? ""
-                : String.format("(%s)", PriceSpecFormatter.getFormattedPriceSpec(trade.getOffer().getPriceSpec(), true)));
-
         model.setPaymentMethod(contract.getNonBtcSidePaymentMethodSpec().getShortDisplayString());
         model.setPaymentMethodsBoxVisible(isBaseCurrencyBitcoin);
 
@@ -122,7 +107,7 @@ public class MuSigTradeDetailsController extends NavigationController implements
 
         model.setPeersPaymentAccountDataDescription(isBaseCurrencyBitcoin
                 ? Res.get("muSig.trade.details.paymentAccountData.fiat")
-                : Res.get("muSig.trade.details.paymentAccountData.crypto", market.getNonBtcCurrencyCode())
+                : Res.get("muSig.trade.details.paymentAccountData.crypto", trade.getMarket().getNonBtcCurrencyCode())
         );
         model.setPeersPaymentAccountData(peersAccountPayload.isEmpty()
                 ? Res.get("muSig.trade.details.dataNotYetProvided")

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsModel.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.content.mu_sig.trade.pending.trade_details;
 
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
+import bisq.contract.mu_sig.MuSigContract;
 import bisq.desktop.common.view.NavigationModel;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.trade.mu_sig.MuSigTrade;
@@ -33,6 +34,7 @@ import java.util.Optional;
 public class MuSigTradeDetailsModel extends NavigationModel {
     private MuSigTrade trade;
     private MuSigOpenTradeChannel channel;
+    private MuSigContract contract;
 
     private String tradeDate;
     private Optional<String> tradeDuration = Optional.empty();
@@ -40,12 +42,6 @@ public class MuSigTradeDetailsModel extends NavigationModel {
     private String peer;
     private String offerType;
     private String market;
-    private String nonBtcAmount;
-    private String nonBtcCurrency;
-    private String btcAmount;
-    private String price;
-    private String priceCodes;
-    private String priceSpec;
     private String paymentMethod;
     private boolean isPaymentMethodsBoxVisible;
     private String tradeId;

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_details/MuSigTradeDetailsView.java
@@ -22,6 +22,7 @@ import bisq.desktop.common.view.NavigationView;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqIconButton;
 import bisq.desktop.components.controls.BisqMenuItem;
+import bisq.desktop.main.content.mu_sig.trade.components.MuSigAmountAndPriceDisplay;
 import bisq.desktop.overlay.OverlayModel;
 import bisq.i18n.Res;
 import javafx.geometry.Insets;
@@ -44,14 +45,14 @@ import static bisq.desktop.components.helpers.LabeledValueRowFactory.getValueLab
 @Slf4j
 public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetailsModel, MuSigTradeDetailsController> {
     private final Button closeButton;
-    private final Label tradeDateLabel, tradeDurationLabel, meLabel, peerLabel, offerTypeLabel, marketLabel, nonBtcAmountLabel,
-            nonBtcCurrencyLabel, btcAmountLabel, priceLabel, priceCodesLabel, priceSpecLabel, paymentMethodValue,
+    private final Label tradeDateLabel, tradeDurationLabel, meLabel, peerLabel, offerTypeLabel, marketLabel, paymentMethodValue,
             tradeIdLabel, peerNetworkAddressLabel,
             peersPaymentAccountData, depositTxDetailsLabel, peersAccountPayloadDescription,
             assignedMediatorLabel;
     private final BisqMenuItem tradersAndRoleCopyButton, tradeIdCopyButton, peerNetworkAddressCopyButton,
             depositTxCopyButton, peersAccountDataCopyButton;
     private final HBox assignedMediatorBox, depositTxBox, tradeDurationBox, paymentMethodsBox;
+    private final MuSigAmountAndPriceDisplay amountAndPriceDisplay;
 
     public MuSigTradeDetailsView(MuSigTradeDetailsModel model, MuSigTradeDetailsController controller) {
         super(new VBox(10), model, controller);
@@ -113,32 +114,8 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
                 offerTypeAndMarketDetailsHBox);
 
         // Amount and price
-        nonBtcAmountLabel = getValueLabel();
-        nonBtcCurrencyLabel = new Label();
-        nonBtcCurrencyLabel.getStyleClass().addAll("text-fill-white", "small-text");
-
-        Label openParenthesisLabel = new Label("(");
-        openParenthesisLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-        btcAmountLabel = getValueLabel();
-        btcAmountLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-        btcAmountLabel.setPadding(new Insets(0, 5, 0, 0));
-        Label btcLabel = new Label("BTC");
-        btcLabel.getStyleClass().addAll("text-fill-grey-dimmed", "small-text");
-        Label closingParenthesisLabel = new Label(")");
-        closingParenthesisLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-        HBox btcAmountHBox = new HBox(openParenthesisLabel, btcAmountLabel, btcLabel, closingParenthesisLabel);
-        btcAmountHBox.setAlignment(Pos.BASELINE_LEFT);
-        Label atLabel = new Label("@");
-        atLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-        priceLabel = getValueLabel();
-        priceCodesLabel = new Label();
-        priceCodesLabel.getStyleClass().addAll("text-fill-white", "small-text");
-        priceSpecLabel = new Label();
-        priceSpecLabel.getStyleClass().addAll("text-fill-grey-dimmed", "normal-text");
-        HBox amountAndPriceDetailsHBox = new HBox(5, nonBtcAmountLabel, nonBtcCurrencyLabel, btcAmountHBox,
-                atLabel, priceLabel, priceCodesLabel, priceSpecLabel);
-        amountAndPriceDetailsHBox.setAlignment(Pos.BASELINE_LEFT);
-        HBox amountAndPriceBox = createAndGetDescriptionAndValueBox("muSig.trade.details.amountAndPrice", amountAndPriceDetailsHBox);
+        amountAndPriceDisplay = new MuSigAmountAndPriceDisplay();
+        HBox amountAndPriceBox = createAndGetDescriptionAndValueBox("muSig.trade.details.amountAndPrice", amountAndPriceDisplay);
 
         // Payment method
         paymentMethodValue = getValueLabel();
@@ -218,12 +195,7 @@ public class MuSigTradeDetailsView extends NavigationView<VBox, MuSigTradeDetail
         peerLabel.setText(model.getPeer());
         offerTypeLabel.setText(model.getOfferType());
         marketLabel.setText(model.getMarket());
-        nonBtcAmountLabel.setText(model.getNonBtcAmount());
-        nonBtcCurrencyLabel.setText(model.getNonBtcCurrency());
-        btcAmountLabel.setText(model.getBtcAmount());
-        priceLabel.setText(model.getPrice());
-        priceCodesLabel.setText(model.getPriceCodes());
-        priceSpecLabel.setText(model.getPriceSpec());
+        amountAndPriceDisplay.setContract(model.getContract());
         paymentMethodValue.setText(model.getPaymentMethod());
         paymentMethodsBox.setVisible(model.isPaymentMethodsBoxVisible());
         paymentMethodsBox.setManaged(model.isPaymentMethodsBoxVisible());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single consolidated amount & price display for MuSig trades for a cleaner, single-line presentation.
* **Refactor**
  * Centralized contract data in the trade model and removed redundant amount/price fields to simplify data flow.
* **UI**
  * Updated deposit transaction, amount/price, and payment/settlement method labels/tooltips to MuSig-specific wording and improved compact/full view rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->