### PR TITLE
UI: Refactor Language & Region settings and fix real-time ticker sync

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/language/LanguageSettingsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/language/LanguageSettingsController.java
@@ -17,17 +17,27 @@
 
 package bisq.desktop.main.content.settings.language;
 
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.common.asset.FiatCurrencyRepository;
+import bisq.common.locale.CountryRepository;
 import bisq.common.locale.LanguageRepository;
+import bisq.common.market.MarketRepository;
 import bisq.common.observable.Pin;
 import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.view.Controller;
+import bisq.desktop.components.overlay.Popup;
+import bisq.i18n.Res;
 import bisq.settings.SettingsService;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
+import java.util.Currency;
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 public class LanguageSettingsController implements Controller {
@@ -35,31 +45,36 @@ public class LanguageSettingsController implements Controller {
     private final LanguageSettingsView view;
     private final LanguageSettingsModel model;
     private final SettingsService settingsService;
-
+    private final MarketPriceService marketPriceService;
     private Pin supportedLanguageTagsPin;
 
     public LanguageSettingsController(ServiceProvider serviceProvider) {
-        settingsService = serviceProvider.getSettingsService();
-        model = new LanguageSettingsModel();
+        this.settingsService = serviceProvider.getSettingsService();
+        this.marketPriceService = serviceProvider.getBondedRolesService().getMarketPriceService();
+
+        this.model = new LanguageSettingsModel(settingsService);
+
+        model.getCountryCodes().sort((c1, c2) ->
+                convertCountryCode(c1).compareToIgnoreCase(convertCountryCode(c2)));
+
+        List<String> supportedCurrencies = MarketRepository.getAllFiatMarkets().stream()
+                .map(market -> market.getQuoteCurrencyCode())
+                .distinct()
+                .sorted()
+                .toList();
+        model.getCurrencyCodes().setAll(supportedCurrencies);
+
         view = new LanguageSettingsView(model, this);
     }
 
     @Override
     public void onActivate() {
         model.getLanguageTags().setAll(getSortedLanguageTags());
-        model.setSelectedLanguageTag(settingsService.getLanguageTag().get());
         model.getSupportedLanguageTags().setAll(getSortedLanguageTags());
 
         supportedLanguageTagsPin = FxBindings.<String, String>bind(model.getSelectedSupportedLanguageTags())
                 .to(settingsService.getSupportedLanguageTags());
-
         model.getSupportedLanguageTagsFilteredList().setPredicate(e -> !model.getSelectedSupportedLanguageTags().contains(e));
-    }
-
-    private List<String> getSortedLanguageTags() {
-        return LanguageRepository.LANGUAGE_TAGS.stream()
-                .sorted((tag1, tag2) -> getDisplayLanguage(tag1).compareTo(getDisplayLanguage(tag2)))
-                .toList();
     }
 
     @Override
@@ -67,19 +82,76 @@ public class LanguageSettingsController implements Controller {
         supportedLanguageTagsPin.unbind();
     }
 
-    void onSelectLanguageTag(String languageTag) {
-        model.setSelectedLanguageTag(languageTag);
-        settingsService.setLanguageTag(languageTag);
+    public String getDisplayCountry(String countryCode) {
+        return convertCountryCode(countryCode);
     }
 
-    String getDisplayLanguage(String languageTag) {
+    public String getDisplayLanguage(String languageTag) {
+        return convertLanguageTag(languageTag);
+    }
+
+    public String getDisplayCurrency(@Nullable String currencyCode) {
+        return convertCurrencyCode(currencyCode);
+    }
+
+    String convertCountryCode(String countryCode) {
+        return CountryRepository.getLocalizedCountryDisplayString(countryCode);
+    }
+
+    String convertLanguageTag(String languageTag) {
         return LanguageRepository.getDisplayString(languageTag);
     }
 
-    void onSelectSupportedLanguage(String languageTag) {
-        if (languageTag != null) {
-            model.getSelectedLSupportedLanguageTag().set(languageTag);
+    String convertCurrencyCode(@Nullable String currencyCode) {
+        if (currencyCode == null) {
+            return "";
         }
+        return FiatCurrencyRepository.findDisplayName(currencyCode)
+                .map(displayName -> displayName + " (" + currencyCode + ")")
+                .orElse(currencyCode);
+    }
+
+    void onSelectCountryCode(@Nullable String countryCode) {
+        if (countryCode == null) return;
+        model.setSelectedCountryCode(countryCode);
+        settingsService.setCountryCode(countryCode);
+        try {
+            Locale locale = new Locale.Builder().setRegion(countryCode).build();
+            Currency defaultCurrency = Currency.getInstance(locale);
+            if (defaultCurrency != null) {
+                onSelectCurrencyCode(defaultCurrency.getCurrencyCode());
+            }
+        } catch (Exception e) {
+            log.warn("Could not derive default currency for country: {}", countryCode);
+        }
+    }
+
+    void onSelectCurrencyCode(@Nullable String currencyCode) {
+        if (currencyCode == null) return;
+        log.debug("User selected default currency: {}", currencyCode);
+        MarketRepository.getAllFiatMarkets().stream()
+                .filter(m -> m.getQuoteCurrencyCode().equalsIgnoreCase(currencyCode))
+                .findFirst()
+                .ifPresentOrElse(market -> {
+                    model.setSelectedCurrencyCode(currencyCode);
+                    settingsService.setCountryCode(model.getSelectedCountryCode());
+                    settingsService.setCurrencyCode(currencyCode);
+                    // R118: Sin Platform.runLater (Contexto de UI garantizado)
+                    if (marketPriceService != null) {
+                        marketPriceService.setSelectedMarket(market);
+                    }
+                }, () -> log.debug("Market not found for: {}", currencyCode));
+    }
+
+    void onSelectLanguageTag(@Nullable String languageTag) {
+        if (languageTag == null) return;
+        model.setSelectedLanguageTag(languageTag);
+        settingsService.setLanguageTag(languageTag);
+        new Popup().feedback(Res.get("settings.language.restart")).useShutDownButton().show();
+    }
+
+    void onSelectSupportedLanguage(@Nullable String languageTag) {
+        if (languageTag != null) model.getSelectedLSupportedLanguageTag().set(languageTag);
     }
 
     void onAddSupportedLanguage() {
@@ -87,14 +159,17 @@ public class LanguageSettingsController implements Controller {
         if (StringUtils.isNotEmpty(selected)) {
             settingsService.getSupportedLanguageTags().add(selected);
             model.getSelectedLSupportedLanguageTag().set(null);
-            model.getSupportedLanguageTagsFilteredList().setPredicate(e -> !model.getSelectedSupportedLanguageTags().contains(e));
         }
     }
 
-    void onRemoveSupportedLanguage(String languageTag) {
-        if (StringUtils.isNotEmpty(languageTag)) {
-            settingsService.getSupportedLanguageTags().remove(languageTag);
-            model.getSupportedLanguageTagsFilteredList().setPredicate(e -> !model.getSelectedSupportedLanguageTags().contains(e));
-        }
+    void onRemoveSupportedLanguage(@Nullable String languageTag) {
+        if (StringUtils.isNotEmpty(languageTag)) settingsService.getSupportedLanguageTags().remove(languageTag);
+    }
+
+
+    private List<String> getSortedLanguageTags() {
+        return LanguageRepository.LANGUAGE_TAGS.stream()
+                .sorted((tag1, tag2) -> convertLanguageTag(tag1).compareTo(convertLanguageTag(tag2)))
+                .toList();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/language/LanguageSettingsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/language/LanguageSettingsModel.java
@@ -17,12 +17,16 @@
 
 package bisq.desktop.main.content.settings.language;
 
+import bisq.common.locale.CountryRepository;
 import bisq.desktop.common.view.Model;
+import bisq.settings.SettingsService;
+
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -30,14 +34,32 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 public class LanguageSettingsModel implements Model {
+
+    public LanguageSettingsModel(SettingsService settingsService) {
+        this.settingsService = settingsService;
+        this.countryCodes.setAll(CountryRepository.getAllCountyCodes());
+        this.selectedCountryCode = settingsService.getCountryCode().get();
+        this.selectedCurrencyCode = settingsService.getCurrencyCode().get();
+        this.selectedLanguageTag = settingsService.getLanguageTag().get();
+    }
+    private final SettingsService settingsService;
+
     @Setter
     private String selectedLanguageTag;
+
+    @Setter
+    private String selectedCountryCode;
+
+    @Setter
+    private String selectedCurrencyCode;
+
     private final StringProperty selectedLSupportedLanguageTag = new SimpleStringProperty();
+
     private final ObservableList<String> languageTags = FXCollections.observableArrayList();
+    private final ObservableList<String> countryCodes = FXCollections.observableArrayList();
+    private final ObservableList<String> currencyCodes = FXCollections.observableArrayList();
+
     private final ObservableList<String> supportedLanguageTags = FXCollections.observableArrayList();
     private final FilteredList<String> supportedLanguageTagsFilteredList = new FilteredList<>(supportedLanguageTags);
     private final ObservableList<String> selectedSupportedLanguageTags = FXCollections.observableArrayList();
-
-    public LanguageSettingsModel() {
-    }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/language/LanguageSettingsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/language/LanguageSettingsView.java
@@ -44,7 +44,7 @@ import org.fxmisc.easybind.Subscription;
 @Slf4j
 public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, LanguageSettingsController> {
     private final Button addLanguageButton;
-    private final AutoCompleteComboBox<String> languageSelection, supportedLanguagesComboBox;
+    private final AutoCompleteComboBox<String> languageSelection, countrySelection, currencySelection, supportedLanguagesComboBox;
     private Subscription getSelectedSupportedLanguageCodePin;
 
     public LanguageSettingsView(LanguageSettingsModel model, LanguageSettingsController controller) {
@@ -52,9 +52,10 @@ public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, Lang
 
         root.setAlignment(Pos.TOP_LEFT);
 
-        // Language
-        Label languageSelectionHeadline = SettingsViewUtils.getHeadline(Res.get("settings.language.headline"));
+        // --- MAIN HEADLINE ---
+        Label mainHeadline = SettingsViewUtils.getHeadline(Res.get("settings.language.headline"));
 
+        // 1. Language Selector
         languageSelection = new AutoCompleteComboBox<>(model.getLanguageTags(), Res.get("settings.language.select"));
         languageSelection.setPrefWidth(300);
         languageSelection.setConverter(new StringConverter<>() {
@@ -62,15 +63,42 @@ public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, Lang
             public String toString(String languageCode) {
                 return languageCode != null ? controller.getDisplayLanguage(languageCode) : "";
             }
-
             @Override
-            public String fromString(String string) {
-                return null;
-            }
+            public String fromString(String string) { return null; }
         });
         languageSelection.validateOnNoItemSelectedWithMessage(Res.get("settings.language.select.invalid"));
 
-        // Supported languages
+        // 2. Country Selector
+        countrySelection = new AutoCompleteComboBox<>(model.getCountryCodes(), Res.get("settings.language.region.country"));
+        countrySelection.setPrefWidth(300); // Increased width
+        countrySelection.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String countryCode) {
+                return countryCode != null ? controller.getDisplayCountry(countryCode) : "";
+            }
+            @Override
+            public String fromString(String string) { return null; }
+        });
+
+        // 3. Currency Selector
+        currencySelection = new AutoCompleteComboBox<>(model.getCurrencyCodes(), Res.get("settings.language.region.currency"));
+        currencySelection.setPrefWidth(300); // Increased width as requested by maintainers
+        currencySelection.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String currencyCode) {
+                // Now shows full display name, e.g., "US Dollar (USD)"
+                return currencyCode != null ? controller.getDisplayCurrency(currencyCode) : "";
+            }
+            @Override
+            public String fromString(String string) { return null; }
+        });
+
+        // --- SELECTORS ROW ---
+        HBox selectorsRow = new HBox(20, languageSelection, countrySelection, currencySelection);
+        selectorsRow.setAlignment(Pos.CENTER_LEFT);
+        VBox.setMargin(selectorsRow, new Insets(0, 5, 0, 5));
+
+        // --- SUPPORTED LANGUAGES SECTION ---
         Label supportedLanguagesHeadline = SettingsViewUtils.getHeadline(Res.get("settings.language.supported.headline"));
 
         GridPane supportedLanguageGridPane = new GridPane();
@@ -89,17 +117,14 @@ public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, Lang
         supportedLanguagesComboBox = new AutoCompleteComboBox<>(model.getSupportedLanguageTagsFilteredList(),
                 Res.get("settings.language.supported.select"));
         supportedLanguagesComboBox.setMinWidth(150);
-        supportedLanguagesComboBox.setMaxWidth(Double.MAX_VALUE); // Needed to force scale to available space
+        supportedLanguagesComboBox.setMaxWidth(Double.MAX_VALUE);
         supportedLanguagesComboBox.setConverter(new StringConverter<>() {
             @Override
             public String toString(String languageCode) {
                 return languageCode != null ? controller.getDisplayLanguage(languageCode) : "";
             }
-
             @Override
-            public String fromString(String string) {
-                return null;
-            }
+            public String fromString(String string) { return null; }
         });
         supportedLanguagesComboBox.validateOnNoItemSelectedWithMessage(Res.get("settings.language.supported.invalid"));
 
@@ -125,16 +150,19 @@ public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, Lang
         supportedLanguageGridPane.setMaxHeight(150);
         supportedLanguageGridPane.add(supportedLanguageListView, 1, ++rowIndex);
 
-        Insets insets = new Insets(0, 5, 0, 5);
-        VBox.setMargin(languageSelection, insets);
-        VBox.setMargin(supportedLanguageGridPane, insets);
+        VBox.setMargin(supportedLanguageGridPane, new Insets(0, 5, 0, 5));
+
+        // --- FINAL UI ASSEMBLY ---
         VBox contentBox = new VBox(50);
-        contentBox.getChildren().addAll(languageSelectionHeadline,
+        contentBox.getChildren().addAll(
+                mainHeadline,
                 SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()),
-                languageSelection,
+                selectorsRow,
                 supportedLanguagesHeadline,
                 SettingsViewUtils.getLineAfterHeadline(contentBox.getSpacing()),
-                supportedLanguageGridPane);
+                supportedLanguageGridPane
+        );
+
         contentBox.getStyleClass().add("bisq-common-bg");
         root.getChildren().add(contentBox);
         root.setPadding(new Insets(0, 40, 20, 40));
@@ -149,6 +177,25 @@ public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, Lang
                 return;
             }
             controller.onSelectLanguageTag(languageSelection.getSelectionModel().getSelectedItem());
+        });
+
+        countrySelection.getSelectionModel().select(model.getSelectedCountryCode());
+        countrySelection.setOnChangeConfirmed(e -> {
+            if (countrySelection.getSelectionModel().getSelectedItem() == null) {
+                countrySelection.getSelectionModel().select(model.getSelectedCountryCode());
+                return;
+            }
+            controller.onSelectCountryCode(countrySelection.getSelectionModel().getSelectedItem());
+            currencySelection.getSelectionModel().select(model.getSelectedCurrencyCode());
+        });
+
+        currencySelection.getSelectionModel().select(model.getSelectedCurrencyCode());
+        currencySelection.setOnChangeConfirmed(e -> {
+            if (currencySelection.getSelectionModel().getSelectedItem() == null) {
+                currencySelection.getSelectionModel().select(model.getSelectedCurrencyCode());
+                return;
+            }
+            controller.onSelectCurrencyCode(currencySelection.getSelectionModel().getSelectedItem());
         });
 
         supportedLanguagesComboBox.getSelectionModel().select(model.getSelectedLSupportedLanguageTag().get());
@@ -178,9 +225,13 @@ public class LanguageSettingsView extends View<VBox, LanguageSettingsModel, Lang
         getSelectedSupportedLanguageCodePin.unsubscribe();
         addLanguageButton.setOnAction(null);
         languageSelection.setOnChangeConfirmed(null);
+        countrySelection.setOnChangeConfirmed(null);
+        currencySelection.setOnChangeConfirmed(null);
         supportedLanguagesComboBox.setOnChangeConfirmed(null);
 
         languageSelection.resetValidation();
+        countrySelection.resetValidation();
+        currencySelection.resetValidation();
         supportedLanguagesComboBox.resetValidation();
     }
 

--- a/i18n/src/main/resources/settings.properties
+++ b/i18n/src/main/resources/settings.properties
@@ -2,14 +2,14 @@
 # Settings
 ################################################################################
 
-settings.language=Language
+settings.language=Language & Region
 settings.notifications=Notifications
 settings.trade=Offer and trade
 settings.network=Network
 settings.bisqConnect=Bisq Connect
 settings.misc=More Options
 
-settings.language.headline=Language selection
+settings.language.headline=Language & Region
 settings.language.select=Select language
 settings.language.select.invalid=Please pick a language from the list
 settings.language.restart=To apply the new language you need to restart the application
@@ -19,6 +19,9 @@ settings.language.supported.select=Select language
 settings.language.supported.addButton.tooltip=Add selected language to list
 settings.language.supported.list.subHeadLine=Fluent in:
 settings.language.supported.invalid=Please pick a language form the list
+
+settings.language.region.country=Select your country
+settings.language.region.currency=Select your default currency
 
 settings.notification.options=Notification options
 settings.notification.option.all=All chat messages
@@ -129,9 +132,6 @@ settings.bisqConnect.apiAccessTransportType.CLEAR=Clearnet
 # suppress inspection "UnusedProperty"
 settings.bisqConnect.apiAccessTransportType.I2P=I2P
 
-
-
-
 settings.bisqConnect.apiConfig.headline=API config
 settings.bisqConnect.apiConfig.info=It is recommended to use Tor for connecting to the API. \
   If you choose clearnet, using LAN is the next best option — apply the detected LAN host. \
@@ -177,7 +177,7 @@ settings.bisqConnect.pairing.headline=Pairing
 settings.bisqConnect.pairing.info=Scan the provided QR code with your mobile phone to start the pairing process.
 
 settings.bisqConnect.qrCode.description=Pairing code
-settings.bisqConnect.qrCode.info=If you can’t scan the pairing code, copy the text below and import it on your mobile phone.
+settings.bisqConnect.qrCode.info=If you cannot scan the pairing code, copy the text below and import it on your mobile phone.
 settings.bisqConnect.qrCode.expiresIn=Pairing code expires in {0}
 settings.bisqConnect.qrCode.expired=The pairing code is expired. Generate a new pairing code if you still have not completed pairing.
 settings.bisqConnect.qrCode.generate=Generate new pairing code

--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -29,6 +29,7 @@ import bisq.common.observable.Observable;
 import bisq.common.observable.Pin;
 import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.observable.collection.ObservableSet;
+import bisq.common.util.StringUtils;
 import bisq.i18n.Res;
 import bisq.network.p2p.node.network_load.NetworkLoad;
 import bisq.persistence.DbSubDirectory;
@@ -41,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.Currency;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -82,7 +84,6 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         instance = this;
     }
 
-
     /* --------------------------------------------------------------------- */
     // Service
     /* --------------------------------------------------------------------- */
@@ -107,6 +108,8 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         pins.add(getBisqEasyTradeRulesConfirmed().addObserver(value -> persist()));
         pins.add(getMuSigTradeRulesConfirmed().addObserver(value -> persist()));
         pins.add(getLanguageTag().addObserver(value -> persist()));
+        pins.add(getCountryCode().addObserver(value -> persist()));
+        pins.add(getCurrencyCode().addObserver(value -> persist()));
         pins.add(getDifficultyAdjustmentFactor().addObserver(value -> persist()));
         pins.add(getIgnoreDiffAdjustmentFromSecManager().addObserver(value -> persist()));
         pins.add(getFavouriteMarkets().addObserver(this::persist));
@@ -127,6 +130,33 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         pins.add(getSelectedWalletMarket().addObserver(value -> persist()));
 
         isInitialized = true;
+
+        boolean needsPersist = false;
+
+        // Fallback for country code using OS locale
+        if (StringUtils.isEmpty(getCountryCode().get())) {
+            String osDefaultCountry = Locale.getDefault().getCountry();
+            setCountryCode(osDefaultCountry);
+            needsPersist = true;
+        }
+
+        // Fallback for currency code using OS locale
+        if (StringUtils.isEmpty(getCurrencyCode().get())) {
+            try {
+                Currency defaultCurrency = Currency.getInstance(Locale.getDefault());
+                if (defaultCurrency != null) {
+                    setCurrencyCode(defaultCurrency.getCurrencyCode());
+                    needsPersist = true;
+                }
+            } catch (Exception e) {
+                log.warn("Could not detect default currency from OS locale");
+            }
+        }
+
+        // Only persist if defaults were applied after initialization is complete
+        if (needsPersist) {
+            persist();
+        }
 
         return CompletableFuture.completedFuture(true);
     }
@@ -154,7 +184,6 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         }
     }
 
-
     /* --------------------------------------------------------------------- */
     // API
     /* --------------------------------------------------------------------- */
@@ -179,7 +208,6 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         CountryRepository.applyDefaultLocale(newLocale);
         FiatCurrencyRepository.setLocale(newLocale);
     }
-
 
     /* --------------------------------------------------------------------- */
     // Getters for Observable
@@ -241,6 +269,14 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         return persistableStore.languageTag;
     }
 
+    public ReadOnlyObservable<String> getCountryCode() {
+        return persistableStore.countryCode;
+    }
+
+    public ReadOnlyObservable<String> getCurrencyCode() {
+        return persistableStore.currencyCode;
+    }
+
     public ObservableSet<Market> getFavouriteMarkets() {
         return persistableStore.favouriteMarkets;
     }
@@ -296,7 +332,6 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
     public ReadOnlyObservable<Market> getSelectedWalletMarket() {
         return persistableStore.selectedWalletMarket;
     }
-
 
     /* --------------------------------------------------------------------- */
     // Setters
@@ -359,6 +394,19 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         }
     }
 
+    public void setCountryCode(String countryCode) {
+        if (StringUtils.isNotEmpty(countryCode)) {
+            persistableStore.countryCode.set(countryCode);
+        }
+    }
+
+    public void setCurrencyCode(String currencyCode) {
+        if (StringUtils.isNotEmpty(currencyCode)) {
+            persistableStore.currencyCode.set(currencyCode);
+        }
+    }
+    // ---------------------------------------------------------------------
+
     public void setShowBuyOffers(boolean showBuyOffers) {
         persistableStore.showBuyOffers.set(showBuyOffers);
     }
@@ -418,19 +466,13 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
         }
     }
 
-
     /* --------------------------------------------------------------------- */
-    // DontShowAgainMap
+    // DontShowAgainMap, Cookie and "Don't show again" flags
     /* --------------------------------------------------------------------- */
 
     public Map<String, Boolean> getDontShowAgainMap() {
         return persistableStore.dontShowAgainMap;
     }
-
-
-    /* --------------------------------------------------------------------- */
-    // Cookie
-    /* --------------------------------------------------------------------- */
 
     public Cookie getCookie() {
         return persistableStore.cookie;

--- a/settings/src/main/java/bisq/settings/SettingsStore.java
+++ b/settings/src/main/java/bisq/settings/SettingsStore.java
@@ -26,14 +26,16 @@ import bisq.common.observable.collection.ObservableSet;
 import bisq.common.platform.PlatformUtils;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.util.StringUtils;
 import bisq.network.p2p.node.network_load.NetworkLoad;
 import bisq.persistence.PersistableStore;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
+import java.util.Currency;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -68,6 +70,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
     final Observable<Boolean> closeMyOfferWhenTaken = new Observable<>();
     final Observable<Boolean> preventStandbyMode = new Observable<>();
     final Observable<String> languageTag = new Observable<>();
+    final Observable<String> countryCode = new Observable<>();
+    final Observable<String> currencyCode = new Observable<>();
     final ObservableSet<String> supportedLanguageTags = new ObservableSet<>();
     final Observable<Double> difficultyAdjustmentFactor = new Observable<>();
     final Observable<Boolean> ignoreDiffAdjustmentFromSecManager = new Observable<>();
@@ -103,6 +107,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 new HashSet<>(),
                 true,
                 LanguageRepository.getDefaultLanguageTag(),
+                Locale.getDefault().getCountry(),
+                "",
                 true,
                 Set.of(LanguageRepository.getDefaultLanguageTag()),
                 NetworkLoad.DEFAULT_DIFFICULTY_ADJUSTMENT,
@@ -137,6 +143,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                   Set<String> consumedAlertIds,
                   boolean closeMyOfferWhenTaken,
                   String languageTag,
+                  String countryCode,
+                  String currencyCode,
                   boolean preventStandbyMode,
                   Set<String> supportedLanguageTags,
                   double difficultyAdjustmentFactor,
@@ -169,6 +177,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
         this.consumedAlertIds.setAll(consumedAlertIds);
         this.closeMyOfferWhenTaken.set(closeMyOfferWhenTaken);
         this.languageTag.set(languageTag);
+        this.countryCode.set(countryCode);
+        this.currencyCode.set(currencyCode);
         this.preventStandbyMode.set(preventStandbyMode);
         this.supportedLanguageTags.setAll(supportedLanguageTags);
         this.difficultyAdjustmentFactor.set(difficultyAdjustmentFactor);
@@ -207,11 +217,13 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 .addAllConsumedAlertIds(new ArrayList<>(consumedAlertIds))
                 .setCloseMyOfferWhenTaken(closeMyOfferWhenTaken.get())
                 .setLanguageTag(languageTag.get())
+                .setCountryCode(countryCode.get() == null ? "" : countryCode.get())
+                .setCurrencyCode(currencyCode.get() == null ? "" : currencyCode.get())
                 .setPreventStandbyMode(preventStandbyMode.get())
                 .addAllSupportedLanguageTags(new ArrayList<>(supportedLanguageTags))
                 .setDifficultyAdjustmentFactor(difficultyAdjustmentFactor.get())
                 .setIgnoreDiffAdjustmentFromSecManager(ignoreDiffAdjustmentFromSecManager.get())
-                .addAllFavouriteMarkets(favouriteMarkets.stream().map(market -> market.toProto(serializeForHash)).collect(Collectors.toList()))
+                .addAllFavouriteMarkets(favouriteMarkets.stream().map(m -> m.toProto(serializeForHash)).collect(java.util.stream.Collectors.toList()))
                 .setIgnoreMinRequiredReputationScoreFromSecManager(ignoreMinRequiredReputationScoreFromSecManager.get())
                 .setMaxTradePriceDeviation(maxTradePriceDeviation.get())
                 .setShowBuyOffers(showBuyOffers.get())
@@ -253,6 +265,21 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
             numDaysAfterRedactingTradeData = DEFAULT_NUM_DAYS_AFTER_REDACTING_TRADE_DATA;
         }
 
+        String parsedCountryCode = proto.getCountryCode();
+        if (StringUtils.isEmpty(parsedCountryCode)) {
+            parsedCountryCode = Locale.getDefault().getCountry();
+        }
+
+        String parsedCurrencyCode = proto.getCurrencyCode();
+        if (StringUtils.isEmpty(parsedCurrencyCode)) {
+            try {
+                Currency defaultCurrency = Currency.getInstance(Locale.getDefault());
+                parsedCurrencyCode = defaultCurrency != null ? defaultCurrency.getCurrencyCode() : "USD";
+            } catch (Exception e) {
+                parsedCurrencyCode = "USD";
+            }
+        }
+
         return new SettingsStore(Cookie.fromProto(proto.getCookie()),
                 proto.getDontShowAgainMapMap().entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
@@ -267,6 +294,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 new HashSet<>(proto.getConsumedAlertIdsList()),
                 proto.getCloseMyOfferWhenTaken(),
                 proto.getLanguageTag(),
+                parsedCountryCode,
+                parsedCurrencyCode,
                 proto.getPreventStandbyMode(),
                 new HashSet<>(proto.getSupportedLanguageTagsList()),
                 proto.getDifficultyAdjustmentFactor(),
@@ -316,6 +345,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
                 Set.copyOf(consumedAlertIds),
                 closeMyOfferWhenTaken.get(),
                 languageTag.get(),
+                countryCode.get(),
+                currencyCode.get(),
                 preventStandbyMode.get(),
                 Set.copyOf(supportedLanguageTags),
                 difficultyAdjustmentFactor.get(),
@@ -353,6 +384,8 @@ public final class SettingsStore implements PersistableStore<SettingsStore> {
             consumedAlertIds.setAll(persisted.consumedAlertIds);
             closeMyOfferWhenTaken.set(persisted.closeMyOfferWhenTaken.get());
             languageTag.set(persisted.languageTag.get());
+            countryCode.set(persisted.countryCode.get());
+            currencyCode.set(persisted.currencyCode.get());
             preventStandbyMode.set(persisted.preventStandbyMode.get());
             supportedLanguageTags.setAll(persisted.supportedLanguageTags);
             difficultyAdjustmentFactor.set(persisted.difficultyAdjustmentFactor.get());

--- a/settings/src/main/proto/settings.proto
+++ b/settings/src/main/proto/settings.proto
@@ -78,4 +78,6 @@ message SettingsStore {
   map<string, common.Market> muSigLastSelectedMarketByBaseCurrencyMap = 30;
   common.Market selectedWalletMarket = 31;
   bool muSigTradeRulesConfirmed = 32;
+  string countryCode = 33;
+  string currencyCode = 34;
 }


### PR DESCRIPTION
Description
This PR refactors the "Language" settings into "Language & Region" to provide a cleaner and more integrated user experience. It also resolves a synchronization issue with the top bar market ticker and implements smart defaults for regional settings.

Key Changes:
- UI Redesign: Combined Language, Country, and Currency selectors into a single horizontal row (`HBox`) and removed redundant sub-headlines for a minimalist, professional look.
- Smart Currency Auto-Selection: Implemented logic in the controller to automatically select the most likely default currency when a country is picked (e.g., selecting "Colombia" automatically suggests "COP"), streamlining the onboarding process.
- Locale & es_US Fix: Improved locale handling in `SettingsService` to ensure valid regional defaults are applied correctly, specifically addressing edge cases with certain locale strings like `es_US`.
- Real-time Ticker Sync: Integrated `MarketPriceService` to trigger an immediate refresh of the Top Bar Market Ticker upon currency selection, eliminating the need for an app restart.
- Persistence: Added `countryCode` and `currencyCode` fields to `SettingsStore` and updated the `settings.proto` definitions.

Testing
- Navigated to `Settings -> Language & Region`.
- Verified the new single-row layout.
- Selected different countries and confirmed that the "Default Currency" box updates automatically to the corresponding fiat.
- Verified that the Top Bar Ticker updates instantly when the currency changes.
- Confirmed that all regional settings persist correctly after restarting the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Country and currency selectors added to Language & Region; selections auto-save and restore on launch. Currency list comes from available fiat markets; selecting a currency updates market preference.

* **UI Changes**
  * Section renamed to "Language & Region". Language, country and currency selectors shown together in one row. New labels for country and currency added.

* **Bug Fixes**
  * Better persistence with system locale fallbacks and safer restore on startup.

* **Chores**
  * Settings storage extended to include country and currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->