### PR TITLE
Enable native macOS arm64 Tor and ad-hoc sign extracted binaries

### DIFF
--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryUrlProvider.kt
@@ -13,11 +13,7 @@ class TorBinaryUrlProvider(private val version: String) : PerPlatformUrlProvider
         get() = "tor-expert-bundle-macos-x86_64-$version.tar.gz"
 
     override val MACOS_ARM_64_URL: String
-        // Currently the Tor version for aarch64 does not work, thus we use the x64 version.
-        // See: https://github.com/bisq-network/bisq2/issues/2679
-        // Once resolved we can use the line below.
-        // get() = "tor-expert-bundle-macos-aarch64-$version.tar.gz"
-        get() = "tor-expert-bundle-macos-x86_64-$version.tar.gz"
+        get() = "tor-expert-bundle-macos-aarch64-$version.tar.gz"
 
     override val WIN_X86_64_URL: String
         get() = "tor-expert-bundle-windows-x86_64-$version.tar.gz"

--- a/network/tor/tor/src/main/java/bisq/network/tor/installer/TorInstaller.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/installer/TorInstaller.java
@@ -19,15 +19,24 @@ package bisq.network.tor.installer;
 
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.FileReaderUtils;
+import bisq.common.platform.OS;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 @Slf4j
 public class TorInstaller {
-    private static final String VERSION = "0.1.0";
+    private static final String CODESIGN_PATH = "/usr/bin/codesign";
+    private static final int CODESIGN_TIMEOUT_SECONDS = 30;
+    private static final String VERSION = "0.2.0";
     private final Path torDirPath;
     private final Path versionFilePath;
 
@@ -66,6 +75,7 @@ public class TorInstaller {
     private void install() throws IOException {
         try {
             new TorBinaryZipExtractor(torDirPath).extractBinary();
+            adHocSignTorBinariesOnMac();
             log.info("Tor files installed to {}", torDirPath.toAbsolutePath());
             // Only if we have successfully extracted all files we write our version file which is used to
             // check if we need to call installFiles.
@@ -73,6 +83,67 @@ public class TorInstaller {
         } catch (IOException e) {
             deleteVersionFile();
             throw e;
+        }
+    }
+
+    private void adHocSignTorBinariesOnMac() throws IOException {
+        if (!OS.isMacOs()) {
+            return;
+        }
+
+        List<String> command = new ArrayList<>();
+        command.add(CODESIGN_PATH);
+        command.add("-s");
+        command.add("-");
+        command.add("-f");
+        command.add("--timestamp=none");
+        int baseCommandSize = command.size();
+
+        try (Stream<Path> stream = Files.walk(torDirPath, 2)) {
+            stream.filter(Files::isRegularFile)
+                    .filter(path -> {
+                        String fileName = path.getFileName().toString();
+                        return fileName.equals("tor") || fileName.endsWith(".dylib");
+                    })
+                    .forEach(path -> command.add(path.toAbsolutePath().toString()));
+        }
+
+        if (command.size() == baseCommandSize) {
+            throw new IOException("No Tor binaries found for ad-hoc signing in " + torDirPath.toAbsolutePath());
+        }
+
+        log.info("Applying macOS ad-hoc codesign to bundled Tor binaries in {}", torDirPath.toAbsolutePath());
+
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+
+        try {
+            boolean completed = process.waitFor(CODESIGN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!completed) {
+                process.destroyForcibly();
+                throw new IOException("Ad-hoc signing Tor binaries timed out after " +
+                        CODESIGN_TIMEOUT_SECONDS + " seconds.");
+            }
+
+            StringBuilder output = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append(System.lineSeparator());
+                }
+            }
+
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                throw new IOException("Ad-hoc signing Tor binaries failed with exit code " + exitCode +
+                        ". Output: " + output);
+            }
+            log.info("Successfully applied macOS ad-hoc codesign to bundled Tor binaries");
+        } catch (InterruptedException e) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while ad-hoc signing Tor binaries", e);
         }
     }
 }


### PR DESCRIPTION
closes #2679

Switch macOS ARM Tor download to the native aarch64 expert bundle and ad-hoc sign extracted Tor binaries on macOS at install time. This avoids startup failure on Apple Silicon where unsigned arm64 Tor binaries are killed by macOS before control socket creation.

Root cause:
- Tor expert bundles are unsigned Mach-O binaries.
- On Apple Silicon, unsigned arm64 `tor` exits with SIGKILL (exit code 137), so Bisq times out waiting for `tor/control/control`.
- x86_64 Tor still runs via Rosetta, which masked this issue in previous fallback behavior.

Why ad-hoc signing here:
- `/usr/bin/codesign` is a standard macOS system tool.
- Ad-hoc signing (`-s -`) does not require Apple Developer certificates, notarization, or user keychain setup.
- It works for both Intel and Apple Silicon binaries, so one macOS code path covers x86_64 and arm64 consistently.
- Applying it to extracted runtime binaries is appropriate because Tor is unpacked into the user data directory, not executed directly from a pre-signed app bundle location.

Manual verification steps:
1) Download and unpack Tor bundles:
   `curl -fsSL https://archive.torproject.org/tor-package-archive/torbrowser/13.5.2/tor-expert-bundle-macos-aarch64-13.5.2.tar.gz -o arm.tar.gz && tar -xzf arm.tar.gz`
2) Confirm binary arch:
   `file tor/tor tor/libevent-2.1.7.dylib`
3) Confirm unsigned:
   `codesign --verify --verbose=4 tor/tor` (fails: not signed)
4) Reproduce failure:
   `tor/tor --version` (arm64 fails, typically RC 137)
5) Confirm workaround:
   `/usr/bin/codesign -s - -f --timestamp=none tor/libevent-2.1.7.dylib tor/tor && tor/tor --version` (succeeds)

Also bump Tor installer version marker to force reinstall so existing macOS users receive signed binaries.

This should unlock building full Apple Silicon aka darwin arm64 dmg files. The workflow [build.yml](https://github.com/bisq-network/bisq2/blob/main/.github/workflows/build.yml) runs on macos-latest which is already arm64 according to https://docs.github.com/en/actions/reference/runners/github-hosted-runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS ARM64 now downloads the correct Apple Silicon Tor binary.

* **Updates**
  * Bundled Tor upgraded from 0.1.0 to 0.2.0.
  * Added a macOS-only post-install signing step for installed Tor binaries; installation will fail and report errors if signing does not complete successfully or times out, ensuring usable signed binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->