### PR TITLE
chore/bring_settings_lang_should_update_res_change_to_main

### DIFF
--- a/api/src/test/java/bisq/api/dto/FiatPaymentMethodLocalizationTest.java
+++ b/api/src/test/java/bisq/api/dto/FiatPaymentMethodLocalizationTest.java
@@ -1,0 +1,81 @@
+package bisq.api.dto;
+
+import bisq.account.payment_method.fiat.FiatPaymentMethodChargebackRisk;
+import bisq.i18n.Res;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that {@code Res.get()} calls respond to language changes.
+ * <p>
+ * This test covers the bug where {@code SettingsService.setLanguageTag()} only persisted
+ * the language value without calling {@code Res.setAndApplyLanguageTag()}, causing all
+ * API responses using {@code Res.get()} to return stale (old-language) strings.
+ */
+class FiatPaymentMethodLocalizationTest {
+
+    @BeforeAll
+    static void initBundles() {
+        Res.setAndApplyLanguageTag("en");
+    }
+
+    @AfterEach
+    void resetToEnglish() {
+        Res.setAndApplyLanguageTag("en");
+    }
+
+    @Test
+    void chargebackRisk_toString_respondsToLanguageChange() {
+        Res.setAndApplyLanguageTag("en");
+        assertEquals("Low", FiatPaymentMethodChargebackRisk.LOW.toString());
+        assertEquals("Very low", FiatPaymentMethodChargebackRisk.VERY_LOW.toString());
+        assertEquals("Medium", FiatPaymentMethodChargebackRisk.MEDIUM.toString());
+        assertEquals("Moderate", FiatPaymentMethodChargebackRisk.MODERATE.toString());
+
+        Res.setAndApplyLanguageTag("es");
+        assertEquals("bajas", FiatPaymentMethodChargebackRisk.LOW.toString());
+        assertEquals("muy bajas", FiatPaymentMethodChargebackRisk.VERY_LOW.toString());
+        assertEquals("Medio", FiatPaymentMethodChargebackRisk.MEDIUM.toString());
+        assertEquals("algunas", FiatPaymentMethodChargebackRisk.MODERATE.toString());
+    }
+
+    @Test
+    void resGet_withoutApply_doesNotUpdateBundles() {
+        // Documents the root cause of the bug: Res.setLanguageTag() without
+        // updateBundles() does NOT reload resource bundles. This is what
+        // SettingsService.setLanguageTag() was doing before the fix — it stored
+        // the tag and persisted it, but never called Res.setAndApplyLanguageTag(),
+        // so all Res.get() calls kept returning the old language.
+        Res.setAndApplyLanguageTag("en");
+        assertEquals("Low", FiatPaymentMethodChargebackRisk.LOW.toString());
+
+        // Only set the tag, don't apply (don't reload bundles)
+        Res.setLanguageTag("es");
+        // Bundles are still English — this was the bug!
+        assertEquals("Low", FiatPaymentMethodChargebackRisk.LOW.toString(),
+                "Without updateBundles(), Res.get() should still return English");
+
+        // Now apply — this reloads bundles and fixes it
+        Res.updateBundles();
+        assertEquals("bajas", FiatPaymentMethodChargebackRisk.LOW.toString(),
+                "After updateBundles(), Res.get() should return Spanish");
+    }
+
+    @Test
+    void multipleLanguageSwitches_allReflectedImmediately() {
+        Res.setAndApplyLanguageTag("en");
+        assertEquals("Low", FiatPaymentMethodChargebackRisk.LOW.toString());
+
+        Res.setAndApplyLanguageTag("es");
+        assertEquals("bajas", FiatPaymentMethodChargebackRisk.LOW.toString());
+
+        Res.setAndApplyLanguageTag("de");
+        assertEquals("geringe", FiatPaymentMethodChargebackRisk.LOW.toString());
+
+        Res.setAndApplyLanguageTag("en");
+        assertEquals("Low", FiatPaymentMethodChargebackRisk.LOW.toString());
+    }
+}

--- a/settings/src/main/java/bisq/settings/SettingsService.java
+++ b/settings/src/main/java/bisq/settings/SettingsService.java
@@ -161,7 +161,16 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
 
     @Override
     public void onPersistedApplied(SettingsStore persisted) {
-        String languageTag = getLanguageTag().get();
+        applyLanguageTag(getLanguageTag().get());
+    }
+
+    /**
+     * Applies the given language tag to all locale-dependent singletons
+     * (Res i18n bundles, default locale, country/currency repositories).
+     * Called both on startup (via onPersistedApplied) and on live language changes
+     * (via setLanguageTag) to ensure Res.get() immediately reflects the new language.
+     */
+    private void applyLanguageTag(String languageTag) {
         LanguageRepository.setDefaultLanguageTag(languageTag);
         Res.setAndApplyLanguageTag(languageTag);
         Locale locale = Locale.forLanguageTag(languageTag);
@@ -346,6 +355,7 @@ public class SettingsService extends RateLimitedPersistenceClient<SettingsStore>
     public void setLanguageTag(String languageTag) {
         if (languageTag != null && LanguageRepository.LANGUAGE_TAGS.contains(languageTag)) {
             persistableStore.languageTag.set(languageTag);
+            applyLanguageTag(languageTag);
         }
     }
 


### PR DESCRIPTION
 - bring https://github.com/bisq-network/bisq2/pull/4585 into main branch
 - fix settings service not updating Res on a language change + tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests to ensure localized content updates correctly when the language preference changes, covering multiple languages including English, Spanish, and German.

* **Bug Fixes**
  * Enhanced language setting application to immediately apply language changes consistently across all application components and locale-dependent services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->