### PR TITLE
Add mediator signature to MuSig mediation result

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationResultSection.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/components/MuSigMediationResultSection.java
@@ -458,6 +458,7 @@ public class MuSigMediationResultSection {
 
                 String summaryNotes = model.getSummaryNotes().get();
                 MuSigMediationResult muSigMediationResult = muSigMediatorService.createMuSigMediationResult(
+                        muSigMediationCase.getMuSigMediationRequest().getContract(),
                         selectedReason,
                         selectedPayoutDistributionType,
                         optionalBuyerPayoutAmount,

--- a/contract/src/main/java/bisq/contract/ContractService.java
+++ b/contract/src/main/java/bisq/contract/ContractService.java
@@ -52,7 +52,7 @@ public class ContractService implements Service {
         return SignatureUtil.verify(contractHash, signatureData.getSignature(), signatureData.getPublicKey());
     }
 
-    private <T extends Offer<?, ?>> byte[] getContractHash(Contract<T> contract) {
+    public static <T extends Offer<?, ?>> byte[] getContractHash(Contract<T> contract) {
         return DigestUtil.hash(contract.serializeForHash());
     }
 }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationCase.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationCase.java
@@ -20,11 +20,14 @@ package bisq.support.mediation.mu_sig;
 import bisq.account.accounts.AccountPayload;
 import bisq.common.observable.Observable;
 import bisq.common.proto.PersistableProto;
+import bisq.common.validation.NetworkDataValidation;
 import bisq.support.mediation.MediationCaseState;
+import com.google.protobuf.ByteString;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +41,7 @@ public class MuSigMediationCase implements PersistableProto {
     private final long requestDate;
     private final Observable<MediationCaseState> mediationCaseState = new Observable<>();
     private final Observable<Optional<MuSigMediationResult>> muSigMediationResult = new Observable<>();
+    private Optional<byte[]> mediationResultSignature = Optional.empty();
     private final Observable<Optional<AccountPayload<?>>> takerAccountPayload = new Observable<>(Optional.empty());
     private final Observable<Optional<AccountPayload<?>>> makerAccountPayload = new Observable<>(Optional.empty());
     private final Observable<List<MuSigMediationIssue>> issues = new Observable<>(List.of());
@@ -49,6 +53,7 @@ public class MuSigMediationCase implements PersistableProto {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 List.of());
     }
 
@@ -56,6 +61,7 @@ public class MuSigMediationCase implements PersistableProto {
                                long requestDate,
                                MediationCaseState mediationCaseState,
                                Optional<MuSigMediationResult> muSigMediationResult,
+                               Optional<byte[]> mediationResultSignature,
                                Optional<AccountPayload<?>> takerAccountPayload,
                                Optional<AccountPayload<?>> makerAccountPayload,
                                List<MuSigMediationIssue> issues) {
@@ -63,6 +69,7 @@ public class MuSigMediationCase implements PersistableProto {
         this.requestDate = requestDate;
         this.mediationCaseState.set(mediationCaseState);
         this.muSigMediationResult.set(muSigMediationResult);
+        this.mediationResultSignature = mediationResultSignature.map(byte[]::clone);
         this.takerAccountPayload.set(takerAccountPayload);
         this.makerAccountPayload.set(makerAccountPayload);
         this.issues.set(issues);
@@ -80,6 +87,7 @@ public class MuSigMediationCase implements PersistableProto {
                 .setMediationCaseState(mediationCaseState.get().toProtoEnum());
         muSigMediationResult.get().ifPresent(item ->
                 builder.setMuSigMediationResult(item.toProto(serializeForHash)));
+        mediationResultSignature.ifPresent(item -> builder.setMediationResultSignature(ByteString.copyFrom(item)));
         takerAccountPayload.get().ifPresent(item -> builder.setTakerAccountPayload(item.toProto(serializeForHash)));
         makerAccountPayload.get().ifPresent(item -> builder.setMakerAccountPayload(item.toProto(serializeForHash)));
         builder.addAllIssues(issues.get().stream()
@@ -100,6 +108,9 @@ public class MuSigMediationCase implements PersistableProto {
                 proto.hasMuSigMediationResult() ?
                         Optional.of(MuSigMediationResult.fromProto(proto.getMuSigMediationResult())) :
                         Optional.empty(),
+                proto.hasMediationResultSignature() ?
+                        Optional.of(proto.getMediationResultSignature().toByteArray()) :
+                        Optional.empty(),
                 proto.hasTakerAccountPayload() ?
                         Optional.of(AccountPayload.fromProto(proto.getTakerAccountPayload())) :
                         Optional.empty(),
@@ -119,16 +130,30 @@ public class MuSigMediationCase implements PersistableProto {
         return true;
     }
 
-    public boolean setMuSigMediationResult(MuSigMediationResult result) {
+    public Optional<byte[]> getMediationResultSignature() {
+        return mediationResultSignature.map(byte[]::clone);
+    }
+
+    public boolean setSignedMuSigMediationResult(MuSigMediationResult result, byte[] signature) {
+        NetworkDataValidation.validateECSignature(signature);
+        byte[] signatureCopy = signature.clone();
         Optional<MuSigMediationResult> currentResult = muSigMediationResult.get();
-        if (currentResult.isPresent() && !currentResult.get().equals(result)) {
+        if (currentResult.isPresent() && !currentResult.orElseThrow().equals(result)) {
             throw new IllegalArgumentException("MuSigMediationResult cannot be changed once set.");
         }
-        var newResult = Optional.of(result);
-        if (currentResult.equals(newResult)) {
+        Optional<byte[]> currentSignature = mediationResultSignature;
+        if (currentSignature.isPresent() && !Arrays.equals(currentSignature.orElseThrow(), signatureCopy)) {
+            throw new IllegalArgumentException("mediationResultSignature cannot be changed once set.");
+        }
+        if (currentResult.isPresent() && currentSignature.isPresent()) {
             return false;
         }
-        muSigMediationResult.set(newResult);
+        if (currentResult.isEmpty()) {
+            muSigMediationResult.set(Optional.of(result));
+        }
+        if (currentSignature.isEmpty()) {
+            mediationResultSignature = Optional.of(signatureCopy);
+        }
         return true;
     }
 

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequestService.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequestService.java
@@ -46,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Optional;
@@ -264,6 +265,10 @@ public class MuSigMediationRequestService implements Service, ConfidentialMessag
                                     pendingMuSigMediationStateChangeMessages.remove(message);
                                     return;
                                 }
+                                if (!hasValidMediatorSignature(channel, message)) {
+                                    pendingMuSigMediationStateChangeMessages.remove(message);
+                                    return;
+                                }
                                 // Closed mediation case still keeps mediator chat participation active.
                                 muSigOpenTradeChannelService.setIsInMediation(channel, true);
                             } else {
@@ -303,6 +308,34 @@ public class MuSigMediationRequestService implements Service, ConfidentialMessag
                                 });
                             }
                         });
+    }
+
+    private boolean hasValidMediatorSignature(MuSigOpenTradeChannel channel,
+                                              MuSigMediationStateChangeMessage message) {
+        try {
+            if (channel.getMediator().isEmpty()) {
+                log.warn("Ignoring MuSigMediationStateChangeMessage for trade {} because channel mediator is missing.",
+                        message.getTradeId());
+                return false;
+            }
+            if (message.getMediationResultSignature().isEmpty()) {
+                log.warn("Ignoring MuSigMediationStateChangeMessage for trade {} because mediator signature is missing.",
+                        message.getTradeId());
+                return false;
+            }
+            if (!MuSigMediationResultService.verifyMediationResult(message.getMuSigMediationResult().orElseThrow(),
+                    message.getMediationResultSignature().orElseThrow(),
+                    channel.getMediator().orElseThrow().getNetworkId().getPubKey().getPublicKey())) {
+                log.warn("Ignoring MuSigMediationStateChangeMessage for trade {} because mediator signature verification failed.",
+                        message.getTradeId());
+                return false;
+            }
+            return true;
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            log.warn("Ignoring MuSigMediationStateChangeMessage for trade {} because mediator signature verification failed.",
+                    message.getTradeId(), e);
+            return false;
+        }
     }
 
     private void maybeProcessPendingMessages() {

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResult.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResult.java
@@ -22,20 +22,22 @@ import bisq.common.proto.PersistableProto;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.support.mediation.MediationPayoutDistributionType;
 import bisq.support.mediation.MediationResultReason;
-import lombok.EqualsAndHashCode;
+import com.google.protobuf.ByteString;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.System.currentTimeMillis;
 
 @Getter
-@EqualsAndHashCode
 public class MuSigMediationResult implements NetworkProto, PersistableProto {
     public static final int MAX_SUMMARY_NOTES_LENGTH = 1_000;
 
     private final long date;
+    private final byte[] contractHash;
     private final MediationResultReason mediationResultReason;
     private final MediationPayoutDistributionType mediationPayoutDistributionType;
     private final Optional<Long> proposedBuyerPayoutAmount;
@@ -43,13 +45,15 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
     private final Optional<Double> payoutAdjustmentPercentage;
     private final Optional<String> summaryNotes;
 
-    public MuSigMediationResult(MediationResultReason mediationResultReason,
+    public MuSigMediationResult(byte[] contractHash,
+                                MediationResultReason mediationResultReason,
                                 MediationPayoutDistributionType mediationPayoutDistributionType,
                                 Optional<Long> proposedBuyerPayoutAmount,
                                 Optional<Long> proposedSellerPayoutAmount,
                                 Optional<Double> payoutAdjustmentPercentage,
                                 Optional<String> summaryNotes) {
         this(currentTimeMillis(),
+                contractHash,
                 mediationResultReason,
                 mediationPayoutDistributionType,
                 proposedBuyerPayoutAmount,
@@ -59,6 +63,7 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
     }
 
     private MuSigMediationResult(long date,
+                                 byte[] contractHash,
                                  MediationResultReason mediationResultReason,
                                  MediationPayoutDistributionType mediationPayoutDistributionType,
                                  Optional<Long> proposedBuyerPayoutAmount,
@@ -66,6 +71,7 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
                                  Optional<Double> payoutAdjustmentPercentage,
                                  Optional<String> summaryNotes) {
         this.date = date;
+        this.contractHash = contractHash.clone();
         this.mediationResultReason = mediationResultReason;
         this.mediationPayoutDistributionType = mediationPayoutDistributionType;
         this.proposedBuyerPayoutAmount = proposedBuyerPayoutAmount;
@@ -79,6 +85,7 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
     @Override
     public void verify() {
         NetworkDataValidation.validateDate(date);
+        NetworkDataValidation.validateHash(contractHash);
         checkArgument(mediationResultReason != null, "mediationResultReason must not be null");
         checkArgument(mediationPayoutDistributionType != null, "mediationPayoutDistributionType must not be null");
         boolean noPayout = mediationPayoutDistributionType == MediationPayoutDistributionType.NO_PAYOUT;
@@ -97,6 +104,7 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
     public bisq.support.protobuf.MuSigMediationResult.Builder getBuilder(boolean serializeForHash) {
         var builder = bisq.support.protobuf.MuSigMediationResult.newBuilder()
                 .setDate(date)
+                .setContractHash(ByteString.copyFrom(contractHash))
                 .setMediationResultReason(mediationResultReason.toProtoEnum())
                 .setMediationPayoutDistributionType(mediationPayoutDistributionType.toProtoEnum());
         proposedBuyerPayoutAmount.ifPresent(builder::setProposedBuyerPayoutAmount);
@@ -106,7 +114,6 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
         return builder;
     }
 
-
     @Override
     public bisq.support.protobuf.MuSigMediationResult toProto(boolean serializeForHash) {
         return unsafeToProto(serializeForHash);
@@ -115,11 +122,44 @@ public class MuSigMediationResult implements NetworkProto, PersistableProto {
     public static MuSigMediationResult fromProto(bisq.support.protobuf.MuSigMediationResult proto) {
         return new MuSigMediationResult(
                 proto.getDate(),
+                proto.getContractHash().toByteArray(),
                 MediationResultReason.fromProto(proto.getMediationResultReason()),
                 MediationPayoutDistributionType.fromProto(proto.getMediationPayoutDistributionType()),
                 proto.hasProposedBuyerPayoutAmount() ? Optional.of(proto.getProposedBuyerPayoutAmount()) : Optional.empty(),
                 proto.hasProposedSellerPayoutAmount() ? Optional.of(proto.getProposedSellerPayoutAmount()) : Optional.empty(),
                 proto.hasPayoutAdjustmentPercentage() ? Optional.of(proto.getPayoutAdjustmentPercentage()) : Optional.empty(),
                 proto.hasSummaryNotes() ? Optional.of(proto.getSummaryNotes()) : Optional.empty());
+    }
+
+    public byte[] getContractHash() {
+        return contractHash.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MuSigMediationResult that)) {
+            return false;
+        }
+        return date == that.date &&
+                Arrays.equals(contractHash, that.contractHash) &&
+                mediationResultReason == that.mediationResultReason &&
+                mediationPayoutDistributionType == that.mediationPayoutDistributionType &&
+                Objects.equals(proposedBuyerPayoutAmount, that.proposedBuyerPayoutAmount) &&
+                Objects.equals(proposedSellerPayoutAmount, that.proposedSellerPayoutAmount) &&
+                Objects.equals(payoutAdjustmentPercentage, that.payoutAdjustmentPercentage) &&
+                Objects.equals(summaryNotes, that.summaryNotes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(date,
+                mediationResultReason,
+                mediationPayoutDistributionType,
+                proposedBuyerPayoutAmount,
+                proposedSellerPayoutAmount,
+                payoutAdjustmentPercentage,
+                summaryNotes);
+        result = 31 * result + Arrays.hashCode(contractHash);
+        return result;
     }
 }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultService.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultService.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.contract.ContractService;
+import bisq.security.DigestUtil;
+import bisq.security.SignatureUtil;
+import bisq.common.validation.NetworkDataValidation;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class MuSigMediationResultService {
+    private MuSigMediationResultService() {
+    }
+
+    public static byte[] signMediationResult(MuSigMediationResult muSigMediationResult,
+                                             KeyPair keyPair)
+            throws GeneralSecurityException {
+        byte[] mediationResultHash = getMediationResultHash(muSigMediationResult);
+        return SignatureUtil.sign(mediationResultHash, keyPair.getPrivate());
+    }
+
+    public static boolean verifyMediationResult(MuSigMediationResult mediationResult,
+                                                byte[] mediationResultSignature,
+                                                PublicKey publicKey) throws GeneralSecurityException {
+        NetworkDataValidation.validateECSignature(mediationResultSignature);
+        return SignatureUtil.verify(getMediationResultHash(mediationResult), mediationResultSignature, publicKey);
+    }
+
+    public static boolean verifyMediationResult(MuSigMediationResult mediationResult,
+                                                byte[] mediationResultSignature,
+                                                MuSigContract contract,
+                                                PublicKey publicKey) throws GeneralSecurityException {
+        checkArgument(Arrays.equals(mediationResult.getContractHash(), ContractService.getContractHash(contract)),
+                "Contract hash from MuSigMediationResult does not match the given contract");
+        return verifyMediationResult(mediationResult, mediationResultSignature, publicKey);
+    }
+
+    private static byte[] getMediationResultHash(MuSigMediationResult mediationResult) {
+        return DigestUtil.hash(mediationResult.serializeForHash());
+    }
+}

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationStateChangeMessage.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationStateChangeMessage.java
@@ -19,17 +19,20 @@ package bisq.support.mediation.mu_sig;
 
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.OptionalUtils;
 import bisq.common.validation.NetworkDataValidation;
 import bisq.network.p2p.message.ExternalNetworkMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
 import bisq.support.mediation.MediationCaseState;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
@@ -38,23 +41,24 @@ import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 @Slf4j
 @Getter
 @ToString
-@EqualsAndHashCode
 public final class MuSigMediationStateChangeMessage implements MailboxMessage, ExternalNetworkMessage {
     private transient final MetaData metaData = new MetaData(TTL_10_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
     private final String id;
     private final String tradeId;
     private final MediationCaseState mediationCaseState;
     private final Optional<MuSigMediationResult> muSigMediationResult;
+    private final Optional<byte[]> mediationResultSignature;
 
     public MuSigMediationStateChangeMessage(String id,
                                             String tradeId,
                                             MediationCaseState mediationCaseState,
-                                            Optional<MuSigMediationResult> muSigMediationResult) {
+                                            Optional<MuSigMediationResult> muSigMediationResult,
+                                            Optional<byte[]> mediationResultSignature) {
         this.id = id;
         this.tradeId = tradeId;
         this.mediationCaseState = mediationCaseState;
         this.muSigMediationResult = muSigMediationResult;
-
+        this.mediationResultSignature = mediationResultSignature.map(byte[]::clone);
         verify();
     }
 
@@ -65,6 +69,10 @@ public final class MuSigMediationStateChangeMessage implements MailboxMessage, E
         if (mediationCaseState == MediationCaseState.CLOSED && muSigMediationResult.isEmpty()) {
             throw new IllegalArgumentException("Closed mediation case state must contain MuSigMediationResult.");
         }
+        if (muSigMediationResult.isPresent() && mediationResultSignature.isEmpty()) {
+            throw new IllegalArgumentException("MuSig mediation result must contain mediationResultSignature.");
+        }
+        mediationResultSignature.ifPresent(NetworkDataValidation::validateECSignature);
     }
 
     @Override
@@ -74,6 +82,7 @@ public final class MuSigMediationStateChangeMessage implements MailboxMessage, E
                 .setTradeId(tradeId)
                 .setMediationCaseState(mediationCaseState.toProtoEnum());
         muSigMediationResult.ifPresent(result -> builder.setMuSigMediationResult(result.toProto(serializeForHash)));
+        mediationResultSignature.ifPresent(signature -> builder.setMediationResultSignature(ByteString.copyFrom(signature)));
         return builder;
     }
 
@@ -84,6 +93,9 @@ public final class MuSigMediationStateChangeMessage implements MailboxMessage, E
                 MediationCaseState.fromProto(proto.getMediationCaseState()),
                 proto.hasMuSigMediationResult()
                         ? Optional.of(MuSigMediationResult.fromProto(proto.getMuSigMediationResult()))
+                        : Optional.empty(),
+                proto.hasMediationResultSignature()
+                        ? Optional.of(proto.getMediationResultSignature().toByteArray())
                         : Optional.empty()
         );
     }
@@ -102,5 +114,28 @@ public final class MuSigMediationStateChangeMessage implements MailboxMessage, E
     @Override
     public double getCostFactor() {
         return getCostFactor(0.1, 0.2);
+    }
+
+    public Optional<byte[]> getMediationResultSignature() {
+        return mediationResultSignature.map(byte[]::clone);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MuSigMediationStateChangeMessage that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id) &&
+                Objects.equals(tradeId, that.tradeId) &&
+                mediationCaseState == that.mediationCaseState &&
+                Objects.equals(muSigMediationResult, that.muSigMediationResult) &&
+                OptionalUtils.optionalByteArrayEquals(mediationResultSignature, that.mediationResultSignature);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(id, tradeId, mediationCaseState, muSigMediationResult);
+        result = 31 * result + mediationResultSignature.map(Arrays::hashCode).orElse(0);
+        return result;
     }
 }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediatorService.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediatorService.java
@@ -27,6 +27,7 @@ import bisq.chat.mu_sig.open_trades.MuSigOpenTradeMessage;
 import bisq.common.application.Service;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.util.StringUtils;
+import bisq.contract.ContractService;
 import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.i18n.Res;
@@ -53,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.security.GeneralSecurityException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -121,13 +123,15 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
     // API
     /* --------------------------------------------------------------------- */
 
-    public MuSigMediationResult createMuSigMediationResult(MediationResultReason mediationResultReason,
+    public MuSigMediationResult createMuSigMediationResult(MuSigContract contract,
+                                                           MediationResultReason mediationResultReason,
                                                            MediationPayoutDistributionType mediationPayoutDistributionType,
                                                            Optional<Long> proposedBuyerPayoutAmount,
                                                            Optional<Long> proposedSellerPayoutAmount,
                                                            Optional<Double> payoutAdjustmentPercentage,
                                                            Optional<String> summaryNotes) {
-        return new MuSigMediationResult(mediationResultReason, mediationPayoutDistributionType,
+        return new MuSigMediationResult(ContractService.getContractHash(contract),
+                mediationResultReason, mediationPayoutDistributionType,
                 proposedBuyerPayoutAmount, proposedSellerPayoutAmount,
                 payoutAdjustmentPercentage, summaryNotes);
     }
@@ -140,11 +144,15 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
         }
 
         MuSigMediationResult resultToUse = existingResult.orElse(muSigMediationResult);
-        boolean resultChanged = muSigMediationCase.setMuSigMediationResult(resultToUse);
+        boolean resultChanged = false;
+        if (existingResult.isEmpty() || muSigMediationCase.getMediationResultSignature().isEmpty()) {
+            byte[] mediationResultSignature = createMediationResultSignature(muSigMediationCase, resultToUse);
+            resultChanged = muSigMediationCase.setSignedMuSigMediationResult(resultToUse, mediationResultSignature);
+        }
         boolean stateChanged = muSigMediationCase.setMediationCaseState(MediationCaseState.CLOSED);
         if (resultChanged || stateChanged) {
             persist();
-            sendMediationCaseStateChangeMessage(muSigMediationCase, Optional.of(resultToUse));
+            sendMediationCaseStateChangeMessage(muSigMediationCase);
             sendMediationCaseStateChangeTradeLogMessage(muSigMediationCase);
         }
     }
@@ -157,7 +165,7 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
     public void reOpenMediationCase(MuSigMediationCase muSigMediationCase) {
         if (muSigMediationCase.setMediationCaseState(MediationCaseState.RE_OPENED)) {
             persist();
-            sendMediationCaseStateChangeMessage(muSigMediationCase, Optional.empty());
+            sendMediationCaseStateChangeMessage(muSigMediationCase);
             sendMediationCaseStateChangeTradeLogMessage(muSigMediationCase);
         }
     }
@@ -195,7 +203,7 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
         }
         if (muSigMediationCase.setMediationCaseState(MediationCaseState.CLOSED)) {
             persist();
-            sendMediationCaseStateChangeMessage(muSigMediationCase, existingResult);
+            sendMediationCaseStateChangeMessage(muSigMediationCase);
             sendMediationCaseStateChangeTradeLogMessage(muSigMediationCase);
         }
     }
@@ -378,19 +386,19 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
                 });
     }
 
-    private void sendMediationCaseStateChangeMessage(MuSigMediationCase muSigMediationCase,
-                                                     Optional<MuSigMediationResult> muSigMediationResult) {
+    private void sendMediationCaseStateChangeMessage(MuSigMediationCase muSigMediationCase) {
         MuSigMediationRequest muSigMediationRequest = muSigMediationCase.getMuSigMediationRequest();
         MediationCaseState mediationCaseState = muSigMediationCase.getMediationCaseState().get();
+        Optional<MuSigMediationResult> muSigMediationResult = muSigMediationCase.getMuSigMediationResult().get();
         findMyMediatorUserIdentity(muSigMediationRequest.getContract().getMediator())
                 .ifPresent(myUserIdentity -> {
-                    NetworkIdWithKeyPair networkIdWithKeyPair = myUserIdentity.getNetworkIdWithKeyPair();
-                    MuSigMediationStateChangeMessage message = new MuSigMediationStateChangeMessage(
-                            StringUtils.createUid(),
+                    String id = StringUtils.createUid();
+                    MuSigMediationStateChangeMessage message = new MuSigMediationStateChangeMessage(id,
                             muSigMediationRequest.getTradeId(),
                             mediationCaseState,
-                            muSigMediationResult
-                    );
+                            muSigMediationResult,
+                            muSigMediationCase.getMediationResultSignature());
+                    NetworkIdWithKeyPair networkIdWithKeyPair = myUserIdentity.getNetworkIdWithKeyPair();
 
                     networkService.confidentialSend(message,
                             muSigMediationRequest.getRequester().getNetworkId(),
@@ -400,5 +408,21 @@ public class MuSigMediatorService extends RateLimitedPersistenceClient<MuSigMedi
                             muSigMediationRequest.getPeer().getNetworkId(),
                             networkIdWithKeyPair);
                 });
+    }
+
+    private byte[] createMediationResultSignature(MuSigMediationCase muSigMediationCase,
+                                                  MuSigMediationResult muSigMediationResult) {
+        MuSigMediationRequest mediationRequest = muSigMediationCase.getMuSigMediationRequest();
+        return findMyMediatorUserIdentity(mediationRequest.getContract().getMediator())
+                .map(myUserIdentity -> {
+                    try {
+                        return MuSigMediationResultService.signMediationResult(
+                                muSigMediationResult,
+                                myUserIdentity.getNetworkIdWithKeyPair().getKeyPair());
+                    } catch (GeneralSecurityException e) {
+                        throw new IllegalStateException("Could not sign MuSigMediationStateChangeMessage for trade " + mediationRequest.getTradeId(), e);
+                    }
+                })
+                .orElseThrow(() -> new IllegalStateException("Could not sign MuSigMediationStateChangeMessage because mediator identity was not found."));
     }
 }

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -81,12 +81,13 @@ message MuSigMediatorsResponse {
 
 message MuSigMediationResult {
   uint64 date = 1;
-  MediationResultReason mediationResultReason = 2;
-  MediationPayoutDistributionType mediationPayoutDistributionType = 3;
-  optional sint64 proposedBuyerPayoutAmount = 4;
-  optional sint64 proposedSellerPayoutAmount = 5;
-  optional double payoutAdjustmentPercentage = 6;
-  optional string summaryNotes = 7;
+  bytes contractHash = 2;
+  MediationResultReason mediationResultReason = 3;
+  MediationPayoutDistributionType mediationPayoutDistributionType = 4;
+  optional sint64 proposedBuyerPayoutAmount = 5;
+  optional sint64 proposedSellerPayoutAmount = 6;
+  optional double payoutAdjustmentPercentage = 7;
+  optional string summaryNotes = 8;
 }
 
 message MuSigMediationStateChangeMessage {
@@ -94,6 +95,7 @@ message MuSigMediationStateChangeMessage {
   string tradeId = 2;
   MediationCaseState mediationCaseState = 3;
   optional MuSigMediationResult muSigMediationResult = 4;
+  optional bytes mediationResultSignature = 5;
 }
 
 message MuSigMediationResultAcceptanceMessage {
@@ -132,9 +134,10 @@ message MuSigMediationCase {
   sint64 requestDate = 2;
   MediationCaseState mediationCaseState = 3;
   optional MuSigMediationResult muSigMediationResult = 4;
-  optional account.AccountPayload takerAccountPayload = 5;
-  optional account.AccountPayload makerAccountPayload = 6;
-  repeated MuSigMediationIssue issues = 7;
+  optional bytes mediationResultSignature = 5;
+  optional account.AccountPayload takerAccountPayload = 6;
+  optional account.AccountPayload makerAccountPayload = 7;
+  repeated MuSigMediationIssue issues = 8;
 }
 
 message MuSigMediatorStore {

--- a/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediationResultServiceTest.java
+++ b/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediationResultServiceTest.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.contract.ContractService;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.security.keys.KeyGeneration;
+import bisq.support.mediation.MediationPayoutDistributionType;
+import bisq.support.mediation.MediationResultReason;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MuSigMediationResultServiceTest {
+    @Test
+    void verifyReturnsTrueForMatchingSignature() throws GeneralSecurityException {
+        KeyPair mediatorKeyPair = KeyGeneration.generateDefaultEcKeyPair();
+        MuSigMediationResult mediationResult = createMediationResult();
+        byte[] mediationResultSignature = MuSigMediationResultService.signMediationResult(mediationResult, mediatorKeyPair);
+
+        assertThat(MuSigMediationResultService.verifyMediationResult(mediationResult,
+                mediationResultSignature,
+                createContract("contract-a"),
+                mediatorKeyPair.getPublic())).isTrue();
+    }
+
+    @Test
+    void verifyReturnsFalseForTamperedResult() throws GeneralSecurityException {
+        KeyPair mediatorKeyPair = KeyGeneration.generateDefaultEcKeyPair();
+        byte[] mediationResultSignature = MuSigMediationResultService.signMediationResult(createMediationResult(), mediatorKeyPair);
+        MuSigMediationResult tamperedResult = new MuSigMediationResult(
+                ContractService.getContractHash(createContract("contract-a")),
+                MediationResultReason.BUG,
+                MediationPayoutDistributionType.CUSTOM_PAYOUT,
+                Optional.of(11L),
+                Optional.of(22L),
+                Optional.empty(),
+                Optional.of("tampered"));
+
+        assertThat(MuSigMediationResultService.verifyMediationResult(tamperedResult,
+                mediationResultSignature,
+                mediatorKeyPair.getPublic())).isFalse();
+    }
+
+    @Test
+    void verifyThrowsForMismatchedContractHash() throws GeneralSecurityException {
+        KeyPair mediatorKeyPair = KeyGeneration.generateDefaultEcKeyPair();
+        MuSigMediationResult mediationResult = createMediationResult();
+        byte[] mediationResultSignature = MuSigMediationResultService.signMediationResult(mediationResult, mediatorKeyPair);
+
+        assertThatThrownBy(() -> MuSigMediationResultService.verifyMediationResult(mediationResult,
+                mediationResultSignature,
+                createContract("contract-b"),
+                mediatorKeyPair.getPublic()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Contract hash");
+    }
+
+    private MuSigMediationResult createMediationResult() {
+        return new MuSigMediationResult(
+                ContractService.getContractHash(createContract("contract-a")),
+                MediationResultReason.BUG,
+                MediationPayoutDistributionType.CUSTOM_PAYOUT,
+                Optional.of(10L),
+                Optional.of(20L),
+                Optional.empty(),
+                Optional.of("summary"));
+    }
+
+    private MuSigContract createContract(String id) {
+        MuSigContract contract = mock(MuSigContract.class);
+        when(contract.serializeForHash()).thenReturn(createContractPayload(id));
+        return contract;
+    }
+
+    private byte[] createContractPayload(String id) {
+        return id.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -55,6 +55,7 @@ import bisq.settings.SettingsService;
 import bisq.support.mediation.MediationCaseState;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultService;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.support.mediation.mu_sig.MuSigMediatorsResponse;
 import bisq.support.mediation.mu_sig.MuSigPaymentDetailsRequest;
@@ -86,6 +87,7 @@ import io.grpc.stub.StreamObserver;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -211,7 +213,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                         @Override
                         public void onRemoved(Object element) {
                             if (element instanceof AuthorizedAlertData authorizedAlertData) {
-                                if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY&& authorizedAlertData.getAppType() == appType ) {
+                                if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY && authorizedAlertData.getAppType() == appType) {
                                     if (authorizedAlertData.isHaltTrading()) {
                                         haltTrading = false;
                                     }
@@ -744,6 +746,9 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                 }
 
                 Optional<MuSigMediationResult> currentResult = trade.getMuSigMediationResult();
+                if (!isValidMediationResultMessage(trade.getContract(), message)) {
+                    return;
+                }
                 if (currentResult.isEmpty()) {
                     resultChanged = trade.setMuSigMediationResult(incomingResult.orElseThrow());
                 } else if (!currentResult.orElseThrow().equals(incomingResult.orElseThrow())) {
@@ -757,6 +762,35 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                 persist();
             }
         });
+    }
+
+    private boolean isValidMediationResultMessage(MuSigContract contract,
+                                                  MuSigMediationStateChangeMessage message) {
+        try {
+            if (contract.getMediator().isEmpty()) {
+                log.warn("Ignoring MuSigMediationResult for trade {} because mediator is missing in contract.",
+                        message.getTradeId());
+                return false;
+            }
+            if (message.getMediationResultSignature().isEmpty()) {
+                log.warn("Ignoring MuSigMediationResult for trade {} because mediator signature is missing.",
+                        message.getTradeId());
+                return false;
+            }
+            if (!MuSigMediationResultService.verifyMediationResult(message.getMuSigMediationResult().orElseThrow(),
+                    message.getMediationResultSignature().orElseThrow(),
+                    contract,
+                    contract.getMediator().orElseThrow().getNetworkId().getPubKey().getPublicKey())) {
+                log.warn("Ignoring MuSigMediationResult for trade {} because mediator signature verification failed.",
+                        message.getTradeId());
+                return false;
+            }
+            return true;
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            log.warn("Ignoring MuSigMediationResult for trade {} because mediator signature verification failed.",
+                    message.getTradeId(), e);
+            return false;
+        }
     }
 
     private void maybeApplyMediationResultAcceptanceMessage(MuSigMediationResultAcceptanceMessage message) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mediation results now carry a contract identifier (hash) and mediator digital signatures; signed results are recorded and transmitted when a mediator key is available.

* **Bug Fixes**
  * Incoming mediation state changes and trade updates are validated against mediator signatures; invalid or missing signatures are rejected.
  * Closing/reopening mediation flows avoid overwriting existing signed results.

* **Tests**
  * Added tests for signing and signature verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->