### PR TITLE
Handle out of order musig mediation messages

### DIFF
--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -579,7 +579,6 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         }
     }
 
-
     /* --------------------------------------------------------------------- */
     // Misc
     /* --------------------------------------------------------------------- */
@@ -760,14 +759,11 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
 
     private void processMediationStateChangeMessage(MuSigMediationStateChangeMessage message, MuSigTrade trade) {
         MuSigDisputeState current = trade.getDisputeState();
-        if (current == MuSigDisputeState.ARBITRATION_REQUESTED
-                || current == MuSigDisputeState.ARBITRATION_OPEN
-                || current == MuSigDisputeState.ARBITRATION_CLOSED) {
+        if (isArbitrationState(current)) {
             return;
         }
 
         MediationCaseState mediationCaseState = message.getMediationCaseState();
-        boolean resultChanged = false;
         boolean shouldSendPeerReport = false;
         MuSigDisputeState next = current;
 
@@ -775,38 +771,57 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             if (current == MuSigDisputeState.NO_DISPUTE || current == MuSigDisputeState.MEDIATION_REQUESTED) {
                 next = MuSigDisputeState.MEDIATION_OPEN;
                 shouldSendPeerReport = current == MuSigDisputeState.NO_DISPUTE;
+            } else if (current == MuSigDisputeState.MEDIATION_OPEN) {
+                return; // duplicate or stale
             }
         } else if (mediationCaseState == MediationCaseState.RE_OPENED) {
-            next = MuSigDisputeState.MEDIATION_RE_OPENED;
+            if (current == MuSigDisputeState.MEDIATION_CLOSED) {
+                next = MuSigDisputeState.MEDIATION_RE_OPENED;
+            } else if (current == MuSigDisputeState.MEDIATION_RE_OPENED) {
+                return; // duplicate
+            } else {
+                addPendingMediationMessage(trade.getId(), message);
+                return;
+            }
         } else if (mediationCaseState == MediationCaseState.CLOSED) {
-            next = MuSigDisputeState.MEDIATION_CLOSED;
-            Optional<MuSigMediationResult> incomingResult = message.getMuSigMediationResult();
-            if (incomingResult.isEmpty()) {
-                log.warn("Ignoring CLOSED MuSigMediationStateChangeMessage without MuSigMediationResult for trade {}.",
-                        message.getTradeId());
-                return;
-            }
+            if (current == MuSigDisputeState.MEDIATION_OPEN || current == MuSigDisputeState.MEDIATION_RE_OPENED) {
+                next = MuSigDisputeState.MEDIATION_CLOSED;
+                Optional<MuSigMediationResult> incomingResult = message.getMuSigMediationResult();
+                if (incomingResult.isEmpty()) {
+                    log.warn("Ignoring CLOSED MuSigMediationStateChangeMessage without MuSigMediationResult for trade {}.",
+                            message.getTradeId());
+                    return;
+                }
 
-            Optional<MuSigMediationResult> currentResult = trade.getMuSigMediationResult();
-            if (!isValidMediationResultMessage(trade.getContract(), message)) {
+                Optional<MuSigMediationResult> currentResult = trade.getMuSigMediationResult();
+                if (!isValidMediationResultMessage(trade.getContract(), message)) {
+                    return;
+                }
+                if (currentResult.isEmpty()) {
+                    trade.setMuSigMediationResult(incomingResult.orElseThrow());
+                } else if (!currentResult.orElseThrow().equals(incomingResult.orElseThrow())) {
+                    log.warn("Ignoring changed MuSigMediationResult for trade {} because result cannot be changed once set.",
+                            message.getTradeId());
+                }
+            } else if (current == MuSigDisputeState.MEDIATION_CLOSED) {
                 return;
-            }
-            if (currentResult.isEmpty()) {
-                resultChanged = trade.setMuSigMediationResult(incomingResult.orElseThrow());
-            } else if (!currentResult.orElseThrow().equals(incomingResult.orElseThrow())) {
-                log.warn("Ignoring changed MuSigMediationResult for trade {} because result cannot be changed once set.",
-                        message.getTradeId());
+            } else {
+                addPendingMediationMessage(trade.getId(), message);
+                return;
             }
         }
 
-        if (next != current || resultChanged) {
+        if (next != current) {
             trade.setDisputeState(next);
             persist();
+            muSigTraderMediationService.applyMediationStateToChannel(trade, current);
+
+            if (shouldSendPeerReport) {
+                muSigTraderMediationService.sendDisputeCaseDataMessage(trade);
+            }
+            maybeProcessPendingMediationMessages(trade.getId());
         }
-        muSigTraderMediationService.applyMediationStateToChannel(trade, current);
-        if (shouldSendPeerReport) {
-            muSigTraderMediationService.sendDisputeCaseDataMessage(trade);
-        }
+
     }
 
     private boolean isValidMediationResultMessage(MuSigContract contract,
@@ -852,8 +867,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     private void processMediationResultAcceptanceMessage(MuSigMediationResultAcceptanceMessage message,
                                                          MuSigTrade trade) {
         if (trade.getMuSigMediationResult().isEmpty()) {
-            log.warn("Ignoring MuSigMediationResultAcceptanceMessage for trade {} because MuSigMediationResult is missing.",
-                    message.getTradeId());
+            addPendingMediationMessage(trade.getId(), message);
             return;
         }
 
@@ -865,13 +879,9 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     static Optional<MuSigTrade> authorizeDisputeCasePaymentDetailsRequest(MuSigDisputeCasePaymentDetailsRequest message,
                                                                           MuSigTrade trade,
                                                                           BannedUserService bannedUserService) {
-        Optional<UserProfile> disputeRole = findActiveDisputeRole(trade);
-        if (disputeRole.isEmpty()) {
-            log.warn("Ignoring MuSigDisputeCasePaymentDetailsRequest for trade {} with unexpected senderUserProfile {}.",
-                    message.getTradeId(), message.getSenderUserProfile());
-            return Optional.empty();
-        }
-        if (!disputeRole.orElseThrow().getId().equals(message.getSenderUserProfile().getId())) {
+        UserProfile sender = message.getSenderUserProfile();
+        // authorize if sender is mediator or arbitrator (state not important for authorize check)
+        if (!isSenderMediator(sender, trade) && !isSenderArbitrator(sender, trade)) {
             log.warn("Ignoring MuSigDisputeCasePaymentDetailsRequest for trade {} with unexpected senderUserProfile {}.",
                     message.getTradeId(), message.getSenderUserProfile());
             return Optional.empty();
@@ -886,6 +896,27 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
 
     private void processDisputeCasePaymentDetailsRequest(MuSigDisputeCasePaymentDetailsRequest message,
                                                          MuSigTrade trade) {
+        UserProfile sender = message.getSenderUserProfile();
+
+        if (isSenderMediator(sender, trade)) {
+            if (isArbitrationState(trade.getDisputeState())) {
+                return;
+            }
+            if (!isMediationState(trade.getDisputeState())) {
+                addPendingMediationMessage(trade.getId(), message);
+                return;
+            }
+        } else if (isSenderArbitrator(sender, trade)) {
+            if (!isArbitrationState(trade.getDisputeState())) {
+                addPendingMediationMessage(trade.getId(), message);
+                return;
+            }
+        } else {
+            log.warn("Ignoring MuSigDisputeCasePaymentDetailsRequest for trade {} with unexpected senderUserProfile {}.",
+                    message.getTradeId(), sender);
+            return;
+        }
+
         if (trade.getMyself().getAccountPayload().isEmpty() || trade.getPeer().getAccountPayload().isEmpty()) {
             log.warn("Ignoring MuSigDisputeCasePaymentDetailsRequest for trade {} because account payloads are incomplete.",
                     message.getTradeId());
@@ -894,20 +925,29 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         muSigTraderMediationService.sendDisputeCasePaymentDetailsResponse(trade, message.getSenderUserProfile());
     }
 
-    static Optional<UserProfile> findActiveDisputeRole(MuSigTrade trade) {
-        MuSigDisputeState disputeState = trade.getDisputeState();
-        if (disputeState == MuSigDisputeState.MEDIATION_REQUESTED ||
+    private static boolean isSenderMediator(UserProfile sender, MuSigTrade trade) {
+        return trade.getContract().getMediator()
+                .map(profile -> profile.getId().equals(sender.getId()))
+                .orElse(false);
+    }
+
+    private static boolean isSenderArbitrator(UserProfile sender, MuSigTrade trade) {
+        return trade.getContract().getArbitrator()
+                .map(profile -> profile.getId().equals(sender.getId()))
+                .orElse(false);
+    }
+
+    static boolean isMediationState(MuSigDisputeState disputeState) {
+        return disputeState == MuSigDisputeState.MEDIATION_REQUESTED ||
                 disputeState == MuSigDisputeState.MEDIATION_OPEN ||
                 disputeState == MuSigDisputeState.MEDIATION_CLOSED ||
-                disputeState == MuSigDisputeState.MEDIATION_RE_OPENED) {
-            return trade.getContract().getMediator();
-        }
-        if (disputeState == MuSigDisputeState.ARBITRATION_REQUESTED ||
+                disputeState == MuSigDisputeState.MEDIATION_RE_OPENED;
+    }
+
+    static boolean isArbitrationState(MuSigDisputeState disputeState) {
+        return disputeState == MuSigDisputeState.ARBITRATION_REQUESTED ||
                 disputeState == MuSigDisputeState.ARBITRATION_OPEN ||
-                disputeState == MuSigDisputeState.ARBITRATION_CLOSED) {
-            return trade.getContract().getArbitrator();
-        }
-        return Optional.empty();
+                disputeState == MuSigDisputeState.ARBITRATION_CLOSED;
     }
 
     private Optional<MuSigTrade> findTradeAndChannelOrQueue(String tradeId, EnvelopePayloadMessage message) {
@@ -916,10 +956,10 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         if (trade.isEmpty() || channel.isEmpty()) {
             addPendingMediationMessage(tradeId, message);
             return Optional.empty();
+        } else {
+            removePendingMediationMessage(tradeId, message);
+            return trade;
         }
-
-        removePendingMediationMessage(tradeId, message);
-        return trade;
     }
 
     private void addPendingMediationMessage(String tradeId, EnvelopePayloadMessage message) {
@@ -936,7 +976,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     }
 
     private void maybeProcessPendingMediationMessages(String tradeId) {
-        Set<EnvelopePayloadMessage> pendingMessages = pendingMediationMessagesByTradeId.get(tradeId);
+        Set<EnvelopePayloadMessage> pendingMessages = pendingMediationMessagesByTradeId.remove(tradeId);
         if (pendingMessages != null) {
             pendingMessages.forEach(this::onMessage);
         }

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceTest.java
@@ -73,6 +73,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.KeyPair;
+import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -204,7 +205,7 @@ class MuSigTradeServiceTest {
     }
 
     @Test
-    void authorizeDisputeCasePaymentDetailsRequest_returnsEmpty_whenNoActiveDisputeRoleIsPresent() {
+    void authorizeDisputeCasePaymentDetailsRequest_returnsTrade_whenMediatorMatchesOutsideActiveDisputeState() {
         UserProfile mediator = createUserProfile(1001);
         UserProfile peer = createUserProfile(1002);
         UserProfile myProfile = createUserProfile(1003);
@@ -217,7 +218,7 @@ class MuSigTradeServiceTest {
                 notBannedUserService()
         );
 
-        assertThat(authorized).isEmpty();
+        assertThat(authorized).containsSame(trade);
     }
 
     @Test
@@ -339,6 +340,132 @@ class MuSigTradeServiceTest {
         assertThat(getPendingMediationMessagesByTradeId(service)).doesNotContainKey(trade.getId());
     }
 
+    @Test
+    void processDisputeCasePaymentDetailsRequest_queuesMediatorRequest_whenTradeIsNotYetInMediation() throws Exception {
+        UserProfile myProfile = createUserProfile(1003);
+        UserProfile peer = createUserProfile(1002);
+        UserProfile mediator = createUserProfile(1001);
+        MuSigTrade trade = createTrade(MuSigDisputeState.NO_DISPUTE, myProfile, peer, Optional.of(mediator), Optional.empty(), "trade-payment-1");
+        MuSigOpenTradeChannel channel = createOpenTradeChannel(trade, myProfile, peer, mediator);
+        MuSigTradeService service = createTradeServiceForPendingQueueTests(trade, channel);
+        MuSigDisputeCasePaymentDetailsRequest message = new MuSigDisputeCasePaymentDetailsRequest(trade.getId(), mediator);
+
+        invokeProcessDisputeCasePaymentDetailsRequest(service, message, trade);
+
+        assertThat(getPendingMediationMessagesByTradeId(service))
+                .containsKey(trade.getId());
+        assertThat(getPendingMediationMessagesByTradeId(service).get(trade.getId()))
+                .containsExactly(message);
+    }
+
+    @Test
+    void processDisputeCasePaymentDetailsRequest_queuesArbitratorRequest_whenTradeIsNotYetInArbitration() throws Exception {
+        UserProfile myProfile = createUserProfile(1003);
+        UserProfile peer = createUserProfile(1002);
+        UserProfile arbitrator = createUserProfile(1005);
+        MuSigTrade trade = createTrade(MuSigDisputeState.MEDIATION_OPEN, myProfile, peer, Optional.empty(), Optional.of(arbitrator), "trade-payment-2");
+        MuSigOpenTradeChannel channel = createOpenTradeChannel(trade, myProfile, peer, createUserProfile(1001));
+        MuSigTradeService service = createTradeServiceForPendingQueueTests(trade, channel);
+        MuSigDisputeCasePaymentDetailsRequest message = new MuSigDisputeCasePaymentDetailsRequest(trade.getId(), arbitrator);
+
+        invokeProcessDisputeCasePaymentDetailsRequest(service, message, trade);
+
+        assertThat(getPendingMediationMessagesByTradeId(service))
+                .containsKey(trade.getId());
+        assertThat(getPendingMediationMessagesByTradeId(service).get(trade.getId()))
+                .containsExactly(message);
+    }
+
+    @Test
+    void processMediationResultAcceptanceMessage_queuesMessage_whenMediationResultIsMissing() throws Exception {
+        UserProfile myProfile = createUserProfile(1003);
+        UserProfile peer = createUserProfile(1002);
+        MuSigTrade trade = createTrade(MuSigDisputeState.MEDIATION_OPEN, myProfile, peer, Optional.empty(), Optional.empty(), "trade-acceptance-1");
+        MuSigOpenTradeChannel channel = createOpenTradeChannel(trade, myProfile, peer, createUserProfile(1001));
+        MuSigTradeService service = createTradeServiceForPendingQueueTests(trade, channel);
+        MuSigMediationResultAcceptanceMessage message = new MuSigMediationResultAcceptanceMessage(trade.getId(), peer, true);
+
+        invokeProcessMediationResultAcceptanceMessage(service, message, trade);
+
+        assertThat(getPendingMediationMessagesByTradeId(service))
+                .containsKey(trade.getId());
+        assertThat(getPendingMediationMessagesByTradeId(service).get(trade.getId()))
+                .containsExactly(message);
+    }
+
+    @Test
+    void processDisputeCasePaymentDetailsRequest_doesNotQueueMediatorRequest_whenTradeIsAlreadyInArbitration() throws Exception {
+        UserProfile myProfile = createUserProfile(1003);
+        UserProfile peer = createUserProfile(1002);
+        UserProfile mediator = createUserProfile(1001);
+        MuSigTrade trade = createTrade(MuSigDisputeState.ARBITRATION_OPEN, myProfile, peer, Optional.of(mediator), Optional.empty(), "trade-payment-3");
+        MuSigOpenTradeChannel channel = createOpenTradeChannel(trade, myProfile, peer, mediator);
+        MuSigTradeService service = createTradeServiceForPendingQueueTests(trade, channel);
+        MuSigDisputeCasePaymentDetailsRequest message = new MuSigDisputeCasePaymentDetailsRequest(trade.getId(), mediator);
+
+        invokeProcessDisputeCasePaymentDetailsRequest(service, message, trade);
+
+        assertThat(getPendingMediationMessagesByTradeId(service)).doesNotContainKey(trade.getId());
+    }
+
+    @Test
+    void processMediationStateChangeMessage_queuesReopened_whenTradeIsNotYetClosed() throws Exception {
+        UserProfile myProfile = createUserProfile(1003);
+        UserProfile peer = createUserProfile(1002);
+        UserProfile mediator = createUserProfile(1001);
+        MuSigTrade trade = createTrade(MuSigDisputeState.MEDIATION_OPEN, myProfile, peer, Optional.of(mediator), Optional.empty(), "trade-mediation-1");
+        MuSigOpenTradeChannel channel = createOpenTradeChannel(trade, myProfile, peer, mediator);
+        MuSigTradeService service = createTradeServiceForPendingQueueTests(trade, channel);
+        MuSigMediationStateChangeMessage message = new MuSigMediationStateChangeMessage(
+                "id-reopened-1",
+                trade.getId(),
+                mediator,
+                MediationCaseState.RE_OPENED,
+                Optional.empty(),
+                Optional.empty()
+        );
+
+        invokeProcessMediationStateChangeMessage(service, message, trade);
+
+        assertThat(getPendingMediationMessagesByTradeId(service))
+                .containsKey(trade.getId());
+        assertThat(getPendingMediationMessagesByTradeId(service).get(trade.getId()))
+                .containsExactly(message);
+    }
+
+    @Test
+    void maybeProcessPendingMediationMessages_replaysOpenThenPaymentDetailsOnce_andRemovesPendingMessages() throws Exception {
+        UserProfile myProfile = createUserProfile(1003);
+        UserProfile peer = createUserProfile(1002);
+        UserProfile mediator = createUserProfile(1001);
+        MuSigTrade trade = createTrade(MuSigDisputeState.NO_DISPUTE, myProfile, peer, Optional.of(mediator), Optional.empty(), "trade-replay-1");
+        MuSigOpenTradeChannel channel = createOpenTradeChannel(trade, myProfile, peer, mediator);
+        MuSigTradeService service = createTradeServiceTestFixture(trade, channel).service();
+
+        MuSigDisputeCasePaymentDetailsRequest paymentDetailsRequest =
+                new MuSigDisputeCasePaymentDetailsRequest(trade.getId(), mediator);
+        MuSigMediationStateChangeMessage openMessage = new MuSigMediationStateChangeMessage(
+                "id-open-replay-1",
+                trade.getId(),
+                mediator,
+                MediationCaseState.OPEN,
+                Optional.empty(),
+                Optional.empty()
+        );
+
+        invokeProcessDisputeCasePaymentDetailsRequest(service, paymentDetailsRequest, trade);
+        assertThat(getPendingMediationMessagesByTradeId(service).get(trade.getId()))
+                .containsExactly(paymentDetailsRequest);
+
+        addPendingMediationMessage(service, trade.getId(), openMessage);
+
+        invokeMaybeProcessPendingMediationMessages(service, trade.getId());
+        invokeMaybeProcessPendingMediationMessages(service, trade.getId());
+
+        assertThat(trade.getDisputeState()).isEqualTo(MuSigDisputeState.MEDIATION_OPEN);
+        assertThat(getPendingMediationMessagesByTradeId(service)).doesNotContainKey(trade.getId());
+    }
+
     private MuSigTrade createTrade(MuSigDisputeState disputeState,
                                    UserProfile myProfile,
                                    UserProfile peer,
@@ -371,11 +498,64 @@ class MuSigTradeServiceTest {
         return result;
     }
 
+    private void invokeProcessDisputeCasePaymentDetailsRequest(MuSigTradeService service,
+                                                               MuSigDisputeCasePaymentDetailsRequest message,
+                                                               MuSigTrade trade) throws Exception {
+        Method method = MuSigTradeService.class.getDeclaredMethod("processDisputeCasePaymentDetailsRequest",
+                MuSigDisputeCasePaymentDetailsRequest.class,
+                MuSigTrade.class);
+        method.setAccessible(true);
+        method.invoke(service, message, trade);
+    }
+
+    private void invokeProcessMediationResultAcceptanceMessage(MuSigTradeService service,
+                                                               MuSigMediationResultAcceptanceMessage message,
+                                                               MuSigTrade trade) throws Exception {
+        Method method = MuSigTradeService.class.getDeclaredMethod("processMediationResultAcceptanceMessage",
+                MuSigMediationResultAcceptanceMessage.class,
+                MuSigTrade.class);
+        method.setAccessible(true);
+        method.invoke(service, message, trade);
+    }
+
+    private void invokeProcessMediationStateChangeMessage(MuSigTradeService service,
+                                                          MuSigMediationStateChangeMessage message,
+                                                          MuSigTrade trade) throws Exception {
+        Method method = MuSigTradeService.class.getDeclaredMethod("processMediationStateChangeMessage",
+                MuSigMediationStateChangeMessage.class,
+                MuSigTrade.class);
+        method.setAccessible(true);
+        method.invoke(service, message, trade);
+    }
+
+    private void addPendingMediationMessage(MuSigTradeService service,
+                                            String tradeId,
+                                            EnvelopePayloadMessage message) throws Exception {
+        Method method = MuSigTradeService.class.getDeclaredMethod("addPendingMediationMessage", String.class, EnvelopePayloadMessage.class);
+        method.setAccessible(true);
+        method.invoke(service, tradeId, message);
+    }
+
+    private void invokeMaybeProcessPendingMediationMessages(MuSigTradeService service,
+                                                            String tradeId) throws Exception {
+        Method method = MuSigTradeService.class.getDeclaredMethod("maybeProcessPendingMediationMessages", String.class);
+        method.setAccessible(true);
+        method.invoke(service, tradeId);
+    }
+
     private MuSigTradeService createTradeServiceForPendingQueueTests() {
-        return createTradeServiceForPendingQueueTests(null, null);
+        return createTradeServiceTestFixture().service();
     }
 
     private MuSigTradeService createTradeServiceForPendingQueueTests(MuSigTrade trade, MuSigOpenTradeChannel channel) {
+        return createTradeServiceTestFixture(trade, channel).service();
+    }
+
+    private TradeServiceTestFixture createTradeServiceTestFixture() {
+        return createTradeServiceTestFixture(null, null);
+    }
+
+    private TradeServiceTestFixture createTradeServiceTestFixture(MuSigTrade trade, MuSigOpenTradeChannel channel) {
         ServiceProvider serviceProvider = mock(ServiceProvider.class);
         NetworkService networkService = mock(NetworkService.class);
         bisq.identity.IdentityService identityService = mock(bisq.identity.IdentityService.class);
@@ -412,6 +592,7 @@ class MuSigTradeServiceTest {
         doReturn(persistence)
                 .when(persistenceService)
                 .getOrCreatePersistence(any(), any(), any(MuSigTradeStore.class));
+        when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(networkService.getConfidentialMessageServices()).thenReturn(Set.of());
         when(openTradeChannelService.getChannels()).thenReturn(new bisq.common.observable.collection.ObservableSet<>());
         when(openTradeChannelService.findChannelByTradeId(anyString())).thenAnswer(invocation -> {
@@ -420,13 +601,34 @@ class MuSigTradeServiceTest {
         });
         when(bannedUserService.isUserProfileBanned(any(UserProfile.class))).thenReturn(false);
         when(bannedUserService.isUserProfileBanned(any(NetworkId.class))).thenReturn(false);
-        when(userProfileService.findUserProfile(anyString())).thenAnswer(invocation -> Optional.empty());
+        when(userProfileService.findUserProfile(anyString())).thenAnswer(invocation -> {
+            String profileId = invocation.getArgument(0);
+            if (trade == null) {
+                return Optional.empty();
+            }
+            if (trade.getMyIdentity().getId().equals(profileId)) {
+                return Optional.of(createUserProfile(1999));
+            }
+            if (trade.getPeer().getNetworkId().getId().equals(profileId)) {
+                return Optional.of(trade.getPeer());
+            }
+            if (trade.getContract().getMediator().map(UserProfile::getId).filter(profileId::equals).isPresent()) {
+                return trade.getContract().getMediator();
+            }
+            if (trade.getContract().getArbitrator().map(UserProfile::getId).filter(profileId::equals).isPresent()) {
+                return trade.getContract().getArbitrator();
+            }
+            return Optional.empty();
+        });
 
         MuSigTradeService service = new MuSigTradeService(new MuSigTradeService.Config("localhost", 9999), serviceProvider, null);
         if (trade != null) {
             service.getTradeById().put(trade.getId(), trade);
         }
-        return service;
+        return new TradeServiceTestFixture(service);
+    }
+
+    private record TradeServiceTestFixture(MuSigTradeService service) {
     }
 
     private MuSigOpenTradeChannel createOpenTradeChannel(MuSigTrade trade,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mediation state transitions to avoid duplicate/stale changes and ensure result validation.
  * Strengthened authorization and sender-role checks for dispute payment requests; unexpected or out-of-state messages are queued or ignored.
  * Messages lacking required data are now queued for later processing.

* **Tests**
  * Added tests covering pending-message queuing/replay and updated authorization/mediation state behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->