### PR TITLE
API endpoints for Dont show again flag updates for bisq-mobile xClients

### DIFF
--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -60,6 +60,7 @@ import bisq.network.NetworkService;
 import bisq.notifications.mobile.registration.DeviceRegistrationService;
 import bisq.persistence.PersistenceService;
 import bisq.security.SecurityService;
+import bisq.settings.DontShowAgainService;
 import bisq.settings.SettingsService;
 import bisq.support.SupportService;
 import bisq.trade.TradeService;
@@ -124,6 +125,7 @@ public class ApiService implements Service {
                       SupportService supportedService,
                       TradeService tradeService,
                       SettingsService settingsService,
+                      DontShowAgainService dontShowAgainService,
                       BisqEasyService bisqEasyService,
                       OpenTradeItemsService openTradeItemsService,
                       AccountService accountService,
@@ -162,7 +164,7 @@ public class ApiService implements Service {
         TradeChatMessagesRestApi tradeChatMessagesRestApi = new TradeChatMessagesRestApi(chatService, userService);
         UserIdentityRestApi userIdentityRestApi = new UserIdentityRestApi(securityService, userService.getUserIdentityService(), bisqEasyService);
         MarketPriceRestApi marketPriceRestApi = new MarketPriceRestApi(bondedRolesService.getMarketPriceService());
-        SettingsRestApi settingsRestApi = new SettingsRestApi(settingsService);
+        SettingsRestApi settingsRestApi = new SettingsRestApi(settingsService, dontShowAgainService);
         PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
         FiatPaymentAccountsRestApi fiatPaymentAccountsRestApi = new FiatPaymentAccountsRestApi(accountService);
         UserProfileRestApi userProfileRestApi = new UserProfileRestApi(

--- a/api/src/main/java/bisq/api/dto/DtoMappings.java
+++ b/api/src/main/java/bisq/api/dto/DtoMappings.java
@@ -1128,7 +1128,8 @@ public class DtoMappings {
                     settingsService.getMaxTradePriceDeviation().get(),
                     MarketMapping.fromBisq2Model(settingsService.getSelectedMuSigMarket().get()),
                     settingsService.getNumDaysAfterRedactingTradeData().get(),
-                    settingsService.getUseAnimations().get()
+                    settingsService.getUseAnimations().get(),
+                    settingsService.getDontShowAgainMap()
             );
         }
     }

--- a/api/src/main/java/bisq/api/dto/settings/SettingsDto.java
+++ b/api/src/main/java/bisq/api/dto/settings/SettingsDto.java
@@ -19,6 +19,7 @@ package bisq.api.dto.settings;
 
 import bisq.api.dto.common.currency.MarketDto;
 
+import java.util.Map;
 import java.util.Set;
 
 public record SettingsDto(boolean isTacAccepted,
@@ -30,5 +31,6 @@ public record SettingsDto(boolean isTacAccepted,
                           double maxTradePriceDeviation,
                           MarketDto selectedMuSigMarket,
                           int numDaysAfterRedactingTradeData,
-                          boolean useAnimations) {
+                          boolean useAnimations,
+                          Map<String, Boolean> dontShowAgainMap) {
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/settings/SettingsChangeRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/settings/SettingsChangeRequest.java
@@ -32,6 +32,10 @@ public record SettingsChangeRequest(
         @Nullable Double maxTradePriceDeviation,
         @Nullable MarketDto selectedMuSigMarket,
         @Nullable Integer numDaysAfterRedactingTradeData,
-        @Nullable Boolean useAnimations
+        @Nullable Boolean useAnimations,
+        @Nullable Boolean webLinkDontShowAgain,
+        @Nullable Boolean resetAllDontShowAgainFlags,
+        @Nullable Integer setCookie,
+        @Nullable Integer unsetCookie
 ) {
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/settings/SettingsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/settings/SettingsRestApi.java
@@ -23,6 +23,9 @@ import bisq.api.dto.DtoMappings;
 import bisq.api.dto.settings.SettingsApiVersionDto;
 import bisq.api.dto.settings.SettingsDto;
 import bisq.api.rest_api.endpoints.RestApiBase;
+import bisq.settings.CookieKey;
+import bisq.settings.DontShowAgainKey;
+import bisq.settings.DontShowAgainService;
 import bisq.settings.SettingsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -43,9 +46,13 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "Settings API", description = "API for managing user settings")
 public class SettingsRestApi extends RestApiBase {
     private final SettingsService settingsService;
+    private final DontShowAgainService dontShowAgainService;
 
-    public SettingsRestApi(SettingsService settingsService) {
+    public SettingsRestApi(
+            SettingsService settingsService,
+            DontShowAgainService dontShowAgainService) {
         this.settingsService = settingsService;
+        this.dontShowAgainService = dontShowAgainService;
     }
 
     @GET
@@ -64,6 +71,25 @@ public class SettingsRestApi extends RestApiBase {
             return buildOkResponse(settingsDto);
         } catch (Exception e) {
             log.error("Failed to retrieve user settings", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    @GET
+    @Path("/cookie/{keyIndex}")
+    @Operation(description = "Get the cookie value for the given keyIndex")
+    public Response getCookie(@PathParam("keyIndex") int keyIndex) {
+        try {
+            CookieKey[] keys = CookieKey.values();
+            if (keyIndex < 0 || keyIndex >= keys.length) {
+                return buildErrorResponse(Response.Status.BAD_REQUEST,
+                        "Invalid keyIndex: " + keyIndex + ". Valid range: 0-" + (keys.length - 1));
+            }
+            CookieKey key = keys[keyIndex];
+            Boolean value = settingsService.getCookie().asBoolean(key).orElse(false);
+            return Response.ok(value).build();
+        } catch (Exception e) {
+            log.error("Error getting Cookie(" + keyIndex + ")", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
         }
     }
@@ -120,6 +146,36 @@ public class SettingsRestApi extends RestApiBase {
                 settingsService.setNumDaysAfterRedactingTradeData(request.numDaysAfterRedactingTradeData());
             } else if (request.useAnimations() != null) {
                 settingsService.setUseAnimations(request.useAnimations());
+            } else if (Boolean.TRUE.equals(request.webLinkDontShowAgain())) {
+                dontShowAgainService.dontShowAgain(DontShowAgainKey.HYPERLINKS_OPEN_IN_BROWSER);
+            } else if (Boolean.TRUE.equals(request.resetAllDontShowAgainFlags())) {
+                dontShowAgainService.resetDontShowAgain();
+            } else if (request.setCookie() != null) {
+                int keyIndex = request.setCookie();
+                CookieKey[] keys = CookieKey.values();
+                if (keyIndex < 0 || keyIndex >= keys.length) {
+                    return buildErrorResponse(Response.Status.BAD_REQUEST,
+                            "Invalid keyIndex: " + keyIndex + ". Valid range: 0-" + (keys.length - 1));
+                }
+                CookieKey key = keys[keyIndex];
+                if (key != null) {
+                    settingsService.setCookie(key, true);
+                }
+                Boolean value = settingsService.getCookie().asBoolean(key).orElse(false);
+                return Response.ok(value).build();
+            } else if (request.unsetCookie() != null) {
+                int keyIndex = request.unsetCookie();
+                CookieKey[] keys = CookieKey.values();
+                if (keyIndex < 0 || keyIndex >= keys.length) {
+                    return buildErrorResponse(Response.Status.BAD_REQUEST,
+                            "Invalid keyIndex: " + keyIndex + ". Valid range: 0-" + (keys.length - 1));
+                }
+                CookieKey key = keys[keyIndex];
+                if (key != null) {
+                    settingsService.setCookie(key, false);
+                }
+                Boolean value = settingsService.getCookie().asBoolean(key).orElse(false);
+                return Response.ok(value).build();
             } else {
                 return buildErrorResponse(Response.Status.BAD_REQUEST, "Invalid request: " + request);
             }

--- a/apps/api-app/src/main/java/bisq/api_app/ApiApplicationService.java
+++ b/apps/api-app/src/main/java/bisq/api_app/ApiApplicationService.java
@@ -44,6 +44,7 @@ import bisq.notifications.system.OsSpecificNotificationService;
 import bisq.notifications.NotificationService;
 import bisq.security.SecurityService;
 import bisq.security.keys.KeyBundleService;
+import bisq.settings.DontShowAgainService;
 import bisq.settings.SettingsService;
 import bisq.support.SupportService;
 import bisq.trade.TradeService;
@@ -82,6 +83,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
     private final UserService userService;
     private final ChatService chatService;
     private final SettingsService settingsService;
+    private final DontShowAgainService dontShowAgainService;
     private final SupportService supportService;
     private final NotificationService notificationService;
     private final TradeService tradeService;
@@ -128,6 +130,8 @@ public class ApiApplicationService extends JavaSeApplicationService {
         accountService = new AccountService(persistenceService, networkService, userService, bondedRolesService);
 
         settingsService = new SettingsService(persistenceService);
+
+        dontShowAgainService = new DontShowAgainService(settingsService);
 
         notificationService = new NotificationService(persistenceService,
                 bondedRolesService.getMobileNotificationRelayClient(),
@@ -178,6 +182,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
                 supportService,
                 tradeService,
                 settingsService,
+                dontShowAgainService,
                 bisqEasyService,
                 openTradeItemsService,
                 accountService,
@@ -210,6 +215,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
                 .thenCompose(result -> accountService.initialize())
                 .thenCompose(result -> burningmanService.initialize())
                 .thenCompose(result -> settingsService.initialize())
+                .thenCompose(result -> dontShowAgainService.initialize())
                 .thenCompose(result -> notificationService.initialize())
                 .thenCompose(result -> offerService.initialize())
                 .thenCompose(result -> chatService.initialize())
@@ -260,6 +266,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
                 .thenCompose(result -> chatService.shutdown())
                 .thenCompose(result -> offerService.shutdown())
                 .thenCompose(result -> notificationService.shutdown())
+                .thenCompose(result -> dontShowAgainService.shutdown())
                 .thenCompose(result -> settingsService.shutdown())
                 .thenCompose(result -> burningmanService.shutdown())
                 .thenCompose(result -> accountService.shutdown())

--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -1,6 +1,6 @@
 application {
     appName="Bisq2_api"
-    devMode=false
+    devMode=true
     devModeReputationScore=0
     devModeWalletSetup=false
     keyIds="E222AA02,387C8307"
@@ -17,7 +17,7 @@ application {
     }
 
     api={
-        accessTransportType="TOR"   # One of: CLEAR | TOR | I2P
+        accessTransportType="CLEAR"   # One of: CLEAR | TOR | I2P
 
         pairing={
             ttlInSeconds=3600           # Pairing code time-to-live (default: 1 hour)
@@ -223,7 +223,7 @@ application {
     network {
         version=1
 
-        supportedTransportTypes=["TOR"]
+        supportedTransportTypes=["CLEAR"]
         features=["INVENTORY_HASH_SET","AUTHORIZATION_HASH_CASH","AUTHORIZATION_HASH_CASH_V2"]
 
         notifyExecutorMaxPoolSize=8

--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -235,6 +235,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
                 supportService,
                 tradeService,
                 settingsService,
+                dontShowAgainService,
                 bisqEasyService,
                 openTradeItemsService,
                 accountService,


### PR DESCRIPTION
For https://github.com/bisq-network/bisq-mobile/pull/1299

Endpoints:
1. GET "/settings/cookie/{keyIndex}" -> Right now used for CookieKey.PERMIT_OPENING_BROWSER / 16
2. PATCH "/settings". Added the following to `SettingsChangeRequest`
    Boolean webLinkDontShowAgain,
    Boolean resetAllDontShowAgainFlags,
    Integer setCookie,
    Integer unsetCookie

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to read cookie preference flags.
  * Settings can now manage "don't show again" notification flags and set/unset cookie state via enhanced options.

* **Chores**
  * Runtime switched to developer mode and network transport defaults changed from TOR to CLEAR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->