### PR TITLE
Refactor open trade channel creation flow

### DIFF
--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannel.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannel.java
@@ -54,28 +54,18 @@ public final class BisqEasyOpenTradeChannel extends PrivateGroupChatChannel<Bisq
         return ChatChannelDomain.BISQ_EASY_OPEN_TRADES.name().toLowerCase(Locale.ROOT) + "." + tradeId;
     }
 
-    public static BisqEasyOpenTradeChannel createByTrader(String tradeId,
-                                                          BisqEasyOffer bisqEasyOffer,
-                                                          UserIdentity myUserIdentity,
-                                                          UserProfile peer,
-                                                          Optional<UserProfile> mediator) {
+    public static BisqEasyOpenTradeChannel create(String tradeId,
+                                                  BisqEasyOffer bisqEasyOffer,
+                                                  UserIdentity myUserIdentity,
+                                                  Set<UserProfile> traders,
+                                                  Optional<UserProfile> mediator,
+                                                  boolean isInMediation) {
         return new BisqEasyOpenTradeChannel(tradeId,
                 bisqEasyOffer,
                 myUserIdentity,
-                peer,
-                mediator);
-    }
-
-    public static BisqEasyOpenTradeChannel createByMediator(String tradeId,
-                                                            BisqEasyOffer bisqEasyOffer,
-                                                            UserIdentity myUserIdentity,
-                                                            UserProfile requestingTrader,
-                                                            UserProfile nonRequestingTrader) {
-        return new BisqEasyOpenTradeChannel(tradeId,
-                bisqEasyOffer,
-                myUserIdentity,
-                requestingTrader,
-                nonRequestingTrader);
+                traders,
+                mediator,
+                isInMediation);
     }
 
     private final String tradeId;
@@ -84,37 +74,20 @@ public final class BisqEasyOpenTradeChannel extends PrivateGroupChatChannel<Bisq
     private final Set<UserProfile> traders;
     private final Optional<UserProfile> mediator;
 
-    // Called from trader
     private BisqEasyOpenTradeChannel(String tradeId,
                                      BisqEasyOffer bisqEasyOffer,
                                      UserIdentity myUserIdentity,
-                                     UserProfile peer,
-                                     Optional<UserProfile> mediator) {
+                                     Set<UserProfile> traders,
+                                     Optional<UserProfile> mediator,
+                                     boolean isInMediation) {
         this(createId(tradeId),
                 tradeId,
                 bisqEasyOffer,
                 myUserIdentity,
-                Set.of(peer),
+                traders,
                 mediator,
                 new HashSet<>(),
-                false,
-                ChatChannelNotificationType.ALL);
-    }
-
-    // Called from mediator
-    private BisqEasyOpenTradeChannel(String tradeId,
-                                     BisqEasyOffer bisqEasyOffer,
-                                     UserIdentity myUserIdentity,
-                                     UserProfile requestingTrader,
-                                     UserProfile nonRequestingTrader) {
-        this(createId(tradeId),
-                tradeId,
-                bisqEasyOffer,
-                myUserIdentity,
-                Set.of(requestingTrader, nonRequestingTrader),
-                Optional.of(myUserIdentity.getUserProfile()),
-                new HashSet<>(),
-                true,
+                isInMediation,
                 ChatChannelNotificationType.ALL);
     }
 

--- a/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
+++ b/chat/src/main/java/bisq/chat/bisq_easy/open_trades/BisqEasyOpenTradeChannelService.java
@@ -92,46 +92,18 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
     // API
     /* --------------------------------------------------------------------- */
 
-    public BisqEasyOpenTradeChannel traderFindOrCreatesChannel(String tradeId,
-                                                               BisqEasyOffer bisqEasyOffer,
-                                                               UserIdentity myUserIdentity,
-                                                               UserProfile peer,
-                                                               Optional<UserProfile> mediator) {
-        BisqEasyOpenTradeChannel channel = findChannelByTradeId(tradeId)
-                .orElseGet(() -> traderCreatesChannel(tradeId, bisqEasyOffer, myUserIdentity, peer, mediator));
-        processPendingMessages(tradeId);
-        return channel;
-    }
-
-    public BisqEasyOpenTradeChannel traderCreatesChannel(String tradeId,
-                                                         BisqEasyOffer bisqEasyOffer,
-                                                         UserIdentity myUserIdentity,
-                                                         UserProfile peer,
-                                                         Optional<UserProfile> mediator) {
-        BisqEasyOpenTradeChannel channel = BisqEasyOpenTradeChannel.createByTrader(tradeId, bisqEasyOffer, myUserIdentity, peer, mediator);
-        getChannels().add(channel);
-        persist();
-        return channel;
-    }
-
     public BisqEasyOpenTradeChannel mediatorFindOrCreatesChannel(String tradeId,
                                                                  BisqEasyOffer bisqEasyOffer,
                                                                  UserIdentity myUserIdentity,
                                                                  UserProfile requestingTrader,
                                                                  UserProfile nonRequestingTrader) {
-        BisqEasyOpenTradeChannel channel = findChannelByTradeId(tradeId)
-                .orElseGet(() -> {
-                    BisqEasyOpenTradeChannel newChannel = BisqEasyOpenTradeChannel.createByMediator(tradeId,
-                            bisqEasyOffer,
-                            myUserIdentity,
-                            requestingTrader,
-                            nonRequestingTrader);
-                    getChannels().add(newChannel);
-                    persist();
-                    return newChannel;
-                });
-        processPendingMessages(tradeId);
-        return channel;
+        return findChannelByTradeId(tradeId)
+                .orElseGet(() -> createAndAddChannel(tradeId,
+                        bisqEasyOffer,
+                        myUserIdentity,
+                        Set.of(requestingTrader, nonRequestingTrader),
+                        Optional.of(myUserIdentity.getUserProfile()),
+                        true));
     }
 
     public CompletableFuture<SendMessageResult> sendTakeOfferMessage(String tradeId,
@@ -342,7 +314,7 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
     protected Optional<BisqEasyOpenTradeChannel> createNewChannelFromReceivedMessage(BisqEasyOpenTradeMessage message) {
         if (message.getBisqEasyOffer().isPresent()) {
             return userIdentityService.findUserIdentity(message.getReceiverUserProfileId())
-                    .map(myUserIdentity -> traderCreatesChannel(message.getTradeId(),
+                    .map(myUserIdentity -> traderFindOrCreatesChannel(message.getTradeId(),
                             message.getBisqEasyOffer().get(),
                             myUserIdentity,
                             message.getSenderUserProfile(),
@@ -359,6 +331,33 @@ public class BisqEasyOpenTradeChannelService extends PrivateGroupChatChannelServ
             pendingMessages.add(message);
             return Optional.empty();
         }
+    }
+
+    private BisqEasyOpenTradeChannel traderFindOrCreatesChannel(String tradeId,
+                                                                BisqEasyOffer bisqEasyOffer,
+                                                                UserIdentity myUserIdentity,
+                                                                UserProfile peer,
+                                                                Optional<UserProfile> mediator) {
+        return findChannelByTradeId(tradeId)
+                .orElseGet(() -> createAndAddChannel(tradeId, bisqEasyOffer, myUserIdentity, Set.of(peer), mediator, false));
+    }
+
+    private BisqEasyOpenTradeChannel createAndAddChannel(String tradeId,
+                                                         BisqEasyOffer bisqEasyOffer,
+                                                         UserIdentity myUserIdentity,
+                                                         Set<UserProfile> traders,
+                                                         Optional<UserProfile> mediator,
+                                                         boolean isInMediation) {
+        BisqEasyOpenTradeChannel channel = BisqEasyOpenTradeChannel.create(tradeId,
+                bisqEasyOffer,
+                myUserIdentity,
+                traders,
+                mediator,
+                isInMediation);
+        getChannels().add(channel);
+        persist();
+        processPendingMessages(tradeId);
+        return channel;
     }
 
     private boolean allowSendLeaveMessage(BisqEasyOpenTradeChannel channel, UserProfile userProfile) {

--- a/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeChannel.java
+++ b/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeChannel.java
@@ -53,24 +53,16 @@ public final class MuSigOpenTradeChannel extends PrivateGroupChatChannel<MuSigOp
         return ChatChannelDomain.MU_SIG_OPEN_TRADES.name().toLowerCase(Locale.ROOT) + "." + tradeId;
     }
 
-    public static MuSigOpenTradeChannel createByTrader(String tradeId,
-                                                       UserIdentity myUserIdentity,
-                                                       UserProfile peer,
-                                                       Optional<UserProfile> mediator) {
+    public static MuSigOpenTradeChannel create(String tradeId,
+                                               UserIdentity myUserIdentity,
+                                               Set<UserProfile> traders,
+                                               Optional<UserProfile> mediator,
+                                               boolean isInMediation) {
         return new MuSigOpenTradeChannel(tradeId,
                 myUserIdentity,
-                peer,
-                mediator);
-    }
-
-    public static MuSigOpenTradeChannel createByMediator(String tradeId,
-                                                         UserIdentity myUserIdentity,
-                                                         UserProfile requestingTrader,
-                                                         UserProfile nonRequestingTrader) {
-        return new MuSigOpenTradeChannel(tradeId,
-                myUserIdentity,
-                requestingTrader,
-                nonRequestingTrader);
+                traders,
+                mediator,
+                isInMediation);
     }
 
     @EqualsAndHashCode.Include
@@ -82,30 +74,16 @@ public final class MuSigOpenTradeChannel extends PrivateGroupChatChannel<MuSigOp
     // Called from trader
     private MuSigOpenTradeChannel(String tradeId,
                                   UserIdentity myUserIdentity,
-                                  UserProfile peer,
-                                  Optional<UserProfile> mediator) {
+                                  Set<UserProfile> traders,
+                                  Optional<UserProfile> mediator,
+                                  boolean isInMediation) {
         this(createId(tradeId),
                 tradeId,
                 myUserIdentity,
-                Set.of(peer),
+                traders,
                 mediator,
                 new HashSet<>(),
-                false,
-                ChatChannelNotificationType.ALL);
-    }
-
-    // Called from mediator
-    private MuSigOpenTradeChannel(String tradeId,
-                                  UserIdentity myUserIdentity,
-                                  UserProfile requestingTrader,
-                                  UserProfile nonRequestingTrader) {
-        this(createId(tradeId),
-                tradeId,
-                myUserIdentity,
-                Set.of(requestingTrader, nonRequestingTrader),
-                Optional.of(myUserIdentity.getUserProfile()),
-                new HashSet<>(),
-                true,
+                isInMediation,
                 ChatChannelNotificationType.ALL);
     }
 

--- a/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeChannelService.java
+++ b/chat/src/main/java/bisq/chat/mu_sig/open_trades/MuSigOpenTradeChannelService.java
@@ -77,10 +77,6 @@ public class MuSigOpenTradeChannelService extends PrivateGroupChatChannelService
     public void onMessage(EnvelopePayloadMessage envelopePayloadMessage) {
         if (envelopePayloadMessage instanceof MuSigOpenTradeMessage) {
             processMessage((MuSigOpenTradeMessage) envelopePayloadMessage);
-            if (!pendingMessages.isEmpty()) {
-                log.info("Processing pendingMessages messages");
-                pendingMessages.forEach(this::processMessage);
-            }
         } else if (envelopePayloadMessage instanceof MuSigOpenTradeMessageReaction) {
             processMessageReaction((MuSigOpenTradeMessageReaction) envelopePayloadMessage);
         }
@@ -96,17 +92,7 @@ public class MuSigOpenTradeChannelService extends PrivateGroupChatChannelService
                                                             UserProfile peer,
                                                             Optional<UserProfile> mediator) {
         return findChannelByTradeId(tradeId)
-                .orElseGet(() -> traderCreatesChannel(tradeId, myUserIdentity, peer, mediator));
-    }
-
-    public MuSigOpenTradeChannel traderCreatesChannel(String tradeId,
-                                                      UserIdentity myUserIdentity,
-                                                      UserProfile peer,
-                                                      Optional<UserProfile> mediator) {
-        MuSigOpenTradeChannel channel = MuSigOpenTradeChannel.createByTrader(tradeId, myUserIdentity, peer, mediator);
-        getChannels().add(channel);
-        persist();
-        return channel;
+                .orElseGet(() -> createAndAddChannel(tradeId, myUserIdentity, Set.of(peer), mediator, false));
     }
 
     public MuSigOpenTradeChannel mediatorFindOrCreatesChannel(String tradeId,
@@ -114,15 +100,11 @@ public class MuSigOpenTradeChannelService extends PrivateGroupChatChannelService
                                                               UserProfile requestingTrader,
                                                               UserProfile nonRequestingTrader) {
         return findChannelByTradeId(tradeId)
-                .orElseGet(() -> {
-                    MuSigOpenTradeChannel channel = MuSigOpenTradeChannel.createByMediator(tradeId,
-                            myUserIdentity,
-                            requestingTrader,
-                            nonRequestingTrader);
-                    getChannels().add(channel);
-                    persist();
-                    return channel;
-                });
+                .orElseGet(() -> createAndAddChannel(tradeId,
+                        myUserIdentity,
+                        Set.of(requestingTrader, nonRequestingTrader),
+                        Optional.of(myUserIdentity.getUserProfile()),
+                        true));
     }
 
     public CompletableFuture<SendMessageResult> sendTradeLogMessage(String text,
@@ -232,6 +214,26 @@ public class MuSigOpenTradeChannelService extends PrivateGroupChatChannelService
     /* --------------------------------------------------------------------- */
 
     @Override
+    protected void processMessage(MuSigOpenTradeMessage message) {
+        if (canProcessMessage(message)) {
+            findChannel(message)
+                    .or(() -> {
+                        if (message.getChatMessageType() == ChatMessageType.LEAVE) {
+                            log.warn("We received a leave message for a non existing channel. This can happen if the peer " +
+                                    "sent a leave message around the same time as we have closed the channel.");
+                        } else {
+                            if (pendingMessages.add(message)) {
+                                log.info("Channel for trade {} does not exist yet. We add the message to pendingMessages.",
+                                        message.getTradeId());
+                            }
+                        }
+                        return Optional.empty();
+                    })
+                    .ifPresent(channel -> addMessageAndProcessQueuedReactions(message, channel));
+        }
+    }
+
+    @Override
     protected MuSigOpenTradeMessage createAndGetNewPrivateChatMessage(String messageId,
                                                                       MuSigOpenTradeChannel channel,
                                                                       UserProfile senderUserProfile,
@@ -304,14 +306,32 @@ public class MuSigOpenTradeChannelService extends PrivateGroupChatChannelService
 
     @Override
     protected Optional<MuSigOpenTradeChannel> createNewChannelFromReceivedMessage(MuSigOpenTradeMessage message) {
-        return userIdentityService.findUserIdentity(message.getReceiverUserProfileId())
-                .map(myUserIdentity -> traderCreatesChannel(message.getTradeId(),
-                        myUserIdentity,
-                        message.getSenderUserProfile(),
-                        message.getMediator()));
+        return Optional.empty();
+    }
+
+    private MuSigOpenTradeChannel createAndAddChannel(String tradeId,
+                                                      UserIdentity myUserIdentity,
+                                                      Set<UserProfile> traders,
+                                                      Optional<UserProfile> mediator,
+                                                      boolean isInMediation) {
+        MuSigOpenTradeChannel channel = MuSigOpenTradeChannel.create(tradeId,
+                myUserIdentity,
+                traders,
+                mediator,
+                isInMediation);
+        getChannels().add(channel);
+        persist();
+        processPendingMessages(tradeId);
+        return channel;
     }
 
     private boolean allowSendLeaveMessage(MuSigOpenTradeChannel channel, UserProfile userProfile) {
         return channel.getUserProfileIdsOfSendingLeaveMessage().contains(userProfile.getId());
+    }
+
+    private void processPendingMessages(String tradeId) {
+        pendingMessages.stream()
+                .filter(message -> message.getTradeId().equals(tradeId))
+                .forEach(this::processMessage);
     }
 }

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
@@ -339,7 +339,7 @@ public class MuSigService extends LifecycleService {
         if (channel.isEmpty()) {
             Optional<UserProfile> makersUserProfile = userProfileService.findUserProfile(muSigTrade.getOffer().getMakersUserProfileId());
             checkArgument(makersUserProfile.isPresent(), "Makers user profile is not present");
-            muSigOpenTradeChannelService.traderCreatesChannel(tradeId,
+            muSigOpenTradeChannelService.traderFindOrCreatesChannel(tradeId,
                     takerIdentity,
                     makersUserProfile.get(),
                     muSigTrade.getContract().getMediator());

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.mu_sig.messages.network.handler.maker;
 
+import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannelService;
 import bisq.common.util.StringUtils;
 import bisq.contract.ContractService;
 import bisq.contract.ContractSignatureData;
@@ -37,6 +38,8 @@ import bisq.trade.mu_sig.protocol.MuSigProtocolException;
 import bisq.trade.protobuf.NonceSharesRequest;
 import bisq.trade.protobuf.PubKeySharesRequest;
 import bisq.trade.protobuf.Role;
+import bisq.user.identity.UserIdentity;
+import bisq.user.profile.UserProfile;
 import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,6 +52,8 @@ public final class SetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerA
     private NonceSharesMessage myNonceSharesMessage;
     private ContractSignatureData peersContractSignatureData;
     private ContractSignatureData myContractSignatureData;
+    private UserIdentity myUserIdentity;
+    private UserProfile peersUserProfile;
 
     public SetupTradeMessage_A_Handler(ServiceProvider serviceProvider, MuSigTrade model) {
         super(serviceProvider, model);
@@ -77,6 +82,11 @@ public final class SetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerA
     @Override
     protected void process(SetupTradeMessage_A message) {
         peersPubKeyShares = message.getPubKeyShares();
+
+        myUserIdentity = serviceProvider.getUserService().getUserIdentityService().findUserIdentity(trade.getMyIdentity().getId())
+                .orElseThrow();
+        peersUserProfile = serviceProvider.getUserService().getUserProfileService().findUserProfile(message.getSender().getId())
+                .orElseThrow();
 
         Role role = trade.isBuyer() ? Role.BUYER_AS_MAKER : Role.SELLER_AS_MAKER;
         PubKeySharesRequest pubKeySharesRequest = PubKeySharesRequest.newBuilder()
@@ -111,6 +121,12 @@ public final class SetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerA
         peer.setPeersPubKeyShares(peersPubKeyShares);
         mySelf.setMyPubKeySharesResponse(myPubKeySharesResponse);
         mySelf.setMyNonceSharesMessage(myNonceSharesMessage);
+
+        MuSigOpenTradeChannelService openTradeChannelService = serviceProvider.getChatService().getMuSigOpenTradeChannelService();
+        openTradeChannelService.traderFindOrCreatesChannel(trade.getId(),
+                myUserIdentity,
+                peersUserProfile,
+                trade.getContract().getMediator());
     }
 
     @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and unified trade-channel creation so trader and mediator flows use the same creation/persistence path.
  * Replaced multiple role-specific creation paths with a single explicit creation interface (including mediation state and participant set).
  * Consolidated pending-message handling: messages are queued and processed during channel creation, not automatically on every receive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->