### PR TITLE
Harden chat reaction compatibility for future clients

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -71,6 +71,7 @@ import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -87,8 +88,6 @@ import java.util.stream.Collectors;
 
 import static bisq.chat.ChatMessageType.*;
 import static bisq.desktop.main.content.chat.message_container.ChatMessageContainerView.EDITED_POST_FIX;
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -416,26 +415,26 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
         userReactionsPin = Optional.ofNullable(chatMessage.getChatMessageReactions().addObserver(new CollectionObserver<>() {
             @Override
             public void onAdded(ChatMessageReaction element) {
-                Reaction reaction = getReactionFromOrdinal(element.getReactionId());
-                UIThread.run(() -> {
-                    if (userReactions.containsKey(reaction)) {
-                        userProfileService.findUserProfile(element.getUserProfileId())
-                                .filter(profile -> !userProfileService.isChatUserIgnored(profile))
-                                .ifPresent(profile -> userReactions.get(reaction).addUser(element, profile));
-                    }
-                });
+                resolveReactionFromOrdinal(element.getReactionId()).ifPresent(reaction ->
+                        UIThread.run(() -> {
+                            if (userReactions.containsKey(reaction)) {
+                                userProfileService.findUserProfile(element.getUserProfileId())
+                                        .filter(profile -> !userProfileService.isChatUserIgnored(profile))
+                                        .ifPresent(profile -> userReactions.get(reaction).addUser(element, profile));
+                            }
+                        }));
             }
 
             @Override
             public void onRemoved(Object element) {
                 ChatMessageReaction chatMessageReaction = (ChatMessageReaction) element;
-                Reaction reaction = getReactionFromOrdinal(chatMessageReaction.getReactionId());
-                UIThread.run(() -> {
-                    if (userReactions.containsKey(reaction)) {
-                        userProfileService.findUserProfile(chatMessageReaction.getUserProfileId())
-                                .ifPresent(profile -> userReactions.get(reaction).removeUser(profile));
-                    }
-                });
+                resolveReactionFromOrdinal(chatMessageReaction.getReactionId()).ifPresent(reaction ->
+                        UIThread.run(() -> {
+                            if (userReactions.containsKey(reaction)) {
+                                userProfileService.findUserProfile(chatMessageReaction.getUserProfileId())
+                                        .ifPresent(profile -> userReactions.get(reaction).removeUser(profile));
+                            }
+                        }));
             }
 
             @Override
@@ -445,9 +444,9 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
         }));
     }
 
-    private static Reaction getReactionFromOrdinal(int ordinal) {
-        checkArgument(ordinal >= 0 && ordinal < Reaction.values().length, "Invalid reaction id: " + ordinal);
-        return Reaction.values()[ordinal];
+    @VisibleForTesting
+    static Optional<Reaction> resolveReactionFromOrdinal(int ordinal) {
+        return Reaction.fromOrdinal(ordinal);
     }
 
     private void onUserIdentity() {

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItemReactionCompatibilityTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItemReactionCompatibilityTest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list;
+
+import bisq.chat.reactions.Reaction;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChatMessageListItemReactionCompatibilityTest {
+    @Test
+    void resolveReactionFromOrdinalReturnsKnownReactions() {
+        assertEquals(Reaction.THUMBS_UP,
+                ChatMessageListItem.resolveReactionFromOrdinal(Reaction.THUMBS_UP.ordinal()).orElseThrow());
+    }
+
+    @Test
+    void resolveReactionFromOrdinalIgnoresUnsupportedFutureReactions() {
+        assertFalse(ChatMessageListItem.resolveReactionFromOrdinal(Reaction.values().length).isPresent());
+        assertTrue(ChatMessageListItem.resolveReactionFromOrdinal(Reaction.HEART.ordinal()).isPresent());
+    }
+}

--- a/chat/src/main/java/bisq/chat/reactions/ChatMessageReaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/ChatMessageReaction.java
@@ -61,7 +61,7 @@ public abstract class ChatMessageReaction implements NetworkProto {
 
     @Override
     public void verify() {
-        checkArgument(reactionId >= 0 && reactionId < Reaction.values().length, "Invalid reaction id: " + reactionId);
+        checkArgument(reactionId >= 0, "Invalid reaction id: " + reactionId);
 
         NetworkDataValidation.validateProfileId(userProfileId);
         NetworkDataValidation.validateText(chatChannelId, 200); // For private channels we combine user profile IDs for channelId

--- a/chat/src/main/java/bisq/chat/reactions/Reaction.java
+++ b/chat/src/main/java/bisq/chat/reactions/Reaction.java
@@ -17,11 +17,23 @@
 
 package bisq.chat.reactions;
 
+import java.util.Optional;
+
 public enum Reaction {
     THUMBS_UP,
     THUMBS_DOWN,
     HAPPY,
     LAUGH,
     HEART,
-    PARTY
+    PARTY;
+
+    public static boolean isSupportedOrdinal(int ordinal) {
+        return ordinal >= 0 && ordinal < values().length;
+    }
+
+    public static Optional<Reaction> fromOrdinal(int ordinal) {
+        return isSupportedOrdinal(ordinal)
+                ? Optional.of(values()[ordinal])
+                : Optional.empty();
+    }
 }

--- a/chat/src/test/java/bisq/chat/reactions/ReactionCompatibilityTest.java
+++ b/chat/src/test/java/bisq/chat/reactions/ReactionCompatibilityTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.chat.reactions;
+
+import bisq.chat.ChatChannelDomain;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReactionCompatibilityTest {
+    @Test
+    void fromOrdinalReturnsEmptyForUnsupportedFutureReaction() {
+        assertTrue(Reaction.fromOrdinal(Reaction.PARTY.ordinal()).isPresent());
+        assertFalse(Reaction.fromOrdinal(Reaction.values().length).isPresent());
+    }
+
+    @Test
+    void commonPublicChatMessageReactionAllowsFutureReactionIds() {
+        bisq.chat.protobuf.ChatMessageReaction proto = bisq.chat.protobuf.ChatMessageReaction.newBuilder()
+                .setId("reaction-id")
+                .setUserProfileId("0123456789abcdef0123456789abcdef01234567")
+                .setChatChannelId("channel-id")
+                .setChatChannelDomain(ChatChannelDomain.DISCUSSION.toProtoEnum())
+                .setChatMessageId("message-id")
+                .setReactionId(Reaction.values().length)
+                .setDate(System.currentTimeMillis())
+                .setCommonPublicChatMessageReaction(
+                        bisq.chat.protobuf.CommonPublicChatMessageReaction.newBuilder().build())
+                .build();
+
+        ChatMessageReaction reaction = assertDoesNotThrow(() -> ChatMessageReaction.fromProto(proto));
+
+        assertEquals(Reaction.values().length, reaction.getReactionId());
+    }
+
+    @Test
+    void commonPublicChatMessageReactionStillRejectsNegativeReactionIds() {
+        assertThrows(IllegalArgumentException.class, () -> new CommonPublicChatMessageReaction(
+                "reaction-id",
+                "0123456789abcdef0123456789abcdef01234567",
+                "channel-id",
+                ChatChannelDomain.DISCUSSION,
+                "message-id",
+                -1,
+                System.currentTimeMillis()));
+    }
+}


### PR DESCRIPTION
## Summary
- tolerate future incoming reaction ordinals in the shared chat model
- ignore unsupported reaction ids in the desktop reaction renderer instead of throwing
- add regression tests for model parsing and desktop ordinal resolution

## Validation
- `./gradlew -x :network:tor:tor:downloadTorBinary -x :network:tor:tor:downloadTorSignature -x :network:tor:tor:verifyTorBinary -x :network:tor:tor:unpackTorBinaryTar -x :network:tor:tor:processUnpackedTorBinaryTar -x :network:tor:tor:packageTorBinary :chat:test --tests bisq.chat.reactions.ReactionCompatibilityTest`
- `./gradlew -x :network:tor:tor:downloadTorBinary -x :network:tor:tor:downloadTorSignature -x :network:tor:tor:verifyTorBinary -x :network:tor:tor:unpackTorBinaryTar -x :network:tor:tor:processUnpackedTorBinaryTar -x :network:tor:tor:packageTorBinary :apps:desktop:desktop:test --tests bisq.desktop.main.content.chat.message_container.list.ChatMessageListItemReactionCompatibilityTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential issues when processing reactions to prevent crashes with unsupported reaction types.

* **Improvements**
  * Enhanced forward compatibility to support future reaction types, ensuring uninterrupted service when new reactions are added to the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->