### PR TITLE
Add new payment accounts dto and create new endpoints

### DIFF
--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -69,6 +69,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.server.ResourceConfig;
 
+import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,7 +77,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /**
  * Swagger docs at: http://localhost:8090/doc/v1/index.html if rest is enabled
@@ -163,8 +163,8 @@ public class ApiService implements Service {
         UserIdentityRestApi userIdentityRestApi = new UserIdentityRestApi(securityService, userService.getUserIdentityService(), bisqEasyService);
         MarketPriceRestApi marketPriceRestApi = new MarketPriceRestApi(bondedRolesService.getMarketPriceService());
         SettingsRestApi settingsRestApi = new SettingsRestApi(settingsService);
-        PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
         FiatPaymentAccountsRestApi fiatPaymentAccountsRestApi = new FiatPaymentAccountsRestApi(accountService);
+        PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
         UserProfileRestApi userProfileRestApi = new UserProfileRestApi(
                 userService.getUserProfileService(),
                 supportedService.getModerationRequestService(),
@@ -188,8 +188,8 @@ public class ApiService implements Service {
                     marketPriceRestApi,
                     settingsRestApi,
                     explorerRestApi,
-                    paymentAccountsRestApi,
                     fiatPaymentAccountsRestApi,
+                    paymentAccountsRestApi,
                     reputationRestApi,
                     userProfileRestApi,
                     devicesRestApi);

--- a/api/src/main/java/bisq/api/dto/DtoMappings.java
+++ b/api/src/main/java/bisq/api/dto/DtoMappings.java
@@ -19,21 +19,67 @@ package bisq.api.dto;
 
 import bisq.account.accounts.Account;
 import bisq.account.accounts.AccountOrigin;
-import bisq.account.accounts.fiat.UserDefinedFiatAccount;
-import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
-import bisq.account.timestamp.KeyType;
 import bisq.account.payment_method.BitcoinPaymentMethod;
-import bisq.account.payment_method.PaymentMethod;
-import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.account.payment_method.BitcoinPaymentMethodSpec;
+import bisq.account.payment_method.PaymentMethod;
 import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.account.payment_method.PaymentMethodSpecUtil;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.account.protocol_type.TradeProtocolType;
-import bisq.api.dto.account.UserDefinedFiatAccountDto;
-import bisq.api.dto.account.UserDefinedFiatAccountPayloadDto;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.AchTransferAccountDto;
+import bisq.api.dto.account.fiat.AdvancedCashAccountDto;
+import bisq.api.dto.account.fiat.AliPayAccountDto;
+import bisq.api.dto.account.fiat.AmazonGiftCardAccountDto;
+import bisq.api.dto.account.fiat.BizumAccountDto;
+import bisq.api.dto.account.fiat.CashByMailAccountDto;
+import bisq.api.dto.account.fiat.CashDepositAccountDto;
+import bisq.api.dto.account.fiat.DomesticWireTransferAccountDto;
+import bisq.api.dto.account.fiat.F2FAccountDto;
+import bisq.api.dto.account.fiat.FasterPaymentsAccountDto;
 import bisq.api.dto.account.fiat.FiatAccountDto;
+import bisq.api.dto.account.fiat.FiatPaymentMethodItemDto;
+import bisq.api.dto.account.fiat.FiatPaymentRailDto;
+import bisq.api.dto.account.fiat.HalCashAccountDto;
+import bisq.api.dto.account.fiat.ImpsAccountDto;
+import bisq.api.dto.account.fiat.InteracETransferAccountDto;
+import bisq.api.dto.account.fiat.MercadoPagoAccountDto;
+import bisq.api.dto.account.fiat.MoneseAccountDto;
+import bisq.api.dto.account.fiat.MoneyBeamAccountDto;
+import bisq.api.dto.account.fiat.MoneyGramAccountDto;
+import bisq.api.dto.account.fiat.NationalBankAccountDto;
+import bisq.api.dto.account.fiat.NeftAccountDto;
+import bisq.api.dto.account.fiat.PayIdAccountDto;
+import bisq.api.dto.account.fiat.PayseraAccountDto;
+import bisq.api.dto.account.fiat.PerfectMoneyAccountDto;
+import bisq.api.dto.account.fiat.Pin4AccountDto;
+import bisq.api.dto.account.fiat.PixAccountDto;
+import bisq.api.dto.account.fiat.PromptPayAccountDto;
+import bisq.api.dto.account.fiat.RevolutAccountDto;
+import bisq.api.dto.account.fiat.SameBankAccountDto;
+import bisq.api.dto.account.fiat.SatispayAccountDto;
+import bisq.api.dto.account.fiat.SbpAccountDto;
+import bisq.api.dto.account.fiat.SepaAccountDto;
+import bisq.api.dto.account.fiat.SepaInstantAccountDto;
+import bisq.api.dto.account.fiat.StrikeAccountDto;
+import bisq.api.dto.account.fiat.SwiftAccountDto;
+import bisq.api.dto.account.fiat.SwishAccountDto;
+import bisq.api.dto.account.fiat.USPostalMoneyOrderAccountDto;
+import bisq.api.dto.account.fiat.USPostalMoneyOrderAccountPayloadDto;
+import bisq.api.dto.account.fiat.UpholdAccountDto;
+import bisq.api.dto.account.fiat.UpholdAccountPayloadDto;
+import bisq.api.dto.account.fiat.UpiAccountDto;
+import bisq.api.dto.account.fiat.UpiAccountPayloadDto;
+import bisq.api.dto.account.fiat.WeChatPayAccountDto;
+import bisq.api.dto.account.fiat.WeChatPayAccountPayloadDto;
+import bisq.api.dto.account.fiat.WiseAccountDto;
+import bisq.api.dto.account.fiat.WiseAccountPayloadDto;
+import bisq.api.dto.account.fiat.WiseUsdAccountDto;
+import bisq.api.dto.account.fiat.WiseUsdAccountPayloadDto;
+import bisq.api.dto.account.fiat.ZelleAccountDto;
+import bisq.api.dto.account.fiat.ZelleAccountPayloadDto;
 import bisq.api.dto.account.protocol_type.TradeProtocolTypeDto;
 import bisq.api.dto.chat.ChatChannelDomainDto;
 import bisq.api.dto.chat.ChatMessageTypeDto;
@@ -55,6 +101,41 @@ import bisq.api.dto.contract.PartyDto;
 import bisq.api.dto.contract.RoleDto;
 import bisq.api.dto.contract.bisq_easy.BisqEasyContractDto;
 import bisq.api.dto.identity.IdentityDto;
+import bisq.api.dto.mappings.fiat.AchTransferAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.AdvancedCashAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.AliPayAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.AmazonGiftCardAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.BizumAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.CashByMailAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.CashDepositAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.DomesticWireTransferAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.F2FAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.FasterPaymentsAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.HalCashAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.ImpsAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.InteracETransferAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.MercadoPagoAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.MoneseAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.MoneyBeamAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.MoneyGramAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.NationalBankAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.NeftAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.PayIdAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.PayseraAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.PerfectMoneyAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.Pin4AccountDtoMapping;
+import bisq.api.dto.mappings.fiat.PixAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.PromptPayAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.RevolutAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SameBankAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SatispayAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SbpAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SepaAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SepaInstantAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.StrikeAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SwiftAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.SwishAccountDtoMapping;
+import bisq.api.dto.mappings.fiat.UserDefinedFiatAccountDtoMapping;
 import bisq.api.dto.network.identity.NetworkIdDto;
 import bisq.api.dto.offer.DirectionDto;
 import bisq.api.dto.offer.amount.spec.AmountSpecDto;
@@ -100,6 +181,8 @@ import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeMessage;
 import bisq.chat.reactions.BisqEasyOpenTradeMessageReaction;
 import bisq.common.encoding.Hex;
+import bisq.common.locale.Country;
+import bisq.common.locale.CountryRepository;
 import bisq.common.market.Market;
 import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
@@ -112,6 +195,7 @@ import bisq.contract.ContractSignatureData;
 import bisq.contract.Party;
 import bisq.contract.Role;
 import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.i18n.Res;
 import bisq.identity.Identity;
 import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
@@ -1134,15 +1218,27 @@ public class DtoMappings {
     }
 
     // paymentaccount
-    public static class UserDefinedFiatAccountMapping {
-        // toBisq2Model method not implemented, as we get accountName, accountData props for account creation calls
+    public static class FiatPaymentMethodItemMapping {
+        public static FiatPaymentMethodItemDto fromBisq2Model(FiatPaymentMethod paymentMethod) {
+            java.util.List<Country> supportedCountries = paymentMethod.getSupportedCountries();
+            java.util.List<String> countryCodes = supportedCountries.stream()
+                    .map(Country::getCode)
+                    .sorted()
+                    .toList();
+            String countryNames = CountryRepository.matchesAllCountries(countryCodes)
+                    ? Res.get("paymentAccounts.allCountries")
+                    : supportedCountries.stream()
+                    .map(Country::getName)
+                    .sorted()
+                    .collect(Collectors.joining(", "));
 
-        public static UserDefinedFiatAccountDto fromBisq2Model(UserDefinedFiatAccount account) {
-            return new UserDefinedFiatAccountDto(
-                    account.getAccountName(),
-                    new UserDefinedFiatAccountPayloadDto(
-                            account.getAccountPayload().getAccountData()
-                    )
+            return new FiatPaymentMethodItemDto(
+                    FiatPaymentRailMapping.fromBisq2Model(paymentMethod.getPaymentRail()),
+                    paymentMethod.getShortDisplayString(),
+                    paymentMethod.getSupportedCurrencyCodesAsDisplayString(),
+                    paymentMethod.getSupportedCurrencyDisplayNameAndCodeAsDisplayString(),
+                    countryNames,
+                    paymentMethod.getPaymentRail().getChargebackRisk().toString()
             );
         }
     }
@@ -1151,85 +1247,624 @@ public class DtoMappings {
      * Mapping for polymorphic fiat accounts.
      * Supports all FiatPaymentRail types through the FiatAccountDto interface.
      */
-    public static class FiatAccountMapping {
-        public static final int MIN_ACCOUNT_NAME_LENGTH = 2;
-        public static final int MAX_ACCOUNT_NAME_LENGTH = 20;
+    public static class FiatPaymentRailMapping {
+        public static FiatPaymentRail toBisq2Model(FiatPaymentRailDto value) {
+            if (value == null) {
+                return null;
+            }
+            return FiatPaymentRail.valueOf(value.name());
+        }
 
-        /**
-         * Convert a FiatAccountDto to a Bisq2 Account model.
-         * Currently only supports CUSTOM (UserDefinedFiatAccount).
-         * TODO: Add support for other fiat account types (SEPA, Revolut, Zelle, etc.)
-         */
+        public static FiatPaymentRailDto fromBisq2Model(FiatPaymentRail value) {
+            if (value == null) {
+                return null;
+            }
+            return FiatPaymentRailDto.valueOf(value.name());
+        }
+    }
+
+    public static class FiatAccountMapping {
         public static Account<? extends PaymentMethod<?>, ?> toBisq2Model(FiatAccountDto dto) {
             if (dto == null) {
                 throw new IllegalArgumentException("FiatAccountDto cannot be null");
             }
 
-            String accountName = dto.accountName();
-            if (accountName == null || accountName.trim().isEmpty()) {
-                throw new IllegalArgumentException("Account name is required");
-            }
-            String trimmedName = accountName.trim();
-            if (trimmedName.length() < MIN_ACCOUNT_NAME_LENGTH || trimmedName.length() > MAX_ACCOUNT_NAME_LENGTH) {
-                throw new IllegalArgumentException(
-                        "Account name must be between " + MIN_ACCOUNT_NAME_LENGTH +
-                                " and " + MAX_ACCOUNT_NAME_LENGTH + " characters");
-            }
-
-            return switch (dto.paymentRail()) {
+            return switch (FiatPaymentRailMapping.toBisq2Model(dto.paymentRail())) {
+                case ACH_TRANSFER -> {
+                    if (dto instanceof AchTransferAccountDto typedDto) {
+                        yield AchTransferAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected AchTransferAccountDto for ACH_TRANSFER payment rail");
+                }
+                case ADVANCED_CASH -> {
+                    if (dto instanceof AdvancedCashAccountDto typedDto) {
+                        yield AdvancedCashAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected AdvancedCashAccountDto for ADVANCED_CASH payment rail");
+                }
+                case ALI_PAY -> {
+                    if (dto instanceof AliPayAccountDto typedDto) {
+                        yield AliPayAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected AliPayAccountDto for ALI_PAY payment rail");
+                }
+                case AMAZON_GIFT_CARD -> {
+                    if (dto instanceof AmazonGiftCardAccountDto typedDto) {
+                        yield AmazonGiftCardAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected AmazonGiftCardAccountDto for AMAZON_GIFT_CARD payment rail");
+                }
+                case BIZUM -> {
+                    if (dto instanceof BizumAccountDto typedDto) {
+                        yield BizumAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected BizumAccountDto for BIZUM payment rail");
+                }
+                case CASH_BY_MAIL -> {
+                    if (dto instanceof CashByMailAccountDto typedDto) {
+                        yield CashByMailAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected CashByMailAccountDto for CASH_BY_MAIL payment rail");
+                }
+                case CASH_DEPOSIT -> {
+                    if (dto instanceof CashDepositAccountDto typedDto) {
+                        yield CashDepositAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected CashDepositAccountDto for CASH_DEPOSIT payment rail");
+                }
                 case CUSTOM -> {
-                    if (dto instanceof bisq.api.dto.account.fiat.UserDefinedFiatAccountDto userDefinedDto) {
-                        bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto payloadDto = userDefinedDto.accountPayload();
-                        UserDefinedFiatAccountPayload payload = new UserDefinedFiatAccountPayload(
+                    if (dto instanceof bisq.api.dto.account.fiat.UserDefinedFiatAccountDto typedDto) {
+                        yield UserDefinedFiatAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected UserDefinedFiatAccountDto for CUSTOM payment rail");
+                }
+                case DOMESTIC_WIRE_TRANSFER -> {
+                    if (dto instanceof DomesticWireTransferAccountDto typedDto) {
+                        yield DomesticWireTransferAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected DomesticWireTransferAccountDto for DOMESTIC_WIRE_TRANSFER payment rail");
+                }
+                case F2F -> {
+                    if (dto instanceof F2FAccountDto typedDto) {
+                        yield F2FAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected F2FAccountDto for F2F payment rail");
+                }
+                case FASTER_PAYMENTS -> {
+                    if (dto instanceof FasterPaymentsAccountDto typedDto) {
+                        yield FasterPaymentsAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected FasterPaymentsAccountDto for FASTER_PAYMENTS payment rail");
+                }
+                case HAL_CASH -> {
+                    if (dto instanceof HalCashAccountDto typedDto) {
+                        yield HalCashAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected HalCashAccountDto for HAL_CASH payment rail");
+                }
+                case IMPS -> {
+                    if (dto instanceof ImpsAccountDto typedDto) {
+                        yield ImpsAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected ImpsAccountDto for IMPS payment rail");
+                }
+                case INTERAC_E_TRANSFER -> {
+                    if (dto instanceof InteracETransferAccountDto typedDto) {
+                        yield InteracETransferAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected InteracETransferAccountDto for INTERAC_E_TRANSFER payment rail");
+                }
+                case MERCADO_PAGO -> {
+                    if (dto instanceof MercadoPagoAccountDto typedDto) {
+                        yield MercadoPagoAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected MercadoPagoAccountDto for MERCADO_PAGO payment rail");
+                }
+                case MONESE -> {
+                    if (dto instanceof MoneseAccountDto typedDto) {
+                        yield MoneseAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected MoneseAccountDto for MONESE payment rail");
+                }
+                case MONEY_BEAM -> {
+                    if (dto instanceof MoneyBeamAccountDto typedDto) {
+                        yield MoneyBeamAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected MoneyBeamAccountDto for MONEY_BEAM payment rail");
+                }
+                case MONEY_GRAM -> {
+                    if (dto instanceof MoneyGramAccountDto typedDto) {
+                        yield MoneyGramAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected MoneyGramAccountDto for MONEY_GRAM payment rail");
+                }
+                case NATIONAL_BANK -> {
+                    if (dto instanceof NationalBankAccountDto typedDto) {
+                        yield NationalBankAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected NationalBankAccountDto for NATIONAL_BANK payment rail");
+                }
+                case NEFT -> {
+                    if (dto instanceof NeftAccountDto typedDto) {
+                        yield NeftAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected NeftAccountDto for NEFT payment rail");
+                }
+                case PAYSERA -> {
+                    if (dto instanceof PayseraAccountDto typedDto) {
+                        yield PayseraAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected PayseraAccountDto for PAYSERA payment rail");
+                }
+                case PAY_ID -> {
+                    if (dto instanceof PayIdAccountDto typedDto) {
+                        yield PayIdAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected PayIdAccountDto for PAY_ID payment rail");
+                }
+                case PERFECT_MONEY -> {
+                    if (dto instanceof PerfectMoneyAccountDto typedDto) {
+                        yield PerfectMoneyAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected PerfectMoneyAccountDto for PERFECT_MONEY payment rail");
+                }
+                case PIN_4 -> {
+                    if (dto instanceof Pin4AccountDto typedDto) {
+                        yield Pin4AccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected Pin4AccountDto for PIN_4 payment rail");
+                }
+                case PIX -> {
+                    if (dto instanceof PixAccountDto typedDto) {
+                        yield PixAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected PixAccountDto for PIX payment rail");
+                }
+                case PROMPT_PAY -> {
+                    if (dto instanceof PromptPayAccountDto typedDto) {
+                        yield PromptPayAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected PromptPayAccountDto for PROMPT_PAY payment rail");
+                }
+                case REVOLUT -> {
+                    if (dto instanceof RevolutAccountDto typedDto) {
+                        yield RevolutAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected RevolutAccountDto for REVOLUT payment rail");
+                }
+                case SAME_BANK -> {
+                    if (dto instanceof SameBankAccountDto typedDto) {
+                        yield SameBankAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SameBankAccountDto for SAME_BANK payment rail");
+                }
+                case SATISPAY -> {
+                    if (dto instanceof SatispayAccountDto typedDto) {
+                        yield SatispayAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SatispayAccountDto for SATISPAY payment rail");
+                }
+                case SBP -> {
+                    if (dto instanceof SbpAccountDto typedDto) {
+                        yield SbpAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SbpAccountDto for SBP payment rail");
+                }
+                case SEPA -> {
+                    if (dto instanceof SepaAccountDto typedDto) {
+                        yield SepaAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SepaAccountDto for SEPA payment rail");
+                }
+                case SEPA_INSTANT -> {
+                    if (dto instanceof SepaInstantAccountDto typedDto) {
+                        yield SepaInstantAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SepaInstantAccountDto for SEPA_INSTANT payment rail");
+                }
+                case STRIKE -> {
+                    if (dto instanceof StrikeAccountDto typedDto) {
+                        yield StrikeAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected StrikeAccountDto for STRIKE payment rail");
+                }
+                case SWIFT -> {
+                    if (dto instanceof SwiftAccountDto typedDto) {
+                        yield SwiftAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SwiftAccountDto for SWIFT payment rail");
+                }
+                case SWISH -> {
+                    if (dto instanceof SwishAccountDto typedDto) {
+                        yield SwishAccountDtoMapping.toBisq2Model(typedDto);
+                    }
+                    throw new IllegalArgumentException("Expected SwishAccountDto for SWISH payment rail");
+                }
+                case UPHOLD -> {
+                    if (dto instanceof UpholdAccountDto typedDto) {
+                        UpholdAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.UpholdAccountPayload payload = new bisq.account.accounts.fiat.UpholdAccountPayload(
                                 bisq.common.util.StringUtils.createUid(),
-                                payloadDto.accountData()
+                                payloadDto.selectedCurrencyCodes(),
+                                payloadDto.holderName(),
+                                payloadDto.accountId()
                         );
                         KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
                         KeyType keyType = KeyType.EC;
-                        yield new UserDefinedFiatAccount(
+                        yield new bisq.account.accounts.fiat.UpholdAccount(
                                 bisq.common.util.StringUtils.createUid(),
                                 System.currentTimeMillis(),
-                                userDefinedDto.accountName(),
+                                typedDto.accountName(),
                                 payload,
                                 keyPair,
                                 keyType,
                                 AccountOrigin.BISQ2_NEW
                         );
                     }
-                    throw new IllegalArgumentException("Expected UserDefinedFiatAccountDto for CUSTOM payment rail");
+                    throw new IllegalArgumentException("Expected UpholdAccountDto for UPHOLD payment rail");
                 }
-                // TODO: Add cases for other payment rails when implemented:
-                // case SEPA -> { ... }
-                // case REVOLUT -> { ... }
-                // case ZELLE -> { ... }
+                case UPI -> {
+                    if (dto instanceof UpiAccountDto typedDto) {
+                        UpiAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.UpiAccountPayload payload = new bisq.account.accounts.fiat.UpiAccountPayload(
+                                bisq.common.util.StringUtils.createUid(),
+                                payloadDto.countryCode(),
+                                payloadDto.virtualPaymentAddress()
+                        );
+                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+                        KeyType keyType = KeyType.EC;
+                        yield new bisq.account.accounts.fiat.UpiAccount(
+                                bisq.common.util.StringUtils.createUid(),
+                                System.currentTimeMillis(),
+                                typedDto.accountName(),
+                                payload,
+                                keyPair,
+                                keyType,
+                                AccountOrigin.BISQ2_NEW
+                        );
+                    }
+                    throw new IllegalArgumentException("Expected UpiAccountDto for UPI payment rail");
+                }
+                case US_POSTAL_MONEY_ORDER -> {
+                    if (dto instanceof USPostalMoneyOrderAccountDto typedDto) {
+                        USPostalMoneyOrderAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.USPostalMoneyOrderAccountPayload payload = new bisq.account.accounts.fiat.USPostalMoneyOrderAccountPayload(
+                                bisq.common.util.StringUtils.createUid(),
+                                payloadDto.holderName(),
+                                payloadDto.postalAddress()
+                        );
+                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+                        KeyType keyType = KeyType.EC;
+                        yield new bisq.account.accounts.fiat.USPostalMoneyOrderAccount(
+                                bisq.common.util.StringUtils.createUid(),
+                                System.currentTimeMillis(),
+                                typedDto.accountName(),
+                                payload,
+                                keyPair,
+                                keyType,
+                                AccountOrigin.BISQ2_NEW
+                        );
+                    }
+                    throw new IllegalArgumentException("Expected USPostalMoneyOrderAccountDto for US_POSTAL_MONEY_ORDER payment rail");
+                }
+                case WECHAT_PAY -> {
+                    if (dto instanceof WeChatPayAccountDto typedDto) {
+                        WeChatPayAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.WeChatPayAccountPayload payload = new bisq.account.accounts.fiat.WeChatPayAccountPayload(
+                                bisq.common.util.StringUtils.createUid(),
+                                payloadDto.accountNr()
+                        );
+                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+                        KeyType keyType = KeyType.EC;
+                        yield new bisq.account.accounts.fiat.WeChatPayAccount(
+                                bisq.common.util.StringUtils.createUid(),
+                                System.currentTimeMillis(),
+                                typedDto.accountName(),
+                                payload,
+                                keyPair,
+                                keyType,
+                                AccountOrigin.BISQ2_NEW
+                        );
+                    }
+                    throw new IllegalArgumentException("Expected WeChatPayAccountDto for WECHAT_PAY payment rail");
+                }
+                case WISE -> {
+                    if (dto instanceof WiseAccountDto typedDto) {
+                        WiseAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.WiseAccountPayload payload = new bisq.account.accounts.fiat.WiseAccountPayload(
+                                bisq.common.util.StringUtils.createUid(),
+                                payloadDto.selectedCurrencyCodes(),
+                                payloadDto.holderName(),
+                                payloadDto.email()
+                        );
+                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+                        KeyType keyType = KeyType.EC;
+                        yield new bisq.account.accounts.fiat.WiseAccount(
+                                bisq.common.util.StringUtils.createUid(),
+                                System.currentTimeMillis(),
+                                typedDto.accountName(),
+                                payload,
+                                keyPair,
+                                keyType,
+                                AccountOrigin.BISQ2_NEW
+                        );
+                    }
+                    throw new IllegalArgumentException("Expected WiseAccountDto for WISE payment rail");
+                }
+                case WISE_USD -> {
+                    if (dto instanceof WiseUsdAccountDto typedDto) {
+                        WiseUsdAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.WiseUsdAccountPayload payload = new bisq.account.accounts.fiat.WiseUsdAccountPayload(
+                                bisq.common.util.StringUtils.createUid(),
+                                payloadDto.countryCode(),
+                                payloadDto.holderName(),
+                                payloadDto.email(),
+                                payloadDto.beneficiaryAddress()
+                        );
+                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+                        KeyType keyType = KeyType.EC;
+                        yield new bisq.account.accounts.fiat.WiseUsdAccount(
+                                bisq.common.util.StringUtils.createUid(),
+                                System.currentTimeMillis(),
+                                typedDto.accountName(),
+                                payload,
+                                keyPair,
+                                keyType,
+                                AccountOrigin.BISQ2_NEW
+                        );
+                    }
+                    throw new IllegalArgumentException("Expected WiseUsdAccountDto for WISE_USD payment rail");
+                }
+                case ZELLE -> {
+                    if (dto instanceof ZelleAccountDto typedDto) {
+                        ZelleAccountPayloadDto payloadDto = typedDto.accountPayload();
+                        bisq.account.accounts.fiat.ZelleAccountPayload payload = new bisq.account.accounts.fiat.ZelleAccountPayload(
+                                bisq.common.util.StringUtils.createUid(),
+                                payloadDto.holderName(),
+                                payloadDto.emailOrMobileNr()
+                        );
+                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+                        KeyType keyType = KeyType.EC;
+                        yield new bisq.account.accounts.fiat.ZelleAccount(
+                                bisq.common.util.StringUtils.createUid(),
+                                System.currentTimeMillis(),
+                                typedDto.accountName(),
+                                payload,
+                                keyPair,
+                                keyType,
+                                AccountOrigin.BISQ2_NEW
+                        );
+                    }
+                    throw new IllegalArgumentException("Expected ZelleAccountDto for ZELLE payment rail");
+                }
                 default -> throw new IllegalArgumentException("Unsupported payment rail: " + dto.paymentRail());
             };
         }
 
-        /**
-         * Convert a Bisq2 Account model to a FiatAccountDto.
-         * Currently only supports UserDefinedFiatAccount.
-         * TODO: Add support for other fiat account types (SEPA, Revolut, Zelle, etc.)
-         */
         public static FiatAccountDto fromBisq2Model(Account<? extends PaymentMethod<?>, ?> account) {
             if (account == null) {
                 throw new IllegalArgumentException("Account cannot be null");
             }
 
-            if (account instanceof UserDefinedFiatAccount userDefinedAccount) {
-                return new bisq.api.dto.account.fiat.UserDefinedFiatAccountDto(
-                        userDefinedAccount.getAccountName(),
-                        FiatPaymentRail.CUSTOM,
-                        new bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto(
-                                userDefinedAccount.getAccountPayload().getAccountData()
+            if (account instanceof bisq.account.accounts.fiat.AchTransferAccount typed) {
+                return AchTransferAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.AdvancedCashAccount typed) {
+                return AdvancedCashAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.AliPayAccount typed) {
+                return AliPayAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.AmazonGiftCardAccount typed) {
+                return AmazonGiftCardAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.BizumAccount typed) {
+                return BizumAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.CashByMailAccount typed) {
+                return CashByMailAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.CashDepositAccount typed) {
+                return CashDepositAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.UserDefinedFiatAccount typed) {
+                return UserDefinedFiatAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.DomesticWireTransferAccount typed) {
+                return DomesticWireTransferAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.F2FAccount typed) {
+                return F2FAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.FasterPaymentsAccount typed) {
+                return FasterPaymentsAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.HalCashAccount typed) {
+                return HalCashAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.ImpsAccount typed) {
+                return ImpsAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.InteracETransferAccount typed) {
+                return InteracETransferAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.MercadoPagoAccount typed) {
+                return MercadoPagoAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.MoneseAccount typed) {
+                return MoneseAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.MoneyBeamAccount typed) {
+                return MoneyBeamAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.MoneyGramAccount typed) {
+                return MoneyGramAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.NationalBankAccount typed) {
+                return NationalBankAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.NeftAccount typed) {
+                return NeftAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.PayseraAccount typed) {
+                return PayseraAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.PayIdAccount typed) {
+                return PayIdAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.PerfectMoneyAccount typed) {
+                return PerfectMoneyAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.Pin4Account typed) {
+                return Pin4AccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.PixAccount typed) {
+                return PixAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.PromptPayAccount typed) {
+                return PromptPayAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.RevolutAccount typed) {
+                return RevolutAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SameBankAccount typed) {
+                return SameBankAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SatispayAccount typed) {
+                return SatispayAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SbpAccount typed) {
+                return SbpAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SepaAccount typed) {
+                return SepaAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SepaInstantAccount typed) {
+                return SepaInstantAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.StrikeAccount typed) {
+                return StrikeAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SwiftAccount typed) {
+                return SwiftAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.SwishAccount typed) {
+                return SwishAccountDtoMapping.fromBisq2Model(typed);
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.UpholdAccount typed) {
+                return new UpholdAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.UPHOLD),
+                        new UpholdAccountPayloadDto(
+                                typed.getAccountPayload().getSelectedCurrencyCodes(),
+                                typed.getAccountPayload().getHolderName(),
+                                typed.getAccountPayload().getAccountId()
                         )
                 );
             }
 
-            // TODO: Add conversions for other account types when implemented:
-            // if (account instanceof SepaAccount sepaAccount) { ... }
-            // if (account instanceof RevolutAccount revolutAccount) { ... }
-            // if (account instanceof ZelleAccount zelleAccount) { ... }
+            if (account instanceof bisq.account.accounts.fiat.UpiAccount typed) {
+                return new UpiAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.UPI),
+                        new UpiAccountPayloadDto(
+                                typed.getAccountPayload().getCountryCode(),
+                                typed.getAccountPayload().getVirtualPaymentAddress()
+                        )
+                );
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.USPostalMoneyOrderAccount typed) {
+                return new USPostalMoneyOrderAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.US_POSTAL_MONEY_ORDER),
+                        new USPostalMoneyOrderAccountPayloadDto(
+                                typed.getAccountPayload().getHolderName(),
+                                typed.getAccountPayload().getPostalAddress()
+                        )
+                );
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.WeChatPayAccount typed) {
+                return new WeChatPayAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.WECHAT_PAY),
+                        new WeChatPayAccountPayloadDto(
+                                typed.getAccountPayload().getAccountNr()
+                        )
+                );
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.WiseAccount typed) {
+                return new WiseAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.WISE),
+                        new WiseAccountPayloadDto(
+                                typed.getAccountPayload().getSelectedCurrencyCodes(),
+                                typed.getAccountPayload().getHolderName(),
+                                typed.getAccountPayload().getEmail()
+                        )
+                );
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.WiseUsdAccount typed) {
+                return new WiseUsdAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.WISE_USD),
+                        new WiseUsdAccountPayloadDto(
+                                typed.getAccountPayload().getCountryCode(),
+                                typed.getAccountPayload().getHolderName(),
+                                typed.getAccountPayload().getEmail(),
+                                typed.getAccountPayload().getBeneficiaryAddress()
+                        )
+                );
+            }
+
+            if (account instanceof bisq.account.accounts.fiat.ZelleAccount typed) {
+                return new ZelleAccountDto(
+                        typed.getAccountName(),
+                        FiatPaymentRailMapping.fromBisq2Model(FiatPaymentRail.ZELLE),
+                        new ZelleAccountPayloadDto(
+                                typed.getAccountPayload().getHolderName(),
+                                typed.getAccountPayload().getEmailOrMobileNr()
+                        )
+                );
+            }
 
             throw new IllegalArgumentException("Unsupported account type: " + account.getClass().getSimpleName());
         }

--- a/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountDto.java
@@ -1,7 +1,0 @@
-package bisq.api.dto.account;
-
-public record UserDefinedFiatAccountDto(
-    String accountName,
-    UserDefinedFiatAccountPayloadDto accountPayload
-) { }
-

--- a/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountPayloadDto.java
@@ -1,5 +1,0 @@
-package bisq.api.dto.account;
-
-public record UserDefinedFiatAccountPayloadDto(
-        String accountData
-) { }

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoAccountDto.java
@@ -1,0 +1,22 @@
+package bisq.api.dto.account.crypto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "paymentRail",
+        visible = true
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = MoneroAccountDto.class, name = "MONERO"),
+        @JsonSubTypes.Type(value = OtherCryptoAssetAccountDto.class, name = "OTHER_CRYPTO_ASSET")
+})
+public interface CryptoAccountDto {
+    String accountName();
+
+    CryptoPaymentRailDto paymentRail();
+
+    CryptoAccountPayloadDto accountPayload();
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoAccountPayloadDto.java
@@ -1,0 +1,4 @@
+package bisq.api.dto.account.crypto;
+
+public interface CryptoAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentMethodItemDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentMethodItemDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.crypto;
+
+public record CryptoPaymentMethodItemDto(
+        String code,
+        String name,
+        String category
+) {
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentRailDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentRailDto.java
@@ -1,0 +1,6 @@
+package bisq.api.dto.account.crypto;
+
+public enum CryptoPaymentRailDto {
+    MONERO,
+    OTHER_CRYPTO_ASSET
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.crypto;
+
+public record MoneroAccountDto(
+        String accountName,
+        CryptoPaymentRailDto paymentRail,
+        MoneroAccountPayloadDto accountPayload
+) implements CryptoAccountDto {
+
+    public MoneroAccountDto {
+        if (paymentRail != CryptoPaymentRailDto.MONERO) {
+            throw new IllegalArgumentException("paymentRail must be MONERO");
+        }
+    }
+
+    public MoneroAccountDto(String accountName,
+                            MoneroAccountPayloadDto accountPayload) {
+        this(accountName, CryptoPaymentRailDto.MONERO, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountPayloadDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.crypto;
+
+import java.util.Optional;
+
+public record MoneroAccountPayloadDto(
+        String currencyCode,
+        String address,
+        boolean isInstant,
+        Optional<Boolean> isAutoConf,
+        Optional<Integer> autoConfNumConfirmations,
+        Optional<Long> autoConfMaxTradeAmount,
+        Optional<String> autoConfExplorerUrls,
+        boolean useSubAddresses,
+        Optional<String> mainAddress,
+        Optional<String> privateViewKey,
+        Optional<String> subAddress,
+        Optional<Integer> accountIndex,
+        Optional<Integer> initialSubAddressIndex
+) implements CryptoAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.crypto;
+
+public record OtherCryptoAssetAccountDto(
+        String accountName,
+        CryptoPaymentRailDto paymentRail,
+        OtherCryptoAssetAccountPayloadDto accountPayload
+) implements CryptoAccountDto {
+
+    public OtherCryptoAssetAccountDto {
+        if (paymentRail != CryptoPaymentRailDto.OTHER_CRYPTO_ASSET) {
+            throw new IllegalArgumentException("paymentRail must be OTHER_CRYPTO_ASSET");
+        }
+    }
+
+    public OtherCryptoAssetAccountDto(String accountName,
+                                      OtherCryptoAssetAccountPayloadDto accountPayload) {
+        this(accountName, CryptoPaymentRailDto.OTHER_CRYPTO_ASSET, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountPayloadDto.java
@@ -1,0 +1,14 @@
+package bisq.api.dto.account.crypto;
+
+import java.util.Optional;
+
+public record OtherCryptoAssetAccountPayloadDto(
+        String currencyCode,
+        String address,
+        boolean isInstant,
+        Optional<Boolean> isAutoConf,
+        Optional<Integer> autoConfNumConfirmations,
+        Optional<Long> autoConfMaxTradeAmount,
+        Optional<String> autoConfExplorerUrls
+) implements CryptoAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AchTransferAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AchTransferAccountDto.java
@@ -1,0 +1,21 @@
+package bisq.api.dto.account.fiat;
+
+public record AchTransferAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        AchTransferAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public AchTransferAccountDto {
+        if (paymentRail != FiatPaymentRailDto.ACH_TRANSFER) {
+            throw new IllegalArgumentException("paymentRail must be ACH_TRANSFER");
+        }
+    }
+
+    public AchTransferAccountDto(String accountName,
+                                 AchTransferAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.ACH_TRANSFER, accountPayload);
+    }
+}
+
+

--- a/api/src/main/java/bisq/api/dto/account/fiat/AchTransferAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AchTransferAccountPayloadDto.java
@@ -1,0 +1,13 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.account.accounts.fiat.BankAccountType;
+
+public record AchTransferAccountPayloadDto(
+        String holderName,
+        String holderAddress,
+        String bankName,
+        String routingNr,
+        String accountNr,
+        BankAccountType bankAccountType
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AdvancedCashAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AdvancedCashAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record AdvancedCashAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        AdvancedCashAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public AdvancedCashAccountDto {
+        if (paymentRail != FiatPaymentRailDto.ADVANCED_CASH) {
+            throw new IllegalArgumentException("paymentRail must be ADVANCED_CASH");
+        }
+    }
+
+    public AdvancedCashAccountDto(String accountName,
+                                  AdvancedCashAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.ADVANCED_CASH, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AdvancedCashAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AdvancedCashAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record AdvancedCashAccountPayloadDto(
+        List<String> selectedCurrencyCodes,
+        String accountNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AliPayAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AliPayAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record AliPayAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        AliPayAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public AliPayAccountDto {
+        if (paymentRail != FiatPaymentRailDto.ALI_PAY) {
+            throw new IllegalArgumentException("paymentRail must be ALI_PAY");
+        }
+    }
+
+    public AliPayAccountDto(String accountName,
+                            AliPayAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.ALI_PAY, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AliPayAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AliPayAccountPayloadDto.java
@@ -1,0 +1,6 @@
+package bisq.api.dto.account.fiat;
+
+public record AliPayAccountPayloadDto(
+        String accountNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AmazonGiftCardAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AmazonGiftCardAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record AmazonGiftCardAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        AmazonGiftCardAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public AmazonGiftCardAccountDto {
+        if (paymentRail != FiatPaymentRailDto.AMAZON_GIFT_CARD) {
+            throw new IllegalArgumentException("paymentRail must be AMAZON_GIFT_CARD");
+        }
+    }
+
+    public AmazonGiftCardAccountDto(String accountName,
+                                    AmazonGiftCardAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.AMAZON_GIFT_CARD, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/AmazonGiftCardAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/AmazonGiftCardAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record AmazonGiftCardAccountPayloadDto(
+        String countryCode,
+        String selectedCurrencyCode,
+        String emailOrMobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/BizumAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/BizumAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record BizumAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        BizumAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public BizumAccountDto {
+        if (paymentRail != FiatPaymentRailDto.BIZUM) {
+            throw new IllegalArgumentException("paymentRail must be BIZUM");
+        }
+    }
+
+    public BizumAccountDto(String accountName,
+                           BizumAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.BIZUM, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/BizumAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/BizumAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record BizumAccountPayloadDto(
+        String countryCode,
+        String mobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/CashByMailAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/CashByMailAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record CashByMailAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        CashByMailAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public CashByMailAccountDto {
+        if (paymentRail != FiatPaymentRailDto.CASH_BY_MAIL) {
+            throw new IllegalArgumentException("paymentRail must be CASH_BY_MAIL");
+        }
+    }
+
+    public CashByMailAccountDto(String accountName,
+                                CashByMailAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.CASH_BY_MAIL, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/CashByMailAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/CashByMailAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+public record CashByMailAccountPayloadDto(
+        String selectedCurrencyCode,
+        String postalAddress,
+        String contact,
+        String extraInfo
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/CashDepositAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/CashDepositAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record CashDepositAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        CashDepositAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public CashDepositAccountDto {
+        if (paymentRail != FiatPaymentRailDto.CASH_DEPOSIT) {
+            throw new IllegalArgumentException("paymentRail must be CASH_DEPOSIT");
+        }
+    }
+
+    public CashDepositAccountDto(String accountName,
+                                 CashDepositAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.CASH_DEPOSIT, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/CashDepositAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/CashDepositAccountPayloadDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.account.accounts.fiat.BankAccountType;
+
+import java.util.Optional;
+
+public record CashDepositAccountPayloadDto(
+        String countryCode,
+        String selectedCurrencyCode,
+        Optional<String> holderName,
+        Optional<String> holderTaxId,
+        Optional<String> bankName,
+        Optional<String> bankId,
+        Optional<String> branchId,
+        String accountNr,
+        Optional<BankAccountType> bankAccountType,
+        Optional<String> nationalAccountId,
+        Optional<String> requirements
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/DomesticWireTransferAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/DomesticWireTransferAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record DomesticWireTransferAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        DomesticWireTransferAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public DomesticWireTransferAccountDto {
+        if (paymentRail != FiatPaymentRailDto.DOMESTIC_WIRE_TRANSFER) {
+            throw new IllegalArgumentException("paymentRail must be DOMESTIC_WIRE_TRANSFER");
+        }
+    }
+
+    public DomesticWireTransferAccountDto(String accountName,
+                                          DomesticWireTransferAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.DOMESTIC_WIRE_TRANSFER, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/DomesticWireTransferAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/DomesticWireTransferAccountPayloadDto.java
@@ -1,0 +1,10 @@
+package bisq.api.dto.account.fiat;
+
+public record DomesticWireTransferAccountPayloadDto(
+        String holderName,
+        String holderAddress,
+        String bankName,
+        String routingNr,
+        String accountNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/F2FAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/F2FAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record F2FAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        F2FAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public F2FAccountDto {
+        if (paymentRail != FiatPaymentRailDto.F2F) {
+            throw new IllegalArgumentException("paymentRail must be F2F");
+        }
+    }
+
+    public F2FAccountDto(String accountName,
+                         F2FAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.F2F, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/F2FAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/F2FAccountPayloadDto.java
@@ -1,0 +1,10 @@
+package bisq.api.dto.account.fiat;
+
+public record F2FAccountPayloadDto(
+        String countryCode,
+        String selectedCurrencyCode,
+        String city,
+        String contact,
+        String extraInfo
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/FasterPaymentsAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FasterPaymentsAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record FasterPaymentsAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        FasterPaymentsAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public FasterPaymentsAccountDto {
+        if (paymentRail != FiatPaymentRailDto.FASTER_PAYMENTS) {
+            throw new IllegalArgumentException("paymentRail must be FASTER_PAYMENTS");
+        }
+    }
+
+    public FasterPaymentsAccountDto(String accountName,
+                                    FasterPaymentsAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.FASTER_PAYMENTS, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/FasterPaymentsAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FasterPaymentsAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record FasterPaymentsAccountPayloadDto(
+        String holderName,
+        String sortCode,
+        String accountNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatAccountDto.java
@@ -5,49 +5,67 @@
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
- *
- * Bisq is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
- * License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package bisq.api.dto.account.fiat;
 
-import bisq.account.payment_method.fiat.FiatPaymentRail;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-/**
- * Base interface for all fiat payment account DTOs.
- * Each fiat payment rail type (CUSTOM, SEPA, REVOLUT, etc.) will have its own implementation.
- * All fiat account DTOs must have an account name, payment rail type, and payload.
- * 
- * Jackson uses the paymentRail field to determine which concrete type to deserialize to.
- */
 @JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    include = JsonTypeInfo.As.EXISTING_PROPERTY,
-    property = "paymentRail",
-    visible = true
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "paymentRail",
+        visible = true
 )
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = UserDefinedFiatAccountDto.class, name = "CUSTOM")
-    // TODO: Add more when implemented:
-    // @JsonSubTypes.Type(value = SepaAccountDto.class, name = "SEPA"),
-    // @JsonSubTypes.Type(value = RevolutAccountDto.class, name = "REVOLUT"),
-    // @JsonSubTypes.Type(value = ZelleAccountDto.class, name = "ZELLE"),
+        @JsonSubTypes.Type(value = AchTransferAccountDto.class, name = "ACH_TRANSFER"),
+        @JsonSubTypes.Type(value = AdvancedCashAccountDto.class, name = "ADVANCED_CASH"),
+        @JsonSubTypes.Type(value = AliPayAccountDto.class, name = "ALI_PAY"),
+        @JsonSubTypes.Type(value = AmazonGiftCardAccountDto.class, name = "AMAZON_GIFT_CARD"),
+        @JsonSubTypes.Type(value = BizumAccountDto.class, name = "BIZUM"),
+        @JsonSubTypes.Type(value = CashByMailAccountDto.class, name = "CASH_BY_MAIL"),
+        @JsonSubTypes.Type(value = CashDepositAccountDto.class, name = "CASH_DEPOSIT"),
+        @JsonSubTypes.Type(value = UserDefinedFiatAccountDto.class, name = "CUSTOM"),
+        @JsonSubTypes.Type(value = DomesticWireTransferAccountDto.class, name = "DOMESTIC_WIRE_TRANSFER"),
+        @JsonSubTypes.Type(value = F2FAccountDto.class, name = "F2F"),
+        @JsonSubTypes.Type(value = FasterPaymentsAccountDto.class, name = "FASTER_PAYMENTS"),
+        @JsonSubTypes.Type(value = HalCashAccountDto.class, name = "HAL_CASH"),
+        @JsonSubTypes.Type(value = ImpsAccountDto.class, name = "IMPS"),
+        @JsonSubTypes.Type(value = InteracETransferAccountDto.class, name = "INTERAC_E_TRANSFER"),
+        @JsonSubTypes.Type(value = MercadoPagoAccountDto.class, name = "MERCADO_PAGO"),
+        @JsonSubTypes.Type(value = MoneseAccountDto.class, name = "MONESE"),
+        @JsonSubTypes.Type(value = MoneyBeamAccountDto.class, name = "MONEY_BEAM"),
+        @JsonSubTypes.Type(value = MoneyGramAccountDto.class, name = "MONEY_GRAM"),
+        @JsonSubTypes.Type(value = NationalBankAccountDto.class, name = "NATIONAL_BANK"),
+        @JsonSubTypes.Type(value = NeftAccountDto.class, name = "NEFT"),
+        @JsonSubTypes.Type(value = PayseraAccountDto.class, name = "PAYSERA"),
+        @JsonSubTypes.Type(value = PayIdAccountDto.class, name = "PAY_ID"),
+        @JsonSubTypes.Type(value = PerfectMoneyAccountDto.class, name = "PERFECT_MONEY"),
+        @JsonSubTypes.Type(value = Pin4AccountDto.class, name = "PIN_4"),
+        @JsonSubTypes.Type(value = PixAccountDto.class, name = "PIX"),
+        @JsonSubTypes.Type(value = PromptPayAccountDto.class, name = "PROMPT_PAY"),
+        @JsonSubTypes.Type(value = RevolutAccountDto.class, name = "REVOLUT"),
+        @JsonSubTypes.Type(value = SameBankAccountDto.class, name = "SAME_BANK"),
+        @JsonSubTypes.Type(value = SatispayAccountDto.class, name = "SATISPAY"),
+        @JsonSubTypes.Type(value = SbpAccountDto.class, name = "SBP"),
+        @JsonSubTypes.Type(value = SepaAccountDto.class, name = "SEPA"),
+        @JsonSubTypes.Type(value = SepaInstantAccountDto.class, name = "SEPA_INSTANT"),
+        @JsonSubTypes.Type(value = StrikeAccountDto.class, name = "STRIKE"),
+        @JsonSubTypes.Type(value = SwiftAccountDto.class, name = "SWIFT"),
+        @JsonSubTypes.Type(value = SwishAccountDto.class, name = "SWISH"),
+        @JsonSubTypes.Type(value = UpholdAccountDto.class, name = "UPHOLD"),
+        @JsonSubTypes.Type(value = UpiAccountDto.class, name = "UPI"),
+        @JsonSubTypes.Type(value = USPostalMoneyOrderAccountDto.class, name = "US_POSTAL_MONEY_ORDER"),
+        @JsonSubTypes.Type(value = WeChatPayAccountDto.class, name = "WECHAT_PAY"),
+        @JsonSubTypes.Type(value = WiseAccountDto.class, name = "WISE"),
+        @JsonSubTypes.Type(value = WiseUsdAccountDto.class, name = "WISE_USD"),
+        @JsonSubTypes.Type(value = ZelleAccountDto.class, name = "ZELLE")
 })
-public sealed interface FiatAccountDto 
-        permits UserDefinedFiatAccountDto {
-    // TODO: Add more permitted types when implemented:
-    // permits UserDefinedFiatAccountDto, SepaAccountDto, RevolutAccountDto, ZelleAccountDto, etc.
-    
+public interface FiatAccountDto {
     String accountName();
-    FiatPaymentRail paymentRail();
+
+    FiatPaymentRailDto paymentRail();
+
     FiatAccountPayloadDto accountPayload();
 }
-

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatAccountPayloadDto.java
@@ -21,9 +21,5 @@ package bisq.api.dto.account.fiat;
  * Base interface for all fiat payment account payload DTOs.
  * Each fiat payment rail type (CUSTOM, SEPA, REVOLUT, etc.) will have its own implementation.
  */
-public sealed interface FiatAccountPayloadDto 
-        permits UserDefinedFiatAccountPayloadDto {
-    // TODO: Add more permitted types when implemented:
-    // permits UserDefinedFiatAccountPayloadDto, SepaAccountPayloadDto, RevolutAccountPayloadDto, etc.
+public interface FiatAccountPayloadDto {
 }
-

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodItemDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodItemDto.java
@@ -15,13 +15,15 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.api.rest_api.endpoints.payment_accounts;
+package bisq.api.dto.account.fiat;
 
-import bisq.api.dto.account.UserDefinedFiatAccountDto;
 
-import javax.annotation.Nullable;
-
-public record PaymentAccountChangeRequest(
-        @Nullable UserDefinedFiatAccountDto selectedAccount
+public record FiatPaymentMethodItemDto(
+        FiatPaymentRailDto paymentRail,
+        String name,
+        String supportedCurrencyCodes,
+        String supportedNameAndCodes,
+        String countryNames,
+        String chargebackRisk
 ) {
 }

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentRailDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentRailDto.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ */
+
+package bisq.api.dto.account.fiat;
+
+public enum FiatPaymentRailDto {
+    ACH_TRANSFER,
+    ADVANCED_CASH,
+    ALI_PAY,
+    AMAZON_GIFT_CARD,
+    BIZUM,
+    CASH_BY_MAIL,
+    CASH_DEPOSIT,
+    CUSTOM,
+    DOMESTIC_WIRE_TRANSFER,
+    F2F,
+    FASTER_PAYMENTS,
+    HAL_CASH,
+    IMPS,
+    INTERAC_E_TRANSFER,
+    MERCADO_PAGO,
+    MONESE,
+    MONEY_BEAM,
+    MONEY_GRAM,
+    NATIONAL_BANK,
+    NEFT,
+    PAY_ID,
+    PAYSERA,
+    PERFECT_MONEY,
+    PIN_4,
+    PIX,
+    PROMPT_PAY,
+    REVOLUT,
+    SAME_BANK,
+    SATISPAY,
+    SBP,
+    SEPA,
+    SEPA_INSTANT,
+    STRIKE,
+    SWIFT,
+    SWISH,
+    UPHOLD,
+    UPI,
+    US_POSTAL_MONEY_ORDER,
+    WECHAT_PAY,
+    WISE,
+    WISE_USD,
+    ZELLE
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/HalCashAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/HalCashAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record HalCashAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        HalCashAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public HalCashAccountDto {
+        if (paymentRail != FiatPaymentRailDto.HAL_CASH) {
+            throw new IllegalArgumentException("paymentRail must be HAL_CASH");
+        }
+    }
+
+    public HalCashAccountDto(String accountName,
+                             HalCashAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.HAL_CASH, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/HalCashAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/HalCashAccountPayloadDto.java
@@ -1,0 +1,6 @@
+package bisq.api.dto.account.fiat;
+
+public record HalCashAccountPayloadDto(
+        String mobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/ImpsAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ImpsAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record ImpsAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        ImpsAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public ImpsAccountDto {
+        if (paymentRail != FiatPaymentRailDto.IMPS) {
+            throw new IllegalArgumentException("paymentRail must be IMPS");
+        }
+    }
+
+    public ImpsAccountDto(String accountName,
+                          ImpsAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.IMPS, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/ImpsAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ImpsAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record ImpsAccountPayloadDto(
+        String holderName,
+        String accountNr,
+        String ifsc
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/InteracETransferAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/InteracETransferAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record InteracETransferAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        InteracETransferAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public InteracETransferAccountDto {
+        if (paymentRail != FiatPaymentRailDto.INTERAC_E_TRANSFER) {
+            throw new IllegalArgumentException("paymentRail must be INTERAC_E_TRANSFER");
+        }
+    }
+
+    public InteracETransferAccountDto(String accountName,
+                                      InteracETransferAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.INTERAC_E_TRANSFER, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/InteracETransferAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/InteracETransferAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+public record InteracETransferAccountPayloadDto(
+        String holderName,
+        String email,
+        String question,
+        String answer
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MercadoPagoAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MercadoPagoAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record MercadoPagoAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        MercadoPagoAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public MercadoPagoAccountDto {
+        if (paymentRail != FiatPaymentRailDto.MERCADO_PAGO) {
+            throw new IllegalArgumentException("paymentRail must be MERCADO_PAGO");
+        }
+    }
+
+    public MercadoPagoAccountDto(String accountName,
+                                 MercadoPagoAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.MERCADO_PAGO, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MercadoPagoAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MercadoPagoAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record MercadoPagoAccountPayloadDto(
+        String holderName,
+        String holderId
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MoneseAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MoneseAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record MoneseAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        MoneseAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public MoneseAccountDto {
+        if (paymentRail != FiatPaymentRailDto.MONESE) {
+            throw new IllegalArgumentException("paymentRail must be MONESE");
+        }
+    }
+
+    public MoneseAccountDto(String accountName,
+                            MoneseAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.MONESE, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MoneseAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MoneseAccountPayloadDto.java
@@ -1,0 +1,10 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record MoneseAccountPayloadDto(
+        List<String> selectedCurrencyCodes,
+        String holderName,
+        String mobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MoneyBeamAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MoneyBeamAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record MoneyBeamAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        MoneyBeamAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public MoneyBeamAccountDto {
+        if (paymentRail != FiatPaymentRailDto.MONEY_BEAM) {
+            throw new IllegalArgumentException("paymentRail must be MONEY_BEAM");
+        }
+    }
+
+    public MoneyBeamAccountDto(String accountName,
+                               MoneyBeamAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.MONEY_BEAM, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MoneyBeamAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MoneyBeamAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record MoneyBeamAccountPayloadDto(
+        String countryCode,
+        String holderName,
+        String emailOrMobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MoneyGramAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MoneyGramAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record MoneyGramAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        MoneyGramAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public MoneyGramAccountDto {
+        if (paymentRail != FiatPaymentRailDto.MONEY_GRAM) {
+            throw new IllegalArgumentException("paymentRail must be MONEY_GRAM");
+        }
+    }
+
+    public MoneyGramAccountDto(String accountName,
+                               MoneyGramAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.MONEY_GRAM, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/MoneyGramAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/MoneyGramAccountPayloadDto.java
@@ -1,0 +1,12 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record MoneyGramAccountPayloadDto(
+        String countryCode,
+        List<String> selectedCurrencyCodes,
+        String holderName,
+        String email,
+        String state
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/NationalBankAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/NationalBankAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record NationalBankAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        NationalBankAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public NationalBankAccountDto {
+        if (paymentRail != FiatPaymentRailDto.NATIONAL_BANK) {
+            throw new IllegalArgumentException("paymentRail must be NATIONAL_BANK");
+        }
+    }
+
+    public NationalBankAccountDto(String accountName,
+                                  NationalBankAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.NATIONAL_BANK, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/NationalBankAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/NationalBankAccountPayloadDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.account.accounts.fiat.BankAccountType;
+
+import java.util.Optional;
+
+public record NationalBankAccountPayloadDto(
+        String countryCode,
+        String selectedCurrencyCode,
+        Optional<String> holderName,
+        Optional<String> holderId,
+        Optional<String> bankName,
+        Optional<String> bankId,
+        Optional<String> branchId,
+        String accountNr,
+        Optional<BankAccountType> bankAccountType,
+        Optional<String> nationalAccountId
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/NeftAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/NeftAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record NeftAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        NeftAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public NeftAccountDto {
+        if (paymentRail != FiatPaymentRailDto.NEFT) {
+            throw new IllegalArgumentException("paymentRail must be NEFT");
+        }
+    }
+
+    public NeftAccountDto(String accountName,
+                          NeftAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.NEFT, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/NeftAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/NeftAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record NeftAccountPayloadDto(
+        String holderName,
+        String accountNr,
+        String ifsc
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PayIdAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PayIdAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record PayIdAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        PayIdAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public PayIdAccountDto {
+        if (paymentRail != FiatPaymentRailDto.PAY_ID) {
+            throw new IllegalArgumentException("paymentRail must be PAY_ID");
+        }
+    }
+
+    public PayIdAccountDto(String accountName,
+                           PayIdAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.PAY_ID, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PayIdAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PayIdAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record PayIdAccountPayloadDto(
+        String holderName,
+        String payId
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PayseraAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PayseraAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record PayseraAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        PayseraAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public PayseraAccountDto {
+        if (paymentRail != FiatPaymentRailDto.PAYSERA) {
+            throw new IllegalArgumentException("paymentRail must be PAYSERA");
+        }
+    }
+
+    public PayseraAccountDto(String accountName,
+                             PayseraAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.PAYSERA, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PayseraAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PayseraAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record PayseraAccountPayloadDto(
+        List<String> selectedCurrencyCodes,
+        String email
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PerfectMoneyAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PerfectMoneyAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record PerfectMoneyAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        PerfectMoneyAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public PerfectMoneyAccountDto {
+        if (paymentRail != FiatPaymentRailDto.PERFECT_MONEY) {
+            throw new IllegalArgumentException("paymentRail must be PERFECT_MONEY");
+        }
+    }
+
+    public PerfectMoneyAccountDto(String accountName,
+                                  PerfectMoneyAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.PERFECT_MONEY, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PerfectMoneyAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PerfectMoneyAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record PerfectMoneyAccountPayloadDto(
+        String selectedCurrencyCode,
+        String accountNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/Pin4AccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/Pin4AccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record Pin4AccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        Pin4AccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public Pin4AccountDto {
+        if (paymentRail != FiatPaymentRailDto.PIN_4) {
+            throw new IllegalArgumentException("paymentRail must be PIN_4");
+        }
+    }
+
+    public Pin4AccountDto(String accountName,
+                          Pin4AccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.PIN_4, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/Pin4AccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/Pin4AccountPayloadDto.java
@@ -1,0 +1,6 @@
+package bisq.api.dto.account.fiat;
+
+public record Pin4AccountPayloadDto(
+        String mobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PixAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PixAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record PixAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        PixAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public PixAccountDto {
+        if (paymentRail != FiatPaymentRailDto.PIX) {
+            throw new IllegalArgumentException("paymentRail must be PIX");
+        }
+    }
+
+    public PixAccountDto(String accountName,
+                         PixAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.PIX, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PixAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PixAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record PixAccountPayloadDto(
+        String countryCode,
+        String holderName,
+        String pixKey
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PromptPayAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PromptPayAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record PromptPayAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        PromptPayAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public PromptPayAccountDto {
+        if (paymentRail != FiatPaymentRailDto.PROMPT_PAY) {
+            throw new IllegalArgumentException("paymentRail must be PROMPT_PAY");
+        }
+    }
+
+    public PromptPayAccountDto(String accountName,
+                               PromptPayAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.PROMPT_PAY, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/PromptPayAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/PromptPayAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record PromptPayAccountPayloadDto(
+        String countryCode,
+        String promptPayId
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/RevolutAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/RevolutAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record RevolutAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        RevolutAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public RevolutAccountDto {
+        if (paymentRail != FiatPaymentRailDto.REVOLUT) {
+            throw new IllegalArgumentException("paymentRail must be REVOLUT");
+        }
+    }
+
+    public RevolutAccountDto(String accountName,
+                             RevolutAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.REVOLUT, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/RevolutAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/RevolutAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record RevolutAccountPayloadDto(
+        String userName,
+        List<String> selectedCurrencyCodes
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SameBankAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SameBankAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SameBankAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SameBankAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SameBankAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SAME_BANK) {
+            throw new IllegalArgumentException("paymentRail must be SAME_BANK");
+        }
+    }
+
+    public SameBankAccountDto(String accountName,
+                              SameBankAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SAME_BANK, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SameBankAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SameBankAccountPayloadDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.account.accounts.fiat.BankAccountType;
+
+import java.util.Optional;
+
+public record SameBankAccountPayloadDto(
+        String countryCode,
+        String selectedCurrencyCode,
+        Optional<String> holderName,
+        Optional<String> holderId,
+        Optional<String> bankName,
+        Optional<String> bankId,
+        Optional<String> branchId,
+        String accountNr,
+        Optional<BankAccountType> bankAccountType,
+        Optional<String> nationalAccountId
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SatispayAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SatispayAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SatispayAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SatispayAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SatispayAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SATISPAY) {
+            throw new IllegalArgumentException("paymentRail must be SATISPAY");
+        }
+    }
+
+    public SatispayAccountDto(String accountName,
+                              SatispayAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SATISPAY, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SatispayAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SatispayAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record SatispayAccountPayloadDto(
+        String holderName,
+        String mobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SbpAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SbpAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SbpAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SbpAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SbpAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SBP) {
+            throw new IllegalArgumentException("paymentRail must be SBP");
+        }
+    }
+
+    public SbpAccountDto(String accountName,
+                         SbpAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SBP, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SbpAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SbpAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record SbpAccountPayloadDto(
+        String holderName,
+        String mobileNumber,
+        String bankName
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SepaAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SepaAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SepaAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SepaAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SepaAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SEPA) {
+            throw new IllegalArgumentException("paymentRail must be SEPA");
+        }
+    }
+
+    public SepaAccountDto(String accountName,
+                          SepaAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SEPA, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SepaAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SepaAccountPayloadDto.java
@@ -1,0 +1,12 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record SepaAccountPayloadDto(
+        String holderName,
+        String iban,
+        String bic,
+        String countryCode,
+        List<String> acceptedCountryCodes
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SepaInstantAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SepaInstantAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SepaInstantAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SepaInstantAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SepaInstantAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SEPA_INSTANT) {
+            throw new IllegalArgumentException("paymentRail must be SEPA_INSTANT");
+        }
+    }
+
+    public SepaInstantAccountDto(String accountName,
+                                 SepaInstantAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SEPA_INSTANT, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SepaInstantAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SepaInstantAccountPayloadDto.java
@@ -1,0 +1,12 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record SepaInstantAccountPayloadDto(
+        String holderName,
+        String iban,
+        String bic,
+        String countryCode,
+        List<String> acceptedCountryCodes
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/StrikeAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/StrikeAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record StrikeAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        StrikeAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public StrikeAccountDto {
+        if (paymentRail != FiatPaymentRailDto.STRIKE) {
+            throw new IllegalArgumentException("paymentRail must be STRIKE");
+        }
+    }
+
+    public StrikeAccountDto(String accountName,
+                            StrikeAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.STRIKE, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/StrikeAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/StrikeAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record StrikeAccountPayloadDto(
+        String countryCode,
+        String holderName
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SwiftAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SwiftAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SwiftAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SwiftAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SwiftAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SWIFT) {
+            throw new IllegalArgumentException("paymentRail must be SWIFT");
+        }
+    }
+
+    public SwiftAccountDto(String accountName,
+                           SwiftAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SWIFT, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SwiftAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SwiftAccountPayloadDto.java
@@ -1,0 +1,23 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.Optional;
+
+public record SwiftAccountPayloadDto(
+        String bankCountryCode,
+        String beneficiaryName,
+        String beneficiaryAccountNr,
+        Optional<String> beneficiaryPhone,
+        String beneficiaryAddress,
+        String selectedCurrencyCode,
+        String bankSwiftCode,
+        String bankName,
+        Optional<String> bankBranch,
+        String bankAddress,
+        Optional<String> intermediaryBankCountryCode,
+        Optional<String> intermediaryBankSwiftCode,
+        Optional<String> intermediaryBankName,
+        Optional<String> intermediaryBankBranch,
+        Optional<String> intermediaryBankAddress,
+        Optional<String> additionalInstructions
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SwishAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SwishAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record SwishAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        SwishAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public SwishAccountDto {
+        if (paymentRail != FiatPaymentRailDto.SWISH) {
+            throw new IllegalArgumentException("paymentRail must be SWISH");
+        }
+    }
+
+    public SwishAccountDto(String accountName,
+                           SwishAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.SWISH, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/SwishAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/SwishAccountPayloadDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public record SwishAccountPayloadDto(
+        String countryCode,
+        String holderName,
+        String mobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/USPostalMoneyOrderAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/USPostalMoneyOrderAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record USPostalMoneyOrderAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        USPostalMoneyOrderAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public USPostalMoneyOrderAccountDto {
+        if (paymentRail != FiatPaymentRailDto.US_POSTAL_MONEY_ORDER) {
+            throw new IllegalArgumentException("paymentRail must be US_POSTAL_MONEY_ORDER");
+        }
+    }
+
+    public USPostalMoneyOrderAccountDto(String accountName,
+                                        USPostalMoneyOrderAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.US_POSTAL_MONEY_ORDER, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/USPostalMoneyOrderAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/USPostalMoneyOrderAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record USPostalMoneyOrderAccountPayloadDto(
+        String holderName,
+        String postalAddress
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UpholdAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UpholdAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record UpholdAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        UpholdAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public UpholdAccountDto {
+        if (paymentRail != FiatPaymentRailDto.UPHOLD) {
+            throw new IllegalArgumentException("paymentRail must be UPHOLD");
+        }
+    }
+
+    public UpholdAccountDto(String accountName,
+                            UpholdAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.UPHOLD, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UpholdAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UpholdAccountPayloadDto.java
@@ -1,0 +1,10 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record UpholdAccountPayloadDto(
+        List<String> selectedCurrencyCodes,
+        String holderName,
+        String accountId
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UpiAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UpiAccountDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.fiat;
+
+
+public record UpiAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        UpiAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public UpiAccountDto {
+        if (paymentRail != FiatPaymentRailDto.UPI) {
+            throw new IllegalArgumentException("paymentRail must be UPI");
+        }
+    }
+
+    public UpiAccountDto(String accountName,
+                         UpiAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.UPI, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UpiAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UpiAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record UpiAccountPayloadDto(
+        String countryCode,
+        String virtualPaymentAddress
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountDto.java
@@ -17,11 +17,21 @@
 
 package bisq.api.dto.account.fiat;
 
-import bisq.account.payment_method.fiat.FiatPaymentRail;
 
 public record UserDefinedFiatAccountDto(
-    String accountName,
-    FiatPaymentRail paymentRail,
-    UserDefinedFiatAccountPayloadDto accountPayload
-) implements FiatAccountDto { }
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        UserDefinedFiatAccountPayloadDto accountPayload
+) implements FiatAccountDto {
 
+    public UserDefinedFiatAccountDto {
+        if (paymentRail != FiatPaymentRailDto.CUSTOM) {
+            throw new IllegalArgumentException("paymentRail must be CUSTOM");
+        }
+    }
+
+    public UserDefinedFiatAccountDto(String accountName,
+                                     UserDefinedFiatAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.CUSTOM, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountPayloadDto.java
@@ -19,5 +19,5 @@ package bisq.api.dto.account.fiat;
 
 public record UserDefinedFiatAccountPayloadDto(
         String accountData
-) implements FiatAccountPayloadDto { }
-
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/WeChatPayAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/WeChatPayAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record WeChatPayAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        WeChatPayAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public WeChatPayAccountDto {
+        if (paymentRail != FiatPaymentRailDto.WECHAT_PAY) {
+            throw new IllegalArgumentException("paymentRail must be WECHAT_PAY");
+        }
+    }
+
+    public WeChatPayAccountDto(String accountName,
+                               WeChatPayAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.WECHAT_PAY, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/WeChatPayAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/WeChatPayAccountPayloadDto.java
@@ -1,0 +1,6 @@
+package bisq.api.dto.account.fiat;
+
+public record WeChatPayAccountPayloadDto(
+        String accountNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/WiseAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/WiseAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record WiseAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        WiseAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public WiseAccountDto {
+        if (paymentRail != FiatPaymentRailDto.WISE) {
+            throw new IllegalArgumentException("paymentRail must be WISE");
+        }
+    }
+
+    public WiseAccountDto(String accountName,
+                          WiseAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.WISE, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/WiseAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/WiseAccountPayloadDto.java
@@ -1,0 +1,10 @@
+package bisq.api.dto.account.fiat;
+
+import java.util.List;
+
+public record WiseAccountPayloadDto(
+        List<String> selectedCurrencyCodes,
+        String holderName,
+        String email
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/WiseUsdAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/WiseUsdAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record WiseUsdAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        WiseUsdAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public WiseUsdAccountDto {
+        if (paymentRail != FiatPaymentRailDto.WISE_USD) {
+            throw new IllegalArgumentException("paymentRail must be WISE_USD");
+        }
+    }
+
+    public WiseUsdAccountDto(String accountName,
+                             WiseUsdAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.WISE_USD, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/WiseUsdAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/WiseUsdAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+public record WiseUsdAccountPayloadDto(
+        String countryCode,
+        String holderName,
+        String email,
+        String beneficiaryAddress
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountDto.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.account.fiat;
+
+public record ZelleAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        ZelleAccountPayloadDto accountPayload
+) implements FiatAccountDto {
+
+    public ZelleAccountDto {
+        if (paymentRail != FiatPaymentRailDto.ZELLE) {
+            throw new IllegalArgumentException("paymentRail must be ZELLE");
+        }
+    }
+
+    public ZelleAccountDto(String accountName,
+                           ZelleAccountPayloadDto accountPayload) {
+        this(accountName, FiatPaymentRailDto.ZELLE, accountPayload);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountPayloadDto.java
@@ -1,0 +1,7 @@
+package bisq.api.dto.account.fiat;
+
+public record ZelleAccountPayloadDto(
+        String holderName,
+        String emailOrMobileNr
+) implements FiatAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/mappings/crypto/CryptoAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/crypto/CryptoAccountDtoMapping.java
@@ -1,0 +1,32 @@
+package bisq.api.dto.mappings.crypto;
+
+import bisq.account.accounts.Account;
+import bisq.account.accounts.crypto.MoneroAccount;
+import bisq.account.accounts.crypto.OtherCryptoAssetAccount;
+import bisq.account.payment_method.PaymentMethod;
+import bisq.api.dto.account.crypto.CryptoAccountDto;
+import bisq.api.dto.account.crypto.MoneroAccountDto;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountDto;
+
+public class CryptoAccountDtoMapping {
+    public static Account<? extends PaymentMethod<?>, ?> toBisq2Model(CryptoAccountDto dto) {
+        if (dto instanceof MoneroAccountDto moneroAccountDto) {
+            return MoneroAccountDtoMapping.toBisq2Model(moneroAccountDto);
+        }
+        if (dto instanceof OtherCryptoAssetAccountDto otherCryptoAssetAccountDto) {
+            return OtherCryptoAssetAccountDtoMapping.toBisq2Model(otherCryptoAssetAccountDto);
+        }
+        throw new IllegalArgumentException("Unsupported crypto account type: " + dto.getClass().getSimpleName());
+    }
+
+    public static CryptoAccountDto fromBisq2Model(Account<? extends PaymentMethod<?>, ?> account) {
+        if (account instanceof MoneroAccount moneroAccount) {
+            return MoneroAccountDtoMapping.fromBisq2Model(moneroAccount);
+        }
+        if (account instanceof OtherCryptoAssetAccount otherCryptoAssetAccount) {
+            return OtherCryptoAssetAccountDtoMapping.fromBisq2Model(otherCryptoAssetAccount);
+        }
+
+        throw new IllegalArgumentException("Unsupported crypto account type: " + account.getClass().getSimpleName());
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/crypto/CryptoPaymentMethodItemDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/crypto/CryptoPaymentMethodItemDtoMapping.java
@@ -1,0 +1,14 @@
+package bisq.api.dto.mappings.crypto;
+
+import bisq.account.payment_method.crypto.CryptoPaymentMethod;
+import bisq.api.dto.account.crypto.CryptoPaymentMethodItemDto;
+
+public class CryptoPaymentMethodItemDtoMapping {
+    public static CryptoPaymentMethodItemDto fromBisq2Model(CryptoPaymentMethod paymentMethod) {
+        return new CryptoPaymentMethodItemDto(
+                paymentMethod.getCode(),
+                paymentMethod.getName(),
+                paymentMethod.getPaymentRail().name()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/crypto/CryptoPaymentRailDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/crypto/CryptoPaymentRailDtoMapping.java
@@ -1,0 +1,13 @@
+package bisq.api.dto.mappings.crypto;
+
+import bisq.api.dto.account.crypto.CryptoPaymentRailDto;
+
+public class CryptoPaymentRailDtoMapping {
+    public static CryptoPaymentRailDto fromMoneroAccountType() {
+        return CryptoPaymentRailDto.MONERO;
+    }
+
+    public static CryptoPaymentRailDto fromOtherCryptoAssetAccountType() {
+        return CryptoPaymentRailDto.OTHER_CRYPTO_ASSET;
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/crypto/MoneroAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/crypto/MoneroAccountDtoMapping.java
@@ -1,0 +1,68 @@
+package bisq.api.dto.mappings.crypto;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.crypto.MoneroAccount;
+import bisq.account.accounts.crypto.MoneroAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.crypto.MoneroAccountDto;
+import bisq.api.dto.account.crypto.MoneroAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class MoneroAccountDtoMapping {
+    public static MoneroAccount toBisq2Model(MoneroAccountDto dto) {
+        MoneroAccountPayloadDto payloadDto = dto.accountPayload();
+        MoneroAccountPayload payload = new MoneroAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.address(),
+                payloadDto.isInstant(),
+                payloadDto.isAutoConf(),
+                payloadDto.autoConfNumConfirmations(),
+                payloadDto.autoConfMaxTradeAmount(),
+                payloadDto.autoConfExplorerUrls(),
+                payloadDto.useSubAddresses(),
+                payloadDto.mainAddress(),
+                payloadDto.privateViewKey(),
+                payloadDto.subAddress(),
+                payloadDto.accountIndex(),
+                payloadDto.initialSubAddressIndex()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new MoneroAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static MoneroAccountDto fromBisq2Model(MoneroAccount account) {
+        MoneroAccountPayload payload = account.getAccountPayload();
+        MoneroAccountPayloadDto payloadDto = new MoneroAccountPayloadDto(
+                payload.getCurrencyCode(),
+                payload.getAddress(),
+                payload.isInstant(),
+                payload.getIsAutoConf(),
+                payload.getAutoConfNumConfirmations(),
+                payload.getAutoConfMaxTradeAmount(),
+                payload.getAutoConfExplorerUrls(),
+                payload.isUseSubAddresses(),
+                payload.getMainAddress(),
+                payload.getPrivateViewKey(),
+                payload.getSubAddress(),
+                payload.getAccountIndex(),
+                payload.getInitialSubAddressIndex()
+        );
+        return new MoneroAccountDto(
+                account.getAccountName(),
+                CryptoPaymentRailDtoMapping.fromMoneroAccountType(),
+                payloadDto
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/crypto/OtherCryptoAssetAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/crypto/OtherCryptoAssetAccountDtoMapping.java
@@ -1,0 +1,57 @@
+package bisq.api.dto.mappings.crypto;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.crypto.OtherCryptoAssetAccount;
+import bisq.account.accounts.crypto.OtherCryptoAssetAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountDto;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class OtherCryptoAssetAccountDtoMapping {
+    public static OtherCryptoAssetAccount toBisq2Model(OtherCryptoAssetAccountDto dto) {
+        OtherCryptoAssetAccountPayloadDto payloadDto = dto.accountPayload();
+        OtherCryptoAssetAccountPayload payload = new OtherCryptoAssetAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.currencyCode(),
+                payloadDto.address(),
+                payloadDto.isInstant(),
+                payloadDto.isAutoConf(),
+                payloadDto.autoConfNumConfirmations(),
+                payloadDto.autoConfMaxTradeAmount(),
+                payloadDto.autoConfExplorerUrls()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new OtherCryptoAssetAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static OtherCryptoAssetAccountDto fromBisq2Model(OtherCryptoAssetAccount account) {
+        OtherCryptoAssetAccountPayload payload = account.getAccountPayload();
+        OtherCryptoAssetAccountPayloadDto payloadDto = new OtherCryptoAssetAccountPayloadDto(
+                payload.getCurrencyCode(),
+                payload.getAddress(),
+                payload.isInstant(),
+                payload.getIsAutoConf(),
+                payload.getAutoConfNumConfirmations(),
+                payload.getAutoConfMaxTradeAmount(),
+                payload.getAutoConfExplorerUrls()
+        );
+        return new OtherCryptoAssetAccountDto(
+                account.getAccountName(),
+                CryptoPaymentRailDtoMapping.fromOtherCryptoAssetAccountType(),
+                payloadDto
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/AchTransferAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/AchTransferAccountDtoMapping.java
@@ -1,0 +1,61 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.AchTransferAccount;
+import bisq.account.accounts.fiat.AchTransferAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.AchTransferAccountDto;
+import bisq.api.dto.account.fiat.AchTransferAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class AchTransferAccountDtoMapping {
+    public static AchTransferAccount toBisq2Model(AchTransferAccountDto dto) {
+        AchTransferAccountPayloadDto payloadDto = dto.accountPayload();
+        AchTransferAccountPayload payload = new AchTransferAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.holderAddress(),
+                payloadDto.bankName(),
+                payloadDto.routingNr(),
+                payloadDto.accountNr(),
+                payloadDto.bankAccountType()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new AchTransferAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static AchTransferAccountDto fromBisq2Model(AchTransferAccount account) {
+        AchTransferAccountPayload payload = account.getAccountPayload();
+        String holderName = payload.getHolderName()
+                .orElseThrow(() -> new IllegalStateException("ACH holderName missing"));
+        String bankName = payload.getBankName()
+                .orElseThrow(() -> new IllegalStateException("ACH bankName missing"));
+        String routingNr = payload.getBankId()
+                .orElseThrow(() -> new IllegalStateException("ACH routingNr missing"));
+
+        return new AchTransferAccountDto(
+                account.getAccountName(),
+                new AchTransferAccountPayloadDto(
+                        holderName,
+                        payload.getHolderAddress(),
+                        bankName,
+                        routingNr,
+                        payload.getAccountNr(),
+                        payload.getBankAccountType()
+                                .orElseThrow(() -> new IllegalStateException("ACH bankAccountType missing"))
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/AdvancedCashAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/AdvancedCashAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.AdvancedCashAccount;
+import bisq.account.accounts.fiat.AdvancedCashAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.AdvancedCashAccountDto;
+import bisq.api.dto.account.fiat.AdvancedCashAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class AdvancedCashAccountDtoMapping {
+    public static AdvancedCashAccount toBisq2Model(AdvancedCashAccountDto dto) {
+        AdvancedCashAccountPayloadDto payloadDto = dto.accountPayload();
+        AdvancedCashAccountPayload payload = new AdvancedCashAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.selectedCurrencyCodes(),
+                payloadDto.accountNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new AdvancedCashAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static AdvancedCashAccountDto fromBisq2Model(AdvancedCashAccount account) {
+        return new AdvancedCashAccountDto(
+                account.getAccountName(),
+                new AdvancedCashAccountPayloadDto(
+                        account.getAccountPayload().getSelectedCurrencyCodes(),
+                        account.getAccountPayload().getAccountNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/AliPayAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/AliPayAccountDtoMapping.java
@@ -1,0 +1,42 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.AliPayAccount;
+import bisq.account.accounts.fiat.AliPayAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.AliPayAccountDto;
+import bisq.api.dto.account.fiat.AliPayAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class AliPayAccountDtoMapping {
+    public static AliPayAccount toBisq2Model(AliPayAccountDto dto) {
+        AliPayAccountPayloadDto payloadDto = dto.accountPayload();
+        AliPayAccountPayload payload = new AliPayAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.accountNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new AliPayAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static AliPayAccountDto fromBisq2Model(AliPayAccount account) {
+        return new AliPayAccountDto(
+                account.getAccountName(),
+                new AliPayAccountPayloadDto(
+                        account.getAccountPayload().getAccountNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/AmazonGiftCardAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/AmazonGiftCardAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.AmazonGiftCardAccount;
+import bisq.account.accounts.fiat.AmazonGiftCardAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.AmazonGiftCardAccountDto;
+import bisq.api.dto.account.fiat.AmazonGiftCardAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class AmazonGiftCardAccountDtoMapping {
+    public static AmazonGiftCardAccount toBisq2Model(AmazonGiftCardAccountDto dto) {
+        AmazonGiftCardAccountPayloadDto payloadDto = dto.accountPayload();
+        AmazonGiftCardAccountPayload payload = new AmazonGiftCardAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.emailOrMobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new AmazonGiftCardAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static AmazonGiftCardAccountDto fromBisq2Model(AmazonGiftCardAccount account) {
+        return new AmazonGiftCardAccountDto(
+                account.getAccountName(),
+                new AmazonGiftCardAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getEmailOrMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/BizumAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/BizumAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.BizumAccount;
+import bisq.account.accounts.fiat.BizumAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.BizumAccountDto;
+import bisq.api.dto.account.fiat.BizumAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class BizumAccountDtoMapping {
+    public static BizumAccount toBisq2Model(BizumAccountDto dto) {
+        BizumAccountPayloadDto payloadDto = dto.accountPayload();
+        BizumAccountPayload payload = new BizumAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.mobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new BizumAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static BizumAccountDto fromBisq2Model(BizumAccount account) {
+        return new BizumAccountDto(
+                account.getAccountName(),
+                new BizumAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/CashByMailAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/CashByMailAccountDtoMapping.java
@@ -1,0 +1,48 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.CashByMailAccount;
+import bisq.account.accounts.fiat.CashByMailAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.CashByMailAccountDto;
+import bisq.api.dto.account.fiat.CashByMailAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class CashByMailAccountDtoMapping {
+    public static CashByMailAccount toBisq2Model(CashByMailAccountDto dto) {
+        CashByMailAccountPayloadDto payloadDto = dto.accountPayload();
+        CashByMailAccountPayload payload = new CashByMailAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.postalAddress(),
+                payloadDto.contact(),
+                payloadDto.extraInfo()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new CashByMailAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static CashByMailAccountDto fromBisq2Model(CashByMailAccount account) {
+        return new CashByMailAccountDto(
+                account.getAccountName(),
+                new CashByMailAccountPayloadDto(
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getPostalAddress(),
+                        account.getAccountPayload().getContact(),
+                        account.getAccountPayload().getExtraInfo()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/CashDepositAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/CashDepositAccountDtoMapping.java
@@ -1,0 +1,62 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.CashDepositAccount;
+import bisq.account.accounts.fiat.CashDepositAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.CashDepositAccountDto;
+import bisq.api.dto.account.fiat.CashDepositAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class CashDepositAccountDtoMapping {
+    public static CashDepositAccount toBisq2Model(CashDepositAccountDto dto) {
+        CashDepositAccountPayloadDto payloadDto = dto.accountPayload();
+        CashDepositAccountPayload payload = new CashDepositAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.holderName().orElse(null),
+                payloadDto.holderTaxId(),
+                payloadDto.bankName().orElse(null),
+                payloadDto.bankId(),
+                payloadDto.branchId(),
+                payloadDto.accountNr(),
+                payloadDto.bankAccountType(),
+                payloadDto.nationalAccountId(),
+                payloadDto.requirements()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new CashDepositAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static CashDepositAccountDto fromBisq2Model(CashDepositAccount account) {
+        return new CashDepositAccountDto(
+                account.getAccountName(),
+                new CashDepositAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getHolderId(),
+                        account.getAccountPayload().getBankName(),
+                        account.getAccountPayload().getBankId(),
+                        account.getAccountPayload().getBranchId(),
+                        account.getAccountPayload().getAccountNr(),
+                        account.getAccountPayload().getBankAccountType(),
+                        account.getAccountPayload().getNationalAccountId(),
+                        account.getAccountPayload().getRequirements()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/DomesticWireTransferAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/DomesticWireTransferAccountDtoMapping.java
@@ -1,0 +1,58 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.DomesticWireTransferAccount;
+import bisq.account.accounts.fiat.DomesticWireTransferAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.DomesticWireTransferAccountDto;
+import bisq.api.dto.account.fiat.DomesticWireTransferAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class DomesticWireTransferAccountDtoMapping {
+    public static DomesticWireTransferAccount toBisq2Model(DomesticWireTransferAccountDto dto) {
+        DomesticWireTransferAccountPayloadDto payloadDto = dto.accountPayload();
+        DomesticWireTransferAccountPayload payload = new DomesticWireTransferAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.holderAddress(),
+                payloadDto.bankName(),
+                payloadDto.routingNr(),
+                payloadDto.accountNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new DomesticWireTransferAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static DomesticWireTransferAccountDto fromBisq2Model(DomesticWireTransferAccount account) {
+        DomesticWireTransferAccountPayload payload = account.getAccountPayload();
+        String holderName = payload.getHolderName()
+                .orElseThrow(() -> new IllegalStateException("DomesticWireTransfer holderName missing"));
+        String bankName = payload.getBankName()
+                .orElseThrow(() -> new IllegalStateException("DomesticWireTransfer bankName missing"));
+        String routingNr = payload.getBankId()
+                .orElseThrow(() -> new IllegalStateException("DomesticWireTransfer routingNr missing"));
+
+        return new DomesticWireTransferAccountDto(
+                account.getAccountName(),
+                new DomesticWireTransferAccountPayloadDto(
+                        holderName,
+                        payload.getHolderAddress(),
+                        bankName,
+                        routingNr,
+                        payload.getAccountNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/F2FAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/F2FAccountDtoMapping.java
@@ -1,0 +1,50 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.F2FAccount;
+import bisq.account.accounts.fiat.F2FAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.F2FAccountDto;
+import bisq.api.dto.account.fiat.F2FAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class F2FAccountDtoMapping {
+    public static F2FAccount toBisq2Model(F2FAccountDto dto) {
+        F2FAccountPayloadDto payloadDto = dto.accountPayload();
+        F2FAccountPayload payload = new F2FAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.city(),
+                payloadDto.contact(),
+                payloadDto.extraInfo()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new F2FAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static F2FAccountDto fromBisq2Model(F2FAccount account) {
+        return new F2FAccountDto(
+                account.getAccountName(),
+                new F2FAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getCity(),
+                        account.getAccountPayload().getContact(),
+                        account.getAccountPayload().getExtraInfo()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/FasterPaymentsAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/FasterPaymentsAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.FasterPaymentsAccount;
+import bisq.account.accounts.fiat.FasterPaymentsAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.FasterPaymentsAccountDto;
+import bisq.api.dto.account.fiat.FasterPaymentsAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class FasterPaymentsAccountDtoMapping {
+    public static FasterPaymentsAccount toBisq2Model(FasterPaymentsAccountDto dto) {
+        FasterPaymentsAccountPayloadDto payloadDto = dto.accountPayload();
+        FasterPaymentsAccountPayload payload = new FasterPaymentsAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.sortCode(),
+                payloadDto.accountNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new FasterPaymentsAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static FasterPaymentsAccountDto fromBisq2Model(FasterPaymentsAccount account) {
+        return new FasterPaymentsAccountDto(
+                account.getAccountName(),
+                new FasterPaymentsAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getSortCode(),
+                        account.getAccountPayload().getAccountNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/HalCashAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/HalCashAccountDtoMapping.java
@@ -1,0 +1,42 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.HalCashAccount;
+import bisq.account.accounts.fiat.HalCashAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.HalCashAccountDto;
+import bisq.api.dto.account.fiat.HalCashAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class HalCashAccountDtoMapping {
+    public static HalCashAccount toBisq2Model(HalCashAccountDto dto) {
+        HalCashAccountPayloadDto payloadDto = dto.accountPayload();
+        HalCashAccountPayload payload = new HalCashAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.mobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new HalCashAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static HalCashAccountDto fromBisq2Model(HalCashAccount account) {
+        return new HalCashAccountDto(
+                account.getAccountName(),
+                new HalCashAccountPayloadDto(
+                        account.getAccountPayload().getMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/ImpsAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/ImpsAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.ImpsAccount;
+import bisq.account.accounts.fiat.ImpsAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.ImpsAccountDto;
+import bisq.api.dto.account.fiat.ImpsAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class ImpsAccountDtoMapping {
+    public static ImpsAccount toBisq2Model(ImpsAccountDto dto) {
+        ImpsAccountPayloadDto payloadDto = dto.accountPayload();
+        ImpsAccountPayload payload = new ImpsAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.accountNr(),
+                payloadDto.ifsc()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new ImpsAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static ImpsAccountDto fromBisq2Model(ImpsAccount account) {
+        return new ImpsAccountDto(
+                account.getAccountName(),
+                new ImpsAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getAccountNr(),
+                        account.getAccountPayload().getIfsc()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/InteracETransferAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/InteracETransferAccountDtoMapping.java
@@ -1,0 +1,48 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.InteracETransferAccount;
+import bisq.account.accounts.fiat.InteracETransferAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.InteracETransferAccountDto;
+import bisq.api.dto.account.fiat.InteracETransferAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class InteracETransferAccountDtoMapping {
+    public static InteracETransferAccount toBisq2Model(InteracETransferAccountDto dto) {
+        InteracETransferAccountPayloadDto payloadDto = dto.accountPayload();
+        InteracETransferAccountPayload payload = new InteracETransferAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.email(),
+                payloadDto.question(),
+                payloadDto.answer()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new InteracETransferAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static InteracETransferAccountDto fromBisq2Model(InteracETransferAccount account) {
+        return new InteracETransferAccountDto(
+                account.getAccountName(),
+                new InteracETransferAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getEmail(),
+                        account.getAccountPayload().getQuestion(),
+                        account.getAccountPayload().getAnswer()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/MercadoPagoAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/MercadoPagoAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.MercadoPagoAccount;
+import bisq.account.accounts.fiat.MercadoPagoAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.MercadoPagoAccountDto;
+import bisq.api.dto.account.fiat.MercadoPagoAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class MercadoPagoAccountDtoMapping {
+    public static MercadoPagoAccount toBisq2Model(MercadoPagoAccountDto dto) {
+        MercadoPagoAccountPayloadDto payloadDto = dto.accountPayload();
+        MercadoPagoAccountPayload payload = new MercadoPagoAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.holderId()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new MercadoPagoAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static MercadoPagoAccountDto fromBisq2Model(MercadoPagoAccount account) {
+        return new MercadoPagoAccountDto(
+                account.getAccountName(),
+                new MercadoPagoAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getHolderId()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/MoneseAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/MoneseAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.MoneseAccount;
+import bisq.account.accounts.fiat.MoneseAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.MoneseAccountDto;
+import bisq.api.dto.account.fiat.MoneseAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class MoneseAccountDtoMapping {
+    public static MoneseAccount toBisq2Model(MoneseAccountDto dto) {
+        MoneseAccountPayloadDto payloadDto = dto.accountPayload();
+        MoneseAccountPayload payload = new MoneseAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.selectedCurrencyCodes(),
+                payloadDto.holderName(),
+                payloadDto.mobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new MoneseAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static MoneseAccountDto fromBisq2Model(MoneseAccount account) {
+        return new MoneseAccountDto(
+                account.getAccountName(),
+                new MoneseAccountPayloadDto(
+                        account.getAccountPayload().getSelectedCurrencyCodes(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/MoneyBeamAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/MoneyBeamAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.MoneyBeamAccount;
+import bisq.account.accounts.fiat.MoneyBeamAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.MoneyBeamAccountDto;
+import bisq.api.dto.account.fiat.MoneyBeamAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class MoneyBeamAccountDtoMapping {
+    public static MoneyBeamAccount toBisq2Model(MoneyBeamAccountDto dto) {
+        MoneyBeamAccountPayloadDto payloadDto = dto.accountPayload();
+        MoneyBeamAccountPayload payload = new MoneyBeamAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.holderName(),
+                payloadDto.emailOrMobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new MoneyBeamAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static MoneyBeamAccountDto fromBisq2Model(MoneyBeamAccount account) {
+        return new MoneyBeamAccountDto(
+                account.getAccountName(),
+                new MoneyBeamAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getEmailOrMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/MoneyGramAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/MoneyGramAccountDtoMapping.java
@@ -1,0 +1,50 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.MoneyGramAccount;
+import bisq.account.accounts.fiat.MoneyGramAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.MoneyGramAccountDto;
+import bisq.api.dto.account.fiat.MoneyGramAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class MoneyGramAccountDtoMapping {
+    public static MoneyGramAccount toBisq2Model(MoneyGramAccountDto dto) {
+        MoneyGramAccountPayloadDto payloadDto = dto.accountPayload();
+        MoneyGramAccountPayload payload = new MoneyGramAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.selectedCurrencyCodes(),
+                payloadDto.holderName(),
+                payloadDto.email(),
+                payloadDto.state()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new MoneyGramAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static MoneyGramAccountDto fromBisq2Model(MoneyGramAccount account) {
+        return new MoneyGramAccountDto(
+                account.getAccountName(),
+                new MoneyGramAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getSelectedCurrencyCodes(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getEmail(),
+                        account.getAccountPayload().getState()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/NationalBankAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/NationalBankAccountDtoMapping.java
@@ -1,0 +1,60 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.NationalBankAccount;
+import bisq.account.accounts.fiat.NationalBankAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.NationalBankAccountDto;
+import bisq.api.dto.account.fiat.NationalBankAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class NationalBankAccountDtoMapping {
+    public static NationalBankAccount toBisq2Model(NationalBankAccountDto dto) {
+        NationalBankAccountPayloadDto payloadDto = dto.accountPayload();
+        NationalBankAccountPayload payload = new NationalBankAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.holderName(),
+                payloadDto.holderId(),
+                payloadDto.bankName(),
+                payloadDto.bankId(),
+                payloadDto.branchId(),
+                payloadDto.accountNr(),
+                payloadDto.bankAccountType(),
+                payloadDto.nationalAccountId()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new NationalBankAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static NationalBankAccountDto fromBisq2Model(NationalBankAccount account) {
+        return new NationalBankAccountDto(
+                account.getAccountName(),
+                new NationalBankAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getHolderId(),
+                        account.getAccountPayload().getBankName(),
+                        account.getAccountPayload().getBankId(),
+                        account.getAccountPayload().getBranchId(),
+                        account.getAccountPayload().getAccountNr(),
+                        account.getAccountPayload().getBankAccountType(),
+                        account.getAccountPayload().getNationalAccountId()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/NeftAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/NeftAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.NeftAccount;
+import bisq.account.accounts.fiat.NeftAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.NeftAccountDto;
+import bisq.api.dto.account.fiat.NeftAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class NeftAccountDtoMapping {
+    public static NeftAccount toBisq2Model(NeftAccountDto dto) {
+        NeftAccountPayloadDto payloadDto = dto.accountPayload();
+        NeftAccountPayload payload = new NeftAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.accountNr(),
+                payloadDto.ifsc()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new NeftAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static NeftAccountDto fromBisq2Model(NeftAccount account) {
+        return new NeftAccountDto(
+                account.getAccountName(),
+                new NeftAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getAccountNr(),
+                        account.getAccountPayload().getIfsc()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/PayIdAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/PayIdAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.PayIdAccount;
+import bisq.account.accounts.fiat.PayIdAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.PayIdAccountDto;
+import bisq.api.dto.account.fiat.PayIdAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class PayIdAccountDtoMapping {
+    public static PayIdAccount toBisq2Model(PayIdAccountDto dto) {
+        PayIdAccountPayloadDto payloadDto = dto.accountPayload();
+        PayIdAccountPayload payload = new PayIdAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.payId()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new PayIdAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static PayIdAccountDto fromBisq2Model(PayIdAccount account) {
+        return new PayIdAccountDto(
+                account.getAccountName(),
+                new PayIdAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getPayId()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/PayseraAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/PayseraAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.PayseraAccount;
+import bisq.account.accounts.fiat.PayseraAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.PayseraAccountDto;
+import bisq.api.dto.account.fiat.PayseraAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class PayseraAccountDtoMapping {
+    public static PayseraAccount toBisq2Model(PayseraAccountDto dto) {
+        PayseraAccountPayloadDto payloadDto = dto.accountPayload();
+        PayseraAccountPayload payload = new PayseraAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.selectedCurrencyCodes(),
+                payloadDto.email()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new PayseraAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static PayseraAccountDto fromBisq2Model(PayseraAccount account) {
+        return new PayseraAccountDto(
+                account.getAccountName(),
+                new PayseraAccountPayloadDto(
+                        account.getAccountPayload().getSelectedCurrencyCodes(),
+                        account.getAccountPayload().getEmail()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/PerfectMoneyAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/PerfectMoneyAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.PerfectMoneyAccount;
+import bisq.account.accounts.fiat.PerfectMoneyAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.PerfectMoneyAccountDto;
+import bisq.api.dto.account.fiat.PerfectMoneyAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class PerfectMoneyAccountDtoMapping {
+    public static PerfectMoneyAccount toBisq2Model(PerfectMoneyAccountDto dto) {
+        PerfectMoneyAccountPayloadDto payloadDto = dto.accountPayload();
+        PerfectMoneyAccountPayload payload = new PerfectMoneyAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.accountNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new PerfectMoneyAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static PerfectMoneyAccountDto fromBisq2Model(PerfectMoneyAccount account) {
+        return new PerfectMoneyAccountDto(
+                account.getAccountName(),
+                new PerfectMoneyAccountPayloadDto(
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getAccountNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/Pin4AccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/Pin4AccountDtoMapping.java
@@ -1,0 +1,42 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.Pin4Account;
+import bisq.account.accounts.fiat.Pin4AccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.Pin4AccountDto;
+import bisq.api.dto.account.fiat.Pin4AccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class Pin4AccountDtoMapping {
+    public static Pin4Account toBisq2Model(Pin4AccountDto dto) {
+        Pin4AccountPayloadDto payloadDto = dto.accountPayload();
+        Pin4AccountPayload payload = new Pin4AccountPayload(
+                StringUtils.createUid(),
+                payloadDto.mobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new Pin4Account(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static Pin4AccountDto fromBisq2Model(Pin4Account account) {
+        return new Pin4AccountDto(
+                account.getAccountName(),
+                new Pin4AccountPayloadDto(
+                        account.getAccountPayload().getMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/PixAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/PixAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.PixAccount;
+import bisq.account.accounts.fiat.PixAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.PixAccountDto;
+import bisq.api.dto.account.fiat.PixAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class PixAccountDtoMapping {
+    public static PixAccount toBisq2Model(PixAccountDto dto) {
+        PixAccountPayloadDto payloadDto = dto.accountPayload();
+        PixAccountPayload payload = new PixAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.holderName(),
+                payloadDto.pixKey()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new PixAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static PixAccountDto fromBisq2Model(PixAccount account) {
+        return new PixAccountDto(
+                account.getAccountName(),
+                new PixAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getPixKey()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/PromptPayAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/PromptPayAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.PromptPayAccount;
+import bisq.account.accounts.fiat.PromptPayAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.PromptPayAccountDto;
+import bisq.api.dto.account.fiat.PromptPayAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class PromptPayAccountDtoMapping {
+    public static PromptPayAccount toBisq2Model(PromptPayAccountDto dto) {
+        PromptPayAccountPayloadDto payloadDto = dto.accountPayload();
+        PromptPayAccountPayload payload = new PromptPayAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.promptPayId()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new PromptPayAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static PromptPayAccountDto fromBisq2Model(PromptPayAccount account) {
+        return new PromptPayAccountDto(
+                account.getAccountName(),
+                new PromptPayAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getPromptPayId()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/RevolutAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/RevolutAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.RevolutAccount;
+import bisq.account.accounts.fiat.RevolutAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.RevolutAccountDto;
+import bisq.api.dto.account.fiat.RevolutAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class RevolutAccountDtoMapping {
+    public static RevolutAccount toBisq2Model(RevolutAccountDto dto) {
+        RevolutAccountPayloadDto payloadDto = dto.accountPayload();
+        RevolutAccountPayload payload = new RevolutAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.userName(),
+                payloadDto.selectedCurrencyCodes()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new RevolutAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static RevolutAccountDto fromBisq2Model(RevolutAccount account) {
+        return new RevolutAccountDto(
+                account.getAccountName(),
+                new RevolutAccountPayloadDto(
+                        account.getAccountPayload().getUserName(),
+                        account.getAccountPayload().getSelectedCurrencyCodes()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SameBankAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SameBankAccountDtoMapping.java
@@ -1,0 +1,60 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SameBankAccount;
+import bisq.account.accounts.fiat.SameBankAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SameBankAccountDto;
+import bisq.api.dto.account.fiat.SameBankAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class SameBankAccountDtoMapping {
+    public static SameBankAccount toBisq2Model(SameBankAccountDto dto) {
+        SameBankAccountPayloadDto payloadDto = dto.accountPayload();
+        SameBankAccountPayload payload = new SameBankAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.holderName(),
+                payloadDto.holderId(),
+                payloadDto.bankName(),
+                payloadDto.bankId(),
+                payloadDto.branchId(),
+                payloadDto.accountNr(),
+                payloadDto.bankAccountType(),
+                payloadDto.nationalAccountId()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SameBankAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SameBankAccountDto fromBisq2Model(SameBankAccount account) {
+        return new SameBankAccountDto(
+                account.getAccountName(),
+                new SameBankAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getHolderId(),
+                        account.getAccountPayload().getBankName(),
+                        account.getAccountPayload().getBankId(),
+                        account.getAccountPayload().getBranchId(),
+                        account.getAccountPayload().getAccountNr(),
+                        account.getAccountPayload().getBankAccountType(),
+                        account.getAccountPayload().getNationalAccountId()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SatispayAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SatispayAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SatispayAccount;
+import bisq.account.accounts.fiat.SatispayAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SatispayAccountDto;
+import bisq.api.dto.account.fiat.SatispayAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class SatispayAccountDtoMapping {
+    public static SatispayAccount toBisq2Model(SatispayAccountDto dto) {
+        SatispayAccountPayloadDto payloadDto = dto.accountPayload();
+        SatispayAccountPayload payload = new SatispayAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.mobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SatispayAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SatispayAccountDto fromBisq2Model(SatispayAccount account) {
+        return new SatispayAccountDto(
+                account.getAccountName(),
+                new SatispayAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SbpAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SbpAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SbpAccount;
+import bisq.account.accounts.fiat.SbpAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SbpAccountDto;
+import bisq.api.dto.account.fiat.SbpAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class SbpAccountDtoMapping {
+    public static SbpAccount toBisq2Model(SbpAccountDto dto) {
+        SbpAccountPayloadDto payloadDto = dto.accountPayload();
+        SbpAccountPayload payload = new SbpAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.mobileNumber(),
+                payloadDto.bankName()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SbpAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SbpAccountDto fromBisq2Model(SbpAccount account) {
+        return new SbpAccountDto(
+                account.getAccountName(),
+                new SbpAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getMobileNumber(),
+                        account.getAccountPayload().getBankName()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SepaAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SepaAccountDtoMapping.java
@@ -1,0 +1,50 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SepaAccount;
+import bisq.account.accounts.fiat.SepaAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SepaAccountDto;
+import bisq.api.dto.account.fiat.SepaAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class SepaAccountDtoMapping {
+    public static SepaAccount toBisq2Model(SepaAccountDto dto) {
+        SepaAccountPayloadDto payloadDto = dto.accountPayload();
+        SepaAccountPayload payload = new SepaAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.iban(),
+                payloadDto.bic(),
+                payloadDto.countryCode(),
+                payloadDto.acceptedCountryCodes()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SepaAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SepaAccountDto fromBisq2Model(SepaAccount account) {
+        return new SepaAccountDto(
+                account.getAccountName(),
+                new SepaAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getIban(),
+                        account.getAccountPayload().getBic(),
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getAcceptedCountryCodes()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SepaInstantAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SepaInstantAccountDtoMapping.java
@@ -1,0 +1,51 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SepaInstantAccount;
+import bisq.account.accounts.fiat.SepaInstantAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SepaInstantAccountDto;
+import bisq.api.dto.account.fiat.SepaInstantAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+import java.util.List;
+
+public class SepaInstantAccountDtoMapping {
+    public static SepaInstantAccount toBisq2Model(SepaInstantAccountDto dto) {
+        SepaInstantAccountPayloadDto payloadDto = dto.accountPayload();
+        SepaInstantAccountPayload payload = new SepaInstantAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.iban(),
+                payloadDto.bic(),
+                payloadDto.countryCode(),
+                payloadDto.acceptedCountryCodes()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SepaInstantAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SepaInstantAccountDto fromBisq2Model(SepaInstantAccount account) {
+        return new SepaInstantAccountDto(
+                account.getAccountName(),
+                new SepaInstantAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getIban(),
+                        account.getAccountPayload().getBic(),
+                        account.getAccountPayload().getCountryCode(),
+                        List.copyOf(account.getAccountPayload().getAcceptedCountryCodes())
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/StrikeAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/StrikeAccountDtoMapping.java
@@ -1,0 +1,44 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.StrikeAccount;
+import bisq.account.accounts.fiat.StrikeAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.StrikeAccountDto;
+import bisq.api.dto.account.fiat.StrikeAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class StrikeAccountDtoMapping {
+    public static StrikeAccount toBisq2Model(StrikeAccountDto dto) {
+        StrikeAccountPayloadDto payloadDto = dto.accountPayload();
+        StrikeAccountPayload payload = new StrikeAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.holderName()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new StrikeAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static StrikeAccountDto fromBisq2Model(StrikeAccount account) {
+        return new StrikeAccountDto(
+                account.getAccountName(),
+                new StrikeAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getHolderName()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SwiftAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SwiftAccountDtoMapping.java
@@ -1,0 +1,72 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SwiftAccount;
+import bisq.account.accounts.fiat.SwiftAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SwiftAccountDto;
+import bisq.api.dto.account.fiat.SwiftAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class SwiftAccountDtoMapping {
+    public static SwiftAccount toBisq2Model(SwiftAccountDto dto) {
+        SwiftAccountPayloadDto payloadDto = dto.accountPayload();
+        SwiftAccountPayload payload = new SwiftAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.bankCountryCode(),
+                payloadDto.beneficiaryName(),
+                payloadDto.beneficiaryAccountNr(),
+                payloadDto.beneficiaryPhone(),
+                payloadDto.beneficiaryAddress(),
+                payloadDto.selectedCurrencyCode(),
+                payloadDto.bankSwiftCode(),
+                payloadDto.bankName(),
+                payloadDto.bankBranch(),
+                payloadDto.bankAddress(),
+                payloadDto.intermediaryBankCountryCode(),
+                payloadDto.intermediaryBankSwiftCode(),
+                payloadDto.intermediaryBankName(),
+                payloadDto.intermediaryBankBranch(),
+                payloadDto.intermediaryBankAddress(),
+                payloadDto.additionalInstructions()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SwiftAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SwiftAccountDto fromBisq2Model(SwiftAccount account) {
+        return new SwiftAccountDto(
+                account.getAccountName(),
+                new SwiftAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getBeneficiaryName(),
+                        account.getAccountPayload().getBeneficiaryAccountNr(),
+                        account.getAccountPayload().getBeneficiaryPhone(),
+                        account.getAccountPayload().getBeneficiaryAddress(),
+                        account.getAccountPayload().getSelectedCurrencyCode(),
+                        account.getAccountPayload().getBankSwiftCode(),
+                        account.getAccountPayload().getBankName(),
+                        account.getAccountPayload().getBankBranch(),
+                        account.getAccountPayload().getBankAddress(),
+                        account.getAccountPayload().getIntermediaryBankCountryCode(),
+                        account.getAccountPayload().getIntermediaryBankSwiftCode(),
+                        account.getAccountPayload().getIntermediaryBankName(),
+                        account.getAccountPayload().getIntermediaryBankBranch(),
+                        account.getAccountPayload().getIntermediaryBankAddress(),
+                        account.getAccountPayload().getAdditionalInstructions()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/SwishAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/SwishAccountDtoMapping.java
@@ -1,0 +1,46 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.SwishAccount;
+import bisq.account.accounts.fiat.SwishAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.SwishAccountDto;
+import bisq.api.dto.account.fiat.SwishAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class SwishAccountDtoMapping {
+    public static SwishAccount toBisq2Model(SwishAccountDto dto) {
+        SwishAccountPayloadDto payloadDto = dto.accountPayload();
+        SwishAccountPayload payload = new SwishAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.countryCode(),
+                payloadDto.holderName(),
+                payloadDto.mobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new SwishAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static SwishAccountDto fromBisq2Model(SwishAccount account) {
+        return new SwishAccountDto(
+                account.getAccountName(),
+                new SwishAccountPayloadDto(
+                        account.getAccountPayload().getCountryCode(),
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getMobileNr()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/fiat/UserDefinedFiatAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/fiat/UserDefinedFiatAccountDtoMapping.java
@@ -1,0 +1,42 @@
+package bisq.api.dto.mappings.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.UserDefinedFiatAccount;
+import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class UserDefinedFiatAccountDtoMapping {
+    public static UserDefinedFiatAccount toBisq2Model(UserDefinedFiatAccountDto dto) {
+        UserDefinedFiatAccountPayloadDto payloadDto = dto.accountPayload();
+        UserDefinedFiatAccountPayload payload = new UserDefinedFiatAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.accountData()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new UserDefinedFiatAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static UserDefinedFiatAccountDto fromBisq2Model(UserDefinedFiatAccount account) {
+        return new UserDefinedFiatAccountDto(
+                account.getAccountName(),
+                new UserDefinedFiatAccountPayloadDto(
+                        account.getAccountPayload().getAccountData()
+                )
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
@@ -35,8 +35,8 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
                                  MarketPriceRestApi marketPriceRestApi,
                                  SettingsRestApi settingsRestApi,
                                  ExplorerRestApi explorerRestApi,
-                                 PaymentAccountsRestApi paymentAccountsRestApi,
                                  FiatPaymentAccountsRestApi fiatPaymentAccountsRestApi,
+                                 PaymentAccountsRestApi paymentAccountsRestApi,
                                  ReputationRestApi reputationRestApi,
                                  UserProfileRestApi userProfileRestApi,
                                  DevicesRestApi devicesRestApi) {
@@ -53,8 +53,8 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
         register(MarketPriceRestApi.class);
         register(SettingsRestApi.class);
         register(ExplorerRestApi.class);
-        register(PaymentAccountsRestApi.class);
         register(FiatPaymentAccountsRestApi.class);
+        register(PaymentAccountsRestApi.class);
         register(ReputationRestApi.class);
         register(UserProfileRestApi.class);
         register(DevicesRestApi.class);
@@ -69,8 +69,8 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
                 bind(marketPriceRestApi).to(MarketPriceRestApi.class);
                 bind(settingsRestApi).to(SettingsRestApi.class);
                 bind(explorerRestApi).to(ExplorerRestApi.class);
-                bind(paymentAccountsRestApi).to(PaymentAccountsRestApi.class);
                 bind(fiatPaymentAccountsRestApi).to(FiatPaymentAccountsRestApi.class);
+                bind(paymentAccountsRestApi).to(PaymentAccountsRestApi.class);
                 bind(reputationRestApi).to(ReputationRestApi.class);
                 bind(userProfileRestApi).to(UserProfileRestApi.class);
                 bind(devicesRestApi).to(DevicesRestApi.class);

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/AddCryptoAccountRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/AddCryptoAccountRequest.java
@@ -1,0 +1,6 @@
+package bisq.api.rest_api.endpoints.payment_accounts;
+
+import bisq.api.dto.account.crypto.CryptoAccountDto;
+
+public record AddCryptoAccountRequest(CryptoAccountDto account) {
+}

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/FiatPaymentAccountsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/FiatPaymentAccountsRestApi.java
@@ -31,7 +31,15 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
@@ -159,7 +167,12 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
             try {
                 Account<? extends PaymentMethod<?>, ?> account = DtoMappings.FiatAccountMapping.toBisq2Model(accountDto);
-                accountService.addPaymentAccount(account);
+                boolean added = accountService.addPaymentAccount(account);
+                if (!added) {
+                    asyncResponse.resume(buildErrorResponse(Response.Status.CONFLICT,
+                            "Payment account already exists: " + accountDto.accountName()));
+                    return;
+                }
             } catch (IllegalArgumentException e) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()));
                 return;

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsDto.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsDto.java
@@ -1,0 +1,12 @@
+package bisq.api.rest_api.endpoints.payment_accounts;
+
+import bisq.api.dto.account.crypto.CryptoAccountDto;
+import bisq.api.dto.account.fiat.FiatAccountDto;
+
+import java.util.List;
+
+public record PaymentAccountsDto(
+        List<FiatAccountDto> fiat,
+        List<CryptoAccountDto> crypto
+) {
+}

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
@@ -1,36 +1,24 @@
-/*
- * This file is part of Bisq.
- *
- * Bisq is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * Bisq is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
- * License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
- */
-
 package bisq.api.rest_api.endpoints.payment_accounts;
 
 import bisq.account.AccountService;
 import bisq.account.accounts.Account;
-import bisq.account.accounts.AccountOrigin;
-import bisq.account.accounts.fiat.UserDefinedFiatAccount;
-import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
+import bisq.account.accounts.crypto.CryptoAssetAccount;
 import bisq.account.payment_method.PaymentMethod;
-import bisq.account.timestamp.KeyType;
-import bisq.common.util.StringUtils;
+import bisq.account.payment_method.crypto.CryptoPaymentMethodUtil;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentRailUtil;
 import bisq.api.dto.DtoMappings;
-import bisq.api.dto.account.UserDefinedFiatAccountDto;
+import bisq.api.dto.account.crypto.CryptoAccountDto;
+import bisq.api.dto.account.crypto.CryptoPaymentMethodItemDto;
+import bisq.api.dto.account.fiat.FiatAccountDto;
+import bisq.api.dto.account.fiat.FiatPaymentMethodItemDto;
+import bisq.api.dto.mappings.crypto.CryptoAccountDtoMapping;
+import bisq.api.dto.mappings.crypto.CryptoPaymentMethodItemDtoMapping;
 import bisq.api.rest_api.endpoints.RestApiBase;
-import bisq.security.keys.KeyGeneration;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,18 +27,17 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import java.security.KeyPair;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +47,7 @@ import java.util.stream.Collectors;
 @Path("/payment-accounts")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Payment Accounts API", description = "API for managing user payment accounts. Right now UserDefinedFiatAccount")
+@Tag(name = "Payment Accounts API", description = "API for retrieving fiat and crypto payment accounts.")
 public class PaymentAccountsRestApi extends RestApiBase {
     private final AccountService accountService;
 
@@ -71,52 +58,32 @@ public class PaymentAccountsRestApi extends RestApiBase {
     @GET
     @Operation(
             summary = "Get payment accounts",
-            description = "Retrieve all the payment accounts (only UserDefinedFiatAccount)",
+            description = "Retrieve fiat and crypto payment accounts",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Payment accounts retrieved successfully",
-                            content = @Content(schema = @Schema(implementation = UserDefinedFiatAccountDto.class))),
+                            content = @Content(schema = @Schema(implementation = PaymentAccountsDto.class))),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
     public Response getPaymentAccounts() {
         try {
-            List<UserDefinedFiatAccountDto> userAccounts = accountService.getAccountByNameMap().values().stream()
-                    .filter(account -> account instanceof UserDefinedFiatAccount)
-                    .map(account -> (UserDefinedFiatAccount) account)
-                    .map(DtoMappings.UserDefinedFiatAccountMapping::fromBisq2Model)
+            var accounts = accountService.getAccounts();
+
+            List<FiatAccountDto> fiatAccounts = accounts.stream()
+                    .filter(this::isFiatAccount)
+                    .map(this::convertToFiatDto)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .collect(Collectors.toList());
 
-            return buildOkResponse(userAccounts);
-        } catch (Exception e) {
-            log.error("Failed to retrieve payment accounts", e);
-            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
-        }
-    }
+            List<CryptoAccountDto> cryptoAccounts = accounts.stream()
+                    .filter(this::isCryptoAccount)
+                    .map(this::convertToCryptoDto)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList());
 
-    @GET
-    @Operation(
-            summary = "Get selected payment account",
-            description = "Get selected payment account (only UserDefinedFiatAccount)",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Selected payment account retrieved successfully",
-                            content = @Content(schema = @Schema(implementation = UserDefinedFiatAccountDto.class))),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
-            }
-    )
-    @Path("/selected")
-    public Response getSelectedPaymentAccount() {
-        try {
-            if (accountService.findSelectedAccount().isPresent()) {
-                Account<? extends PaymentMethod<?>, ?> account = accountService.findSelectedAccount().get();
-                if (account instanceof UserDefinedFiatAccount castedAccount) {
-                    UserDefinedFiatAccountDto userAccount = DtoMappings.UserDefinedFiatAccountMapping.fromBisq2Model(castedAccount);
-                    return buildOkResponse(userAccount);
-                } else {
-                    return buildNoContentResponse();
-                }
-            }
-
-            return buildNoContentResponse();
+            return buildOkResponse(new PaymentAccountsDto(fiatAccounts, cryptoAccounts));
         } catch (Exception e) {
             log.error("Failed to retrieve payment accounts", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
@@ -124,37 +91,128 @@ public class PaymentAccountsRestApi extends RestApiBase {
     }
 
     @POST
+    @Path("/fiat")
     @Operation(
-            summary = "Add new payment account",
-            description = "Add new payment account (only UserDefinedFiatAccount)",
+            summary = "Add new fiat payment account",
+            description = "Create a new fiat payment account. The payment rail type is specified in the request body.",
             requestBody = @RequestBody(
-                    description = "",
-                    content = @Content(schema = @Schema(implementation = AddAccountRequest.class))
+                    description = "Fiat account details including payment rail type, account name, and payload",
+                    content = @Content(
+                            schema = @Schema(implementation = AddFiatAccountRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Zelle account",
+                                            value = "{\n  \"account\": {\n    \"accountName\": \"My Zelle Account\",\n    \"paymentRail\": \"ZELLE\",\n    \"accountPayload\": {\n      \"holderName\": \"John Doe\",\n      \"emailOrMobileNr\": \"john.doe@example.com\"\n    }\n  }\n}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "ACH transfer account",
+                                            value = "{\n  \"account\": {\n    \"accountName\": \"My Ach Account\",\n    \"paymentRail\": \"ACH_TRANSFER\",\n    \"accountPayload\": {\n      \"holderName\": \"John Doe\",\n      \"holderAddress\": \"Some Address\",\n      \"bankName\": \"Bank of Test\",\n      \"routingNr\": \"123456789\",\n      \"accountNr\": \"000123456789\",\n      \"bankAccountType\": \"CHECKING\"\n    }\n  }\n}"
+                                    )
+                            }
+                    )
             ),
             responses = {
-                    @ApiResponse(responseCode = "201", description = "",
-                            content = @Content(schema = @Schema(example = ""))),
-                    @ApiResponse(responseCode = "400", description = "Invalid input"),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
+                    @ApiResponse(responseCode = "201", description = "Fiat payment account created successfully",
+                            content = @Content(schema = @Schema(implementation = FiatAccountDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid input or unsupported payment rail"),
+                    @ApiResponse(responseCode = "409", description = "Payment account already exists"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error"),
+                    @ApiResponse(responseCode = "503", description = "Request timed out")
             }
     )
-    public void addAccount(AddAccountRequest request, @Suspended AsyncResponse asyncResponse) {
+    @SuppressWarnings("deprecation")
+    public void addFiatAccount(@Valid AddFiatAccountRequest request,
+                               @Suspended AsyncResponse asyncResponse) {
         asyncResponse.setTimeout(10, TimeUnit.SECONDS);
-        asyncResponse.setTimeoutHandler(response -> {
-            response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out"));
-        });
+        asyncResponse.setTimeoutHandler(response ->
+                response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out")));
         try {
-            KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-            KeyType keyType = KeyType.EC;
-            UserDefinedFiatAccountPayload accountPayload = new UserDefinedFiatAccountPayload(StringUtils.createUid(), request.accountData());
-            accountService.addPaymentAccount(new UserDefinedFiatAccount(StringUtils.createUid(),
-                    System.currentTimeMillis(),
-                    request.accountName(),
-                    accountPayload,
-                    keyPair,
-                    keyType,
-                    AccountOrigin.BISQ2_NEW));
-            asyncResponse.resume(buildResponse(Response.Status.CREATED, new AddAccountResponse(request.accountName())));
+            FiatAccountDto accountDto = request.account();
+            if (accountDto == null) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account data is required"));
+                return;
+            }
+
+            FiatPaymentRail paymentRail = DtoMappings.FiatPaymentRailMapping.toBisq2Model(accountDto.paymentRail());
+            if (paymentRail == FiatPaymentRail.CUSTOM) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST,
+                        "Unsupported payment rail for this endpoint: " + paymentRail));
+                return;
+            }
+
+            try {
+                Account<? extends PaymentMethod<?>, ?> account = DtoMappings.FiatAccountMapping.toBisq2Model(accountDto);
+                if (!accountService.addPaymentAccount(account)) {
+                    asyncResponse.resume(buildErrorResponse(Response.Status.CONFLICT,
+                            "Payment account already exists: " + accountDto.accountName()));
+                    return;
+                }
+            } catch (IllegalArgumentException e) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()));
+                return;
+            }
+
+            asyncResponse.resume(buildResponse(Response.Status.CREATED, accountDto));
+        } catch (Exception e) {
+            asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
+        }
+    }
+
+    @POST
+    @Path("/crypto")
+    @Operation(
+            summary = "Add new crypto payment account",
+            description = "Create a new crypto payment account using a wrapped polymorphic crypto account DTO.",
+            requestBody = @RequestBody(
+                    description = "Crypto account details",
+                    content = @Content(
+                            schema = @Schema(implementation = AddCryptoAccountRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Monero account",
+                                            value = "{\n  \"account\": {\n    \"accountName\": \"My Monero Account\",\n    \"paymentRail\": \"MONERO\",\n    \"accountPayload\": {\n      \"currencyCode\": \"XMR\",\n      \"address\": \"84f....\",\n      \"isInstant\": false,\n      \"isAutoConf\": false,\n      \"autoConfNumConfirmations\": 1,\n      \"autoConfMaxTradeAmount\": 100000,\n      \"autoConfExplorerUrls\": \"https://xmrchain.net\",\n      \"useSubAddresses\": false,\n      \"mainAddress\": null,\n      \"privateViewKey\": null,\n      \"subAddress\": null,\n      \"accountIndex\": null,\n      \"initialSubAddressIndex\": null\n    }\n  }\n}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "Other crypto account",
+                                            value = "{\n  \"account\": {\n    \"accountName\": \"My LTC Account\",\n    \"paymentRail\": \"OTHER_CRYPTO_ASSET\",\n    \"accountPayload\": {\n      \"currencyCode\": \"LTC\",\n      \"address\": \"ltc1....\",\n      \"isInstant\": false,\n      \"isAutoConf\": false,\n      \"autoConfNumConfirmations\": 1,\n      \"autoConfMaxTradeAmount\": 100000,\n      \"autoConfExplorerUrls\": \"https://blockchair.com/litecoin\"\n    }\n  }\n}"
+                                    )
+                            }
+                    )
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Crypto payment account created successfully",
+                            content = @Content(schema = @Schema(implementation = CryptoAccountDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid input"),
+                    @ApiResponse(responseCode = "409", description = "Payment account already exists"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error"),
+                    @ApiResponse(responseCode = "503", description = "Request timed out")
+            }
+    )
+    public void addCryptoAccount(@Valid AddCryptoAccountRequest request,
+                                 @Suspended AsyncResponse asyncResponse) {
+        asyncResponse.setTimeout(10, TimeUnit.SECONDS);
+        asyncResponse.setTimeoutHandler(response ->
+                response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out")));
+        try {
+            CryptoAccountDto accountDto = request.account();
+            if (accountDto == null) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account data is required"));
+                return;
+            }
+
+            try {
+                Account<? extends PaymentMethod<?>, ?> account = CryptoAccountDtoMapping.toBisq2Model(accountDto);
+                if (!accountService.addPaymentAccount(account)) {
+                    asyncResponse.resume(buildErrorResponse(Response.Status.CONFLICT,
+                            "Payment account already exists: " + accountDto.accountName()));
+                    return;
+                }
+            } catch (IllegalArgumentException e) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()));
+                return;
+            }
+
+            asyncResponse.resume(buildResponse(Response.Status.CREATED, accountDto));
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
@@ -162,21 +220,21 @@ public class PaymentAccountsRestApi extends RestApiBase {
 
     @DELETE
     @Operation(
-            summary = "Delete Payment account",
-            description = "Delete Payment account",
+            summary = "Delete payment account",
+            description = "Delete a payment account by account name (fiat or crypto)",
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Offer successfully deleted"),
-                    @ApiResponse(responseCode = "400", description = "Invalid input"),
-                    @ApiResponse(responseCode = "404", description = "Offer or user identity not found"),
+                    @ApiResponse(responseCode = "204", description = "Payment account successfully deleted"),
+                    @ApiResponse(responseCode = "400", description = "Account name is required"),
+                    @ApiResponse(responseCode = "404", description = "Account not found"),
                     @ApiResponse(responseCode = "500", description = "Internal server error"),
                     @ApiResponse(responseCode = "503", description = "Request timed out")
             }
     )
-    public void removeAccount(@QueryParam("accountName") String accountName, @Suspended AsyncResponse asyncResponse) {
+    public void removeAccount(@QueryParam("accountName") String accountName,
+                              @Suspended AsyncResponse asyncResponse) {
         asyncResponse.setTimeout(10, TimeUnit.SECONDS);
-        asyncResponse.setTimeoutHandler(response -> {
-            response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out"));
-        });
+        asyncResponse.setTimeoutHandler(response ->
+                response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out")));
         try {
             if (accountName == null || accountName.trim().isEmpty()) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account name is required"));
@@ -184,56 +242,93 @@ public class PaymentAccountsRestApi extends RestApiBase {
             }
 
             Optional<Account<? extends PaymentMethod<?>, ?>> result = accountService.findAccount(accountName);
-            if (result.isPresent()) {
-                Account<? extends PaymentMethod<?>, ?> toRemove = result.get();
-                accountService.removePaymentAccount(toRemove);
-                asyncResponse.resume(buildNoContentResponse());
-            } else {
-                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found"));
+            if (result.isEmpty()) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.NOT_FOUND, "Payment account not found"));
+                return;
             }
+
+            accountService.removePaymentAccount(result.get());
+            asyncResponse.resume(buildNoContentResponse());
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
     }
 
-    @PATCH
+    @GET
+    @Path("/payment-methods/fiat")
     @Operation(
-            summary = "Update selected payment account",
-            description = "Update selected payment account (only UserDefinedFiatAccount)",
-            requestBody = @RequestBody(
-                    description = "The setting key and value to be updated",
-                    required = true,
-                    content = @Content(schema = @Schema(implementation = PaymentAccountChangeRequest.class))
-            ),
+            summary = "Get fiat payment methods",
+            description = "Retrieve all available fiat payment methods as displayed by the desktop payment method selection",
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Selected payment account set successfully"),
-                    @ApiResponse(responseCode = "400", description = "Invalid input data"),
+                    @ApiResponse(responseCode = "200", description = "Fiat payment methods retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = FiatPaymentMethodItemDto.class, type = "array"))),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
-    @Path("/selected")
-    public Response setSelectedPaymentAccount(@Valid PaymentAccountChangeRequest request) {
+    @SuppressWarnings("deprecation")
+    public Response getFiatPaymentMethods() {
         try {
-            UserDefinedFiatAccountDto account = request.selectedAccount();
-            if (account != null) {
-                Optional<Account<? extends PaymentMethod<?>, ?>> result = accountService.findAccount(account.accountName());
-                if (result.isPresent()) {
-                    Account<? extends PaymentMethod<?>, ?> foundAccount = result.get();
-                    if (foundAccount instanceof UserDefinedFiatAccount castedAccount) {
-                        accountService.setSelectedAccount(castedAccount);
-                    } else {
-                        return buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found");
-                    }
-                } else {
-                    return buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found");
-                }
-            }
-
-            log.info("Updated selected payment account from request: {}", request);
-            return Response.noContent().build();
+            List<FiatPaymentMethodItemDto> items = FiatPaymentRailUtil.getPaymentRails().stream()
+                    .filter(rail -> rail != FiatPaymentRail.CUSTOM)
+                    .filter(rail -> rail != FiatPaymentRail.CASH_APP)
+                    .map(FiatPaymentMethod::fromPaymentRail)
+                    .map(DtoMappings.FiatPaymentMethodItemMapping::fromBisq2Model)
+                    .sorted(Comparator.comparing(FiatPaymentMethodItemDto::name, String.CASE_INSENSITIVE_ORDER))
+                    .collect(Collectors.toList());
+            return buildOkResponse(items);
         } catch (Exception e) {
-            log.error("Error updating select payment account", e);
+            log.error("Failed to retrieve fiat payment methods", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/payment-methods/crypto")
+    @Operation(
+            summary = "Get crypto payment methods",
+            description = "Retrieve all available crypto payment methods",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Crypto payment methods retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = CryptoPaymentMethodItemDto.class, type = "array"))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getCryptoPaymentMethods() {
+        try {
+            List<CryptoPaymentMethodItemDto> items = CryptoPaymentMethodUtil.getPaymentMethods().stream()
+                    .filter(e -> !e.getCode().equals("BTC"))
+                    .map(CryptoPaymentMethodItemDtoMapping::fromBisq2Model)
+                    .collect(Collectors.toList());
+            return buildOkResponse(items);
+        } catch (Exception e) {
+            log.error("Failed to retrieve crypto payment methods", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    private boolean isFiatAccount(Account<? extends PaymentMethod<?>, ?> account) {
+        return account.getPaymentMethod() instanceof FiatPaymentMethod;
+    }
+
+    public boolean isCryptoAccount(Account<? extends PaymentMethod<?>, ?> account) {
+        return account instanceof CryptoAssetAccount;
+    }
+
+    private Optional<FiatAccountDto> convertToFiatDto(Account<? extends PaymentMethod<?>, ?> account) {
+        try {
+            return Optional.of(DtoMappings.FiatAccountMapping.fromBisq2Model(account));
+        } catch (IllegalArgumentException e) {
+            log.warn("Unsupported fiat account type: {}", account.getClass().getSimpleName());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<CryptoAccountDto> convertToCryptoDto(Account<? extends PaymentMethod<?>, ?> account) {
+        try {
+            return Optional.of(CryptoAccountDtoMapping.fromBisq2Model(account));
+        } catch (IllegalArgumentException e) {
+            log.warn("Unsupported crypto account type: {}", account.getClass().getSimpleName());
+            return Optional.empty();
         }
     }
 }

--- a/api/src/main/java/bisq/api/rest_api/util/SwaggerResolution.java
+++ b/api/src/main/java/bisq/api/rest_api/util/SwaggerResolution.java
@@ -16,6 +16,7 @@
  */
 package bisq.api.rest_api.util;
 
+import bisq.api.access.AllowUnauthenticated;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -33,6 +34,7 @@ import jakarta.ws.rs.core.MediaType;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@AllowUnauthenticated
 @Path("openapi.json")
 @Produces(MediaType.APPLICATION_JSON)
 @Hidden


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for 40+ fiat payment rails plus crypto account types; endpoints to list fiat and crypto payment methods and create fiat or crypto accounts.

* **Improvements**
  * Unified payment-accounts API returning separate fiat and crypto lists; stronger per-method validation, clearer conflict responses, and async account creation with timeout handling.

* **Bug Fixes**
  * OpenAPI (Swagger) now publicly accessible; delete/list endpoints return more appropriate status codes; duplicate-account creation returns 409.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->