### PR TITLE
fix: subscribe before building the payload to prevent missed updates

### DIFF
--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
@@ -132,9 +132,16 @@ public class SubscriptionService implements Service {
                     try {
                         webSocketService.validate(request);
                         subscriber = subscriberRepository.add(request, webSocket);
-                        Optional<String> jsonPayload = webSocketService.getJsonPayload(subscriber);
-                        jsonPayload.ifPresent(json ->
-                                sendSubscriptionResponse(webSocket, request.getRequestId(), json, null));
+                        Optional<String> jsonPayload = webSocketService.getJsonPayload(request);
+                        if (jsonPayload.isPresent()) {
+                            sendSubscriptionResponse(webSocket, request.getRequestId(), jsonPayload.get(), null);
+                        } else {
+                            removeSubscriber(subscriber);
+                            sendSubscriptionResponse(webSocket,
+                                    request.getRequestId(),
+                                    null,
+                                    String.format("Unexpected error when subscribing to %s", request.getTopic().name()));
+                        }
                     } catch (IllegalArgumentException e) {
                         removeSubscriber(subscriber);
                         sendSubscriptionResponse(webSocket, request.getRequestId(), null, e.getMessage());

--- a/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
@@ -17,6 +17,8 @@
 
 package bisq.api.web_socket.subscription;
 
+import bisq.api.web_socket.domain.BaseWebSocketService;
+import bisq.api.web_socket.domain.market_price.MarketPriceWebSocketService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.bisq_easy.BisqEasyService;
 import bisq.bonded_roles.BondedRolesService;
@@ -26,17 +28,24 @@ import bisq.chat.ChatService;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.trade.TradeService;
 import bisq.user.UserService;
+import org.glassfish.grizzly.impl.ReadyFutureImpl;
 import org.glassfish.grizzly.websockets.WebSocket;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 
@@ -59,20 +68,82 @@ class SubscriptionServiceTest {
         );
 
         WebSocket webSocket = mock(WebSocket.class);
-        doThrow(new RuntimeException("send failed")).when(webSocket).send(anyString());
+        doThrow(new RuntimeException("send failed"))
+            .doReturn(null)
+            .when(webSocket)
+            .send(anyString());
 
         String requestJson = "{\"type\":\"SubscriptionRequest\",\"requestId\":\"request-1\",\"topic\":\"ALERT_NOTIFICATIONS\"}";
 
-        assertThatThrownBy(() -> service.onMessage(requestJson, webSocket))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("send failed");
+        service.onMessage(requestJson, webSocket);
 
         assertThat(getSubscriberRepository(service).findSubscribers(Topic.ALERT_NOTIFICATIONS)).isEmpty();
+    }
+
+    @Test
+    void subscribeDeliversLiveEventEmittedDuringInitialSnapshot() throws Exception {
+        SubscriptionService service = new SubscriptionService(
+                mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
+                mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
+                mock(ChatService.class, RETURNS_DEEP_STUBS),
+                mock(TradeService.class, RETURNS_DEEP_STUBS),
+                mock(UserService.class, RETURNS_DEEP_STUBS),
+                mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
+        );
+        SubscriberRepository subscriberRepository = getSubscriberRepository(service);
+        replaceWebSocketService(service, "marketPriceWebSocketService", new TestMarketPriceWebSocketService(subscriberRepository));
+
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = mock(WebSocket.class, RETURNS_DEEP_STUBS);
+        doAnswer(invocation -> {
+            sentMessages.add(invocation.getArgument(0));
+            return ReadyFutureImpl.create(null);
+        }).when(webSocket).send(anyString());
+
+        String requestJson = "{\"type\":\"SubscriptionRequest\",\"requestId\":\"request-1\",\"topic\":\"MARKET_PRICE\"}";
+
+        service.onMessage(requestJson, webSocket);
+
+        verify(webSocket, timeout(1000).times(2)).send(anyString());
+        assertThat(sentMessages)
+            .anySatisfy(message -> assertThat(message)
+                .contains("\"type\":\"SubscriptionResponse\"")
+                .contains("snapshot"));
+        assertThat(sentMessages)
+            .anySatisfy(message -> assertThat(message)
+                .contains("\"type\":\"WebSocketEvent\"")
+                .contains("live-event"));
     }
 
     private SubscriberRepository getSubscriberRepository(SubscriptionService service) throws NoSuchFieldException, IllegalAccessException {
         Field subscriberRepositoryField = SubscriptionService.class.getDeclaredField("subscriberRepository");
         subscriberRepositoryField.setAccessible(true);
         return (SubscriberRepository) subscriberRepositoryField.get(service);
+    }
+
+    private void replaceWebSocketService(SubscriptionService service,
+                                         String fieldName,
+                                         Object replacement) throws Exception {
+        Field field = SubscriptionService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, replacement);
+    }
+
+    private static final class TestMarketPriceWebSocketService extends MarketPriceWebSocketService {
+        private TestMarketPriceWebSocketService(SubscriberRepository subscriberRepository) {
+            super(subscriberRepository, mock(BondedRolesService.class, RETURNS_DEEP_STUBS));
+        }
+
+        @Override
+        public Optional<String> getJsonPayload() {
+            return Optional.of("\"snapshot\"");
+        }
+
+        @Override
+        public Optional<String> getJsonPayload(SubscriptionRequest request) {
+            send(Optional.of("\"live-event\""), topic, ModificationType.REPLACE);
+            return getJsonPayload();
+        }
     }
 }


### PR DESCRIPTION
a follow up to main branch will be sent shortly after

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription initialization flow by validating payloads before registration.
  * Enhanced error handling for subscription requests with unavailable payloads, providing clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket subscriptions now remove stalled subscribers when the initial payload is missing and return an explicit error response with a null payload.
* **Tests**
  * Added tests ensuring subscribers are cleaned up on failed initial delivery and that live events can be delivered during initial snapshot flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->