### PR TITLE
Process pending Bisq Easy open-trade messages after channel creation

### DIFF
--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
@@ -40,7 +40,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -98,8 +97,10 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
                                                                UserIdentity myUserIdentity,
                                                                UserProfile peer,
                                                                Optional<UserProfile> mediator) {
-        return findChannelByTradeId(tradeId)
+        BisqEasyOpenTradeChannel channel = findChannelByTradeId(tradeId)
                 .orElseGet(() -> traderCreatesChannel(tradeId, bisqEasyOffer, myUserIdentity, peer, mediator));
+        processPendingMessages(tradeId);
+        return channel;
     }
 
     public BisqEasyOpenTradeChannel traderCreatesChannel(String tradeId,
@@ -118,17 +119,19 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
                                                                  UserIdentity myUserIdentity,
                                                                  UserProfile requestingTrader,
                                                                  UserProfile nonRequestingTrader) {
-        return findChannelByTradeId(tradeId)
+        BisqEasyOpenTradeChannel channel = findChannelByTradeId(tradeId)
                 .orElseGet(() -> {
-                    BisqEasyOpenTradeChannel channel = BisqEasyOpenTradeChannel.createByMediator(tradeId,
+                    BisqEasyOpenTradeChannel newChannel = BisqEasyOpenTradeChannel.createByMediator(tradeId,
                             bisqEasyOffer,
                             myUserIdentity,
                             requestingTrader,
                             nonRequestingTrader);
-                    getChannels().add(channel);
+                    getChannels().add(newChannel);
                     persist();
-                    return channel;
+                    return newChannel;
                 });
+        processPendingMessages(tradeId);
+        return channel;
     }
 
     public CompletableFuture<SendMessageResult> sendTakeOfferMessage(String tradeId,
@@ -360,5 +363,11 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
 
     private boolean allowSendLeaveMessage(BisqEasyOpenTradeChannel channel, UserProfile userProfile) {
         return channel.getUserProfileIdsOfSendingLeaveMessage().contains(userProfile.getId());
+    }
+
+    private void processPendingMessages(String tradeId) {
+        pendingMessages.stream()
+                .filter(message -> message.getTradeId().equals(tradeId))
+                .forEach(this::processMessage);
     }
 }


### PR DESCRIPTION
fixes #4556 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling in trade channels. Pending messages are now processed and delivered reliably when channels are established or reconnected for trades. Both traders and mediators will receive complete message history without delays during channel initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->