### PR TITLE
feat: improve external tor UX, add file socket control support, add tails support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ hs_err_pid*
 *.wallet
 *.ser
 *.sh
+!apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
 .DS_Store
 .gradle
 build

--- a/application/src/main/java/bisq/application/ApplicationService.java
+++ b/application/src/main/java/bisq/application/ApplicationService.java
@@ -29,6 +29,7 @@ import bisq.common.locale.LocaleRepository;
 import bisq.common.logging.AsciiLogo;
 import bisq.common.logging.LogSetup;
 import bisq.common.observable.Observable;
+import bisq.common.platform.TailsPersistenceGuard;
 import bisq.i18n.Res;
 import bisq.persistence.PersistenceService;
 import ch.qos.logback.classic.Level;
@@ -52,6 +53,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Slf4j
 public abstract class ApplicationService implements Service {
     public static final String CUSTOM_CONFIG_FILE_NAME = "bisq.conf";
+    // Explicit user permission to run on Tails without persistent storage (data lost on shutdown).
+    public static final String ALLOW_NON_PERSISTENT_TAILS_ENV = "BISQ_ALLOW_NON_PERSISTENT_TAILS";
 
     @Getter
     @ToString
@@ -159,6 +162,11 @@ public abstract class ApplicationService implements Service {
     // We keep the reference for the lifetime of the application. If the InstanceLock got garbage collected the file
     // lock would be released silently.
     private InstanceLock instanceLock;
+    // True when running on Tails with a data directory that is not on Persistent Storage and the
+    // user has not granted explicit permission to run anyway. The presentation layer decides what
+    // to do with this (the desktop app shows a quit/continue warning popup).
+    @Getter
+    private final boolean tailsDataDirNonPersistent;
     @Getter
     protected final Observable<State> state = new Observable<>(State.INITIALIZE_APP);
 
@@ -219,6 +227,8 @@ public abstract class ApplicationService implements Service {
             checkInstanceLock();
         }
 
+        tailsDataDirNonPersistent = evaluateTailsDataDirNonPersistent(appDataDirPath);
+
         setupLogging(appDataDirPath);
 
         persistenceService = new PersistenceService(appDataDirPath);
@@ -267,6 +277,38 @@ public abstract class ApplicationService implements Service {
         log.info("Data directory: {}", appDataDirPath);
         log.info("Version: v{} / Commit hash: {}", ApplicationVersion.getVersion().getVersionAsString(), ApplicationVersion.getBuildCommitShortHash());
         log.info("Tor Version: v{}", ApplicationVersion.getTorVersionString());
+    }
+
+    /**
+     * On Tails, abort early if the data directory is not on the unlocked Persistent Storage volume.
+     * Otherwise the user would lose their identity keys and open offers on shutdown (Tails is amnesic).
+     * The user can override and proceed at their own risk via the {@value #ALLOW_NON_PERSISTENT_TAILS_ENV}
+     * environment variable, which is the explicit permission to run without persistence.
+     */
+    /**
+     * Detects whether we run on Tails with a data directory that is NOT on the Persistent Storage
+     * volume. We do not abort here (that is a UX decision the presentation layer owns — e.g. the
+     * desktop app shows a warning popup with a quit/continue choice). Headless apps still get the
+     * logged warning. Returns false when the user has granted explicit permission to run without
+     * persistence via {@value #ALLOW_NON_PERSISTENT_TAILS_ENV}.
+     */
+    private boolean evaluateTailsDataDirNonPersistent(Path appDataDirPath) {
+        if (!TailsPersistenceGuard.isDataDirAmnesic(appDataDirPath)) {
+            return false;
+        }
+
+        String overrideValue = System.getenv(ALLOW_NON_PERSISTENT_TAILS_ENV);
+        boolean userAllowsNonPersistent = overrideValue != null && !overrideValue.isBlank();
+        if (userAllowsNonPersistent) {
+            log.warn("Running on Tails with a non-persistent data directory ({}). {} is set, so Bisq " +
+                            "continues at the user's request — ALL data will be lost on shutdown.",
+                    appDataDirPath, ALLOW_NON_PERSISTENT_TAILS_ENV);
+            return false;
+        }
+
+        log.warn("Running on Tails but the data directory '{}' is not on the Persistent Storage volume. " +
+                "Identity keys and open offers would be lost on shutdown.", appDataDirPath);
+        return true;
     }
 
     protected void checkInstanceLock() {

--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -338,10 +338,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -340,10 +340,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -342,10 +342,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/desktop/desktop-app-launcher/package/linux/deb/postinst
+++ b/apps/desktop/desktop-app-launcher/package/linux/deb/postinst
@@ -1,0 +1,56 @@
+#!/bin/sh
+# postinst script for APPLICATION_PACKAGE
+#
+# see: dh_installdeb(1)
+
+set -e
+
+# summary of how this script can be called:
+#        * <postinst> `configure' <most-recently-configured-version>
+#        * <old-postinst> `abort-upgrade' <new version>
+#        * <conflictor's-postinst> `abort-remove' `in-favour' <package>
+#          <new-version>
+#        * <postinst> `abort-remove'
+#        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
+#          <failed-install-package> <version> `removing'
+#          <conflicting-package> <version>
+# for details, see https://www.debian.org/doc/debian-policy/ or
+# the debian-policy package
+
+package_type=deb
+LAUNCHER_AS_SERVICE_SCRIPTS
+
+# Enable Bisq's onion-grater profile on Tails so Bisq can reach the system Tor
+# control port without a manual preparation step. No-op on non-Tails systems
+# (the /etc/onion-grater.d directory only exists on Tails). Idempotent and
+# non-fatal: a failure here must never abort package installation.
+enable_onion_grater_on_tails() {
+    [ -d /etc/onion-grater.d ] || return 0
+
+    profile="$(ls /opt/*/lib/onion-grater/40_bisq_tails.yml 2>/dev/null | head -n1)"
+    [ -n "$profile" ] || profile="$(ls /opt/*/onion-grater/40_bisq_tails.yml 2>/dev/null | head -n1)"
+    [ -n "$profile" ] && [ -f "$profile" ] || return 0
+
+    install -m 0644 "$profile" /etc/onion-grater.d/bisq.yml || return 0
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl restart onion-grater.service >/dev/null 2>&1 || true
+    fi
+}
+
+case "$1" in
+    configure)
+DESKTOP_COMMANDS_INSTALL
+LAUNCHER_AS_SERVICE_COMMANDS_INSTALL
+        enable_onion_grater_on_tails || true
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0

--- a/apps/desktop/desktop-app-launcher/package/linux/deb/prerm
+++ b/apps/desktop/desktop-app-launcher/package/linux/deb/prerm
@@ -1,0 +1,51 @@
+#!/bin/sh
+# prerm script for APPLICATION_PACKAGE
+#
+# see: dh_installdeb(1)
+
+set -e
+
+# summary of how this script can be called:
+#        * <prerm> `remove'
+#        * <old-prerm> `upgrade' <new-version>
+#        * <new-prerm> `failed-upgrade' <old-version>
+#        * <conflictor's-prerm> `remove' `in-favour' <package> <new-version>
+#        * <deconfigured's-prerm> `deconfigure' `in-favour'
+#          <package-being-installed> <version> `removing'
+#          <conflicting-package> <version>
+# for details, see https://www.debian.org/doc/debian-policy/ or
+# the debian-policy package
+
+
+package_type=deb
+DESKTOP_SCRIPTS
+LAUNCHER_AS_SERVICE_SCRIPTS
+
+# Remove Bisq's onion-grater profile that postinst installed on Tails. On upgrade
+# postinst reinstalls it afterwards, so this stays idempotent. Non-fatal.
+disable_onion_grater_on_tails() {
+    [ -f /etc/onion-grater.d/bisq.yml ] || return 0
+
+    rm -f /etc/onion-grater.d/bisq.yml || return 0
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl restart onion-grater.service >/dev/null 2>&1 || true
+    fi
+}
+
+case "$1" in
+    remove|upgrade|deconfigure)
+DESKTOP_COMMANDS_UNINSTALL
+LAUNCHER_AS_SERVICE_COMMANDS_UNINSTALL
+        disable_onion_grater_on_tails || true
+    ;;
+
+    failed-upgrade)
+    ;;
+
+    *)
+        echo "prerm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0

--- a/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
+++ b/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Bisq2 - Tails OS preparation script
+# Copies the onion-grater profile required for Bisq2 to work on Tails.
+# Must be run with root privileges.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BISQ_LIB_DIR="$SCRIPT_DIR"
+ONION_GRATER_SRC="$BISQ_LIB_DIR/onion-grater/40_bisq_tails.yml"
+ONION_GRATER_DEST="/etc/onion-grater.d/bisq.yml"
+DataDirectory="/home/amnesia/Persistent/bisq/Bisq2"
+DEFAULT_EXTERNAL_TOR_CONFIG="/home/amnesia/.local/share/Bisq2/tor/external_tor.config"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: This script must be run as root (use sudo)." >&2
+    exit 1
+fi
+
+if [ ! -f "$ONION_GRATER_SRC" ]; then
+    echo "Error: Onion-grater profile not found at $ONION_GRATER_SRC" >&2
+    exit 1
+fi
+
+if [ ! -d "/etc/onion-grater.d" ]; then
+    echo "Error: /etc/onion-grater.d directory not found. Is this a Tails system?" >&2
+    exit 1
+fi
+
+# Gracefully shut down Bisq2 if it is running
+if pgrep -x "Bisq2" > /dev/null 2>&1; then
+    echo "Bisq2 is running. Sending SIGTERM and waiting for exit ..."
+    pkill -SIGTERM -x "Bisq2"
+    for i in $(seq 1 30); do
+        if ! pgrep -x "Bisq2" > /dev/null 2>&1; then
+            echo "Bisq2 has exited."
+            break
+        fi
+        sleep 1
+    done
+    if pgrep -x "Bisq2" > /dev/null 2>&1; then
+        echo "Warning: Bisq2 did not exit within 30 seconds. Exiting..." >&2
+        exit 1
+    fi
+fi
+
+# Remove stale external Tor config if present
+if [ -f "$DEFAULT_EXTERNAL_TOR_CONFIG" ]; then
+    rm -f "$DEFAULT_EXTERNAL_TOR_CONFIG"
+    echo "Removed existing external Tor config: $DEFAULT_EXTERNAL_TOR_CONFIG"
+fi
+
+cp "$ONION_GRATER_SRC" "$ONION_GRATER_DEST"
+chmod 644 "$ONION_GRATER_DEST"
+echo "Onion-grater profile installed to $ONION_GRATER_DEST"
+echo "Restart onion-grater service ..."
+systemctl restart onion-grater.service
+
+echo "Redirect user data to Tails Persistent Storage at $DataDirectory ..."
+if [ ! -d "$DataDirectory" ]; then
+    mkdir -p "$DataDirectory"
+    chown -R amnesia:amnesia "$DataDirectory"
+fi
+
+TARGET_LINK="/home/amnesia/.local/share/Bisq2"
+if [ -e "$TARGET_LINK" ]; then
+    if [ -L "$TARGET_LINK" ]; then
+        echo "Symlink already exists: $TARGET_LINK"
+    else
+        echo "Warning: $TARGET_LINK exists and is not a symlink; skipping creation" >&2
+    fi
+else
+    ln -s "$DataDirectory" "$TARGET_LINK"
+    echo "Created symlink: $TARGET_LINK -> $DataDirectory"
+fi
+
+echo "Preparations complete."

--- a/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
+++ b/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
@@ -74,11 +74,10 @@ if [ -L "$TARGET_LINK" ]; then
 elif [ -d "$TARGET_LINK" ]; then
     BACKUP_DIR="${TARGET_LINK}.pre-tails-migration.$(date +%Y%m%d%H%M%S)"
     echo "Found existing non-persistent data at $TARGET_LINK; migrating into $DataDirectory ..."
-    if ! command -v rsync >/dev/null 2>&1; then
-        echo "Error: rsync not found; cannot migrate existing $TARGET_LINK safely." >&2
-        exit 1
-    fi
-    rsync -aHAX --info=stats2 -- "$TARGET_LINK"/ "$DataDirectory"/
+    # Use cp (always present) instead of rsync (not guaranteed). cp -a == -dR --preserve=all,
+    # preserving mode, ownership, timestamps, symlinks, hard links, ACLs and xattrs. The trailing
+    # "/." copies the directory contents (including dotfiles) into the existing $DataDirectory.
+    cp -a -- "$TARGET_LINK"/. "$DataDirectory"/
     mv -- "$TARGET_LINK" "$BACKUP_DIR"
     echo "Backed up original directory to $BACKUP_DIR"
     chown -R amnesia:amnesia "$DataDirectory"

--- a/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
+++ b/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Bisq2 - Tails OS preparation script
+# Copies the onion-grater profile required for Bisq2 to work on Tails.
+# Must be run with root privileges.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BISQ_LIB_DIR="$SCRIPT_DIR"
+ONION_GRATER_SRC="$BISQ_LIB_DIR/onion-grater/40_bisq_tails.yml"
+ONION_GRATER_DEST="/etc/onion-grater.d/bisq.yml"
+DataDirectory="/home/amnesia/Persistent/bisq/Bisq2"
+DEFAULT_EXTERNAL_TOR_CONFIG="/home/amnesia/.local/share/Bisq2/tor/external_tor.config"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: This script must be run as root (use sudo)." >&2
+    exit 1
+fi
+
+if [ ! -f "$ONION_GRATER_SRC" ]; then
+    echo "Error: Onion-grater profile not found at $ONION_GRATER_SRC" >&2
+    exit 1
+fi
+
+if [ ! -d "/etc/onion-grater.d" ]; then
+    echo "Error: /etc/onion-grater.d directory not found. Is this a Tails system?" >&2
+    exit 1
+fi
+
+# Gracefully shut down Bisq2 if it is running
+if pgrep -x "Bisq2" > /dev/null 2>&1; then
+    echo "Bisq2 is running. Sending SIGTERM and waiting for exit ..."
+    pkill -SIGTERM -x "Bisq2"
+    for i in $(seq 1 30); do
+        if ! pgrep -x "Bisq2" > /dev/null 2>&1; then
+            echo "Bisq2 has exited."
+            break
+        fi
+        sleep 1
+    done
+    if pgrep -x "Bisq2" > /dev/null 2>&1; then
+        echo "Warning: Bisq2 did not exit within 30 seconds. Exiting..." >&2
+        exit 1
+    fi
+fi
+
+# Remove stale external Tor config if present
+if [ -f "$DEFAULT_EXTERNAL_TOR_CONFIG" ]; then
+    rm -f "$DEFAULT_EXTERNAL_TOR_CONFIG"
+    echo "Removed existing external Tor config: $DEFAULT_EXTERNAL_TOR_CONFIG"
+fi
+
+cp "$ONION_GRATER_SRC" "$ONION_GRATER_DEST"
+chmod 644 "$ONION_GRATER_DEST"
+echo "Onion-grater profile installed to $ONION_GRATER_DEST"
+echo "Restart onion-grater service ..."
+systemctl restart onion-grater.service
+
+echo "Redirect user data to Tails Persistent Storage at $DataDirectory ..."
+if [ ! -d "$DataDirectory" ]; then
+    mkdir -p "$DataDirectory"
+fi
+chown -R amnesia:amnesia "$DataDirectory"
+
+TARGET_LINK="/home/amnesia/.local/share/Bisq2"
+if [ -L "$TARGET_LINK" ]; then
+    CURRENT_TARGET="$(readlink -f "$TARGET_LINK")"
+    EXPECTED_TARGET="$(readlink -f "$DataDirectory")"
+    if [ "$CURRENT_TARGET" != "$EXPECTED_TARGET" ]; then
+        echo "Error: $TARGET_LINK is a symlink to $CURRENT_TARGET, expected $EXPECTED_TARGET. Remove it manually and re-run." >&2
+        exit 1
+    fi
+    echo "Symlink already exists: $TARGET_LINK -> $CURRENT_TARGET"
+elif [ -d "$TARGET_LINK" ]; then
+    BACKUP_DIR="${TARGET_LINK}.pre-tails-migration.$(date +%Y%m%d%H%M%S)"
+    echo "Found existing non-persistent data at $TARGET_LINK; migrating into $DataDirectory ..."
+    if ! command -v rsync >/dev/null 2>&1; then
+        echo "Error: rsync not found; cannot migrate existing $TARGET_LINK safely." >&2
+        exit 1
+    fi
+    rsync -aHAX --info=stats2 -- "$TARGET_LINK"/ "$DataDirectory"/
+    mv -- "$TARGET_LINK" "$BACKUP_DIR"
+    echo "Backed up original directory to $BACKUP_DIR"
+    chown -R amnesia:amnesia "$DataDirectory"
+    ln -s "$DataDirectory" "$TARGET_LINK"
+    echo "Created symlink: $TARGET_LINK -> $DataDirectory"
+elif [ -e "$TARGET_LINK" ]; then
+    echo "Error: $TARGET_LINK exists and is neither a symlink nor a directory; refusing to overwrite. Remove it manually and re-run." >&2
+    exit 1
+else
+    ln -s "$DataDirectory" "$TARGET_LINK"
+    echo "Created symlink: $TARGET_LINK -> $DataDirectory"
+fi
+
+echo "Preparations complete."

--- a/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
+++ b/apps/desktop/desktop-app-launcher/package/linux/prepare_tails.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Bisq2 - Tails OS preparation script
-# Copies the onion-grater profile required for Bisq2 to work on Tails.
+# Copies the onion-grater profile required for Bisq2 to work on Tails and migrates data
+# written to the volatile home directory by earlier versions into Persistent Storage.
 # Must be run with root privileges.
 
 set -euo pipefail
@@ -9,8 +10,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BISQ_LIB_DIR="$SCRIPT_DIR"
 ONION_GRATER_SRC="$BISQ_LIB_DIR/onion-grater/40_bisq_tails.yml"
 ONION_GRATER_DEST="/etc/onion-grater.d/bisq.yml"
-DataDirectory="/home/amnesia/Persistent/bisq/Bisq2"
-DEFAULT_EXTERNAL_TOR_CONFIG="/home/amnesia/.local/share/Bisq2/tor/external_tor.config"
+PERSISTENT_STORAGE_DIR="/home/amnesia/Persistent"
+PERSISTENT_DATA_DIR="$PERSISTENT_STORAGE_DIR/Bisq2"
+VOLATILE_DATA_DIR="/home/amnesia/.local/share/Bisq2"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo "Error: This script must be run as root (use sudo)." >&2
@@ -44,51 +46,51 @@ if pgrep -x "Bisq2" > /dev/null 2>&1; then
     fi
 fi
 
-# Remove stale external Tor config if present
-if [ -f "$DEFAULT_EXTERNAL_TOR_CONFIG" ]; then
-    rm -f "$DEFAULT_EXTERNAL_TOR_CONFIG"
-    echo "Removed existing external Tor config: $DEFAULT_EXTERNAL_TOR_CONFIG"
-fi
-
 cp "$ONION_GRATER_SRC" "$ONION_GRATER_DEST"
 chmod 644 "$ONION_GRATER_DEST"
 echo "Onion-grater profile installed to $ONION_GRATER_DEST"
 echo "Restart onion-grater service ..."
 systemctl restart onion-grater.service
 
-echo "Redirect user data to Tails Persistent Storage at $DataDirectory ..."
-if [ ! -d "$DataDirectory" ]; then
-    mkdir -p "$DataDirectory"
-fi
-chown -R amnesia:amnesia "$DataDirectory"
+# Bisq2 uses Persistent Storage as its data directory whenever it is unlocked, so no symlink is
+# needed. Running amnesically is a supported choice, so a locked volume is a warning, not an error.
+if [ -d "$PERSISTENT_STORAGE_DIR" ]; then
+    DATA_DIR="$PERSISTENT_DATA_DIR"
+    mkdir -p "$DATA_DIR"
 
-TARGET_LINK="/home/amnesia/.local/share/Bisq2"
-if [ -L "$TARGET_LINK" ]; then
-    CURRENT_TARGET="$(readlink -f "$TARGET_LINK")"
-    EXPECTED_TARGET="$(readlink -f "$DataDirectory")"
-    if [ "$CURRENT_TARGET" != "$EXPECTED_TARGET" ]; then
-        echo "Error: $TARGET_LINK is a symlink to $CURRENT_TARGET, expected $EXPECTED_TARGET. Remove it manually and re-run." >&2
-        exit 1
+    # Earlier versions wrote to the volatile home directory; migrate that data once.
+    if [ -L "$VOLATILE_DATA_DIR" ]; then
+        # Symlink created by an earlier version of this script; the app no longer needs it.
+        rm -f "$VOLATILE_DATA_DIR"
+        echo "Removed obsolete symlink: $VOLATILE_DATA_DIR"
+    elif [ -d "$VOLATILE_DATA_DIR" ]; then
+        if [ -n "$(find "$DATA_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+            echo "Error: Both $VOLATILE_DATA_DIR and $DATA_DIR contain data." >&2
+            echo "Refusing to merge them because that would overwrite the persistent profile." >&2
+            echo "Back up both directories and keep the one you want at $DATA_DIR, then re-run." >&2
+            exit 1
+        fi
+        echo "Migrating $VOLATILE_DATA_DIR into $DATA_DIR ..."
+        # Use cp (always present) instead of rsync (not guaranteed). cp -a == -dR --preserve=all,
+        # preserving mode, ownership, timestamps, symlinks, hard links, ACLs and xattrs. The trailing
+        # "/." copies the directory contents (including dotfiles) into the existing $DATA_DIR.
+        cp -a -- "$VOLATILE_DATA_DIR"/. "$DATA_DIR"/
+        echo "Migration complete. The original is left at $VOLATILE_DATA_DIR until the next reboot."
     fi
-    echo "Symlink already exists: $TARGET_LINK -> $CURRENT_TARGET"
-elif [ -d "$TARGET_LINK" ]; then
-    BACKUP_DIR="${TARGET_LINK}.pre-tails-migration.$(date +%Y%m%d%H%M%S)"
-    echo "Found existing non-persistent data at $TARGET_LINK; migrating into $DataDirectory ..."
-    # Use cp (always present) instead of rsync (not guaranteed). cp -a == -dR --preserve=all,
-    # preserving mode, ownership, timestamps, symlinks, hard links, ACLs and xattrs. The trailing
-    # "/." copies the directory contents (including dotfiles) into the existing $DataDirectory.
-    cp -a -- "$TARGET_LINK"/. "$DataDirectory"/
-    mv -- "$TARGET_LINK" "$BACKUP_DIR"
-    echo "Backed up original directory to $BACKUP_DIR"
-    chown -R amnesia:amnesia "$DataDirectory"
-    ln -s "$DataDirectory" "$TARGET_LINK"
-    echo "Created symlink: $TARGET_LINK -> $DataDirectory"
-elif [ -e "$TARGET_LINK" ]; then
-    echo "Error: $TARGET_LINK exists and is neither a symlink nor a directory; refusing to overwrite. Remove it manually and re-run." >&2
-    exit 1
+
+    chown -R amnesia:amnesia "$DATA_DIR"
 else
-    ln -s "$DataDirectory" "$TARGET_LINK"
-    echo "Created symlink: $TARGET_LINK -> $DataDirectory"
+    DATA_DIR="$VOLATILE_DATA_DIR"
+    echo "Warning: Persistent Storage is not unlocked, so Bisq2 uses $DATA_DIR." >&2
+    echo "All data, including identity keys and open offers, will be lost on shutdown." >&2
 fi
 
-echo "Preparations complete."
+# The external Tor config is only auto-detected when absent, so drop a stale file written
+# before Tails was detected. Bisq2 recreates it with the onion-grater control port.
+STALE_EXTERNAL_TOR_CONFIG="$DATA_DIR/tor/external_tor.config"
+if [ -f "$STALE_EXTERNAL_TOR_CONFIG" ]; then
+    rm -f "$STALE_EXTERNAL_TOR_CONFIG"
+    echo "Removed existing external Tor config: $STALE_EXTERNAL_TOR_CONFIG"
+fi
+
+echo "Preparations complete. Bisq2 uses $DATA_DIR."

--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopExecutable.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopExecutable.java
@@ -22,12 +22,16 @@ import bisq.application.Executable;
 import bisq.application.InstanceLockException;
 import bisq.application.InstanceLockUnavailableException;
 import bisq.desktop.DesktopController;
+import bisq.desktop.common.application.JavaFxApplicationData;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.overlay.Popup;
 import bisq.i18n.Res;
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -36,6 +40,7 @@ import javax.swing.SwingUtilities;
 import java.awt.GraphicsEnvironment;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static bisq.common.platform.PlatformUtils.EXIT_FAILURE;
 
@@ -68,11 +73,7 @@ public class DesktopExecutable extends Executable<DesktopApplicationService> {
                         try {
                             log.info("Java FX Application launched");
                             setupStartupAndShutdownErrorHandlers();
-                            desktopController = new DesktopController(applicationService.getState(),
-                                    applicationService.getServiceProvider(),
-                                    applicationData,
-                                    this::onApplicationLaunched);
-                            desktopController.init();
+                            startDesktopControllerAfterTailsCheck(applicationData);
                         } catch (Throwable t) {
                             shutdownAfterStartupFailure("Desktop startup failed", t);
                         }
@@ -80,6 +81,51 @@ public class DesktopExecutable extends Executable<DesktopApplicationService> {
                         shutdownAfterStartupFailure("Could not launch JavaFX application.", throwable);
                     }
                 });
+    }
+
+    /**
+     * On Tails, if the data directory is not on the Persistent Storage volume the user would lose
+     * their identity keys and open offers on shutdown. Warn with a quit/continue popup before any
+     * domain initialization starts (domain init is only triggered from desktopController via the
+     * onApplicationLaunched callback, so deferring its creation defers initialization too).
+     */
+    private void startDesktopControllerAfterTailsCheck(JavaFxApplicationData applicationData) {
+        if (!applicationService.isTailsDataDirNonPersistent()) {
+            startDesktopController(applicationData);
+            return;
+        }
+
+        // The app UI does not exist yet, so the Bisq Popup (which needs an owner scene) cannot be used.
+        // Defer a standalone JavaFX Alert via runLater so it shows after the startup pulse, then gate
+        // domain initialization on the user's choice (continue) or shut down.
+        Platform.runLater(() -> {
+            Alert alert = new Alert(Alert.AlertType.WARNING);
+            alert.setTitle(Res.get("action.shutDown"));
+            alert.setHeaderText(null);
+            alert.setContentText(Res.get("popup.tails.noPersistentStorage.warning"));
+            alert.getDialogPane().setMinWidth(560);
+
+            ButtonType continueButton = new ButtonType(
+                    Res.get("popup.tails.noPersistentStorage.continue"), ButtonBar.ButtonData.OK_DONE);
+            ButtonType shutDownButton = new ButtonType(
+                    Res.get("action.shutDown"), ButtonBar.ButtonData.CANCEL_CLOSE);
+            alert.getButtonTypes().setAll(continueButton, shutDownButton);
+
+            Optional<ButtonType> result = alert.showAndWait();
+            if (result.isPresent() && result.get() == continueButton) {
+                startDesktopController(applicationData);
+            } else {
+                exitJavaFXPlatform();
+            }
+        });
+    }
+
+    private void startDesktopController(JavaFxApplicationData applicationData) {
+        desktopController = new DesktopController(applicationService.getState(),
+                applicationService.getServiceProvider(),
+                applicationData,
+                this::onApplicationLaunched);
+        desktopController.init();
     }
 
     @Override

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -317,10 +317,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -319,10 +319,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -321,10 +321,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -317,10 +317,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -319,10 +319,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -321,10 +321,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -313,10 +313,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -317,10 +317,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -315,10 +315,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 socketTimeout=120

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -315,10 +315,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 defaultNodePort=2000

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -319,10 +319,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 defaultNodePort=2000

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -317,10 +317,23 @@ application {
                 hsUploadTimeout=120
                 testNetwork=false
                 directoryAuthorities=[]
-                torrcOverrides={}
                 sendMessageThrottleTime=200
                 receiveMessageThrottleTime=200
+                # See torrcOverrideFilePath comment below for external Tor config source and fallback behavior.
                 useExternalTor=false
+                # Key/value pairs forwarded verbatim to the generated torrc.
+                # Each value can be a single string or a list of strings (needed for
+                # directives that may appear multiple times, e.g. Bridge):
+                #   torrcOverrides { SocksPort = "9050" }
+                #   torrcOverrides { Bridge = ["obfs4 1.2.3.4:1234 FP1", "obfs4 5.6.7.8:5678 FP2"] }
+                torrcOverrides={}
+                # Path to a torrc-style file (one "Key Value" per line) whose entries are
+                # used instead of the inline torrcOverrides above.  Supports both absolute
+                # paths and paths relative to the data directory.  Takes precedence over
+                # torrcOverrides when non-empty; leave empty to use torrcOverrides.
+                # Also used as external Tor config source when useExternalTor=true.
+                # If unset/missing, Bisq falls back to data-dir external_tor.config.
+                torrcOverrideFilePath=""
             }
             i2p {
                 defaultNodePort=2000

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
@@ -122,14 +122,16 @@ abstract class JPackageTask : DefaultTask() {
             contentPaths.add(dest)
         }
 
-        // Stage onion-grater YAMLs into lib/onion-grater/
+        // Stage the Tails onion-grater profile into lib/onion-grater/. Only the Tails profile is
+        // shipped: the deb postinst enables it on Tails, while Whonix gets the Bisq profile from the
+        // OS (onion-grater upstream), so the Whonix variant would be dead weight in the package.
         if (onionGraterDir.isPresent) {
             val onionGraterStageDir = stagingDir.resolve("onion-grater")
             Files.createDirectories(onionGraterStageDir)
             val srcDir = onionGraterDir.asFile.get().toPath()
             Files.list(srcDir).use { paths ->
                 paths
-                    .filter { it.toString().endsWith(".yml") }
+                    .filter { it.fileName.toString().endsWith("_tails.yml") }
                     .forEach { src ->
                         Files.copy(src, onionGraterStageDir.resolve(src.fileName), StandardCopyOption.REPLACE_EXISTING)
                     }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JPackageTask.kt
@@ -14,6 +14,10 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.notExists
 
 abstract class JPackageTask : DefaultTask() {
 
@@ -44,6 +48,10 @@ abstract class JPackageTask : DefaultTask() {
     @get:InputDirectory
     abstract val packageResourcesDir: DirectoryProperty
 
+    @get:Optional
+    @get:InputDirectory
+    abstract val onionGraterDir: DirectoryProperty
+
     @get:InputDirectory
     abstract val runtimeImageDirectory: DirectoryProperty
 
@@ -55,20 +63,20 @@ abstract class JPackageTask : DefaultTask() {
         val jPackagePath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jpackage")
 
         val jPackageConfig = JPackageConfig(
-                inputDirPath = distDirFile.get().toPath().resolve("lib"),
-                outputDirPath = outputDirectory.asFile.get().toPath(),
-                runtimeImageDirPath = runtimeImageDirectory.asFile.get().toPath(),
+            inputDirPath = distDirFile.get().toPath().resolve("lib"),
+            outputDirPath = outputDirectory.asFile.get().toPath(),
+            runtimeImageDirPath = runtimeImageDirectory.asFile.get().toPath(),
 
-                appConfig = JPackageAppConfig(
-                    name = appName.get(),
-                    appVersion = appVersion.get(),
-                    mainJarFileName = mainJarFile.asFile.get().name,
-                    mainClassName = mainClassName.get(),
-                    jvmArgs = jvmArgs.get(),
-                    licenceFilePath = licenseFile.get().absolutePath
-                ),
+            appConfig = JPackageAppConfig(
+                name = appName.get(),
+                appVersion = appVersion.get(),
+                mainJarFileName = mainJarFile.asFile.get().name,
+                mainClassName = mainClassName.get(),
+                jvmArgs = jvmArgs.get(),
+                licenceFilePath = licenseFile.get().absolutePath
+            ),
 
-                packageFormatConfigs = getPackageFormatConfigs()
+            packageFormatConfigs = getPackageFormatConfigs()
         )
 
         val packageFactory = PackageFactory(jPackagePath, jPackageConfig)
@@ -90,8 +98,45 @@ abstract class JPackageTask : DefaultTask() {
 
             OS.LINUX -> {
                 val resourcesPath = packagePath.resolve("linux")
-                LinuxPackages(resourcesPath, appName.get())
+                val appContentPaths = stageLinuxAppContent(resourcesPath)
+                LinuxPackages(resourcesPath, appName.get(), appContentPaths)
             }
         }
+    }
+
+    private fun stageLinuxAppContent(linuxResourcesPath: Path): List<Path> {
+        val stagingDir = project.layout.buildDirectory.get().asFile.toPath()
+            .resolve("packaging").resolve("app-content")
+        if (stagingDir.notExists()) {
+            Files.createDirectories(stagingDir)
+        }
+
+        val contentPaths = mutableListOf<Path>()
+
+        // Stage prepare_tails.sh as a standalone file in lib/prepare_tails.sh
+        val prepareTailsSrc = linuxResourcesPath.resolve("prepare_tails.sh")
+        if (Files.exists(prepareTailsSrc)) {
+            val dest = stagingDir.resolve("prepare_tails.sh")
+            Files.copy(prepareTailsSrc, dest, StandardCopyOption.REPLACE_EXISTING)
+            dest.toFile().setExecutable(true)
+            contentPaths.add(dest)
+        }
+
+        // Stage onion-grater YAMLs into lib/onion-grater/
+        if (onionGraterDir.isPresent) {
+            val onionGraterStageDir = stagingDir.resolve("onion-grater")
+            Files.createDirectories(onionGraterStageDir)
+            val srcDir = onionGraterDir.asFile.get().toPath()
+            Files.list(srcDir).use { paths ->
+                paths
+                    .filter { it.toString().endsWith(".yml") }
+                    .forEach { src ->
+                        Files.copy(src, onionGraterStageDir.resolve(src.fileName), StandardCopyOption.REPLACE_EXISTING)
+                    }
+            }
+            contentPaths.add(stagingDir.resolve("onion-grater"))
+        }
+
+        return contentPaths
     }
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -94,10 +94,15 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             val packageResourcesDirFile = File(project.projectDir, "package")
             packageResourcesDir.set(packageResourcesDirFile)
 
-            // Onion-grater profiles for Tails/Whonix packaging
-            val onionGraterPath = File(project.rootProject.projectDir, "network/tor/tor/onion-grater")
-            if (onionGraterPath.isDirectory) {
-                onionGraterDir.set(onionGraterPath)
+            // Onion-grater profiles for Tails/Whonix packaging. apps/desktop is its own Gradle build,
+            // so project.rootProject is that build's root, NOT the repository root. Anchor on this
+            // launcher project (<repo>/apps/desktop/desktop-app-launcher) and walk three levels up to
+            // the repo root, matching the depth the licenseFile lookup above already relies on. Build
+            // the path via Gradle's Directory DSL so segments use the platform separator.
+            val onionGraterDirectory = project.layout.projectDirectory
+                .dir("../../../network/tor/tor/onion-grater")
+            if (onionGraterDirectory.asFile.isDirectory) {
+                onionGraterDir.set(onionGraterDirectory)
             }
 
             runtimeImageDirectory.set(

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -94,6 +94,12 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             val packageResourcesDirFile = File(project.projectDir, "package")
             packageResourcesDir.set(packageResourcesDirFile)
 
+            // Onion-grater profiles for Tails/Whonix packaging
+            val onionGraterPath = File(project.rootProject.projectDir, "network/tor/tor/onion-grater")
+            if (onionGraterPath.isDirectory) {
+                onionGraterDir.set(onionGraterPath)
+            }
+
             runtimeImageDirectory.set(
                 getJPackageJdkDirectory(extension)
             )

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -94,6 +94,12 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             val packageResourcesDirFile = File(project.projectDir, "package")
             packageResourcesDir.set(packageResourcesDirFile)
 
+            // Onion-grater profiles for Tails/Whonix packaging
+            val onionGraterPath = File(project.rootProject.projectDir, "network/tor/tor/onion-grater")
+            if (onionGraterPath.isDirectory) {
+                onionGraterDir.set(onionGraterPath)
+            }
+
             runtimeImageDirectory.set(
                 getJPackageJdkDirectory(project)
             )

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
@@ -1,5 +1,6 @@
 package bisq.gradle.packaging.jpackage.package_formats
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.*
 
@@ -36,6 +37,15 @@ class LinuxPackages(
         if (packageFormat == PackageFormat.DEB) {
             arguments.add("--linux-deb-maintainer")
             arguments.add("noreply@bisq.network")
+
+            // Override the deb maintainer scripts (postinst/prerm) to auto-enable Bisq's
+            // onion-grater profile on Tails. jpackage still applies its token substitution to
+            // these overrides, so the default desktop/service integration is preserved.
+            val debResourceDir = resourcesPath.resolve("deb")
+            if (Files.isDirectory(debResourceDir)) {
+                arguments.add("--resource-dir")
+                arguments.add(debResourceDir.toAbsolutePath().toString())
+            }
         }
 
         if (packageFormat == PackageFormat.RPM) {

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/jpackage/package_formats/LinuxPackages.kt
@@ -3,7 +3,11 @@ package bisq.gradle.packaging.jpackage.package_formats
 import java.nio.file.Path
 import java.util.*
 
-class LinuxPackages(private val resourcesPath: Path, private val appName: String) : JPackagePackageFormatConfigs {
+class LinuxPackages(
+        private val resourcesPath: Path,
+        private val appName: String,
+        private val appContentPaths: List<Path> = emptyList()
+) : JPackagePackageFormatConfigs {
     override val packageFormats = setOf(PackageFormat.DEB, PackageFormat.RPM)
 
     override fun createArgumentsForJPackage(packageFormat: PackageFormat): List<String> {
@@ -23,6 +27,11 @@ class LinuxPackages(private val resourcesPath: Path, private val appName: String
                 "--linux-deb-maintainer",
                 "noreply@bisq.network",
         )
+
+        appContentPaths.forEach { contentPath ->
+            arguments.add("--app-content")
+            arguments.add(contentPath.toAbsolutePath().toString())
+        }
 
         if (packageFormat == PackageFormat.DEB) {
             arguments.add("--linux-deb-maintainer")

--- a/common/src/main/java/bisq/common/application/ConfigUtil.java
+++ b/common/src/main/java/bisq/common/application/ConfigUtil.java
@@ -20,6 +20,7 @@ package bisq.common.application;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -66,6 +67,16 @@ public class ConfigUtil {
         } catch (Exception ex) {
             throw toConfigValidationException.apply(path, ex);
         }
+    }
+
+    public static boolean parseBooleanFlag(@Nullable String value) { // config.get() may return null
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim();
+        return normalized.equals("1") ||
+                normalized.equalsIgnoreCase("true") ||
+                normalized.equalsIgnoreCase("yes");
     }
 
     public static List<String> getStringList(Config config, String path) {

--- a/common/src/main/java/bisq/common/platform/LinuxDistribution.java
+++ b/common/src/main/java/bisq/common/platform/LinuxDistribution.java
@@ -25,7 +25,8 @@ import java.nio.file.Paths;
 public enum LinuxDistribution {
     DEBIAN("debian"),
     RED_HAT("redhat"),
-    WHONIX("whonix");
+    WHONIX("whonix"),
+    TAILS("tails");
 
     @Getter
     private final String canonicalName;
@@ -40,6 +41,10 @@ public enum LinuxDistribution {
 
     public static boolean isRedHat() {
         return OS.isLinux() && Files.isRegularFile(Paths.get("/etc/redhat-release"));
+    }
+
+    public static boolean isTails() {
+        return OS.isLinux() && Files.isDirectory(Paths.get("/usr/share/tails"));
     }
 
     public static boolean isWhonix() {

--- a/common/src/main/java/bisq/common/platform/LinuxDistribution.java
+++ b/common/src/main/java/bisq/common/platform/LinuxDistribution.java
@@ -18,10 +18,15 @@
 package bisq.common.platform;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
+@Slf4j
 public enum LinuxDistribution {
     DEBIAN("debian"),
     RED_HAT("redhat"),
@@ -44,7 +49,51 @@ public enum LinuxDistribution {
     }
 
     public static boolean isTails() {
-        return OS.isLinux() && Files.isDirectory(Paths.get("/usr/share/tails"));
+        if (!OS.isLinux()) {
+            return false;
+        }
+        // Official, distribution-agnostic marker: /etc/os-release with ID=tails. Fall back to the
+        // legacy amnesia marker and the tails data directory for older or partially-mounted systems.
+        return osReleaseIdEquals("tails")
+                || Files.isRegularFile(Paths.get("/etc/amnesia_version"))
+                || Files.isDirectory(Paths.get("/usr/share/tails"));
+    }
+
+    /**
+     * Reads the {@code ID} field of {@code /etc/os-release} and compares it case-insensitively.
+     * The value may be quoted (e.g. {@code ID="tails"}); surrounding quotes are stripped.
+     */
+    private static boolean osReleaseIdEquals(String expectedId) {
+        return readOsReleaseId()
+                .map(id -> id.equalsIgnoreCase(expectedId))
+                .orElse(false);
+    }
+
+    private static Optional<String> readOsReleaseId() {
+        Path osReleasePath = Paths.get("/etc/os-release");
+        if (!Files.isRegularFile(osReleasePath)) {
+            return Optional.empty();
+        }
+        try {
+            return Files.readAllLines(osReleasePath).stream()
+                    .map(String::trim)
+                    .filter(line -> line.startsWith("ID="))
+                    .map(line -> line.substring("ID=".length()).trim())
+                    .map(LinuxDistribution::unquote)
+                    .findFirst();
+        } catch (IOException e) {
+            log.warn("Could not read /etc/os-release", e);
+            return Optional.empty();
+        }
+    }
+
+    private static String unquote(String value) {
+        if (value.length() >= 2
+                && (value.startsWith("\"") && value.endsWith("\"")
+                || value.startsWith("'") && value.endsWith("'"))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     public static boolean isWhonix() {

--- a/common/src/main/java/bisq/common/platform/PlatformUtils.java
+++ b/common/src/main/java/bisq/common/platform/PlatformUtils.java
@@ -47,6 +47,16 @@ public class PlatformUtils {
         }
 
         // *nix
+        // Tails runs the home directory in tmpfs, so the default path is wiped on every reboot.
+        // Persistent Storage is mounted at ~/Persistent, but only once the user unlocked it at boot.
+        // While it is locked we stay on the default path and let TailsPersistenceGuard report the risk.
+        if (LinuxDistribution.isTails()) {
+            Path persistentStoragePath = Paths.get(System.getProperty("user.home"), "Persistent");
+            if (Files.isDirectory(persistentStoragePath)) {
+                return persistentStoragePath;
+            }
+        }
+
         return Paths.get(System.getProperty("user.home"), ".local", "share");
     }
 

--- a/common/src/main/java/bisq/common/platform/TailsPersistenceGuard.java
+++ b/common/src/main/java/bisq/common/platform/TailsPersistenceGuard.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.platform;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tails runs amnesically: anything not stored on the unlocked Persistent Storage volume is lost on
+ * shutdown. If Bisq's data directory is not backed by that volume the user would silently lose their
+ * identity keys and open offers (dead offers, more mediation). This guard detects that situation so
+ * the caller can warn and abort before any data is written.
+ */
+@Slf4j
+public class TailsPersistenceGuard {
+    // The persistent volume is unlocked to this mountpoint; persistent directories (e.g.
+    // /home/amnesia/Persistent) are bind-mounted from it, so /proc/mounts references it as the source.
+    private static final String PERSISTENCE_MOUNT = "/live/persistence/TailsData_unlocked";
+    private static final String PERSISTENCE_DEVICE_MARKER = "TailsData_unlocked";
+
+    /**
+     * @return true only when running on Tails AND the given data directory is NOT backed by the
+     * unlocked Persistent Storage volume. Returns false on every non-Tails system.
+     */
+    public static boolean isDataDirAmnesic(Path dataDirPath) {
+        if (!LinuxDistribution.isTails()) {
+            return false;
+        }
+        return !isOnPersistentStorage(dataDirPath);
+    }
+
+    private static boolean isOnPersistentStorage(Path dataDirPath) {
+        Path realPath = toRealPath(dataDirPath);
+
+        // Fast path: the resolved path lives directly under the unlocked volume.
+        if (realPath.startsWith(PERSISTENCE_MOUNT)) {
+            return true;
+        }
+
+        // Tails bind-mounts persistent directories elsewhere (e.g. /home/amnesia/Persistent), so
+        // consult /proc/mounts: find the mount that backs the data dir and check it is the persistent
+        // volume rather than an amnesic tmpfs/overlay.
+        return findBackingMount(realPath)
+                .map(TailsPersistenceGuard::isPersistentMount)
+                .orElse(false);
+    }
+
+    private static boolean isPersistentMount(MountEntry mount) {
+        return mount.source().contains(PERSISTENCE_DEVICE_MARKER)
+                || mount.mountPoint().startsWith(PERSISTENCE_MOUNT);
+    }
+
+    private static Optional<MountEntry> findBackingMount(Path realPath) {
+        Path mountsPath = Paths.get("/proc/mounts");
+        if (!Files.isRegularFile(mountsPath)) {
+            return Optional.empty();
+        }
+
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(mountsPath);
+        } catch (IOException e) {
+            log.warn("Could not read /proc/mounts", e);
+            return Optional.empty();
+        }
+
+        MountEntry best = null;
+        int bestLength = -1;
+        for (String line : lines) {
+            String[] fields = line.split(" ");
+            if (fields.length < 3) {
+                continue;
+            }
+            String source = unescapeMount(fields[0]);
+            Path mountPoint = Paths.get(unescapeMount(fields[1]));
+            // Longest matching mountpoint prefix is the filesystem actually backing the path.
+            if (realPath.startsWith(mountPoint)) {
+                int length = mountPoint.toString().length();
+                if (length > bestLength) {
+                    bestLength = length;
+                    best = new MountEntry(source, mountPoint.toString());
+                }
+            }
+        }
+        return Optional.ofNullable(best);
+    }
+
+    private static Path toRealPath(Path dataDirPath) {
+        try {
+            return dataDirPath.toRealPath();
+        } catch (IOException e) {
+            log.debug("Could not resolve real path of {}, using normalized absolute path", dataDirPath, e);
+            return dataDirPath.toAbsolutePath().normalize();
+        }
+    }
+
+    // /proc/mounts escapes spaces, tabs, newlines and backslashes as octal sequences.
+    private static String unescapeMount(String field) {
+        return field.replace("\\040", " ")
+                .replace("\\011", "\t")
+                .replace("\\012", "\n")
+                .replace("\\134", "\\");
+    }
+
+    private record MountEntry(String source, String mountPoint) {
+    }
+}

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -187,6 +187,22 @@ public class StringUtils {
         return Optional.ofNullable(toNullIfEmpty(value));
     }
 
+    public static String unquote(String value) {
+        if (value.length() < 2) {
+            return value;
+        }
+
+        int lastIndex = value.length() - 1;
+        char firstChar = value.charAt(0);
+        char lastChar = value.charAt(lastIndex);
+        boolean isDoubleQuoted = firstChar == '"' && lastChar == '"';
+        boolean isSingleQuoted = firstChar == '\'' && lastChar == '\'';
+        if (isDoubleQuoted || isSingleQuoted) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
     public static String snakeCaseToCamelCase(String value, Locale locale) {
         return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, value.toLowerCase(locale));
     }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -184,6 +184,22 @@ public class StringUtils {
         return Optional.ofNullable(toNullIfEmpty(value));
     }
 
+    public static String unquote(String value) {
+        if (value.length() < 2) {
+            return value;
+        }
+
+        int lastIndex = value.length() - 1;
+        char firstChar = value.charAt(0);
+        char lastChar = value.charAt(lastIndex);
+        boolean isDoubleQuoted = firstChar == '"' && lastChar == '"';
+        boolean isSingleQuoted = firstChar == '\'' && lastChar == '\'';
+        if (isDoubleQuoted || isSingleQuoted) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
     public static String snakeCaseToCamelCase(String value, Locale locale) {
         return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, value.toLowerCase(locale));
     }

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -185,6 +185,22 @@ public class StringUtils {
         return Optional.ofNullable(toNullIfEmpty(value));
     }
 
+    public static String unquote(String value) {
+        if (value.length() < 2) {
+            return value;
+        }
+
+        int lastIndex = value.length() - 1;
+        char firstChar = value.charAt(0);
+        char lastChar = value.charAt(lastIndex);
+        boolean isDoubleQuoted = firstChar == '"' && lastChar == '"';
+        boolean isSingleQuoted = firstChar == '\'' && lastChar == '\'';
+        if (isDoubleQuoted || isSingleQuoted) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
     public static String snakeCaseToCamelCase(String value, Locale locale) {
         return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, value.toLowerCase(locale));
     }

--- a/common/src/test/java/bisq/common/application/ConfigUtilTest.java
+++ b/common/src/test/java/bisq/common/application/ConfigUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.application;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigUtilTest {
+    @Test
+    void parseBooleanFlagSupportsExpectedTruthValues() {
+        assertThat(ConfigUtil.parseBooleanFlag("1")).isTrue();
+        assertThat(ConfigUtil.parseBooleanFlag("true")).isTrue();
+        assertThat(ConfigUtil.parseBooleanFlag("TRUE")).isTrue();
+        assertThat(ConfigUtil.parseBooleanFlag("yes")).isTrue();
+        assertThat(ConfigUtil.parseBooleanFlag("  yes  ")).isTrue();
+
+        assertThat(ConfigUtil.parseBooleanFlag("0")).isFalse();
+        assertThat(ConfigUtil.parseBooleanFlag("false")).isFalse();
+        assertThat(ConfigUtil.parseBooleanFlag("no")).isFalse();
+        assertThat(ConfigUtil.parseBooleanFlag(null)).isFalse();
+    }
+}

--- a/common/src/test/java/bisq/common/util/StringUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/StringUtilsTest.java
@@ -165,4 +165,16 @@ public class StringUtilsTest {
         String expected = "user@example.com";
         assertEquals(expected, StringUtils.cleanUserInput(input));
     }
+
+    @Test
+    void testUnquoteReturnsUnquotedValue() {
+        assertEquals("value", StringUtils.unquote("\"value\""));
+        assertEquals("value", StringUtils.unquote("'value'"));
+    }
+
+    @Test
+    void testUnquoteLeavesNonMatchingQuotesUntouched() {
+        assertEquals("value", StringUtils.unquote("value"));
+        assertEquals("\"value'", StringUtils.unquote("\"value'"));
+    }
 }

--- a/common/src/test/java/bisq/common/util/StringUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/StringUtilsTest.java
@@ -160,4 +160,16 @@ public class StringUtilsTest {
         assertEquals("x?WARN forged?line reversed?text?bell?zwsp", StringUtils.sanitizeForLog(injected));
         assertEquals("", StringUtils.sanitizeForLog(null));
     }
+
+    @Test
+    void testUnquoteReturnsUnquotedValue() {
+        assertEquals("value", StringUtils.unquote("\"value\""));
+        assertEquals("value", StringUtils.unquote("'value'"));
+    }
+
+    @Test
+    void testUnquoteLeavesNonMatchingQuotesUntouched() {
+        assertEquals("value", StringUtils.unquote("value"));
+        assertEquals("\"value'", StringUtils.unquote("\"value'"));
+    }
 }

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -374,6 +374,11 @@ popup.startup.error=An error occurred at initializing Bisq: {0}.
 popup.shutdown=Shut down is in process.\n\n\
   It might take up to {0} seconds until shut down is completed.
 popup.shutdown.error=An error occurred at shut down: {0}.
+popup.tails.noPersistentStorage.warning=Bisq is running on Tails, but its data directory is not on the Persistent Storage volume.\n\n\
+  Tails forgets everything on shutdown, so your identity keys and open offers would be lost, leaving dead offers and increasing mediation.\n\n\
+  Enable Tails Persistent Storage (with the Dotfiles feature) so Bisq stores its data there, then restart Bisq.\n\n\
+  If you continue anyway, all Bisq data will be lost when you shut down.
+popup.tails.noPersistentStorage.continue=Continue anyway (data will be lost)
 popup.hyperlink.openInBrowser.tooltip=Open link in browser: {0}.
 popup.hyperlink.copy.tooltip=Copy link: {0}.
 

--- a/network/network/src/main/resources/tor/external_tor.config
+++ b/network/network/src/main/resources/tor/external_tor.config
@@ -2,6 +2,7 @@
 
 ## This configuration follows the torrc format but only supports the options listed below.
 ## Ensure the torrc file of the external Tor process is configured accordingly.
+## Bisq will prefer ControlSocket when both ControlSocket and ControlPort are configured.
 
 ## If UseExternalTor is set to '1' Bisq use the external Tor process.
 #UseExternalTor 1
@@ -13,8 +14,13 @@ CookieAuthentication 0
 ## Example: /opt/homebrew/etc/tor/control_auth_cookie
 CookieAuthFile /path/to/control_auth_cookie
 
+## ControlSocket specifies the path to the Tor control socket.
+## Use this on systems where Tor exposes a Unix-domain control socket.
+## ControlSocket /path/to/tor/control.socket
+
 ## ControlPort specifies the address for the Tor control port.
 ## This must match the configuration in the external Tor process's torrc file.
+## When both ControlSocket and ControlPort are configured, Bisq prefers ControlSocket.
 ## By default, this is:
 ControlPort 127.0.0.1:9051
 

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/BaseTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/BaseTorrcGenerator.java
@@ -20,11 +20,16 @@ package bisq.network.tor.common.torrc;
 import lombok.Builder;
 
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static bisq.network.tor.common.torrc.Torrc.Keys.*;
-import static bisq.network.tor.common.torrc.Torrc.Values.EmbeddedTor.*;
+import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_PORT;
+import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_PORT_WRITE_TO_FILE;
+import static bisq.network.tor.common.torrc.Torrc.Keys.DATA_DIRECTORY;
+import static bisq.network.tor.common.torrc.Torrc.Keys.HASHED_CONTROL_PASSWORD;
+import static bisq.network.tor.common.torrc.Torrc.Keys.SOCKS_PORT;
+import static bisq.network.tor.common.torrc.Torrc.Values.EmbeddedTor.CONTROL_PORT_AUTO;
+import static bisq.network.tor.common.torrc.Torrc.Values.EmbeddedTor.SOCKS_PORT_DISABLED;
 
 public class BaseTorrcGenerator implements TorrcConfigGenerator {
     public static final String CONTROL_DIR_NAME = "control";
@@ -44,7 +49,7 @@ public class BaseTorrcGenerator implements TorrcConfigGenerator {
 
     @Override
     public Map<String, String> generate() {
-        Map<String, String> torConfigMap = new HashMap<>();
+        Map<String, String> torConfigMap = new LinkedHashMap<>();
         torConfigMap.put(DATA_DIRECTORY, dataDirPath.toAbsolutePath().toString());
 
         torConfigMap.put(CONTROL_PORT, CONTROL_PORT_AUTO);

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/BaseTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/BaseTorrcGenerator.java
@@ -21,6 +21,7 @@ import lombok.Builder;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_PORT;
@@ -48,20 +49,20 @@ public class BaseTorrcGenerator implements TorrcConfigGenerator {
     }
 
     @Override
-    public Map<String, String> generate() {
-        Map<String, String> torConfigMap = new LinkedHashMap<>();
-        torConfigMap.put(DATA_DIRECTORY, dataDirPath.toAbsolutePath().toString());
+    public Map<String, List<String>> generate() {
+        Map<String, List<String>> torConfigMap = new LinkedHashMap<>();
+        torConfigMap.put(DATA_DIRECTORY, List.of(dataDirPath.toAbsolutePath().toString()));
 
-        torConfigMap.put(CONTROL_PORT, CONTROL_PORT_AUTO);
-        torConfigMap.put(CONTROL_PORT_WRITE_TO_FILE, controlPortWriteFilePath.toAbsolutePath().toString());
-        torConfigMap.put(HASHED_CONTROL_PASSWORD, hashedControlPassword);
+        torConfigMap.put(CONTROL_PORT, List.of(CONTROL_PORT_AUTO));
+        torConfigMap.put(CONTROL_PORT_WRITE_TO_FILE, List.of(controlPortWriteFilePath.toAbsolutePath().toString()));
+        torConfigMap.put(HASHED_CONTROL_PASSWORD, List.of(hashedControlPassword));
 
         String logLevel = isTestNetwork ? "debug" : "notice";
         torConfigMap.put("Log",
-                logLevel + " file " + dataDirPath.resolve("debug.log").toAbsolutePath()
+                List.of(logLevel + " file " + dataDirPath.resolve("debug.log").toAbsolutePath())
         );
 
-        torConfigMap.put(SOCKS_PORT, SOCKS_PORT_DISABLED);
+        torConfigMap.put(SOCKS_PORT, List.of(SOCKS_PORT_DISABLED));
         return torConfigMap;
     }
 }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/ClientTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/ClientTorrcGenerator.java
@@ -19,6 +19,7 @@ package bisq.network.tor.common.torrc;
 
 import lombok.Builder;
 
+import java.util.List;
 import java.util.Map;
 
 import static bisq.network.tor.common.torrc.Torrc.Keys.SOCKS_PORT;
@@ -33,9 +34,9 @@ public class ClientTorrcGenerator implements TorrcConfigGenerator {
     }
 
     @Override
-    public Map<String, String> generate() {
-        Map<String, String> torConfigMap = baseTorrcConfigGenerator.generate();
-        torConfigMap.put(SOCKS_PORT,  SOCKS_PORT_AUTO);
+    public Map<String, List<String>> generate() {
+        Map<String, List<String>> torConfigMap = baseTorrcConfigGenerator.generate();
+        torConfigMap.put(SOCKS_PORT, List.of(SOCKS_PORT_AUTO));
         return torConfigMap;
     }
 }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/DirectoryAuthorityTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/DirectoryAuthorityTorrcGenerator.java
@@ -17,6 +17,7 @@
 
 package bisq.network.tor.common.torrc;
 
+import java.util.List;
 import java.util.Map;
 
 public class DirectoryAuthorityTorrcGenerator implements TorrcConfigGenerator {
@@ -29,24 +30,24 @@ public class DirectoryAuthorityTorrcGenerator implements TorrcConfigGenerator {
     }
 
     @Override
-    public Map<String, String> generate() {
-        Map<String, String> torConfigMap = baseTorrcConfigGenerator.generate();
+    public Map<String, List<String>> generate() {
+        Map<String, List<String>> torConfigMap = baseTorrcConfigGenerator.generate();
 
-        torConfigMap.put("AuthoritativeDirectory", "1");
-        torConfigMap.put("V3AuthoritativeDirectory", "1");
-        torConfigMap.put("ContactInfo", "auth-" + nickname + "@test.test\n");
+        torConfigMap.put("AuthoritativeDirectory", List.of("1"));
+        torConfigMap.put("V3AuthoritativeDirectory", List.of("1"));
+        torConfigMap.put("ContactInfo", List.of("auth-" + nickname + "@test.test\n"));
 
-        torConfigMap.put("AssumeReachable", "1");
-        torConfigMap.put("TestingV3AuthInitialVotingInterval", "20");
+        torConfigMap.put("AssumeReachable", List.of("1"));
+        torConfigMap.put("TestingV3AuthInitialVotingInterval", List.of("20"));
 
-        torConfigMap.put("TestingV3AuthInitialVoteDelay", "4");
-        torConfigMap.put("TestingV3AuthInitialDistDelay", "4");
+        torConfigMap.put("TestingV3AuthInitialVoteDelay", List.of("4"));
+        torConfigMap.put("TestingV3AuthInitialDistDelay", List.of("4"));
 
-        torConfigMap.put("V3AuthVotingInterval", "20");
-        torConfigMap.put("V3AuthVoteDelay", "4");
-        torConfigMap.put("V3AuthDistDelay", "4");
+        torConfigMap.put("V3AuthVotingInterval", List.of("20"));
+        torConfigMap.put("V3AuthVoteDelay", List.of("4"));
+        torConfigMap.put("V3AuthDistDelay", List.of("4"));
 
-        torConfigMap.put("ExitPolicy", "accept *:*");
+        torConfigMap.put("ExitPolicy", List.of("accept *:*"));
 
         return torConfigMap;
     }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/RelayTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/RelayTorrcGenerator.java
@@ -17,6 +17,7 @@
 
 package bisq.network.tor.common.torrc;
 
+import java.util.List;
 import java.util.Map;
 
 public class RelayTorrcGenerator implements TorrcConfigGenerator {
@@ -27,12 +28,12 @@ public class RelayTorrcGenerator implements TorrcConfigGenerator {
     }
 
     @Override
-    public Map<String, String> generate() {
-        Map<String, String> torConfigMap = baseTorrcConfigGenerator.generate();
+    public Map<String, List<String>> generate() {
+        Map<String, List<String>> torConfigMap = baseTorrcConfigGenerator.generate();
 
-        torConfigMap.put("ExitRelay", "1");
-        torConfigMap.put("ExitPolicy", "accept 127.0.0.0/8:*,accept private:*,accept *:*,reject *:*");
-        torConfigMap.put("ExitPolicyRejectPrivate", "0");
+        torConfigMap.put("ExitRelay", List.of("1"));
+        torConfigMap.put("ExitPolicy", List.of("accept 127.0.0.0/8:*,accept private:*,accept *:*,reject *:*"));
+        torConfigMap.put("ExitPolicyRejectPrivate", List.of("0"));
 
         return torConfigMap;
     }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TestNetworkTorrcGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TestNetworkTorrcGenerator.java
@@ -19,6 +19,7 @@ package bisq.network.tor.common.torrc;
 
 import lombok.Builder;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,33 +41,33 @@ public class TestNetworkTorrcGenerator implements TorrcConfigGenerator {
     private final Optional<Integer> dirPort = Optional.empty();
 
     @Override
-    public Map<String, String> generate() {
-        Map<String, String> torConfigMap = baseTorrcConfigGenerator.generate();
+    public Map<String, List<String>> generate() {
+        Map<String, List<String>> torConfigMap = baseTorrcConfigGenerator.generate();
 
-        torConfigMap.put("TestingTorNetwork", "1");
-        torConfigMap.put("TestingDirAuthVoteExit", "*");
-        torConfigMap.put("TestingDirAuthVoteHSDir", "*");
+        torConfigMap.put("TestingTorNetwork", List.of("1"));
+        torConfigMap.put("TestingDirAuthVoteExit", List.of("*"));
+        torConfigMap.put("TestingDirAuthVoteHSDir", List.of("*"));
 
-        torConfigMap.put("V3AuthNIntervalsValid", "2");
-        torConfigMap.put("TestingDirAuthVoteGuard", "*");
-        torConfigMap.put("TestingMinExitFlagThreshold", "0");
+        torConfigMap.put("V3AuthNIntervalsValid", List.of("2"));
+        torConfigMap.put("TestingDirAuthVoteGuard", List.of("*"));
+        torConfigMap.put("TestingMinExitFlagThreshold", List.of("0"));
 
 
-        nickname.ifPresent(nickname -> torConfigMap.put("Nickname", nickname));
-        torConfigMap.put("ShutdownWaitLength", "2");
-        torConfigMap.put("DisableDebuggerAttachment", "0");
+        nickname.ifPresent(nickname -> torConfigMap.put("Nickname", List.of(nickname)));
+        torConfigMap.put("ShutdownWaitLength", List.of("2"));
+        torConfigMap.put("DisableDebuggerAttachment", List.of("0"));
 
-        torConfigMap.put("ProtocolWarnings", "1");
-        torConfigMap.put("SafeLogging", "0");
-        torConfigMap.put("LogTimeGranularity", "1");
+        torConfigMap.put("ProtocolWarnings", List.of("1"));
+        torConfigMap.put("SafeLogging", List.of("0"));
+        torConfigMap.put("LogTimeGranularity", List.of("1"));
 
-        orPort.ifPresent(orPort -> torConfigMap.put("OrPort", String.valueOf(orPort)));
-        torConfigMap.put("Address", "127.0.0.1");
-        torConfigMap.put("ServerDNSDetectHijacking", "0");
+        orPort.ifPresent(orPort -> torConfigMap.put("OrPort", List.of(String.valueOf(orPort))));
+        torConfigMap.put("Address", List.of("127.0.0.1"));
+        torConfigMap.put("ServerDNSDetectHijacking", List.of("0"));
 
-        torConfigMap.put("ServerDNSTestAddresses", "");
+        torConfigMap.put("ServerDNSTestAddresses", List.of(""));
 
-        dirPort.ifPresent(dirPort -> torConfigMap.put("DirPort", String.valueOf(dirPort)));
+        dirPort.ifPresent(dirPort -> torConfigMap.put("DirPort", List.of(String.valueOf(dirPort))));
 
         return torConfigMap;
     }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/Torrc.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/Torrc.java
@@ -21,6 +21,7 @@ package bisq.network.tor.common.torrc;
 public class Torrc {
     public static class Keys {
         public static final String CONTROL_PORT = "ControlPort";
+        public static final String CONTROL_SOCKET = "ControlSocket";
         public static final String SOCKS_PORT = "SocksPort";
         public static final String DISABLE_NETWORK = "DisableNetwork";
         public static final String COOKIE_AUTHENTICATION = "CookieAuthentication";

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcConfigGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcConfigGenerator.java
@@ -17,8 +17,9 @@
 
 package bisq.network.tor.common.torrc;
 
+import java.util.List;
 import java.util.Map;
 
 public interface TorrcConfigGenerator {
-    Map<String, String> generate();
+    Map<String, List<String>> generate();
 }

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
@@ -21,29 +21,41 @@ import bisq.common.file.FileMutatorUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class TorrcFileGenerator {
     private final Path torrcPath;
-    private final Map<String, String> torrcConfigMap;
+    private final List<String> torrcConfigLines;
     private final Set<DirectoryAuthority> customDirectoryAuthorities;
 
     public TorrcFileGenerator(Path torrcPath,
-                              Map<String, String> torrcConfigMap,
+                              List<String> torrcConfigLines,
                               Set<DirectoryAuthority> customDirectoryAuthorities) {
         this.torrcPath = torrcPath;
-        this.torrcConfigMap = torrcConfigMap;
+        this.torrcConfigLines = torrcConfigLines;
         this.customDirectoryAuthorities = customDirectoryAuthorities;
+    }
+
+    // Constructor to keep the change to List<String> smaller in scope
+    public TorrcFileGenerator(Path torrcPath,
+                              Map<String, String> torrcConfigMap,
+                              Set<DirectoryAuthority> customDirectoryAuthorities) {
+        this(torrcPath, mapToLines(torrcConfigMap), customDirectoryAuthorities);
+    }
+
+    private static List<String> mapToLines(Map<String, String> map) {
+        List<String> lines = new ArrayList<>();
+        map.forEach((key, value) -> lines.add(key + " " + value));
+        return lines;
     }
 
     public void generate() {
         StringBuilder torrcStringBuilder = new StringBuilder();
-        torrcConfigMap.forEach((key, value) ->
-                torrcStringBuilder.append(key)
-                        .append(" ")
-                        .append(value)
-                        .append("\n")
+        torrcConfigLines.forEach(line ->
+                torrcStringBuilder.append(line).append("\n")
         );
 
         customDirectoryAuthorities.forEach(dirAuthority ->

--- a/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
+++ b/network/tor/tor-common/src/main/java/bisq/network/tor/common/torrc/TorrcFileGenerator.java
@@ -21,42 +21,35 @@ import bisq.common.file.FileMutatorUtils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class TorrcFileGenerator {
     private final Path torrcPath;
-    private final List<String> torrcConfigLines;
+    private final Map<String, List<String>> torrcConfigMap;
     private final Set<DirectoryAuthority> customDirectoryAuthorities;
 
     public TorrcFileGenerator(Path torrcPath,
-                              List<String> torrcConfigLines,
+                              Map<String, List<String>> torrcConfigMap,
                               Set<DirectoryAuthority> customDirectoryAuthorities) {
         this.torrcPath = torrcPath;
-        this.torrcConfigLines = torrcConfigLines;
+        this.torrcConfigMap = torrcConfigMap;
         this.customDirectoryAuthorities = customDirectoryAuthorities;
-    }
-
-    // Constructor to keep the change to List<String> smaller in scope
-    public TorrcFileGenerator(Path torrcPath,
-                              Map<String, String> torrcConfigMap,
-                              Set<DirectoryAuthority> customDirectoryAuthorities) {
-        this(torrcPath, mapToLines(torrcConfigMap), customDirectoryAuthorities);
-    }
-
-    private static List<String> mapToLines(Map<String, String> map) {
-        List<String> lines = new ArrayList<>();
-        map.forEach((key, value) -> lines.add(key + " " + value));
-        return lines;
     }
 
     public void generate() {
         StringBuilder torrcStringBuilder = new StringBuilder();
-        torrcConfigLines.forEach(line ->
-                torrcStringBuilder.append(line).append("\n")
-        );
+
+        for (Map.Entry<String, List<String>> entry : torrcConfigMap.entrySet()) {
+            String key = entry.getKey();
+            for (String value : entry.getValue()) {
+                torrcStringBuilder.append(key)
+                        .append(" ")
+                        .append(value)
+                        .append("\n");
+            }
+        }
 
         customDirectoryAuthorities.forEach(dirAuthority ->
                 torrcStringBuilder.append("DirAuthority ").append(dirAuthority.getNickname())

--- a/network/tor/tor-local-network/src/integrationTest/java/bisq/network/tor/local_network/DirectoryAuthorityTests.java
+++ b/network/tor/tor-local-network/src/integrationTest/java/bisq/network/tor/local_network/DirectoryAuthorityTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -89,7 +90,7 @@ public class DirectoryAuthorityTests {
         Set<TorNode> allDAs = dirAuthFactory.getAllDirectoryAuthorities();
         for (TorNode da : allDAs) {
             TorrcConfigGenerator torDaTorrcGenerator = TestNetworkTorrcGeneratorFactory.directoryTorrcGenerator(da);
-            Map<String, String> torrcConfigs = torDaTorrcGenerator.generate();
+            Map<String, List<String>> torrcConfigs = torDaTorrcGenerator.generate();
 
             Path torrcPath = da.getTorrcPath();
             Set<DirectoryAuthority> directoryAuthorities = allDAs.stream()

--- a/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/TorNetwork.java
+++ b/network/tor/tor-local-network/src/main/java/bisq/network/tor/local_network/TorNetwork.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -133,19 +134,19 @@ public class TorNetwork {
         Set<TorNode> allDAs = dirAuthFactory.getAllDirectoryAuthorities();
         for (TorNode da : allDAs) {
             TorrcConfigGenerator torDaTorrcGenerator = TestNetworkTorrcGeneratorFactory.directoryTorrcGenerator(da);
-            Map<String, String> torrcConfigs = torDaTorrcGenerator.generate();
+            Map<String, List<String>> torrcConfigs = torDaTorrcGenerator.generate();
             generateTorrc(da, torrcConfigs, allDAs);
         }
 
         for (TorNode relay : relays) {
             TorrcConfigGenerator relayTorrcGenerator = TestNetworkTorrcGeneratorFactory.relayTorrcGenerator(relay);
-            Map<String, String> torrcConfigs = relayTorrcGenerator.generate();
+            Map<String, List<String>> torrcConfigs = relayTorrcGenerator.generate();
             generateTorrc(relay, torrcConfigs, allDAs);
         }
 
         for (TorNode client : clients) {
             TorrcConfigGenerator clientTorrcGenerator = TestNetworkTorrcGeneratorFactory.clientTorrcGenerator(client);
-            Map<String, String> torrcConfigs = clientTorrcGenerator.generate();
+            Map<String, List<String>> torrcConfigs = clientTorrcGenerator.generate();
             generateTorrc(client, torrcConfigs, allDAs);
         }
     }
@@ -192,7 +193,7 @@ public class TorNetwork {
         return processBuilder.start();
     }
 
-    private void generateTorrc(TorNode torNode, Map<String, String> torrcConfigs, Set<TorNode> allDAs) {
+    private void generateTorrc(TorNode torNode, Map<String, List<String>> torrcConfigs, Set<TorNode> allDAs) {
         if (Files.exists(torNode.getTorrcPath())) {
             return;
         }

--- a/network/tor/tor-local-network/src/test/java/bisq/network/tor/local_network/DirectoryAuthorityTorrcGeneratorTests.java
+++ b/network/tor/tor-local-network/src/test/java/bisq/network/tor/local_network/DirectoryAuthorityTorrcGeneratorTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -87,7 +88,7 @@ public class DirectoryAuthorityTorrcGeneratorTests {
         TorrcConfigGenerator torDaTorrcGenerator = TestNetworkTorrcGeneratorFactory.directoryTorrcGenerator(firstDirAuth);
         var allDirAuthorities = Set.of(firstDirAuth, secondDirAuth);
 
-        Map<String, String> torrcConfigs = torDaTorrcGenerator.generate();
+        Map<String, List<String>> torrcConfigs = torDaTorrcGenerator.generate();
 
         Path torrcPath = firstDirAuth.getTorrcPath();
         Set<DirectoryAuthority> allDAs = allDirAuthorities.stream()

--- a/network/tor/tor-local-network/src/test/java/bisq/network/tor/local_network/RelayTorrcGeneratorTests.java
+++ b/network/tor/tor-local-network/src/test/java/bisq/network/tor/local_network/RelayTorrcGeneratorTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -84,7 +85,7 @@ public class RelayTorrcGeneratorTests {
                 .getRelayKeyFingerprint();
 
         TorrcConfigGenerator relayTorrcGenerator = TestNetworkTorrcGeneratorFactory.relayTorrcGenerator(firstRelay);
-        Map<String, String> torrcConfigs = relayTorrcGenerator.generate();
+        Map<String, List<String>> torrcConfigs = relayTorrcGenerator.generate();
 
         TorNode dirAuth = spy(
                 TorNode.builder()

--- a/network/tor/tor/onion-grater/40_bisq_tails.yml
+++ b/network/tor/tor/onion-grater/40_bisq_tails.yml
@@ -9,6 +9,12 @@
 #### meta end
 
 ---
+# Match the client by the apparmor-profiles selector with Bisq's executable path. Bisq runs
+# unconfined on Tails (/proc/<pid>/attr/current is "unconfined"), and onion-grater matches an
+# unconfined client through this selector by falling back to its executable path — so the value is
+# the launcher path. The newer exe-paths selector is NOT honored by Tails' onion-grater version
+# (verified: with exe-paths the SOCKS GETINFO returned "510 Command filtered" because no profile
+# matched), so apparmor-profiles is the correct selector here.
 - apparmor-profiles:
     - '/opt/bisq2/bin/Bisq2'
   users:

--- a/network/tor/tor/onion-grater/40_bisq_tails.yml
+++ b/network/tor/tor/onion-grater/40_bisq_tails.yml
@@ -2,17 +2,17 @@
 ## See the file COPYING for copying conditions
 
 #### meta start
-#### project Whonix
+#### project Tails
 #### category tor-control
 #### description
 ## Shipped but not enabled by default onion-grater profile.
 #### meta end
 
 ---
-- exe-paths:
-    - '*'
+- apparmor-profiles:
+    - '/opt/bisq2/bin/Bisq2'
   users:
-    - '*'
+    - 'amnesia'
   hosts:
     - '*'
   commands:

--- a/network/tor/tor/src/integrationTest/java/bisq/network/tor/TorServiceTest.java
+++ b/network/tor/tor/src/integrationTest/java/bisq/network/tor/TorServiceTest.java
@@ -23,9 +23,11 @@ import org.junit.jupiter.api.io.TempDir;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.UnixDomainSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,14 +94,12 @@ class TorServiceTest {
         invokeReadExternalTorConfigMap(torService);
 
         Map<String, String> externalTorConfigMap = getExternalTorConfigMap(torService);
-        Method getControlEndpoint = TorService.class.getDeclaredMethod("getControlEndpoint", Map.class);
-        getControlEndpoint.setAccessible(true);
-        Object controlEndpoint = getControlEndpoint.invoke(torService, externalTorConfigMap);
-        assertThat(controlEndpoint.getClass().getSimpleName()).isEqualTo("UnixSocketControlEndpoint");
-        Method controlSocketPathAccessor = controlEndpoint.getClass().getDeclaredMethod("controlSocketPath");
-        controlSocketPathAccessor.setAccessible(true);
+        Method getControlSocketAddress = TorService.class.getDeclaredMethod("getControlSocketAddress", Map.class);
+        getControlSocketAddress.setAccessible(true);
+        Object socketAddress = getControlSocketAddress.invoke(torService, externalTorConfigMap);
 
-        assertThat(controlSocketPathAccessor.invoke(controlEndpoint)).isEqualTo(controlSocketPath);
+        assertThat(socketAddress).isInstanceOf(UnixDomainSocketAddress.class);
+        assertThat(((UnixDomainSocketAddress) socketAddress).getPath()).isEqualTo(controlSocketPath);
         assertThat(externalTorConfigMap.get("CookieAuthFile"))
                 .isEqualTo("'" + tempDir.resolve("control.authcookie") + "'");
     }
@@ -122,7 +122,7 @@ class TorServiceTest {
                 false,
                 Set.of(),
                 Map.of(),
-                "",
+                Optional.empty(),
                 200,
                 200,
                 false
@@ -181,6 +181,9 @@ class TorServiceTest {
     }
 
     private static TorTransportConfig createConfig(Path dataDirPath, String torrcOverrideFilePath) {
+        Optional<Path> overridePath = torrcOverrideFilePath.isBlank()
+                ? Optional.empty()
+                : Optional.of(dataDirPath.resolve(torrcOverrideFilePath));
         return new TorTransportConfig(
                 dataDirPath,
                 -1,
@@ -190,7 +193,7 @@ class TorServiceTest {
                 false,
                 Set.of(),
                 Map.of(),
-                torrcOverrideFilePath,
+                overridePath,
                 200,
                 200,
                 false
@@ -205,7 +208,7 @@ class TorServiceTest {
 
     private static Object invokeGetControlEndpoint(TorService torService,
                                                    Map<String, String> externalTorConfigMap) throws Throwable {
-        Method getControlEndpoint = TorService.class.getDeclaredMethod("getControlEndpoint", Map.class);
+        Method getControlEndpoint = TorService.class.getDeclaredMethod("getControlSocketAddress", Map.class);
         getControlEndpoint.setAccessible(true);
         try {
             return getControlEndpoint.invoke(torService, externalTorConfigMap);

--- a/network/tor/tor/src/integrationTest/java/bisq/network/tor/controller/TorControlProtocolTest.java
+++ b/network/tor/tor/src/integrationTest/java/bisq/network/tor/controller/TorControlProtocolTest.java
@@ -42,7 +42,7 @@ class TorControlProtocolTest {
 
             TorControlProtocol torControlProtocol = new TorControlProtocol();
             try {
-                torControlProtocol.initialize(controlSocketPath);
+                torControlProtocol.initialize(UnixDomainSocketAddress.of(controlSocketPath));
                 torControlProtocol.authenticate(new byte[0]);
 
                 assertThat(commandReceived.await(2, TimeUnit.SECONDS)).isTrue();

--- a/network/tor/tor/src/main/java/bisq/network/tor/ExternalTorConfigHeuristics.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/ExternalTorConfigHeuristics.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import bisq.common.platform.LinuxDistribution;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+final class ExternalTorConfigHeuristics {
+    private static final Path SYSTEM_TOR_CONTROL_SOCKET_PATH = Path.of("/var/run/tor/control");
+    private static final String TAILS_ONION_GRATER_ADDRESS = "127.0.0.1:951";
+    private static final List<Path> SYSTEM_TOR_COOKIE_AUTH_FILE_CANDIDATES = List.of(
+            Path.of("/var/run/tor/control.authcookie"),
+            Path.of("/run/tor/control.authcookie")
+    );
+
+    private ExternalTorConfigHeuristics() {
+    }
+
+    static String apply(String torConfig) {
+        return apply(torConfig, SYSTEM_TOR_CONTROL_SOCKET_PATH, SYSTEM_TOR_COOKIE_AUTH_FILE_CANDIDATES, LinuxDistribution.isTails());
+    }
+
+    static String apply(String torConfig,
+                        Path systemTorControlSocketPath,
+                        List<Path> cookieAuthFileCandidates,
+                        boolean isTails) {
+        boolean controlSocketExists = Files.exists(systemTorControlSocketPath);
+        boolean controlSocketAccessible = controlSocketExists
+                && Files.isReadable(systemTorControlSocketPath)
+                && Files.isWritable(systemTorControlSocketPath);
+
+        Optional<Path> cookieAuthFilePath = cookieAuthFileCandidates.stream()
+                .filter(path -> Files.exists(path) && Files.isReadable(path))
+                .findFirst();
+
+        String configWithDetectedValues = torConfig;
+        String source;
+
+        if (controlSocketAccessible) {
+            configWithDetectedValues = configWithDetectedValues
+                    .replace("## ControlSocket /path/to/tor/control.socket", "ControlSocket " + systemTorControlSocketPath)
+                    .replace("#UseExternalTor 1", "UseExternalTor 1");
+            source = "Detected accessible system Tor control socket at '" + systemTorControlSocketPath + "'";
+        } else if (isTails) {
+            configWithDetectedValues = configWithDetectedValues
+                    .replace("ControlPort 127.0.0.1:9051", "ControlPort " + TAILS_ONION_GRATER_ADDRESS)
+                    .replace("#UseExternalTor 1", "UseExternalTor 1");
+            source = "Tails OS detected, using onion grater at '" + TAILS_ONION_GRATER_ADDRESS + "'";
+        } else {
+            log.debug("No external Tor auto-configured: controlSocket exists={}, accessible={}, isTails={}, " +
+                            "cookieAuthFile present={}. socketPath='{}', cookieAuthCandidates={}",
+                    controlSocketExists, controlSocketAccessible, isTails, cookieAuthFilePath.isPresent(),
+                    systemTorControlSocketPath, cookieAuthFileCandidates);
+            return torConfig;
+        }
+
+        if (cookieAuthFilePath.isPresent()) {
+            configWithDetectedValues = configWithDetectedValues
+                    .replace("CookieAuthentication 0", "CookieAuthentication 1")
+                    .replace("CookieAuthFile /path/to/control_auth_cookie", "CookieAuthFile " + cookieAuthFilePath.get());
+            log.info("{}. Writing external_tor.config with UseExternalTor=1, CookieAuthentication=1 and CookieAuthFile='{}'.",
+                    source, cookieAuthFilePath.get());
+        } else {
+            log.info("{}. Writing external_tor.config with UseExternalTor=1 and leaving CookieAuthentication disabled because no readable auth cookie file was found.",
+                    source);
+        }
+
+        return configWithDetectedValues;
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -18,7 +18,6 @@
 package bisq.network.tor;
 
 import bisq.common.application.Service;
-import bisq.common.data.Pair;
 import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.FileReaderUtils;
@@ -28,8 +27,9 @@ import bisq.common.platform.OS;
 import bisq.common.util.StringUtils;
 import bisq.network.tor.common.torrc.BaseTorrcGenerator;
 import bisq.network.tor.common.torrc.TorrcFileGenerator;
-import bisq.network.tor.controller.TorControlAuthenticationFailed;
+import bisq.network.tor.controller.TorControlConnectionClosedException;
 import bisq.network.tor.controller.TorController;
+import bisq.network.tor.controller.exceptions.CannotConnectWithTorException;
 import bisq.network.tor.controller.events.events.TorBootstrapEvent;
 import bisq.network.tor.installer.TorInstaller;
 import bisq.network.tor.process.EmbeddedTorProcess;
@@ -37,19 +37,20 @@ import bisq.network.tor.process.control_port.ControlPortFileParser;
 import bisq.security.keys.TorKeyPair;
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -57,10 +58,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static bisq.common.threading.ExecutorFactory.commonForkJoinPool;
 import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_PORT;
+import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_SOCKET;
 import static bisq.network.tor.common.torrc.Torrc.Keys.COOKIE_AUTHENTICATION;
 import static bisq.network.tor.common.torrc.Torrc.Keys.COOKIE_AUTH_FILE;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -87,6 +88,7 @@ public class TorService implements Service {
     private Optional<EmbeddedTorProcess> torProcess = Optional.empty();
     private Optional<TorSocksProxyFactory> torSocksProxyFactory = Optional.empty();
     private final Map<String, String> externalTorConfigMap = new HashMap<>();
+    private Optional<Path> activeExternalTorConfigPath = Optional.empty();
 
     public TorService(TorTransportConfig transportConfig) {
         this.transportConfig = transportConfig;
@@ -111,13 +113,10 @@ public class TorService implements Service {
             if (connectedToExternalTor(externalTorConfigMap)) {
                 log.info("External Tor will be used");
                 return CompletableFuture.completedFuture(true);
-            } else if (LinuxDistribution.isWhonix()) {
-                // In case we failed at connectedToExternalTor, we do not start the embedded Tor as fallback if we are on Whonix.
-                throw new RuntimeException("Bisq runs on a Whonix system but it could not connect to the Whonix system Tor. " +
-                        "Please check the Bisq external_tor.config and the system Tor torrc config.");
             } else {
-                // In case connectedToExternalTor failed we try embedded Tor (if not running on Whonix)
-                useExternalTor.set(false);
+                isRunning.set(false);
+                throw new RuntimeException("`useExternalTor` is enabled, but Bisq could not connect to the external Tor control " +
+                        "server. Please check " + getExternalTorConfigDescription() + " and your system Tor configuration.");
             }
         }
 
@@ -141,7 +140,7 @@ public class TorService implements Service {
         torController = new TorController(transportConfig.getBootstrapTimeout(), transportConfig.getHsUploadTimeout(), bootstrapEvent);
 
         PasswordDigest hashedControlPassword = PasswordDigest.generateDigest();
-        Map<String, String> torrcConfigMap = createTorrcConfigFile(torDataDirPath, hashedControlPassword);
+        createTorrcConfigFile(torDataDirPath, hashedControlPassword);
 
         // remove the control port file before we launch tor, just in case it exists from
         // a previous run
@@ -187,29 +186,24 @@ public class TorService implements Service {
     }
 
     private boolean evaluateUseExternalTor() {
-        boolean useExternalTor = false;
-        if (LinuxDistribution.isWhonix()) {
-            log.info("Bisq runs on a Whonix system and use the Whonix system Tor");
-            return true;
-        } else {
-            // If environment variable is set we take that.
-            String torSkipLaunch = System.getenv(TOR_SKIP_LAUNCH);
-            if (StringUtils.isNotEmpty(torSkipLaunch)) {
-                log.info("Environment variable 'TOR_SKIP_LAUNCH' is set to '{}'", torSkipLaunch);
-                return torSkipLaunch.equals("1") ||
-                        torSkipLaunch.equalsIgnoreCase("true") ||
-                        torSkipLaunch.equalsIgnoreCase("yes");
-            } else {
-                // We check if external_tor.config value is set. If so we use that value
-                Optional<String> externalTorFromConfigMap = Optional.ofNullable(externalTorConfigMap.get("UseExternalTor"));
-                if (externalTorFromConfigMap.isPresent()) {
-                    return externalTorFromConfigMap.get().equals("1");
-                } else {
-                    // Last we take the value form the JVM config
-                    return transportConfig.isUseExternalTor();
-                }
-            }
+        boolean isWhonixOrTails = LinuxDistribution.isWhonix() || LinuxDistribution.isTails();
+        String torSkipLaunch = System.getenv(TOR_SKIP_LAUNCH);
+        String useExternalTorFromConfig = externalTorConfigMap.get("UseExternalTor");
+        boolean useExternalTorFromJvmConfig = transportConfig.isUseExternalTor();
+
+        boolean useExternalTor = UseExternalTorResolver.evaluateUseExternalTorValue(
+                isWhonixOrTails,
+                torSkipLaunch,
+                useExternalTorFromJvmConfig,
+                useExternalTorFromConfig);
+
+        if (isWhonixOrTails) {
+            log.info("Bisq runs on a Whonix/Tails system and use the system Tor");
+        } else if (StringUtils.isNotEmpty(torSkipLaunch)) {
+            log.info("Environment variable 'TOR_SKIP_LAUNCH' is set to '{}'", torSkipLaunch);
         }
+
+        return useExternalTor;
     }
 
     @Override
@@ -225,6 +219,7 @@ public class TorService implements Service {
             torSocksProxyFactory = Optional.empty();
             publishedOnionServices.clear();
             externalTorConfigMap.clear();
+            activeExternalTorConfigPath = Optional.empty();
             return true;
         }, commonForkJoinPool());
     }
@@ -294,20 +289,24 @@ public class TorService implements Service {
     }
 
     private boolean connectedToExternalTor(Map<String, String> torConfigMap) {
-        Pair<String, Integer> controlHostAndPort = getControlHostAndPort(torConfigMap);
-        String controlHost = controlHostAndPort.getFirst();
-        int controlPort = controlHostAndPort.getSecond();
-        if (!isTorControlAvailable(controlHost, controlPort)) {
-            log.warn("Couldn't connect to external Tor control server. " +
-                    "This could happen if the control port is not correctly set up in 'external_tor.config' file.");
-            return false;
-        }
+        ControlEndpoint controlEndpoint = getControlEndpoint(torConfigMap);
 
         if (torController != null) {
             torController.shutdown();
         }
         torController = new TorController(transportConfig.getBootstrapTimeout(), transportConfig.getHsUploadTimeout(), bootstrapEvent);
-        torController.initialize(controlPort);
+        try {
+            if (controlEndpoint instanceof UnixSocketControlEndpoint socketControlEndpoint) {
+                torController.initialize(socketControlEndpoint.controlSocketPath());
+            } else if (controlEndpoint instanceof TcpControlEndpoint tcpControlEndpoint) {
+                torController.initialize(tcpControlEndpoint.controlHost(), tcpControlEndpoint.controlPort());
+            }
+        } catch (CannotConnectWithTorException e) {
+            log.warn("Could not connect to external Tor control endpoint.", e);
+            torController.shutdown();
+            torController = null;
+            return false;
+        }
 
         boolean isAuthenticated = false;
         boolean noCookieAuthenticationRequired = Optional.ofNullable(torConfigMap.get(COOKIE_AUTHENTICATION)).orElse("0").equals("0");
@@ -317,23 +316,26 @@ public class TorService implements Service {
             try {
                 torController.authenticate();
                 isAuthenticated = true;
-            } catch (TorControlAuthenticationFailed e) {
-                log.warn("Authentication to Tor Control failed.");
+            } catch (Exception e) {
+                log.warn("Authentication to Tor Control failed.", e);
                 return false;
             }
         }
 
         if (!isAuthenticated) {
             if (torConfigMap.containsKey(COOKIE_AUTH_FILE)) {
-                String authCookiePath = torConfigMap.get(COOKIE_AUTH_FILE);
+                String authCookiePath = StringUtils.unquote(torConfigMap.get(COOKIE_AUTH_FILE));
                 try {
                     byte[] authCookie = Files.readAllBytes(Paths.get(authCookiePath));
                     torController.authenticate(authCookie);
                     isAuthenticated = true;
-                } catch (TorControlAuthenticationFailed e) {
-                    log.warn("Authentication with authCookie failed.");
                 } catch (IOException e) {
                     log.warn("Couldn't read the COOKIE_AUTH_FILE '{}' from the config.", authCookiePath);
+                } catch (TorControlConnectionClosedException e) {
+                    log.warn("Tor control connection was closed unexpectedly when trying to authenticate.", e);
+                    return false; // since pipe is broken
+                } catch (Exception e) {
+                    log.warn("Authentication to Tor Control failed.", e);
                 }
             } else {
                 log.warn("The user did not provide the path to the COOKIE_AUTH_FILE.");
@@ -344,8 +346,8 @@ public class TorService implements Service {
             log.info("We try to call authenticate without parameters for the case that authentication is not required.");
             try {
                 torController.authenticate();
-            } catch (TorControlAuthenticationFailed ex) {
-                log.warn("Authentication to Tor Control failed.");
+            } catch (Exception e) {
+                log.warn("Authentication to Tor Control failed.", e);
                 return false;
             }
         }
@@ -360,8 +362,16 @@ public class TorService implements Service {
         return true;
     }
 
-    private Pair<String, Integer> getControlHostAndPort(Map<String, String> externalTorConfigMap) {
+    private ControlEndpoint getControlEndpoint(Map<String, String> externalTorConfigMap) {
+        String controlSocketString = externalTorConfigMap.get(CONTROL_SOCKET);
+        if (controlSocketString != null && !controlSocketString.isBlank()) {
+            Path controlSocketPath = Path.of(StringUtils.unquote(controlSocketString));
+            return ControlEndpoint.forSocket(controlSocketPath);
+        }
+
         String controlPortString = externalTorConfigMap.get(CONTROL_PORT);
+        checkArgument(controlPortString != null && !controlPortString.isBlank(),
+                "Either ControlSocket or ControlPort must be set in " + getExternalTorConfigDescription());
         String[] tokens = controlPortString.split(":");
         String controlHost;
         int controlPort;
@@ -374,22 +384,16 @@ public class TorService implements Service {
             controlHost = "127.0.0.1";
             controlPort = Integer.parseInt(tokens[0]);
         }
-        return new Pair<>(controlHost, controlPort);
+        return ControlEndpoint.forPort(controlHost, controlPort);
     }
 
     private void readExternalTorConfigMap() {
         try {
-            String torConfigFileName = "external_tor.config";
-            Path torConfigFilePath = transportConfig.getDataDirPath().resolve(torConfigFileName);
-            String torConfig;
-            if (!Files.exists(torConfigFilePath)) {
-                torConfig = FileReaderUtils.readStringFromResource("tor/" + torConfigFileName);
-                FileMutatorUtils.writeToPath(torConfig, torConfigFilePath);
-            } else {
-                torConfig = FileReaderUtils.readUTF8String(torConfigFilePath);
-            }
-            Set<String> lines = torConfig.lines().collect(Collectors.toSet());
-            for (String line : lines) {
+            Path externalTorConfigPath = getExternalTorConfigPath();
+            activeExternalTorConfigPath = Optional.of(externalTorConfigPath);
+            externalTorConfigMap.clear();
+            String torConfig = readExternalTorConfig(externalTorConfigPath);
+            for (String line : torConfig.lines().toList()) {
                 line = line.trim();
                 if (!line.isEmpty() && !line.startsWith("#")) {
                     int firstSpaceIndex = line.indexOf(" ");
@@ -397,6 +401,8 @@ public class TorService implements Service {
                         String key = line.substring(0, firstSpaceIndex);
                         String value = line.substring(firstSpaceIndex + 1);
                         externalTorConfigMap.put(key, value);
+                    } else {
+                        log.warn("Ignoring malformed line (no key/value separator) in external Tor config: '{}'", line);
                     }
                 }
             }
@@ -405,15 +411,35 @@ public class TorService implements Service {
         }
     }
 
-    private boolean isTorControlAvailable(String controlHost, int controlPort) {
-        try (Socket socket = new Socket()) {
-            var socketAddress = new InetSocketAddress(controlHost, controlPort);
-            socket.connect(socketAddress);
-            log.info("Test connection to control server of external tor process successful.");
-            return true;
-        } catch (IOException e) {
-            return false;
+    private String readExternalTorConfig(Path externalTorConfigPath) throws IOException {
+        if (!Files.exists(externalTorConfigPath)) {
+            String fallbackTorConfigFileName = "external_tor.config";
+            Path fallbackTorConfigPath = transportConfig.getDataDirPath().resolve(fallbackTorConfigFileName);
+            String fallbackTorConfigTemplate = FileReaderUtils.readStringFromResource("tor/" + fallbackTorConfigFileName);
+            String fallbackTorConfig = ExternalTorConfigHeuristics.apply(fallbackTorConfigTemplate);
+            FileMutatorUtils.writeToPath(fallbackTorConfig, fallbackTorConfigPath);
+            return fallbackTorConfig;
         }
+        return FileReaderUtils.readUTF8String(externalTorConfigPath);
+    }
+
+    private String getExternalTorConfigDescription() {
+        return activeExternalTorConfigPath
+                .map(path -> "the external Tor config file '" + path + "'")
+                .orElse("the external Tor config file");
+    }
+
+    private Path getExternalTorConfigPath() {
+        String torrcOverrideFilePath = transportConfig.getTorrcOverrideFilePath();
+        if (torrcOverrideFilePath != null && !torrcOverrideFilePath.isBlank()) {
+            Path overrideFilePath = resolveTorrcOverrideFilePath(transportConfig.getDataDirPath(), torrcOverrideFilePath);
+            if (Files.exists(overrideFilePath)) {
+                return overrideFilePath;
+            }
+            log.warn("torrcOverrideFilePath '{}' does not exist. Falling back to external_tor.config.",
+                    torrcOverrideFilePath);
+        }
+        return transportConfig.getDataDirPath().resolve("external_tor.config");
     }
 
     private void makeTorDir() {
@@ -459,21 +485,77 @@ public class TorService implements Service {
         torInstaller.installIfNotUpToDate();
     }
 
-    private Map<String, String> createTorrcConfigFile(Path dataDirPath, PasswordDigest hashedControlPassword) {
+    private List<String> createTorrcConfigFile(Path dataDirPath, PasswordDigest hashedControlPassword) {
         TorrcClientConfigFactory torrcClientConfigFactory = TorrcClientConfigFactory.builder()
                 .isTestNetwork(transportConfig.isTestNetwork())
                 .dataDirPath(dataDirPath)
                 .hashedControlPassword(hashedControlPassword)
                 .build();
 
-        Map<String, String> torrcOverrideConfigs = transportConfig.getTorrcOverrides();
-        Map<String, String> torrcConfigMap = torrcClientConfigFactory.torrcClientConfigMap(torrcOverrideConfigs);
+        Map<String, List<String>> overrides = resolveOverrides(dataDirPath);
+        List<String> torrcConfigLines = torrcClientConfigFactory.torrcClientConfigLines(overrides);
 
         Path torrcPath = dataDirPath.resolve("torrc");
         var torrcFileGenerator = new TorrcFileGenerator(torrcPath,
-                torrcConfigMap,
+                torrcConfigLines,
                 transportConfig.getDirectoryAuthorities());
         torrcFileGenerator.generate();
-        return torrcConfigMap;
+        return torrcConfigLines;
+    }
+
+    /**
+     * Returns the effective torrc overrides.  If {@code torrcOverrideFilePath} is set it is
+     * resolved against the data directory (when relative) and its contents take precedence over
+     * the inline {@code torrcOverrides} map.  Falls back to {@code torrcOverrides} when the
+     * file path is empty or the file cannot be read.
+     */
+    private Map<String, List<String>> resolveOverrides(Path dataDirPath) {
+        String filePathStr = transportConfig.getTorrcOverrideFilePath();
+        if (filePathStr == null || filePathStr.isBlank()) {
+            return transportConfig.getTorrcOverrides();
+        }
+        try {
+            Path overrideFilePath = resolveTorrcOverrideFilePath(dataDirPath, filePathStr);
+            return TorTransportConfig.parseTorrcOverrideFile(overrideFilePath);
+        } catch (IOException e) {
+            log.warn("Could not read torrcOverrideFilePath '{}', falling back to torrcOverrides. Error: {}",
+                    filePathStr, e.getMessage());
+            return transportConfig.getTorrcOverrides();
+        }
+    }
+
+    private Path resolveTorrcOverrideFilePath(Path dataDirPath, String torrcOverrideFilePath) {
+        Path overrideFilePath = Path.of(torrcOverrideFilePath);
+        if (!overrideFilePath.isAbsolute()) {
+            overrideFilePath = dataDirPath.resolve(overrideFilePath);
+        }
+        return overrideFilePath;
+    }
+
+    private sealed interface ControlEndpoint permits TcpControlEndpoint, UnixSocketControlEndpoint {
+
+        static ControlEndpoint forPort(String controlHost, int controlPort) {
+            return new TcpControlEndpoint(controlHost, controlPort);
+        }
+
+        static ControlEndpoint forSocket(Path controlSocketPath) {
+            return new UnixSocketControlEndpoint(controlSocketPath);
+        }
+    }
+
+    private record TcpControlEndpoint(String controlHost, int controlPort) implements ControlEndpoint {
+        @Override
+        @NonNull
+        public String toString() {
+            return String.format("TcpControlEndpoint(host: %s, port: %d)", controlHost, controlPort);
+        }
+    }
+
+    private record UnixSocketControlEndpoint(Path controlSocketPath) implements ControlEndpoint {
+        @Override
+        @NonNull
+        public String toString() {
+            return String.format("UnixSocketControlEndpoint(controlSocketPath: %s)", controlSocketPath);
+        }
     }
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -18,7 +18,6 @@
 package bisq.network.tor;
 
 import bisq.common.application.Service;
-import bisq.common.data.Pair;
 import bisq.common.facades.FacadeProvider;
 import bisq.common.file.FileMutatorUtils;
 import bisq.common.file.FileReaderUtils;
@@ -28,7 +27,7 @@ import bisq.common.platform.OS;
 import bisq.common.util.StringUtils;
 import bisq.network.tor.common.torrc.BaseTorrcGenerator;
 import bisq.network.tor.common.torrc.TorrcFileGenerator;
-import bisq.network.tor.controller.TorControlAuthenticationFailed;
+import bisq.network.tor.controller.TorControlConnectionClosedException;
 import bisq.network.tor.controller.TorController;
 import bisq.network.tor.controller.events.events.TorBootstrapEvent;
 import bisq.network.tor.installer.TorInstaller;
@@ -37,19 +36,20 @@ import bisq.network.tor.process.control_port.ControlPortFileParser;
 import bisq.security.keys.TorKeyPair;
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -57,10 +57,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static bisq.common.threading.ExecutorFactory.commonForkJoinPool;
 import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_PORT;
+import static bisq.network.tor.common.torrc.Torrc.Keys.CONTROL_SOCKET;
 import static bisq.network.tor.common.torrc.Torrc.Keys.COOKIE_AUTHENTICATION;
 import static bisq.network.tor.common.torrc.Torrc.Keys.COOKIE_AUTH_FILE;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -85,6 +85,7 @@ public class TorService implements Service {
     private Optional<EmbeddedTorProcess> torProcess = Optional.empty();
     private Optional<TorSocksProxyFactory> torSocksProxyFactory = Optional.empty();
     private final Map<String, String> externalTorConfigMap = new HashMap<>();
+    private Optional<Path> activeExternalTorConfigPath = Optional.empty();
 
     public TorService(TorTransportConfig transportConfig) {
         this.transportConfig = transportConfig;
@@ -109,13 +110,9 @@ public class TorService implements Service {
             if (connectedToExternalTor(externalTorConfigMap)) {
                 log.info("External Tor will be used");
                 return CompletableFuture.completedFuture(true);
-            } else if (LinuxDistribution.isWhonix()) {
-                // In case we failed at connectedToExternalTor, we do not start the embedded Tor as fallback if we are on Whonix.
-                throw new RuntimeException("Bisq runs on a Whonix system but it could not connect to the Whonix system Tor. " +
-                        "Please check the Bisq external_tor.config and the system Tor torrc config.");
             } else {
-                // In case connectedToExternalTor failed we try embedded Tor (if not running on Whonix)
-                useExternalTor.set(false);
+                throw new RuntimeException("`useExternalTor` is enabled, but Bisq could not connect to the external Tor control " +
+                        "server. Please check " + getExternalTorConfigDescription() + " and your system Tor configuration.");
             }
         }
 
@@ -139,7 +136,7 @@ public class TorService implements Service {
         torController = new TorController(transportConfig.getBootstrapTimeout(), transportConfig.getHsUploadTimeout(), bootstrapEvent);
 
         PasswordDigest hashedControlPassword = PasswordDigest.generateDigest();
-        Map<String, String> torrcConfigMap = createTorrcConfigFile(torDataDirPath, hashedControlPassword);
+        createTorrcConfigFile(torDataDirPath, hashedControlPassword);
 
         // remove the control port file before we launch tor, just in case it exists from
         // a previous run
@@ -176,29 +173,24 @@ public class TorService implements Service {
     }
 
     private boolean evaluateUseExternalTor() {
-        boolean useExternalTor = false;
-        if (LinuxDistribution.isWhonix()) {
-            log.info("Bisq runs on a Whonix system and use the Whonix system Tor");
-            return true;
-        } else {
-            // If environment variable is set we take that.
-            String torSkipLaunch = System.getenv(TOR_SKIP_LAUNCH);
-            if (StringUtils.isNotEmpty(torSkipLaunch)) {
-                log.info("Environment variable 'TOR_SKIP_LAUNCH' is set to '{}'", torSkipLaunch);
-                return torSkipLaunch.equals("1") ||
-                        torSkipLaunch.equalsIgnoreCase("true") ||
-                        torSkipLaunch.equalsIgnoreCase("yes");
-            } else {
-                // We check if external_tor.config value is set. If so we use that value
-                Optional<String> externalTorFromConfigMap = Optional.ofNullable(externalTorConfigMap.get("UseExternalTor"));
-                if (externalTorFromConfigMap.isPresent()) {
-                    return externalTorFromConfigMap.get().equals("1");
-                } else {
-                    // Last we take the value form the JVM config
-                    return transportConfig.isUseExternalTor();
-                }
-            }
+        boolean isWhonixOrTails = LinuxDistribution.isWhonix() || LinuxDistribution.isTails();
+        String torSkipLaunch = System.getenv(TOR_SKIP_LAUNCH);
+        String useExternalTorFromConfig = externalTorConfigMap.get("UseExternalTor");
+        boolean useExternalTorFromJvmConfig = transportConfig.isUseExternalTor();
+
+        boolean useExternalTor = UseExternalTorResolver.evaluateUseExternalTorValue(
+                isWhonixOrTails,
+                torSkipLaunch,
+                useExternalTorFromJvmConfig,
+                useExternalTorFromConfig);
+
+        if (isWhonixOrTails) {
+            log.info("Bisq runs on a Whonix/Tails system and use the system Tor");
+        } else if (StringUtils.isNotEmpty(torSkipLaunch)) {
+            log.info("Environment variable 'TOR_SKIP_LAUNCH' is set to '{}'", torSkipLaunch);
         }
+
+        return useExternalTor;
     }
 
     @Override
@@ -212,6 +204,7 @@ public class TorService implements Service {
             torSocksProxyFactory = Optional.empty();
             publishedOnionServices.clear();
             externalTorConfigMap.clear();
+            activeExternalTorConfigPath = Optional.empty();
             return true;
         }, commonForkJoinPool());
     }
@@ -281,20 +274,17 @@ public class TorService implements Service {
     }
 
     private boolean connectedToExternalTor(Map<String, String> torConfigMap) {
-        Pair<String, Integer> controlHostAndPort = getControlHostAndPort(torConfigMap);
-        String controlHost = controlHostAndPort.getFirst();
-        int controlPort = controlHostAndPort.getSecond();
-        if (!isTorControlAvailable(controlHost, controlPort)) {
-            log.warn("Couldn't connect to external Tor control server. " +
-                    "This could happen if the control port is not correctly set up in 'external_tor.config' file.");
-            return false;
-        }
+        ControlEndpoint controlEndpoint = getControlEndpoint(torConfigMap);
 
         if (torController != null) {
             torController.shutdown();
         }
         torController = new TorController(transportConfig.getBootstrapTimeout(), transportConfig.getHsUploadTimeout(), bootstrapEvent);
-        torController.initialize(controlPort);
+        if (controlEndpoint instanceof UnixSocketControlEndpoint socketControlEndpoint) {
+            torController.initialize(socketControlEndpoint.controlSocketPath());
+        } else if (controlEndpoint instanceof TcpControlEndpoint tcpControlEndpoint) {
+            torController.initialize(tcpControlEndpoint.controlHost(), tcpControlEndpoint.controlPort());
+        }
 
         boolean isAuthenticated = false;
         boolean noCookieAuthenticationRequired = Optional.ofNullable(torConfigMap.get(COOKIE_AUTHENTICATION)).orElse("0").equals("0");
@@ -304,23 +294,26 @@ public class TorService implements Service {
             try {
                 torController.authenticate();
                 isAuthenticated = true;
-            } catch (TorControlAuthenticationFailed e) {
-                log.warn("Authentication to Tor Control failed.");
+            } catch (Exception e) {
+                log.warn("Authentication to Tor Control failed.", e);
                 return false;
             }
         }
 
         if (!isAuthenticated) {
             if (torConfigMap.containsKey(COOKIE_AUTH_FILE)) {
-                String authCookiePath = torConfigMap.get(COOKIE_AUTH_FILE);
+                String authCookiePath = StringUtils.unquote(torConfigMap.get(COOKIE_AUTH_FILE));
                 try {
                     byte[] authCookie = Files.readAllBytes(Paths.get(authCookiePath));
                     torController.authenticate(authCookie);
                     isAuthenticated = true;
-                } catch (TorControlAuthenticationFailed e) {
-                    log.warn("Authentication with authCookie failed.");
                 } catch (IOException e) {
                     log.warn("Couldn't read the COOKIE_AUTH_FILE '{}' from the config.", authCookiePath);
+                } catch (TorControlConnectionClosedException e) {
+                    log.warn("Tor control connection was closed unexpectedly when trying to authenticate.", e);
+                    return false; // since pipe is broken
+                } catch (Exception e) {
+                    log.warn("Authentication to Tor Control failed.", e);
                 }
             } else {
                 log.warn("The user did not provide the path to the COOKIE_AUTH_FILE.");
@@ -331,8 +324,8 @@ public class TorService implements Service {
             log.info("We try to call authenticate without parameters for the case that authentication is not required.");
             try {
                 torController.authenticate();
-            } catch (TorControlAuthenticationFailed ex) {
-                log.warn("Authentication to Tor Control failed.");
+            } catch (Exception e) {
+                log.warn("Authentication to Tor Control failed.", e);
                 return false;
             }
         }
@@ -347,8 +340,16 @@ public class TorService implements Service {
         return true;
     }
 
-    private Pair<String, Integer> getControlHostAndPort(Map<String, String> externalTorConfigMap) {
+    private ControlEndpoint getControlEndpoint(Map<String, String> externalTorConfigMap) {
+        String controlSocketString = externalTorConfigMap.get(CONTROL_SOCKET);
+        if (controlSocketString != null && !controlSocketString.isBlank()) {
+            Path controlSocketPath = Path.of(StringUtils.unquote(controlSocketString));
+            return ControlEndpoint.forSocket(controlSocketPath);
+        }
+
         String controlPortString = externalTorConfigMap.get(CONTROL_PORT);
+        checkArgument(controlPortString != null && !controlPortString.isBlank(),
+                "Either ControlSocket or ControlPort must be set in " + getExternalTorConfigDescription());
         String[] tokens = controlPortString.split(":");
         String controlHost;
         int controlPort;
@@ -361,22 +362,16 @@ public class TorService implements Service {
             controlHost = "127.0.0.1";
             controlPort = Integer.parseInt(tokens[0]);
         }
-        return new Pair<>(controlHost, controlPort);
+        return ControlEndpoint.forPort(controlHost, controlPort);
     }
 
     private void readExternalTorConfigMap() {
         try {
-            String torConfigFileName = "external_tor.config";
-            Path torConfigFilePath = transportConfig.getDataDirPath().resolve(torConfigFileName);
-            String torConfig;
-            if (!Files.exists(torConfigFilePath)) {
-                torConfig = FileReaderUtils.readStringFromResource("tor/" + torConfigFileName);
-                FileMutatorUtils.writeToPath(torConfig, torConfigFilePath);
-            } else {
-                torConfig = FileReaderUtils.readUTF8String(torConfigFilePath);
-            }
-            Set<String> lines = torConfig.lines().collect(Collectors.toSet());
-            for (String line : lines) {
+            Path externalTorConfigPath = getExternalTorConfigPath();
+            activeExternalTorConfigPath = Optional.of(externalTorConfigPath);
+            externalTorConfigMap.clear();
+            String torConfig = readExternalTorConfig(externalTorConfigPath);
+            for (String line : torConfig.lines().toList()) {
                 line = line.trim();
                 if (!line.isEmpty() && !line.startsWith("#")) {
                     int firstSpaceIndex = line.indexOf(" ");
@@ -384,6 +379,8 @@ public class TorService implements Service {
                         String key = line.substring(0, firstSpaceIndex);
                         String value = line.substring(firstSpaceIndex + 1);
                         externalTorConfigMap.put(key, value);
+                    } else {
+                        log.warn("Ignoring malformed line (no key/value separator) in external Tor config: '{}'", line);
                     }
                 }
             }
@@ -392,15 +389,35 @@ public class TorService implements Service {
         }
     }
 
-    private boolean isTorControlAvailable(String controlHost, int controlPort) {
-        try (Socket socket = new Socket()) {
-            var socketAddress = new InetSocketAddress(controlHost, controlPort);
-            socket.connect(socketAddress);
-            log.info("Test connection to control server of external tor process successful.");
-            return true;
-        } catch (IOException e) {
-            return false;
+    private String readExternalTorConfig(Path externalTorConfigPath) throws IOException {
+        if (!Files.exists(externalTorConfigPath)) {
+            String fallbackTorConfigFileName = "external_tor.config";
+            Path fallbackTorConfigPath = transportConfig.getDataDirPath().resolve(fallbackTorConfigFileName);
+            String fallbackTorConfigTemplate = FileReaderUtils.readStringFromResource("tor/" + fallbackTorConfigFileName);
+            String fallbackTorConfig = ExternalTorConfigHeuristics.apply(fallbackTorConfigTemplate);
+            FileMutatorUtils.writeToPath(fallbackTorConfig, fallbackTorConfigPath);
+            return fallbackTorConfig;
         }
+        return FileReaderUtils.readUTF8String(externalTorConfigPath);
+    }
+
+    private String getExternalTorConfigDescription() {
+        return activeExternalTorConfigPath
+                .map(path -> "the external Tor config file '" + path + "'")
+                .orElse("the external Tor config file");
+    }
+
+    private Path getExternalTorConfigPath() {
+        String torrcOverrideFilePath = transportConfig.getTorrcOverrideFilePath();
+        if (torrcOverrideFilePath != null && !torrcOverrideFilePath.isBlank()) {
+            Path overrideFilePath = resolveTorrcOverrideFilePath(transportConfig.getDataDirPath(), torrcOverrideFilePath);
+            if (Files.exists(overrideFilePath)) {
+                return overrideFilePath;
+            }
+            log.warn("torrcOverrideFilePath '{}' does not exist. Falling back to external_tor.config.",
+                    torrcOverrideFilePath);
+        }
+        return transportConfig.getDataDirPath().resolve("external_tor.config");
     }
 
     private void makeTorDir() {
@@ -430,21 +447,77 @@ public class TorService implements Service {
         torInstaller.installIfNotUpToDate();
     }
 
-    private Map<String, String> createTorrcConfigFile(Path dataDirPath, PasswordDigest hashedControlPassword) {
+    private List<String> createTorrcConfigFile(Path dataDirPath, PasswordDigest hashedControlPassword) {
         TorrcClientConfigFactory torrcClientConfigFactory = TorrcClientConfigFactory.builder()
                 .isTestNetwork(transportConfig.isTestNetwork())
                 .dataDirPath(dataDirPath)
                 .hashedControlPassword(hashedControlPassword)
                 .build();
 
-        Map<String, String> torrcOverrideConfigs = transportConfig.getTorrcOverrides();
-        Map<String, String> torrcConfigMap = torrcClientConfigFactory.torrcClientConfigMap(torrcOverrideConfigs);
+        Map<String, List<String>> overrides = resolveOverrides(dataDirPath);
+        List<String> torrcConfigLines = torrcClientConfigFactory.torrcClientConfigLines(overrides);
 
         Path torrcPath = dataDirPath.resolve("torrc");
         var torrcFileGenerator = new TorrcFileGenerator(torrcPath,
-                torrcConfigMap,
+                torrcConfigLines,
                 transportConfig.getDirectoryAuthorities());
         torrcFileGenerator.generate();
-        return torrcConfigMap;
+        return torrcConfigLines;
+    }
+
+    /**
+     * Returns the effective torrc overrides.  If {@code torrcOverrideFilePath} is set it is
+     * resolved against the data directory (when relative) and its contents take precedence over
+     * the inline {@code torrcOverrides} map.  Falls back to {@code torrcOverrides} when the
+     * file path is empty or the file cannot be read.
+     */
+    private Map<String, List<String>> resolveOverrides(Path dataDirPath) {
+        String filePathStr = transportConfig.getTorrcOverrideFilePath();
+        if (filePathStr == null || filePathStr.isBlank()) {
+            return transportConfig.getTorrcOverrides();
+        }
+        try {
+            Path overrideFilePath = resolveTorrcOverrideFilePath(dataDirPath, filePathStr);
+            return TorTransportConfig.parseTorrcOverrideFile(overrideFilePath);
+        } catch (IOException e) {
+            log.warn("Could not read torrcOverrideFilePath '{}', falling back to torrcOverrides. Error: {}",
+                    filePathStr, e.getMessage());
+            return transportConfig.getTorrcOverrides();
+        }
+    }
+
+    private Path resolveTorrcOverrideFilePath(Path dataDirPath, String torrcOverrideFilePath) {
+        Path overrideFilePath = Path.of(torrcOverrideFilePath);
+        if (!overrideFilePath.isAbsolute()) {
+            overrideFilePath = dataDirPath.resolve(overrideFilePath);
+        }
+        return overrideFilePath;
+    }
+
+    private sealed interface ControlEndpoint permits TcpControlEndpoint, UnixSocketControlEndpoint {
+
+        static ControlEndpoint forPort(String controlHost, int controlPort) {
+            return new TcpControlEndpoint(controlHost, controlPort);
+        }
+
+        static ControlEndpoint forSocket(Path controlSocketPath) {
+            return new UnixSocketControlEndpoint(controlSocketPath);
+        }
+    }
+
+    private record TcpControlEndpoint(String controlHost, int controlPort) implements ControlEndpoint {
+        @Override
+        @NonNull
+        public String toString() {
+            return String.format("TcpControlEndpoint(host: %s, port: %d)", controlHost, controlPort);
+        }
+    }
+
+    private record UnixSocketControlEndpoint(Path controlSocketPath) implements ControlEndpoint {
+        @Override
+        @NonNull
+        public String toString() {
+            return String.format("UnixSocketControlEndpoint(controlSocketPath: %s)", controlSocketPath);
+        }
     }
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -37,15 +37,17 @@ import bisq.network.tor.process.control_port.ControlPortFileParser;
 import bisq.security.keys.TorKeyPair;
 import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -175,7 +177,8 @@ public class TorService implements Service {
 
         FileMutatorUtils.deleteOnExit(controlPortFilePath);
 
-        torController.initialize(controlPort);
+        var socketAddress = new InetSocketAddress("127.0.0.1", controlPort);
+        torController.initialize(socketAddress);
         torController.authenticate(hashedControlPassword);
         torController.bootstrap();
 
@@ -247,8 +250,12 @@ public class TorService implements Service {
     public CompletableFuture<ServerSocket> publishOnionServiceAndCreateServerSocket(int port, TorKeyPair torKeyPair) {
         long ts = System.currentTimeMillis();
         try {
-            InetAddress bindAddress = !LinuxDistribution.isWhonix() ? Inet4Address.getLoopbackAddress()
-                    : Inet4Address.getByName("0.0.0.0");
+            // Whonix's gateway reaches Bisq from a different host, so the maker server socket must
+            // listen on all interfaces there. On Tails the system Tor (via onion-grater) calls back
+            // to 127.0.0.1 — verified on Tails: inbound rendezvous connections to the listen port have
+            // local address 127.0.0.1 — so loopback is correct and required (Tails blocks global binds).
+            InetAddress bindAddress = LinuxDistribution.isWhonix() ? Inet4Address.getByName("0.0.0.0")
+                    : Inet4Address.getLoopbackAddress();
             var localServerSocket = new ServerSocket(RANDOM_PORT, 50, bindAddress);
 
             String onionAddress = torKeyPair.getOnionAddress();
@@ -289,18 +296,14 @@ public class TorService implements Service {
     }
 
     private boolean connectedToExternalTor(Map<String, String> torConfigMap) {
-        ControlEndpoint controlEndpoint = getControlEndpoint(torConfigMap);
+        SocketAddress socketAddress = getControlSocketAddress(torConfigMap);
 
         if (torController != null) {
             torController.shutdown();
         }
         torController = new TorController(transportConfig.getBootstrapTimeout(), transportConfig.getHsUploadTimeout(), bootstrapEvent);
         try {
-            if (controlEndpoint instanceof UnixSocketControlEndpoint socketControlEndpoint) {
-                torController.initialize(socketControlEndpoint.controlSocketPath());
-            } else if (controlEndpoint instanceof TcpControlEndpoint tcpControlEndpoint) {
-                torController.initialize(tcpControlEndpoint.controlHost(), tcpControlEndpoint.controlPort());
-            }
+            torController.initialize(socketAddress);
         } catch (CannotConnectWithTorException e) {
             log.warn("Could not connect to external Tor control endpoint.", e);
             torController.shutdown();
@@ -362,11 +365,11 @@ public class TorService implements Service {
         return true;
     }
 
-    private ControlEndpoint getControlEndpoint(Map<String, String> externalTorConfigMap) {
+    private SocketAddress getControlSocketAddress(Map<String, String> externalTorConfigMap) {
         String controlSocketString = externalTorConfigMap.get(CONTROL_SOCKET);
         if (controlSocketString != null && !controlSocketString.isBlank()) {
             Path controlSocketPath = Path.of(StringUtils.unquote(controlSocketString));
-            return ControlEndpoint.forSocket(controlSocketPath);
+            return UnixDomainSocketAddress.of(controlSocketPath);
         }
 
         String controlPortString = externalTorConfigMap.get(CONTROL_PORT);
@@ -384,7 +387,7 @@ public class TorService implements Service {
             controlHost = "127.0.0.1";
             controlPort = Integer.parseInt(tokens[0]);
         }
-        return ControlEndpoint.forPort(controlHost, controlPort);
+        return new InetSocketAddress(controlHost, controlPort);
     }
 
     private void readExternalTorConfigMap() {
@@ -392,20 +395,23 @@ public class TorService implements Service {
             Path externalTorConfigPath = getExternalTorConfigPath();
             activeExternalTorConfigPath = Optional.of(externalTorConfigPath);
             externalTorConfigMap.clear();
-            String torConfig = readExternalTorConfig(externalTorConfigPath);
-            for (String line : torConfig.lines().toList()) {
-                line = line.trim();
-                if (!line.isEmpty() && !line.startsWith("#")) {
-                    int firstSpaceIndex = line.indexOf(" ");
-                    if (firstSpaceIndex != -1) {
-                        String key = line.substring(0, firstSpaceIndex);
-                        String value = line.substring(firstSpaceIndex + 1);
-                        externalTorConfigMap.put(key, value);
-                    } else {
-                        log.warn("Ignoring malformed line (no key/value separator) in external Tor config: '{}'", line);
-                    }
-                }
-            }
+
+            readExternalTorConfig(externalTorConfigPath)
+                    .lines()
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                    .forEach(line -> {
+                        int firstSpaceIndex = line.indexOf(" ");
+                        if (firstSpaceIndex != -1) {
+                            String key = line.substring(0, firstSpaceIndex);
+                            String value = line.substring(firstSpaceIndex + 1);
+                            externalTorConfigMap.put(key, value);
+                        } else {
+                            log.warn("Ignoring malformed line (no key/value separator) in external " +
+                                    "Tor config: '{}'", line);
+                        }
+                    });
+
         } catch (IOException e) {
             log.warn("Could not read external tor config file.", e);
         }
@@ -430,14 +436,14 @@ public class TorService implements Service {
     }
 
     private Path getExternalTorConfigPath() {
-        String torrcOverrideFilePath = transportConfig.getTorrcOverrideFilePath();
-        if (torrcOverrideFilePath != null && !torrcOverrideFilePath.isBlank()) {
-            Path overrideFilePath = resolveTorrcOverrideFilePath(transportConfig.getDataDirPath(), torrcOverrideFilePath);
+        Optional<Path> torrcOverrideFilePath = transportConfig.getTorrcOverrideFilePath();
+        if (torrcOverrideFilePath.isPresent()) {
+            Path overrideFilePath = torrcOverrideFilePath.get();
             if (Files.exists(overrideFilePath)) {
                 return overrideFilePath;
             }
             log.warn("torrcOverrideFilePath '{}' does not exist. Falling back to external_tor.config.",
-                    torrcOverrideFilePath);
+                    overrideFilePath);
         }
         return transportConfig.getDataDirPath().resolve("external_tor.config");
     }
@@ -485,77 +491,41 @@ public class TorService implements Service {
         torInstaller.installIfNotUpToDate();
     }
 
-    private List<String> createTorrcConfigFile(Path dataDirPath, PasswordDigest hashedControlPassword) {
+    private void createTorrcConfigFile(Path dataDirPath, PasswordDigest hashedControlPassword) {
         TorrcClientConfigFactory torrcClientConfigFactory = TorrcClientConfigFactory.builder()
                 .isTestNetwork(transportConfig.isTestNetwork())
                 .dataDirPath(dataDirPath)
                 .hashedControlPassword(hashedControlPassword)
                 .build();
 
-        Map<String, List<String>> overrides = resolveOverrides(dataDirPath);
-        List<String> torrcConfigLines = torrcClientConfigFactory.torrcClientConfigLines(overrides);
+        Map<String, List<String>> torrcOverrideConfigs = resolveOverrides();
+        Map<String, List<String>> torrcConfigMap = torrcClientConfigFactory.torrcClientConfigMap(torrcOverrideConfigs);
 
         Path torrcPath = dataDirPath.resolve("torrc");
         var torrcFileGenerator = new TorrcFileGenerator(torrcPath,
-                torrcConfigLines,
+                torrcConfigMap,
                 transportConfig.getDirectoryAuthorities());
         torrcFileGenerator.generate();
-        return torrcConfigLines;
     }
 
     /**
-     * Returns the effective torrc overrides.  If {@code torrcOverrideFilePath} is set it is
-     * resolved against the data directory (when relative) and its contents take precedence over
-     * the inline {@code torrcOverrides} map.  Falls back to {@code torrcOverrides} when the
-     * file path is empty or the file cannot be read.
+     * Returns the effective torrc overrides.  If {@code torrcOverrideFilePath} is set its
+     * contents take precedence over the inline {@code torrcOverrides} map.  Falls back to
+     * {@code torrcOverrides} when the file path is empty or the file cannot be read.
      */
-    private Map<String, List<String>> resolveOverrides(Path dataDirPath) {
-        String filePathStr = transportConfig.getTorrcOverrideFilePath();
-        if (filePathStr == null || filePathStr.isBlank()) {
+    private Map<String, List<String>> resolveOverrides() {
+        Optional<Path> torrcOverrideFilePath = transportConfig.getTorrcOverrideFilePath();
+        if (torrcOverrideFilePath.isEmpty()) {
             return transportConfig.getTorrcOverrides();
         }
+
+        Path overrideFilePath = torrcOverrideFilePath.get();
         try {
-            Path overrideFilePath = resolveTorrcOverrideFilePath(dataDirPath, filePathStr);
-            return TorTransportConfig.parseTorrcOverrideFile(overrideFilePath);
+            return TorrcFileParser.parseTorrcOverrideFile(overrideFilePath);
         } catch (IOException e) {
             log.warn("Could not read torrcOverrideFilePath '{}', falling back to torrcOverrides. Error: {}",
-                    filePathStr, e.getMessage());
+                    overrideFilePath, e.getMessage());
             return transportConfig.getTorrcOverrides();
-        }
-    }
-
-    private Path resolveTorrcOverrideFilePath(Path dataDirPath, String torrcOverrideFilePath) {
-        Path overrideFilePath = Path.of(torrcOverrideFilePath);
-        if (!overrideFilePath.isAbsolute()) {
-            overrideFilePath = dataDirPath.resolve(overrideFilePath);
-        }
-        return overrideFilePath;
-    }
-
-    private sealed interface ControlEndpoint permits TcpControlEndpoint, UnixSocketControlEndpoint {
-
-        static ControlEndpoint forPort(String controlHost, int controlPort) {
-            return new TcpControlEndpoint(controlHost, controlPort);
-        }
-
-        static ControlEndpoint forSocket(Path controlSocketPath) {
-            return new UnixSocketControlEndpoint(controlSocketPath);
-        }
-    }
-
-    private record TcpControlEndpoint(String controlHost, int controlPort) implements ControlEndpoint {
-        @Override
-        @NonNull
-        public String toString() {
-            return String.format("TcpControlEndpoint(host: %s, port: %d)", controlHost, controlPort);
-        }
-    }
-
-    private record UnixSocketControlEndpoint(Path controlSocketPath) implements ControlEndpoint {
-        @Override
-        @NonNull
-        public String toString() {
-            return String.format("UnixSocketControlEndpoint(controlSocketPath: %s)", controlSocketPath);
         }
     }
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorService.java
@@ -398,19 +398,9 @@ public class TorService implements Service {
 
             readExternalTorConfig(externalTorConfigPath)
                     .lines()
-                    .map(String::trim)
-                    .filter(line -> !line.isEmpty() && !line.startsWith("#"))
-                    .forEach(line -> {
-                        int firstSpaceIndex = line.indexOf(" ");
-                        if (firstSpaceIndex != -1) {
-                            String key = line.substring(0, firstSpaceIndex);
-                            String value = line.substring(firstSpaceIndex + 1);
-                            externalTorConfigMap.put(key, value);
-                        } else {
-                            log.warn("Ignoring malformed line (no key/value separator) in external " +
-                                    "Tor config: '{}'", line);
-                        }
-                    });
+                    .map(TorrcFileParser::parseDirective)
+                    .flatMap(Optional::stream)
+                    .forEach(directive -> externalTorConfigMap.put(directive.getFirst(), directive.getSecond()));
 
         } catch (IOException e) {
             log.warn("Could not read external tor config file.", e);

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorTransportConfig.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorTransportConfig.java
@@ -20,20 +20,18 @@ package bisq.network.tor;
 import bisq.common.network.TransportConfig;
 import bisq.network.tor.common.torrc.DirectoryAuthority;
 import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigValue;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -51,8 +49,8 @@ public class TorTransportConfig implements TransportConfig {
                 (int) TimeUnit.SECONDS.toMillis(config.getInt("socketTimeout")),
                 config.getBoolean("testNetwork"),
                 parseDirectoryAuthorities(config.getList("directoryAuthorities")),
-                parseTorrcOverrideConfig(config.getConfig("torrcOverrides")),
-                config.hasPath("torrcOverrideFilePath") ? config.getString("torrcOverrideFilePath") : "",
+                parseTorrcOverrideConfig(config.getObject("torrcOverrides")),
+                parseTorrcOverrideFilePath(dataDirPath, config),
                 config.getInt("sendMessageThrottleTime"),
                 config.getInt("receiveMessageThrottleTime"),
                 config.getBoolean("useExternalTor")
@@ -75,49 +73,24 @@ public class TorTransportConfig implements TransportConfig {
         return allDirectoryAuthorities;
     }
 
-    private static Map<String, List<String>> parseTorrcOverrideConfig(com.typesafe.config.Config torrcOverrides) {
-        Map<String, List<String>> result = new LinkedHashMap<>();
-        torrcOverrides.entrySet().forEach(entry -> {
-            Object unwrapped = entry.getValue().unwrapped();
-            if (unwrapped instanceof List<?> values) {
-                List<String> stringValues = new ArrayList<>();
-                values.forEach(v -> stringValues.add(String.valueOf(v)));
-                result.put(entry.getKey(), stringValues);
-            } else {
-                result.put(entry.getKey(), List.of(String.valueOf(unwrapped)));
-            }
-        });
-        return result;
+    private static Map<String, List<String>> parseTorrcOverrideConfig(ConfigObject torrcOverrides) {
+        return TorrcOverrideConfigParser.parse(torrcOverrides);
     }
 
-    /**
-     * Parses a torrc-style override file into a map of key → list of values.
-     * Each non-blank, non-comment line is expected to have the form {@code Key Value}.
-     * Repeated keys (e.g. multiple {@code Bridge} lines) accumulate into a list so that
-     * all entries appear in the generated torrc.
-     */
-    public static Map<String, List<String>> parseTorrcOverrideFile(Path filePath) throws IOException {
-        Map<String, List<String>> result = new LinkedHashMap<>();
-        for (String line : Files.readAllLines(filePath)) {
-            String trimmed = line.strip();
-            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                continue;
-            }
-            int spaceIndex = -1;
-            for (int i = 0; i < trimmed.length(); i++) {
-                if (Character.isWhitespace(trimmed.charAt(i))) {
-                    spaceIndex = i;
-                    break;
-                }
-            }
-            if (spaceIndex < 0) {
-                continue; // bare key with no value — skip
-            }
-            String key = trimmed.substring(0, spaceIndex);
-            String value = trimmed.substring(spaceIndex + 1).strip();
-            result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    private static Optional<Path> parseTorrcOverrideFilePath(Path dataDirPath,
+                                                             com.typesafe.config.Config config) {
+        if (!config.hasPath("torrcOverrideFilePath")) {
+            return Optional.empty();
         }
-        return result;
+
+        String filePath = config.getString("torrcOverrideFilePath");
+        if (filePath.isBlank()) {
+            return Optional.empty();
+        }
+
+        Path torrcOverridePath = Path.of(filePath);
+        return torrcOverridePath.isAbsolute() ? Optional.of(torrcOverridePath) :
+                Optional.of(dataDirPath.resolve(torrcOverridePath));
     }
 
     private static String getStringFromConfigValue(ConfigValue configValue, String key) {
@@ -138,11 +111,11 @@ public class TorTransportConfig implements TransportConfig {
     private final Map<String, List<String>> torrcOverrides;
     /**
      * Optional path to a torrc-style file whose entries override {@code torrcOverrides}.
-     * Supports both absolute paths and paths relative to the data directory.
-     * When non-empty this file takes precedence over the inline {@code torrcOverrides} map.
-     * Leave empty (the default) to use {@code torrcOverrides} instead.
+     * Relative paths are resolved against the data directory at parse time, so the value
+     * is always absolute when present. When present this file takes precedence over the
+     * inline {@code torrcOverrides} map. Empty (the default) means use {@code torrcOverrides}.
      */
-    private final String torrcOverrideFilePath;
+    private final Optional<Path> torrcOverrideFilePath;
     private final int sendMessageThrottleTime;
     private final int receiveMessageThrottleTime;
     private final boolean useExternalTor;
@@ -155,7 +128,7 @@ public class TorTransportConfig implements TransportConfig {
                               boolean isTestNetwork,
                               Set<DirectoryAuthority> directoryAuthorities,
                               Map<String, List<String>> torrcOverrides,
-                              String torrcOverrideFilePath,
+                              Optional<Path> torrcOverrideFilePath,
                               int sendMessageThrottleTime,
                               int receiveMessageThrottleTime,
                               boolean useExternalTor) {

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorTransportConfig.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorTransportConfig.java
@@ -26,9 +26,13 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +52,7 @@ public class TorTransportConfig implements TransportConfig {
                 config.getBoolean("testNetwork"),
                 parseDirectoryAuthorities(config.getList("directoryAuthorities")),
                 parseTorrcOverrideConfig(config.getConfig("torrcOverrides")),
+                config.hasPath("torrcOverrideFilePath") ? config.getString("torrcOverrideFilePath") : "",
                 config.getInt("sendMessageThrottleTime"),
                 config.getInt("receiveMessageThrottleTime"),
                 config.getBoolean("useExternalTor")
@@ -70,13 +75,49 @@ public class TorTransportConfig implements TransportConfig {
         return allDirectoryAuthorities;
     }
 
-    private static Map<String, String> parseTorrcOverrideConfig(com.typesafe.config.Config torrcOverrides) {
-        Map<String, String> torrcOverrideConfigMap = new HashMap<>();
-        torrcOverrides.entrySet()
-                .forEach(entry -> torrcOverrideConfigMap.put(
-                        entry.getKey(), (String) entry.getValue().unwrapped()
-                ));
-        return torrcOverrideConfigMap;
+    private static Map<String, List<String>> parseTorrcOverrideConfig(com.typesafe.config.Config torrcOverrides) {
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        torrcOverrides.entrySet().forEach(entry -> {
+            Object unwrapped = entry.getValue().unwrapped();
+            if (unwrapped instanceof List<?> values) {
+                List<String> stringValues = new ArrayList<>();
+                values.forEach(v -> stringValues.add(String.valueOf(v)));
+                result.put(entry.getKey(), stringValues);
+            } else {
+                result.put(entry.getKey(), List.of(String.valueOf(unwrapped)));
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Parses a torrc-style override file into a map of key → list of values.
+     * Each non-blank, non-comment line is expected to have the form {@code Key Value}.
+     * Repeated keys (e.g. multiple {@code Bridge} lines) accumulate into a list so that
+     * all entries appear in the generated torrc.
+     */
+    public static Map<String, List<String>> parseTorrcOverrideFile(Path filePath) throws IOException {
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        for (String line : Files.readAllLines(filePath)) {
+            String trimmed = line.strip();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            int spaceIndex = -1;
+            for (int i = 0; i < trimmed.length(); i++) {
+                if (Character.isWhitespace(trimmed.charAt(i))) {
+                    spaceIndex = i;
+                    break;
+                }
+            }
+            if (spaceIndex < 0) {
+                continue; // bare key with no value — skip
+            }
+            String key = trimmed.substring(0, spaceIndex);
+            String value = trimmed.substring(spaceIndex + 1).strip();
+            result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+        return result;
     }
 
     private static String getStringFromConfigValue(ConfigValue configValue, String key) {
@@ -94,7 +135,14 @@ public class TorTransportConfig implements TransportConfig {
     private final int socketTimeout; // in ms
     private final boolean isTestNetwork;
     private final Set<DirectoryAuthority> directoryAuthorities;
-    private final Map<String, String> torrcOverrides;
+    private final Map<String, List<String>> torrcOverrides;
+    /**
+     * Optional path to a torrc-style file whose entries override {@code torrcOverrides}.
+     * Supports both absolute paths and paths relative to the data directory.
+     * When non-empty this file takes precedence over the inline {@code torrcOverrides} map.
+     * Leave empty (the default) to use {@code torrcOverrides} instead.
+     */
+    private final String torrcOverrideFilePath;
     private final int sendMessageThrottleTime;
     private final int receiveMessageThrottleTime;
     private final boolean useExternalTor;
@@ -106,7 +154,8 @@ public class TorTransportConfig implements TransportConfig {
                               int socketTimeout,
                               boolean isTestNetwork,
                               Set<DirectoryAuthority> directoryAuthorities,
-                              Map<String, String> torrcOverrides,
+                              Map<String, List<String>> torrcOverrides,
+                              String torrcOverrideFilePath,
                               int sendMessageThrottleTime,
                               int receiveMessageThrottleTime,
                               boolean useExternalTor) {
@@ -118,6 +167,7 @@ public class TorTransportConfig implements TransportConfig {
         this.isTestNetwork = isTestNetwork;
         this.directoryAuthorities = directoryAuthorities;
         this.torrcOverrides = torrcOverrides;
+        this.torrcOverrideFilePath = torrcOverrideFilePath;
         this.sendMessageThrottleTime = sendMessageThrottleTime;
         this.receiveMessageThrottleTime = receiveMessageThrottleTime;
         this.useExternalTor = useExternalTor;

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorrcClientConfigFactory.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorrcClientConfigFactory.java
@@ -25,9 +25,12 @@ import lombok.Builder;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static bisq.network.tor.common.torrc.Torrc.Keys.DISABLE_NETWORK;
+
 
 @Builder
 public class TorrcClientConfigFactory {
@@ -43,14 +46,23 @@ public class TorrcClientConfigFactory {
         this.hashedControlPassword = hashedControlPassword;
     }
 
-    public Map<String, String> torrcClientConfigMap(Map<String, String> torrcOverrides) {
-        Map<String, String> torrcClientConfig = clientTorrcGenerator().generate();
-        torrcClientConfig.putAll(torrcOverrides);
-        torrcClientConfig.put(DISABLE_NETWORK, "1");
-        return torrcClientConfig;
+    public List<String> torrcClientConfigLines(Map<String, List<String>> torrcOverrides) {
+        Map<String, String> baseConfig = clientTorrcGenerator().generate();
+        baseConfig.put(DISABLE_NETWORK, "1");
+
+        List<String> lines = new ArrayList<>();
+        baseConfig.forEach((key, value) -> {
+            if (!torrcOverrides.containsKey(key)) {
+                lines.add(key + " " + value);
+            }
+        });
+        torrcOverrides.forEach((key, values) ->
+                values.forEach(value -> lines.add(key + " " + value))
+        );
+        return lines;
     }
 
-    private TorrcConfigGenerator clientTorrcGenerator() {
+    TorrcConfigGenerator clientTorrcGenerator() {
         TorrcConfigGenerator baseTorrcGenerator = baseTorrcGenerator();
         if (isTestNetwork) {
             baseTorrcGenerator = testNetworkTorrcGenerator(baseTorrcGenerator);

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorrcClientConfigFactory.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorrcClientConfigFactory.java
@@ -25,7 +25,6 @@ import lombok.Builder;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -46,20 +45,11 @@ public class TorrcClientConfigFactory {
         this.hashedControlPassword = hashedControlPassword;
     }
 
-    public List<String> torrcClientConfigLines(Map<String, List<String>> torrcOverrides) {
-        Map<String, String> baseConfig = clientTorrcGenerator().generate();
-        baseConfig.put(DISABLE_NETWORK, "1");
-
-        List<String> lines = new ArrayList<>();
-        baseConfig.forEach((key, value) -> {
-            if (!torrcOverrides.containsKey(key)) {
-                lines.add(key + " " + value);
-            }
-        });
-        torrcOverrides.forEach((key, values) ->
-                values.forEach(value -> lines.add(key + " " + value))
-        );
-        return lines;
+    public Map<String, List<String>> torrcClientConfigMap(Map<String, List<String>> torrcOverrides) {
+        Map<String, List<String>> torrcClientConfig = clientTorrcGenerator().generate();
+        torrcClientConfig.put(DISABLE_NETWORK, List.of("1"));
+        torrcClientConfig.putAll(torrcOverrides);
+        return torrcClientConfig;
     }
 
     TorrcConfigGenerator clientTorrcGenerator() {

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorrcFileParser.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorrcFileParser.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TorrcFileParser {
+
+    /**
+     * Parses a torrc-style override file into a map of key → list of values.
+     * Each non-blank, non-comment line is expected to have the form {@code Key Value}.
+     * Repeated keys (e.g. multiple {@code Bridge} lines) accumulate into a list so that
+     * all entries appear in the generated torrc.
+     */
+    public static Map<String, List<String>> parseTorrcOverrideFile(Path filePath) throws IOException {
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        for (String line : Files.readAllLines(filePath)) {
+            String trimmed = line.strip();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            int spaceIndex = -1;
+            for (int i = 0; i < trimmed.length(); i++) {
+                if (Character.isWhitespace(trimmed.charAt(i))) {
+                    spaceIndex = i;
+                    break;
+                }
+            }
+            if (spaceIndex < 0) {
+                continue; // bare key with no value — skip
+            }
+            String key = trimmed.substring(0, spaceIndex);
+            String value = trimmed.substring(spaceIndex + 1).strip();
+            result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+        return result;
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorrcFileParser.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorrcFileParser.java
@@ -17,6 +17,9 @@
 
 package bisq.network.tor;
 
+import bisq.common.data.Pair;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,36 +27,66 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+@Slf4j
 public class TorrcFileParser {
 
     /**
      * Parses a torrc-style override file into a map of key → list of values.
-     * Each non-blank, non-comment line is expected to have the form {@code Key Value}.
      * Repeated keys (e.g. multiple {@code Bridge} lines) accumulate into a list so that
      * all entries appear in the generated torrc.
      */
     public static Map<String, List<String>> parseTorrcOverrideFile(Path filePath) throws IOException {
         Map<String, List<String>> result = new LinkedHashMap<>();
         for (String line : Files.readAllLines(filePath)) {
-            String trimmed = line.strip();
-            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                continue;
-            }
-            int spaceIndex = -1;
-            for (int i = 0; i < trimmed.length(); i++) {
-                if (Character.isWhitespace(trimmed.charAt(i))) {
-                    spaceIndex = i;
-                    break;
-                }
-            }
-            if (spaceIndex < 0) {
-                continue; // bare key with no value — skip
-            }
-            String key = trimmed.substring(0, spaceIndex);
-            String value = trimmed.substring(spaceIndex + 1).strip();
-            result.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+            parseDirective(line).ifPresent(directive ->
+                    result.computeIfAbsent(directive.getFirst(), key -> new ArrayList<>()).add(directive.getSecond()));
         }
         return result;
+    }
+
+    /**
+     * Parses a single torrc line into its key and value. Blank lines, comment lines and keys
+     * without a value yield an empty result. Key and value may be separated by any whitespace,
+     * and a trailing {@code #} comment is removed unless it appears inside a quoted value.
+     */
+    static Optional<Pair<String, String>> parseDirective(String line) {
+        String directive = stripComment(line).strip();
+        if (directive.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int separatorIndex = indexOfFirstWhitespace(directive);
+        String value = separatorIndex < 0 ? "" : directive.substring(separatorIndex + 1).strip();
+        if (value.isEmpty()) {
+            log.warn("Ignoring torrc line without a value: '{}'", directive);
+            return Optional.empty();
+        }
+        return Optional.of(new Pair<>(directive.substring(0, separatorIndex), value));
+    }
+
+    private static String stripComment(String line) {
+        boolean isInQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char current = line.charAt(i);
+            if (isInQuotes && current == '\\') {
+                i++; // Skip the escaped character so an escaped quote does not end the value
+            } else if (current == '"') {
+                isInQuotes = !isInQuotes;
+            } else if (current == '#' && !isInQuotes) {
+                return line.substring(0, i);
+            }
+        }
+        return line;
+    }
+
+    private static int indexOfFirstWhitespace(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isWhitespace(value.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorrcOverrideConfigParser.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorrcOverrideConfigParser.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import bisq.common.data.Pair;
+import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Parses the {@code torrcOverrides} HOCON object into a map of key → list of values.
+ * Supported value types are numbers, strings, booleans and lists/objects of those.
+ * Entries whose value type is not supported are dropped.
+ */
+public class TorrcOverrideConfigParser {
+
+    static Map<String, List<String>> parse(ConfigObject torrcOverrides) {
+        return torrcOverrides.entrySet().stream()
+                .map(TorrcOverrideConfigParser::tryToParseTorrcOverrideEntry)
+                .filter(TorrcOverrideConfigParser::isValidTorrcOverrideEntry)
+                .map(TorrcOverrideConfigParser::flattenTorrcOverrideOptionalValue)
+                .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond, (a, b) -> b, LinkedHashMap::new));
+    }
+
+    private static Pair<String, Optional<List<String>>> tryToParseTorrcOverrideEntry(Map.Entry<String, ConfigValue> entry) {
+        String key = entry.getKey();
+        ConfigValue configValue = entry.getValue();
+
+        Optional<List<String>> value = tryToParseBasicDataType(configValue)
+                .map(List::of)
+                .or(tryToParseList(configValue));
+
+        return new Pair<>(key, value);
+    }
+
+    private static boolean isValidTorrcOverrideEntry(Pair<String, Optional<List<String>>> keyValuePair) {
+        Optional<List<String>> optionalValue = keyValuePair.getSecond();
+        return optionalValue.isPresent();
+    }
+
+    private static Pair<String, List<String>> flattenTorrcOverrideOptionalValue(Pair<String, Optional<List<String>>> keyValuePair) {
+        //noinspection OptionalGetWithoutIsPresent
+        return new Pair<>(keyValuePair.getFirst(), keyValuePair.getSecond().get());
+    }
+
+    private static Optional<String> tryToParseBasicDataType(ConfigValue configValue) {
+        return tryToParseNumber(configValue)
+                .or(tryToParseString(configValue))
+                .or(tryToParseBoolean(configValue));
+    }
+
+    private static Supplier<Optional<? extends List<String>>> tryToParseList(ConfigValue configValue) {
+        return () -> {
+            // A HOCON array (e.g. Bridge = ["a", "b"]) has valueType() == LIST and is a ConfigList,
+            // which is itself a List<ConfigValue> — it is NOT a ConfigObject, so it must not be cast to one.
+            if (configValue.valueType() == ConfigValueType.LIST) {
+                ConfigList configList = (ConfigList) configValue;
+
+                List<String> values = configList.stream()
+                        .map(TorrcOverrideConfigParser::tryToParseBasicDataType)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .toList();
+
+                return Optional.of(values);
+            }
+            return Optional.empty();
+        };
+    }
+
+    private static Optional<String> tryToParseNumber(ConfigValue configValue) {
+        if (configValue.valueType() == ConfigValueType.NUMBER) {
+            int value = (int) configValue.unwrapped();
+            return Optional.of(String.valueOf(value));
+        }
+        return Optional.empty();
+    }
+
+    private static Supplier<Optional<? extends String>> tryToParseString(ConfigValue configValue) {
+        return () -> {
+            if (configValue.valueType() == ConfigValueType.STRING) {
+                String value = (String) configValue.unwrapped();
+                return Optional.of(value);
+            }
+            return Optional.empty();
+        };
+    }
+
+    private static Supplier<Optional<? extends String>> tryToParseBoolean(ConfigValue configValue) {
+        return () -> {
+            if (configValue.valueType() == ConfigValueType.BOOLEAN) {
+                boolean value = (boolean) configValue.unwrapped();
+                return Optional.of(String.valueOf(value));
+            }
+            return Optional.empty();
+        };
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/TorrcOverrideConfigParser.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/TorrcOverrideConfigParser.java
@@ -93,8 +93,10 @@ public class TorrcOverrideConfigParser {
 
     private static Optional<String> tryToParseNumber(ConfigValue configValue) {
         if (configValue.valueType() == ConfigValueType.NUMBER) {
-            int value = (int) configValue.unwrapped();
-            return Optional.of(String.valueOf(value));
+            // HOCON unwraps a NUMBER to Integer, Long or Double depending on the literal
+            // (e.g. CircuitPriorityHalflife=1.5 or MaxMemInQueues=4294967296), so it must not
+            // be cast to int. String.valueOf renders all three in the form torrc expects.
+            return Optional.of(String.valueOf(configValue.unwrapped()));
         }
         return Optional.empty();
     }

--- a/network/tor/tor/src/main/java/bisq/network/tor/UseExternalTorResolver.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/UseExternalTorResolver.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import bisq.common.application.ConfigUtil;
+import bisq.common.util.StringUtils;
+
+final class UseExternalTorResolver {
+    private UseExternalTorResolver() {
+    }
+
+    static boolean evaluateUseExternalTorValue(boolean isWhonix,
+                                               String torSkipLaunch,
+                                               boolean useExternalTorFromJvmConfig,
+                                               String useExternalTorFromConfig) {
+        if (isWhonix) {
+            return true;
+        }
+
+        // If environment variable is set we take that.
+        if (StringUtils.isNotEmpty(torSkipLaunch)) {
+            return ConfigUtil.parseBooleanFlag(torSkipLaunch);
+        }
+
+        // JVM config has higher priority than external_tor.config to make CLI/JVM overrides reliable.
+        if (useExternalTorFromJvmConfig) {
+            return true;
+        }
+
+        // Finally, check external_tor.config value.
+        return ConfigUtil.parseBooleanFlag(useExternalTorFromConfig);
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlConnectionClosedException.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlConnectionClosedException.java
@@ -1,0 +1,7 @@
+package bisq.network.tor.controller;
+
+public class TorControlConnectionClosedException extends RuntimeException {
+    public TorControlConnectionClosedException(String message) {
+        super(message);
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
@@ -10,11 +10,17 @@ import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
-import java.net.Socket;
+import java.net.ProtocolFamily;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -26,7 +32,7 @@ import java.util.stream.Stream;
 public class TorControlProtocol implements AutoCloseable {
     private static final int MAX_CONNECTION_ATTEMPTS = 10;
 
-    private Socket controlSocket;
+    private AutoCloseable controlConnection;
     private final TorControlReader torControlReader;
     private Optional<OutputStream> outputStream = Optional.empty();
 
@@ -40,29 +46,63 @@ public class TorControlProtocol implements AutoCloseable {
     }
 
     public void initialize(int port) {
+        initialize("127.0.0.1", port);
+    }
+
+    public void initialize(String host, int port) {
         try {
-            this.controlSocket = createAndConnectControlSocket(port);
-            this.outputStream = Optional.of(this.controlSocket.getOutputStream());
-            this.torControlReader.start(this.controlSocket.getInputStream());
-            log.info("TorControlProtocol initialized successfully for port {}", port);
+            SocketChannel socketChannel = createAndConnectTcpControlSocket(host, port);
+            initializeControlConnection(socketChannel,
+                    Channels.newInputStream(socketChannel),
+                    Channels.newOutputStream(socketChannel),
+                    host + ":" + port);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();  // Restore interrupted state
-            log.error("TorControlProtocol initialization for port {} was interrupted.", port, e);
-            close();
-            throw new CannotConnectWithTorException(e);
-        } catch (IOException e) {
-            log.error("TorControlProtocol failed to set up streams for port {}.", port, e);
+            log.error("TorControlProtocol initialization for control endpoint {}:{} was interrupted.", host, port, e);
             close();
             throw new CannotConnectWithTorException(e);
         } catch (CannotConnectWithTorException e) {
-            log.error("TorControlProtocol failed to connect to Tor control port {} (as thrown by createAndConnectControlSocket).", port, e);
+            log.error("TorControlProtocol failed to connect to Tor control endpoint {}:{}.", host, port, e);
             close();
             throw e;
         } catch (Exception e) {
-            log.error("Unexpected exception during TorControlProtocol initialization for port {}.", port, e);
+            log.error("Unexpected exception during TorControlProtocol initialization for control endpoint {}:{}.", host, port, e);
             close();
             throw new CannotConnectWithTorException(e);
         }
+    }
+
+    public void initialize(Path controlSocketPath) {
+        try {
+            SocketChannel socketChannel = createAndConnectUnixControlSocket(controlSocketPath);
+            initializeControlConnection(socketChannel,
+                    Channels.newInputStream(socketChannel),
+                    Channels.newOutputStream(socketChannel),
+                    controlSocketPath.toString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("TorControlProtocol initialization for control socket {} was interrupted.", controlSocketPath, e);
+            close();
+            throw new CannotConnectWithTorException(e);
+        } catch (CannotConnectWithTorException e) {
+            log.error("TorControlProtocol failed to connect to Tor control socket {}.", controlSocketPath, e);
+            close();
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected exception during TorControlProtocol initialization for control socket {}.", controlSocketPath, e);
+            close();
+            throw new CannotConnectWithTorException(e);
+        }
+    }
+
+    private void initializeControlConnection(AutoCloseable controlConnection,
+                                             InputStream inputStream,
+                                             OutputStream outputStream,
+                                             String endpointDescription) {
+        this.controlConnection = controlConnection;
+        this.outputStream = Optional.of(outputStream);
+        this.torControlReader.start(inputStream);
+        log.info("TorControlProtocol initialized successfully for control endpoint {}", endpointDescription);
     }
 
     @Override
@@ -73,12 +113,12 @@ public class TorControlProtocol implements AutoCloseable {
         closeInProgress = true;
         log.debug("Closing TorControlProtocol resources.");
         try {
-            if (controlSocket != null && !controlSocket.isClosed()) {
-                controlSocket.close();
-                log.debug("Control socket closed.");
+            if (controlConnection != null) {
+                controlConnection.close();
+                log.debug("Control connection closed.");
             }
-        } catch (IOException e) {
-            log.warn("IOException while closing control socket. This may be expected if connection was problematic.", e);
+        } catch (Exception e) {
+            log.warn("Exception while closing control connection. This may be expected if connection was problematic.", e);
         }
         try {
             torControlReader.close();
@@ -86,6 +126,7 @@ public class TorControlProtocol implements AutoCloseable {
         } catch (Exception e) {
             log.warn("Exception while closing TorControlReader.", e);
         }
+        controlConnection = null;
         outputStream = Optional.empty();
         closeInProgress = false;
     }
@@ -262,51 +303,112 @@ public class TorControlProtocol implements AutoCloseable {
         }
     }
 
-    private Socket createAndConnectControlSocket(int port) throws InterruptedException, CannotConnectWithTorException {
+    private SocketChannel createAndConnectTcpControlSocket(String host,
+                                                           int port) throws InterruptedException, CannotConnectWithTorException {
         int connectionAttempt = 0;
         Exception lastException = null;
 
         while (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
-            Socket attemptSocket = new Socket();
+            SocketChannel socketChannel = null;
             try {
-                // The Tor Control Port communication is typically unencrypted. 
+                // The Tor Control Port communication is typically unencrypted.
                 // This is considered safe because the connection is made to 127.0.0.1 (localhost),
-                // ensuring that the communication does not leave the local machine and is not 
-                // exposed to external networks. Authentication (via cookie or password) 
+                // ensuring that the communication does not leave the local machine and is not
+                // exposed to external networks. Authentication (via cookie or password)
                 // is handled by the Tor control protocol itself after connection.
-                var socketAddress = new InetSocketAddress("127.0.0.1", port);
-                log.debug("Attempting to connect to Tor control port {} ({}/{})", socketAddress, connectionAttempt + 1, MAX_CONNECTION_ATTEMPTS);
-                attemptSocket.connect(socketAddress);
-                log.info("Successfully connected control socket to Tor port {} after {} attempts", port, connectionAttempt + 1);
-                return attemptSocket;
+                //
+                // Explicitly use INET (IPv4) so the socket's local address appears as
+                // "127.0.0.1" in /proc/net/tcp.  Java's default NioSocketImpl creates
+                // AF_INET6 dual-stack sockets, causing the local address to appear as
+                // "::ffff:127.0.0.1" in /proc/net/tcp6.  On Tails, onion-grater resolves
+                // the client PID via psutil.net_connections() matching on local address;
+                // the IPv6-mapped form does not match, so PID lookup fails and
+                // onion-grater silently closes the connection.
+                socketChannel = SocketChannel.open(StandardProtocolFamily.INET);
+                var socketAddress = new InetSocketAddress(host, port);
+                log.debug("Attempting to connect to Tor control endpoint {} ({}/{})", socketAddress, connectionAttempt + 1, MAX_CONNECTION_ATTEMPTS);
+                socketChannel.connect(socketAddress);
+                log.info("Successfully connected control socket to Tor endpoint {} after {} attempts", socketAddress, connectionAttempt + 1);
+                return socketChannel;
             } catch (ConnectException e) {
                 lastException = e;
-                log.warn("ConnectException on attempt {} to Tor control port {}: {}. Closing attemptSocket.",
-                        connectionAttempt + 1, port, e.getMessage());
-                try {
-                    attemptSocket.close();
-                } catch (IOException closeEx) {
-                    log.warn("Failed to close attemptSocket after ConnectException on port {}: {}", port, closeEx.getMessage(), closeEx);
+                log.warn("ConnectException on attempt {} to Tor control endpoint {}:{}: {}. Closing channel.",
+                        connectionAttempt + 1, host, port, e.getMessage());
+                if (socketChannel != null) {
+                    try {
+                        socketChannel.close();
+                    } catch (IOException closeEx) {
+                        log.warn("Failed to close channel after ConnectException on endpoint {}:{}: {}",
+                                host, port, closeEx.getMessage(), closeEx);
+                    }
                 }
             } catch (IOException e) {
                 lastException = e;
-                log.warn("IOException on attempt {} to Tor control port {}: {}. Closing attemptSocket.",
-                        connectionAttempt + 1, port, e.getMessage());
-                try {
-                    attemptSocket.close();
-                } catch (IOException closeEx) {
-                    log.warn("Failed to close attemptSocket after IOException on port {}: {}", port, closeEx.getMessage(), closeEx);
+                log.warn("IOException on attempt {} to Tor control endpoint {}:{}: {}. Closing channel.",
+                        connectionAttempt + 1, host, port, e.getMessage());
+                if (socketChannel != null) {
+                    try {
+                        socketChannel.close();
+                    } catch (IOException closeEx) {
+                        log.warn("Failed to close channel after IOException on endpoint {}:{}: {}",
+                                host, port, closeEx.getMessage(), closeEx);
+                    }
                 }
             }
 
             connectionAttempt++;
             if (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
-                log.debug("Connection attempt to Tor control port {} failed. Retrying in 200ms...", port);
+                log.debug("Connection attempt to Tor control endpoint {}:{} failed. Retrying in 200ms...", host, port);
                 Thread.sleep(200);
             }
         }
 
-        String errorMessage = "Failed to connect to Tor control port " + port + " after " + MAX_CONNECTION_ATTEMPTS + " attempts.";
+        String errorMessage = "Failed to connect to Tor control endpoint " + host + ":" + port +
+                " after " + MAX_CONNECTION_ATTEMPTS + " attempts.";
+        IOException wrapperException = new IOException(errorMessage, lastException);
+        log.error(errorMessage, wrapperException);
+        throw new CannotConnectWithTorException(wrapperException);
+    }
+
+    private SocketChannel createAndConnectUnixControlSocket(Path controlSocketPath) throws InterruptedException, CannotConnectWithTorException {
+        int connectionAttempt = 0;
+        Exception lastException = null;
+
+        while (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
+            SocketChannel socketChannel = null;
+            try {
+                ProtocolFamily protocolFamily = StandardProtocolFamily.UNIX;
+                socketChannel = SocketChannel.open(protocolFamily);
+                UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(controlSocketPath);
+                log.debug("Attempting to connect to Tor control socket {} ({}/{})",
+                        controlSocketPath, connectionAttempt + 1, MAX_CONNECTION_ATTEMPTS);
+                socketChannel.connect(socketAddress);
+                log.info("Successfully connected control socket to Tor socket {} after {} attempts",
+                        controlSocketPath, connectionAttempt + 1);
+                return socketChannel;
+            } catch (IOException | UnsupportedOperationException e) {
+                lastException = e;
+                log.warn("Connection attempt {} to Tor control socket {} failed: {}. Closing channel.",
+                        connectionAttempt + 1, controlSocketPath, e.getMessage());
+                if (socketChannel != null) {
+                    try {
+                        socketChannel.close();
+                    } catch (IOException closeEx) {
+                        log.warn("Failed to close socket channel for control socket {}: {}",
+                                controlSocketPath, closeEx.getMessage(), closeEx);
+                    }
+                }
+            }
+
+            connectionAttempt++;
+            if (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
+                log.debug("Connection attempt to Tor control socket {} failed. Retrying in 200ms...", controlSocketPath);
+                Thread.sleep(200);
+            }
+        }
+
+        String errorMessage = "Failed to connect to Tor control socket " + controlSocketPath +
+                " after " + MAX_CONNECTION_ATTEMPTS + " attempts.";
         IOException wrapperException = new IOException(errorMessage, lastException);
         log.error(errorMessage, wrapperException);
         throw new CannotConnectWithTorException(wrapperException);

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlProtocol.java
@@ -10,17 +10,11 @@ import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ConnectException;
-import java.net.InetSocketAddress;
-import java.net.ProtocolFamily;
-import java.net.StandardProtocolFamily;
-import java.net.UnixDomainSocketAddress;
+import java.net.SocketAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -30,8 +24,6 @@ import java.util.stream.Stream;
 
 @Slf4j
 public class TorControlProtocol implements AutoCloseable {
-    private static final int MAX_CONNECTION_ATTEMPTS = 10;
-
     private AutoCloseable controlConnection;
     private final TorControlReader torControlReader;
     private Optional<OutputStream> outputStream = Optional.empty();
@@ -45,64 +37,27 @@ public class TorControlProtocol implements AutoCloseable {
         torControlReader = new TorControlReader();
     }
 
-    public void initialize(int port) {
-        initialize("127.0.0.1", port);
-    }
-
-    public void initialize(String host, int port) {
+    public void initialize(SocketAddress socketAddress) {
         try {
-            SocketChannel socketChannel = createAndConnectTcpControlSocket(host, port);
-            initializeControlConnection(socketChannel,
-                    Channels.newInputStream(socketChannel),
-                    Channels.newOutputStream(socketChannel),
-                    host + ":" + port);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();  // Restore interrupted state
-            log.error("TorControlProtocol initialization for control endpoint {}:{} was interrupted.", host, port, e);
-            close();
-            throw new CannotConnectWithTorException(e);
-        } catch (CannotConnectWithTorException e) {
-            log.error("TorControlProtocol failed to connect to Tor control endpoint {}:{}.", host, port, e);
-            close();
-            throw e;
+            SocketChannel socketChannel = new TorControlSocketChannelFactory(socketAddress).createAndConnect();
+            initializeControlConnection(socketChannel);
+
         } catch (Exception e) {
-            log.error("Unexpected exception during TorControlProtocol initialization for control endpoint {}:{}.", host, port, e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();  // Restore interrupted state
+            }
+
+            log.error("TorControlProtocol initialization for control endpoint {}.", socketAddress, e);
             close();
             throw new CannotConnectWithTorException(e);
         }
     }
 
-    public void initialize(Path controlSocketPath) {
-        try {
-            SocketChannel socketChannel = createAndConnectUnixControlSocket(controlSocketPath);
-            initializeControlConnection(socketChannel,
-                    Channels.newInputStream(socketChannel),
-                    Channels.newOutputStream(socketChannel),
-                    controlSocketPath.toString());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("TorControlProtocol initialization for control socket {} was interrupted.", controlSocketPath, e);
-            close();
-            throw new CannotConnectWithTorException(e);
-        } catch (CannotConnectWithTorException e) {
-            log.error("TorControlProtocol failed to connect to Tor control socket {}.", controlSocketPath, e);
-            close();
-            throw e;
-        } catch (Exception e) {
-            log.error("Unexpected exception during TorControlProtocol initialization for control socket {}.", controlSocketPath, e);
-            close();
-            throw new CannotConnectWithTorException(e);
-        }
-    }
-
-    private void initializeControlConnection(AutoCloseable controlConnection,
-                                             InputStream inputStream,
-                                             OutputStream outputStream,
-                                             String endpointDescription) {
-        this.controlConnection = controlConnection;
-        this.outputStream = Optional.of(outputStream);
-        this.torControlReader.start(inputStream);
-        log.info("TorControlProtocol initialized successfully for control endpoint {}", endpointDescription);
+    private void initializeControlConnection(SocketChannel socketChannel) throws IOException {
+        this.controlConnection = socketChannel;
+        this.outputStream = Optional.of(Channels.newOutputStream(socketChannel));
+        this.torControlReader.start(Channels.newInputStream(socketChannel));
+        log.info("TorControlProtocol initialized successfully for control endpoint {}", socketChannel.getRemoteAddress());
     }
 
     @Override
@@ -301,117 +256,6 @@ public class TorControlProtocol implements AutoCloseable {
         if (!isSuccessReply(reply)) {
             throw new ControlCommandFailedException("Couldn't set events: " + events);
         }
-    }
-
-    private SocketChannel createAndConnectTcpControlSocket(String host,
-                                                           int port) throws InterruptedException, CannotConnectWithTorException {
-        int connectionAttempt = 0;
-        Exception lastException = null;
-
-        while (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
-            SocketChannel socketChannel = null;
-            try {
-                // The Tor Control Port communication is typically unencrypted.
-                // This is considered safe because the connection is made to 127.0.0.1 (localhost),
-                // ensuring that the communication does not leave the local machine and is not
-                // exposed to external networks. Authentication (via cookie or password)
-                // is handled by the Tor control protocol itself after connection.
-                //
-                // Explicitly use INET (IPv4) so the socket's local address appears as
-                // "127.0.0.1" in /proc/net/tcp.  Java's default NioSocketImpl creates
-                // AF_INET6 dual-stack sockets, causing the local address to appear as
-                // "::ffff:127.0.0.1" in /proc/net/tcp6.  On Tails, onion-grater resolves
-                // the client PID via psutil.net_connections() matching on local address;
-                // the IPv6-mapped form does not match, so PID lookup fails and
-                // onion-grater silently closes the connection.
-                socketChannel = SocketChannel.open(StandardProtocolFamily.INET);
-                var socketAddress = new InetSocketAddress(host, port);
-                log.debug("Attempting to connect to Tor control endpoint {} ({}/{})", socketAddress, connectionAttempt + 1, MAX_CONNECTION_ATTEMPTS);
-                socketChannel.connect(socketAddress);
-                log.info("Successfully connected control socket to Tor endpoint {} after {} attempts", socketAddress, connectionAttempt + 1);
-                return socketChannel;
-            } catch (ConnectException e) {
-                lastException = e;
-                log.warn("ConnectException on attempt {} to Tor control endpoint {}:{}: {}. Closing channel.",
-                        connectionAttempt + 1, host, port, e.getMessage());
-                if (socketChannel != null) {
-                    try {
-                        socketChannel.close();
-                    } catch (IOException closeEx) {
-                        log.warn("Failed to close channel after ConnectException on endpoint {}:{}: {}",
-                                host, port, closeEx.getMessage(), closeEx);
-                    }
-                }
-            } catch (IOException e) {
-                lastException = e;
-                log.warn("IOException on attempt {} to Tor control endpoint {}:{}: {}. Closing channel.",
-                        connectionAttempt + 1, host, port, e.getMessage());
-                if (socketChannel != null) {
-                    try {
-                        socketChannel.close();
-                    } catch (IOException closeEx) {
-                        log.warn("Failed to close channel after IOException on endpoint {}:{}: {}",
-                                host, port, closeEx.getMessage(), closeEx);
-                    }
-                }
-            }
-
-            connectionAttempt++;
-            if (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
-                log.debug("Connection attempt to Tor control endpoint {}:{} failed. Retrying in 200ms...", host, port);
-                Thread.sleep(200);
-            }
-        }
-
-        String errorMessage = "Failed to connect to Tor control endpoint " + host + ":" + port +
-                " after " + MAX_CONNECTION_ATTEMPTS + " attempts.";
-        IOException wrapperException = new IOException(errorMessage, lastException);
-        log.error(errorMessage, wrapperException);
-        throw new CannotConnectWithTorException(wrapperException);
-    }
-
-    private SocketChannel createAndConnectUnixControlSocket(Path controlSocketPath) throws InterruptedException, CannotConnectWithTorException {
-        int connectionAttempt = 0;
-        Exception lastException = null;
-
-        while (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
-            SocketChannel socketChannel = null;
-            try {
-                ProtocolFamily protocolFamily = StandardProtocolFamily.UNIX;
-                socketChannel = SocketChannel.open(protocolFamily);
-                UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(controlSocketPath);
-                log.debug("Attempting to connect to Tor control socket {} ({}/{})",
-                        controlSocketPath, connectionAttempt + 1, MAX_CONNECTION_ATTEMPTS);
-                socketChannel.connect(socketAddress);
-                log.info("Successfully connected control socket to Tor socket {} after {} attempts",
-                        controlSocketPath, connectionAttempt + 1);
-                return socketChannel;
-            } catch (IOException | UnsupportedOperationException e) {
-                lastException = e;
-                log.warn("Connection attempt {} to Tor control socket {} failed: {}. Closing channel.",
-                        connectionAttempt + 1, controlSocketPath, e.getMessage());
-                if (socketChannel != null) {
-                    try {
-                        socketChannel.close();
-                    } catch (IOException closeEx) {
-                        log.warn("Failed to close socket channel for control socket {}: {}",
-                                controlSocketPath, closeEx.getMessage(), closeEx);
-                    }
-                }
-            }
-
-            connectionAttempt++;
-            if (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
-                log.debug("Connection attempt to Tor control socket {} failed. Retrying in 200ms...", controlSocketPath);
-                Thread.sleep(200);
-            }
-        }
-
-        String errorMessage = "Failed to connect to Tor control socket " + controlSocketPath +
-                " after " + MAX_CONNECTION_ATTEMPTS + " attempts.";
-        IOException wrapperException = new IOException(errorMessage, lastException);
-        log.error(errorMessage, wrapperException);
-        throw new CannotConnectWithTorException(wrapperException);
     }
 
     private void sendCommand(String command) {

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlReader.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlReader.java
@@ -89,7 +89,7 @@ public class TorControlReader implements AutoCloseable {
                 if (!isStopped) {
                     log.warn("Tor control connection closed unexpectedly.");
                 }
-                replies.offer(CONNECTION_CLOSED_SENTINEL);
+                replies.add(CONNECTION_CLOSED_SENTINEL);
             }
         });
         workerThread = Optional.of(thread);

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlReader.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlReader.java
@@ -21,6 +21,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 @Slf4j
 public class TorControlReader implements AutoCloseable {
+    // Sentinel inserted into the queue when the reader thread terminates so that
+    // any thread blocked in readLine() gets unblocked and can detect the closure.
+    static final String CONNECTION_CLOSED_SENTINEL = "__CONNECTION_CLOSED__";
+
     private final BlockingQueue<String> replies = new LinkedBlockingQueue<>();
     @Getter
     private final List<BootstrapEventListener> bootstrapEventListeners = new CopyOnWriteArrayList<>();
@@ -81,6 +85,11 @@ public class TorControlReader implements AutoCloseable {
                 if (!isStopped) {
                     log.error("Tor control port reader couldn't read reply.", e);
                 }
+            } finally {
+                if (!isStopped) {
+                    log.warn("Tor control connection closed unexpectedly.");
+                }
+                replies.offer(CONNECTION_CLOSED_SENTINEL);
             }
         });
         workerThread = Optional.of(thread);
@@ -95,7 +104,13 @@ public class TorControlReader implements AutoCloseable {
 
     public String readLine() {
         try {
-            return replies.take();
+            String line = replies.take();
+            if (CONNECTION_CLOSED_SENTINEL.equals(line)) {
+                // Re-enqueue so subsequent callers also unblock immediately.
+                replies.add(CONNECTION_CLOSED_SENTINEL);
+                throw new TorControlConnectionClosedException("Tor control connection was closed unexpectedly");
+            }
+            return line;
         } catch (InterruptedException e) {
             log.warn("Thread got interrupted at readLine method", e);
             Thread.currentThread().interrupt(); // Restore interrupted state

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlSocketChannelFactory.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorControlSocketChannelFactory.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor.controller;
+
+import bisq.network.tor.controller.exceptions.CannotConnectWithTorException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Creates and connects a {@link SocketChannel} to a Tor control endpoint, retrying on failure.
+ * Supports both TCP ({@link InetSocketAddress}) and Unix domain ({@code UnixDomainSocketAddress})
+ * control endpoints via a single {@link SocketAddress} abstraction.
+ */
+@Slf4j
+public class TorControlSocketChannelFactory {
+    private static final int MAX_CONNECTION_ATTEMPTS = 10;
+
+    private final SocketAddress socketAddress;
+    private int connectionAttempt;
+
+    TorControlSocketChannelFactory(SocketAddress socketAddress) {
+        this.socketAddress = socketAddress;
+    }
+
+    SocketChannel createAndConnect() throws InterruptedException {
+        Exception lastException = null;
+
+        while (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
+            SocketChannel socketChannel = null;
+            try {
+                ++connectionAttempt;
+                socketChannel = connectToControlSocketRaw();
+                return socketChannel;
+
+            } catch (Exception e) {
+                lastException = e;
+                log.warn("Connection attempt {} to Tor control endpoint {} failed. Closing channel.",
+                        connectionAttempt, socketAddress, e);
+                closeSocketChannel(socketChannel, socketAddress);
+            }
+
+            if (connectionAttempt < MAX_CONNECTION_ATTEMPTS) {
+                log.debug("Connection attempt to Tor control endpoint {} failed. Retrying in 200ms...", socketAddress);
+                //noinspection BusyWait
+                Thread.sleep(200);
+            }
+        }
+
+        String errorMessage = "Failed to connect to Tor control endpoint " + socketAddress +
+                " after " + MAX_CONNECTION_ATTEMPTS + " attempts.";
+        IOException wrapperException = new IOException(errorMessage, lastException);
+        log.error(errorMessage, wrapperException);
+        throw new CannotConnectWithTorException(wrapperException);
+    }
+
+    private SocketChannel connectToControlSocketRaw() throws IOException {
+        log.debug("Attempting to connect to Tor control endpoint {} ({}/{})",
+                socketAddress, connectionAttempt, MAX_CONNECTION_ATTEMPTS);
+        SocketChannel socketChannel = openSocketChannel();
+        socketChannel.connect(socketAddress);
+        log.info("Successfully connected control socket to Tor endpoint {} after {} attempts",
+                socketAddress, connectionAttempt);
+        return socketChannel;
+    }
+
+    private SocketChannel openSocketChannel() throws IOException {
+        if (socketAddress instanceof InetSocketAddress) {
+            // Explicitly use INET (IPv4) so the socket's local address appears as
+            // "127.0.0.1" in /proc/net/tcp.  Java's default NioSocketImpl creates
+            // AF_INET6 dual-stack sockets, causing the local address to appear as
+            // "::ffff:127.0.0.1" in /proc/net/tcp6.  On Tails, onion-grater resolves
+            // the client PID via psutil.net_connections() matching on local address;
+            // the IPv6-mapped form does not match, so PID lookup fails and
+            // onion-grater silently closes the connection.
+            return SocketChannel.open(StandardProtocolFamily.INET);
+        }
+        return SocketChannel.open(StandardProtocolFamily.UNIX);
+    }
+
+    private void closeSocketChannel(SocketChannel socketChannel, SocketAddress socketAddress) {
+        if (socketChannel != null) {
+            try {
+                socketChannel.close();
+            } catch (IOException e) {
+                log.warn("Failed to close channel on endpoint {}", socketAddress, e);
+            }
+        }
+    }
+}

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorController.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorController.java
@@ -7,7 +7,7 @@ import bisq.security.keys.TorKeyPair;
 import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
-import java.nio.file.Path;
+import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -32,16 +32,8 @@ public class TorController {
         this.bootstrapEvent = bootstrapEvent;
     }
 
-    public void initialize(int controlPort) {
-        initialize("127.0.0.1", controlPort);
-    }
-
-    public void initialize(String controlHost, int controlPort) {
-        torControlProtocol.initialize(controlHost, controlPort);
-    }
-
-    public void initialize(Path controlSocketPath) {
-        torControlProtocol.initialize(controlSocketPath);
+    public void initialize(SocketAddress socketAddress) {
+        torControlProtocol.initialize(socketAddress);
     }
 
     public void authenticate(byte[] authCookie) {

--- a/network/tor/tor/src/main/java/bisq/network/tor/controller/TorController.java
+++ b/network/tor/tor/src/main/java/bisq/network/tor/controller/TorController.java
@@ -7,6 +7,7 @@ import bisq.security.keys.TorKeyPair;
 import lombok.extern.slf4j.Slf4j;
 import net.freehaven.tor.control.PasswordDigest;
 
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -32,7 +33,15 @@ public class TorController {
     }
 
     public void initialize(int controlPort) {
-        torControlProtocol.initialize(controlPort);
+        initialize("127.0.0.1", controlPort);
+    }
+
+    public void initialize(String controlHost, int controlPort) {
+        torControlProtocol.initialize(controlHost, controlPort);
+    }
+
+    public void initialize(Path controlSocketPath) {
+        torControlProtocol.initialize(controlSocketPath);
     }
 
     public void authenticate(byte[] authCookie) {

--- a/network/tor/tor/src/test/java/bisq/network/tor/ExternalTorConfigHeuristicsTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/ExternalTorConfigHeuristicsTest.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExternalTorConfigHeuristicsTest {
+
+    @Test
+    void applyUsesDetectedSystemTorPaths(@TempDir Path tempDir) throws Exception {
+        Path controlSocketPath = tempDir.resolve("control");
+        Path cookieAuthFilePath = tempDir.resolve("control.authcookie");
+        Files.createFile(controlSocketPath);
+        Files.createFile(cookieAuthFilePath);
+
+        String template = "#UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n" +
+                "## ControlSocket /path/to/tor/control.socket\n" +
+                "ControlPort 127.0.0.1:9051\n";
+
+        String result = ExternalTorConfigHeuristics.apply(
+                template,
+                controlSocketPath,
+                List.of(cookieAuthFilePath),
+                false);
+
+        String expected = "UseExternalTor 1\n" +
+                "CookieAuthentication 1\n" +
+                "CookieAuthFile " + cookieAuthFilePath + "\n" +
+                "ControlSocket " + controlSocketPath + "\n" +
+                "ControlPort 127.0.0.1:9051\n";
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void applyLeavesTemplateUnchangedWithoutSystemTorSocket(@TempDir Path tempDir) {
+        String template = "#UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n";
+
+        String result = ExternalTorConfigHeuristics.apply(
+                template,
+                tempDir.resolve("missing-control"),
+                List.of(tempDir.resolve("missing-cookie")),
+                false);
+
+        assertThat(result).isEqualTo(template);
+    }
+
+    @Test
+    void applyLeavesCookieAuthenticationDisabledWhenCookieFileIsMissing(@TempDir Path tempDir) throws Exception {
+        Path controlSocketPath = tempDir.resolve("control");
+        Files.createFile(controlSocketPath);
+
+        String template = "#UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n" +
+                "## ControlSocket /path/to/tor/control.socket\n" +
+                "ControlPort 127.0.0.1:9051\n";
+
+        String result = ExternalTorConfigHeuristics.apply(
+                template,
+                controlSocketPath,
+                List.of(tempDir.resolve("missing-control.authcookie")),
+                false);
+
+        String expected = "UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n" +
+                "ControlSocket " + controlSocketPath + "\n" +
+                "ControlPort 127.0.0.1:9051\n";
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void applyUsesOnionGraterOnTailsWhenSocketNotReadable(@TempDir Path tempDir) throws Exception {
+        Path cookieAuthFilePath = tempDir.resolve("control.authcookie");
+        Files.createFile(cookieAuthFilePath);
+
+        String template = "#UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n" +
+                "## ControlSocket /path/to/tor/control.socket\n" +
+                "ControlPort 127.0.0.1:9051\n";
+
+        String result = ExternalTorConfigHeuristics.apply(
+                template,
+                tempDir.resolve("missing-control"),
+                List.of(cookieAuthFilePath),
+                true);
+
+        String expected = "UseExternalTor 1\n" +
+                "CookieAuthentication 1\n" +
+                "CookieAuthFile " + cookieAuthFilePath + "\n" +
+                "## ControlSocket /path/to/tor/control.socket\n" +
+                "ControlPort 127.0.0.1:951\n";
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void applyUsesOnionGraterOnTailsWithoutCookieAuth(@TempDir Path tempDir) {
+        String template = "#UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n" +
+                "## ControlSocket /path/to/tor/control.socket\n" +
+                "ControlPort 127.0.0.1:9051\n";
+
+        String result = ExternalTorConfigHeuristics.apply(
+                template,
+                tempDir.resolve("missing-control"),
+                List.of(tempDir.resolve("missing-cookie")),
+                true);
+
+        String expected = "UseExternalTor 1\n" +
+                "CookieAuthentication 0\n" +
+                "CookieAuthFile /path/to/control_auth_cookie\n" +
+                "## ControlSocket /path/to/tor/control.socket\n" +
+                "ControlPort 127.0.0.1:951\n";
+
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/network/tor/tor/src/test/java/bisq/network/tor/TorServiceTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/TorServiceTest.java
@@ -1,0 +1,223 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TorServiceTest {
+
+    @Test
+    void readExternalTorConfigMapUsesTorrcOverrideFilePathWhenSet(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("external_tor.config"),
+                "UseExternalTor 0\n" +
+                        "ControlPort 127.0.0.1:9051\n");
+        Files.writeString(tempDir.resolve("custom_external_tor.config"),
+                "UseExternalTor 1\n" +
+                        "ControlPort 127.0.0.1:1111\n");
+
+        TorService torService = new TorService(createConfig(tempDir, "custom_external_tor.config"));
+        invokeReadExternalTorConfigMap(torService);
+
+        Map<String, String> externalTorConfigMap = getExternalTorConfigMap(torService);
+        assertThat(externalTorConfigMap.get("UseExternalTor")).isEqualTo("1");
+        assertThat(externalTorConfigMap.get("ControlPort")).isEqualTo("127.0.0.1:1111");
+    }
+
+    @Test
+    void readExternalTorConfigMapFallsBackToExternalTorConfigWhenOverridePathMissing(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("external_tor.config"),
+                "UseExternalTor 1\n" +
+                        "ControlPort 127.0.0.1:2222\n");
+
+        TorService torService = new TorService(createConfig(tempDir, "missing_external_tor.config"));
+        invokeReadExternalTorConfigMap(torService);
+
+        Map<String, String> externalTorConfigMap = getExternalTorConfigMap(torService);
+        assertThat(externalTorConfigMap.get("UseExternalTor")).isEqualTo("1");
+        assertThat(externalTorConfigMap.get("ControlPort")).isEqualTo("127.0.0.1:2222");
+    }
+
+    @Test
+    void readExternalTorConfigMapIncludesControlSocketWhenConfigured(@TempDir Path tempDir) throws Exception {
+        Path controlSocketPath = tempDir.resolve("tor-control.sock");
+        Files.writeString(tempDir.resolve("external_tor.config"),
+                "UseExternalTor 1\n" +
+                        "ControlSocket " + controlSocketPath + "\n" +
+                        "ControlPort 127.0.0.1:9051\n");
+
+        TorService torService = new TorService(createConfig(tempDir, ""));
+        invokeReadExternalTorConfigMap(torService);
+
+        Map<String, String> externalTorConfigMap = getExternalTorConfigMap(torService);
+        assertThat(externalTorConfigMap.get("ControlSocket")).isEqualTo(controlSocketPath.toString());
+        assertThat(externalTorConfigMap.get("ControlPort")).isEqualTo("127.0.0.1:9051");
+    }
+
+    @Test
+    void getControlEndpointUnquotesConfiguredControlSocket(@TempDir Path tempDir) throws Exception {
+        Path controlSocketPath = tempDir.resolve("tor-control.sock");
+        Files.writeString(tempDir.resolve("external_tor.config"),
+                "UseExternalTor 1\n" +
+                        "ControlSocket \"" + controlSocketPath + "\"\n" +
+                        "CookieAuthFile '" + tempDir.resolve("control.authcookie") + "'\n");
+
+        TorService torService = new TorService(createConfig(tempDir, ""));
+        invokeReadExternalTorConfigMap(torService);
+
+        Map<String, String> externalTorConfigMap = getExternalTorConfigMap(torService);
+        Method getControlEndpoint = TorService.class.getDeclaredMethod("getControlEndpoint", Map.class);
+        getControlEndpoint.setAccessible(true);
+        Object controlEndpoint = getControlEndpoint.invoke(torService, externalTorConfigMap);
+        assertThat(controlEndpoint.getClass().getSimpleName()).isEqualTo("UnixSocketControlEndpoint");
+        Method controlSocketPathAccessor = controlEndpoint.getClass().getDeclaredMethod("controlSocketPath");
+        controlSocketPathAccessor.setAccessible(true);
+
+        assertThat(controlSocketPathAccessor.invoke(controlEndpoint)).isEqualTo(controlSocketPath);
+        assertThat(externalTorConfigMap.get("CookieAuthFile"))
+                .isEqualTo("'" + tempDir.resolve("control.authcookie") + "'");
+    }
+
+    @Test
+    void initializeFailsWhenExternalTorIsEnabledButControlServerIsUnreachable(@TempDir Path tempDir) throws Exception {
+        // Keep this test deterministic by using an invalid local control port.
+        Files.writeString(tempDir.resolve("external_tor.config"),
+                "UseExternalTor 1\n" +
+                        "ControlPort 127.0.0.1:1\n" +
+                        "CookieAuthentication 0\n");
+
+        // TorService decides from external_tor.config, not from TorTransportConfig.useExternalTor.
+        TorTransportConfig config = new TorTransportConfig(
+                tempDir,
+                -1,
+                500,
+                500,
+                500,
+                false,
+                Set.of(),
+                Map.of(),
+                "",
+                200,
+                200,
+                false
+        );
+
+        TorService torService = new TorService(config);
+
+        assertThatThrownBy(torService::initialize)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("could not connect to the external Tor control server");
+    }
+
+    @Test
+    void initializeFailsWhenExternalTorControlSocketIsUnavailable(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("external_tor.config"),
+                "UseExternalTor 1\n" +
+                        "ControlSocket " + tempDir.resolve("missing-control.sock") + "\n" +
+                        "CookieAuthentication 0\n");
+
+        TorService torService = new TorService(createConfig(tempDir, ""));
+
+        assertThatThrownBy(torService::initialize)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("could not connect to the external Tor control server");
+    }
+
+    @Test
+    void initializeFailureMentionsCustomExternalTorConfigPath(@TempDir Path tempDir) throws Exception {
+        Path customConfigPath = tempDir.resolve("custom_external_tor.config");
+        Files.writeString(customConfigPath,
+                "UseExternalTor 1\n" +
+                        "ControlPort 127.0.0.1:1\n" +
+                        "CookieAuthentication 0\n");
+
+        TorService torService = new TorService(createConfig(tempDir, "custom_external_tor.config"));
+
+        assertThatThrownBy(torService::initialize)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining(customConfigPath.toString());
+    }
+
+    @Test
+    void getControlEndpointFailureMentionsCustomExternalTorConfigPath(@TempDir Path tempDir) throws Exception {
+        Path customConfigPath = tempDir.resolve("custom_external_tor.config");
+        Files.writeString(customConfigPath,
+                "UseExternalTor 1\n" +
+                        "CookieAuthentication 0\n");
+
+        TorService torService = new TorService(createConfig(tempDir, "custom_external_tor.config"));
+        invokeReadExternalTorConfigMap(torService);
+
+        assertThatThrownBy(() -> invokeGetControlEndpoint(torService, getExternalTorConfigMap(torService)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(customConfigPath.toString())
+                .hasMessageContaining("Either ControlSocket or ControlPort must be set");
+    }
+
+    private static TorTransportConfig createConfig(Path dataDirPath, String torrcOverrideFilePath) {
+        return new TorTransportConfig(
+                dataDirPath,
+                -1,
+                500,
+                500,
+                500,
+                false,
+                Set.of(),
+                Map.of(),
+                torrcOverrideFilePath,
+                200,
+                200,
+                false
+        );
+    }
+
+    private static void invokeReadExternalTorConfigMap(TorService torService) throws Exception {
+        Method readExternalTorConfigMap = TorService.class.getDeclaredMethod("readExternalTorConfigMap");
+        readExternalTorConfigMap.setAccessible(true);
+        readExternalTorConfigMap.invoke(torService);
+    }
+
+    private static Object invokeGetControlEndpoint(TorService torService,
+                                                   Map<String, String> externalTorConfigMap) throws Throwable {
+        Method getControlEndpoint = TorService.class.getDeclaredMethod("getControlEndpoint", Map.class);
+        getControlEndpoint.setAccessible(true);
+        try {
+            return getControlEndpoint.invoke(torService, externalTorConfigMap);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> getExternalTorConfigMap(TorService torService) throws Exception {
+        Field externalTorConfigMapField = TorService.class.getDeclaredField("externalTorConfigMap");
+        externalTorConfigMapField.setAccessible(true);
+        return (Map<String, String>) externalTorConfigMapField.get(torService);
+    }
+}

--- a/network/tor/tor/src/test/java/bisq/network/tor/TorTransportConfigTorrcOverridesTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/TorTransportConfigTorrcOverridesTest.java
@@ -1,0 +1,213 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import com.typesafe.config.ConfigFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TorTransportConfigTorrcOverridesTest {
+
+    private static final String MINIMAL_CONFIG_TEMPLATE =
+            "bootstrapTimeout=240\n" +
+                    "hsUploadTimeout=120\n" +
+                    "socketTimeout=120\n" +
+                    "testNetwork=false\n" +
+                    "directoryAuthorities=[]\n" +
+                    "sendMessageThrottleTime=200\n" +
+                    "receiveMessageThrottleTime=200\n" +
+                    "useExternalTor=false\n";
+
+    @Test
+    void oldFormatSingleKeyValueIsSupported(@TempDir Path tempDir) {
+        // Old format: torrcOverrides { SomeKey = someValue }
+        // This is what all existing production configs use
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides { SocksPort = 9999 }\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        Map<String, List<String>> overrides = torTransportConfig.getTorrcOverrides();
+        assertThat(overrides).hasSize(1);
+        assertThat(overrides.get("SocksPort")).containsExactly("9999");
+    }
+
+    @Test
+    void newFormatListValueAllowsMultipleEntriesForSameKey(@TempDir Path tempDir) {
+        // New format: torrcOverrides { Bridge = ["value1", "value2"] }
+        // Needed for directives like Bridge that can legitimately appear multiple times
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides {\n" +
+                "  UseBridges = 1\n" +
+                "  Bridge = [\"obfs4 192.0.2.1:1234 FP1\", \"obfs4 192.0.2.2:5678 FP2\"]\n" +
+                "}\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        Map<String, List<String>> overrides = torTransportConfig.getTorrcOverrides();
+        assertThat(overrides.get("Bridge")).containsExactly(
+                "obfs4 192.0.2.1:1234 FP1",
+                "obfs4 192.0.2.2:5678 FP2"
+        );
+        assertThat(overrides.get("UseBridges")).containsExactly("1");
+    }
+
+    @Test
+    void oldFormatSingleStringBridgeIsSupported(@TempDir Path tempDir) {
+        // A single Bridge string value (non-list) still works
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides { Bridge = \"obfs4 192.0.2.1:1234 FP1\" }\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrides().get("Bridge"))
+                .containsExactly("obfs4 192.0.2.1:1234 FP1");
+    }
+
+    @Test
+    void oldFormatDuplicateBridgeKeysLastValueWins(@TempDir Path tempDir) {
+        // HOCON does not support duplicate keys — the second assignment silently replaces the first.
+        // Users who need multiple Bridge lines must use the list format instead.
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides {\n" +
+                "  Bridge = \"obfs4 192.0.2.1:1234 FP1\"\n" +
+                "  Bridge = \"obfs4 192.0.2.2:5678 FP2\"\n" +
+                "}\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        // Only the last value survives due to HOCON semantics
+        assertThat(torTransportConfig.getTorrcOverrides().get("Bridge"))
+                .containsExactly("obfs4 192.0.2.2:5678 FP2");
+    }
+
+    @Test
+    void emptyOverridesProducesEmptyMap(@TempDir Path tempDir) {
+        // Production default: torrcOverrides={}
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides={}\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrides()).isEmpty();
+    }
+
+    // ── torrcOverrideFilePath ──────────────────────────────────────────────────
+
+    @Test
+    void torrcOverrideFilePathDefaultsToEmptyString(@TempDir Path tempDir) {
+        // When missing from config, torrcOverrideFilePath should be an empty string (feature disabled)
+        String configStr = MINIMAL_CONFIG_TEMPLATE + "torrcOverrides={}\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrideFilePath()).isEmpty();
+    }
+
+    @Test
+    void torrcOverrideFilePathIsParsedFromConfig(@TempDir Path tempDir) {
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides={}\n" +
+                "torrcOverrideFilePath=\"/etc/bisq/custom.torrc\"\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrideFilePath()).isEqualTo("/etc/bisq/custom.torrc");
+    }
+
+    @Test
+    void parseTorrcOverrideFileParsesSimpleKeyValueLines(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file, "SocksPort 9050\nUseBridges 1\n");
+
+        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("SocksPort")).containsExactly("9050");
+        assertThat(result.get("UseBridges")).containsExactly("1");
+    }
+
+    @Test
+    void parseTorrcOverrideFileAccumulatesRepeatedKeys(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file,
+                "UseBridges 1\n" +
+                        "Bridge obfs4 1.2.3.4:1234 FP1\n" +
+                        "Bridge obfs4 5.6.7.8:5678 FP2\n");
+
+        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("Bridge")).containsExactly(
+                "obfs4 1.2.3.4:1234 FP1",
+                "obfs4 5.6.7.8:5678 FP2");
+        assertThat(result.get("UseBridges")).containsExactly("1");
+    }
+
+    @Test
+    void parseTorrcOverrideFileSkipsCommentAndBlankLines(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file,
+                "# This is a comment\n" +
+                        "\n" +
+                        "SocksPort 9050\n" +
+                        "  \n" +
+                        "# another comment\n" +
+                        "UseBridges 1\n");
+
+        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get("SocksPort")).containsExactly("9050");
+        assertThat(result.get("UseBridges")).containsExactly("1");
+    }
+
+    @Test
+    void parseTorrcOverrideFileHandlesTabAsKeyValueDelimiter(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file, "SocksPort\t9050\n");
+
+        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("SocksPort")).containsExactly("9050");
+    }
+
+    @Test
+    void parseTorrcOverrideFileHandlesValuesWithSpaces(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        // Bridge values contain spaces — everything after the first space is the value
+        Files.writeString(file, "Bridge obfs4 1.2.3.4:1234 ABCDEF fingerprint\n");
+
+        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("Bridge")).containsExactly("obfs4 1.2.3.4:1234 ABCDEF fingerprint");
+    }
+}

--- a/network/tor/tor/src/test/java/bisq/network/tor/TorTransportConfigTorrcOverridesTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/TorTransportConfigTorrcOverridesTest.java
@@ -123,8 +123,8 @@ class TorTransportConfigTorrcOverridesTest {
     // ── torrcOverrideFilePath ──────────────────────────────────────────────────
 
     @Test
-    void torrcOverrideFilePathDefaultsToEmptyString(@TempDir Path tempDir) {
-        // When missing from config, torrcOverrideFilePath should be an empty string (feature disabled)
+    void torrcOverrideFilePathDefaultsToEmpty(@TempDir Path tempDir) {
+        // When missing from config, torrcOverrideFilePath should be empty (feature disabled)
         String configStr = MINIMAL_CONFIG_TEMPLATE + "torrcOverrides={}\n";
 
         var config = ConfigFactory.parseString(configStr);
@@ -134,7 +134,7 @@ class TorTransportConfigTorrcOverridesTest {
     }
 
     @Test
-    void torrcOverrideFilePathIsParsedFromConfig(@TempDir Path tempDir) {
+    void torrcOverrideFilePathAbsoluteIsParsedFromConfig(@TempDir Path tempDir) {
         String configStr = MINIMAL_CONFIG_TEMPLATE +
                 "torrcOverrides={}\n" +
                 "torrcOverrideFilePath=\"/etc/bisq/custom.torrc\"\n";
@@ -142,7 +142,21 @@ class TorTransportConfigTorrcOverridesTest {
         var config = ConfigFactory.parseString(configStr);
         TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
 
-        assertThat(torTransportConfig.getTorrcOverrideFilePath()).isEqualTo("/etc/bisq/custom.torrc");
+        assertThat(torTransportConfig.getTorrcOverrideFilePath())
+                .contains(Path.of("/etc/bisq/custom.torrc"));
+    }
+
+    @Test
+    void torrcOverrideFilePathRelativeIsResolvedAgainstDataDir(@TempDir Path tempDir) {
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides={}\n" +
+                "torrcOverrideFilePath=\"custom.torrc\"\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrideFilePath())
+                .contains(tempDir.resolve("custom.torrc"));
     }
 
     @Test
@@ -150,7 +164,7 @@ class TorTransportConfigTorrcOverridesTest {
         Path file = tempDir.resolve("overrides.torrc");
         Files.writeString(file, "SocksPort 9050\nUseBridges 1\n");
 
-        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
 
         assertThat(result.get("SocksPort")).containsExactly("9050");
         assertThat(result.get("UseBridges")).containsExactly("1");
@@ -164,7 +178,7 @@ class TorTransportConfigTorrcOverridesTest {
                         "Bridge obfs4 1.2.3.4:1234 FP1\n" +
                         "Bridge obfs4 5.6.7.8:5678 FP2\n");
 
-        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
 
         assertThat(result.get("Bridge")).containsExactly(
                 "obfs4 1.2.3.4:1234 FP1",
@@ -183,7 +197,7 @@ class TorTransportConfigTorrcOverridesTest {
                         "# another comment\n" +
                         "UseBridges 1\n");
 
-        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
 
         assertThat(result).hasSize(2);
         assertThat(result.get("SocksPort")).containsExactly("9050");
@@ -195,7 +209,7 @@ class TorTransportConfigTorrcOverridesTest {
         Path file = tempDir.resolve("overrides.torrc");
         Files.writeString(file, "SocksPort\t9050\n");
 
-        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
 
         assertThat(result.get("SocksPort")).containsExactly("9050");
     }
@@ -206,7 +220,7 @@ class TorTransportConfigTorrcOverridesTest {
         // Bridge values contain spaces — everything after the first space is the value
         Files.writeString(file, "Bridge obfs4 1.2.3.4:1234 ABCDEF fingerprint\n");
 
-        var result = TorTransportConfig.parseTorrcOverrideFile(file);
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
 
         assertThat(result.get("Bridge")).containsExactly("obfs4 1.2.3.4:1234 ABCDEF fingerprint");
     }

--- a/network/tor/tor/src/test/java/bisq/network/tor/TorTransportConfigTorrcOverridesTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/TorTransportConfigTorrcOverridesTest.java
@@ -120,6 +120,32 @@ class TorTransportConfigTorrcOverridesTest {
         assertThat(torTransportConfig.getTorrcOverrides()).isEmpty();
     }
 
+    @Test
+    void fractionalNumberOverrideIsNotNarrowedToInt(@TempDir Path tempDir) {
+        // HOCON unwraps this to a Double, which must not be cast to int
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides { CircuitPriorityHalflife = 1.5 }\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrides().get("CircuitPriorityHalflife"))
+                .containsExactly("1.5");
+    }
+
+    @Test
+    void numberOverrideExceedingIntRangeIsNotNarrowedToInt(@TempDir Path tempDir) {
+        // HOCON unwraps this to a Long, which must not be cast to int
+        String configStr = MINIMAL_CONFIG_TEMPLATE +
+                "torrcOverrides { MaxMemInQueues = 4294967296 }\n";
+
+        var config = ConfigFactory.parseString(configStr);
+        TorTransportConfig torTransportConfig = TorTransportConfig.from(tempDir, config);
+
+        assertThat(torTransportConfig.getTorrcOverrides().get("MaxMemInQueues"))
+                .containsExactly("4294967296");
+    }
+
     // ── torrcOverrideFilePath ──────────────────────────────────────────────────
 
     @Test
@@ -223,5 +249,49 @@ class TorTransportConfigTorrcOverridesTest {
         var result = TorrcFileParser.parseTorrcOverrideFile(file);
 
         assertThat(result.get("Bridge")).containsExactly("obfs4 1.2.3.4:1234 ABCDEF fingerprint");
+    }
+
+    @Test
+    void parseTorrcOverrideFileStripsInlineComments(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file, "SocksPort 9050 # the default SOCKS port\n");
+
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("SocksPort")).containsExactly("9050");
+    }
+
+    @Test
+    void parseTorrcOverrideFileKeepsHashInsideQuotedValue(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file, "CookieAuthFile \"/run/tor/co#ntrol.authcookie\" # trailing comment\n");
+
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("CookieAuthFile")).containsExactly("\"/run/tor/co#ntrol.authcookie\"");
+    }
+
+    @Test
+    void parseTorrcOverrideFileCollapsesRepeatedSeparatorWhitespace(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file, "SocksPort   9050  \n");
+
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
+
+        assertThat(result.get("SocksPort")).containsExactly("9050");
+    }
+
+    @Test
+    void parseTorrcOverrideFileSkipsKeyWithoutValue(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("overrides.torrc");
+        Files.writeString(file,
+                "UseBridges\n" +
+                        "SocksPort # only a comment\n" +
+                        "UseBridges 1\n");
+
+        var result = TorrcFileParser.parseTorrcOverrideFile(file);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get("UseBridges")).containsExactly("1");
     }
 }

--- a/network/tor/tor/src/test/java/bisq/network/tor/TorrcClientConfigFactoryTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/TorrcClientConfigFactoryTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,98 +58,95 @@ class TorrcClientConfigFactoryTest {
         doReturn(mockGenerator).when(factory).clientTorrcGenerator();
     }
 
+    private static Map<String, List<String>> mutableBaseConfig(Map<String, List<String>> entries) {
+        return new LinkedHashMap<>(entries);
+    }
+
     @Test
-    void baseConfigLinesAppearsWhenNoOverrides() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
-                "SocksPort", "auto",
-                "DataDirectory", "/tmp/tor"
+    void baseConfigAppearsWhenNoOverrides() {
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of(
+                "SocksPort", List.of("auto"),
+                "DataDirectory", List.of("/tmp/tor")
         )));
 
-        List<String> lines = factory.torrcClientConfigLines(Map.of());
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of());
 
-        assertThat(lines).contains("SocksPort auto", "DataDirectory /tmp/tor");
+        assertThat(config.get("SocksPort")).containsExactly("auto");
+        assertThat(config.get("DataDirectory")).containsExactly("/tmp/tor");
     }
 
     @Test
     void disableNetworkIsAlwaysAdded() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of("SocksPort", List.of("auto"))));
 
-        List<String> lines = factory.torrcClientConfigLines(Map.of());
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of());
 
-        assertThat(lines).contains(DISABLE_NETWORK + " 1");
+        assertThat(config.get(DISABLE_NETWORK)).containsExactly("1");
     }
 
     @Test
     void overrideReplacesBaseConfigKeyWithSameName() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
-                "SocksPort", "auto",
-                "DataDirectory", "/tmp/tor"
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of(
+                "SocksPort", List.of("auto"),
+                "DataDirectory", List.of("/tmp/tor")
         )));
 
-        List<String> lines = factory.torrcClientConfigLines(Map.of("SocksPort", List.of("9999")));
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of("SocksPort", List.of("9999")));
 
-        assertThat(lines).contains("SocksPort 9999");
-        assertThat(lines).doesNotContain("SocksPort auto");
+        assertThat(config.get("SocksPort")).containsExactly("9999");
         // unrelated base config key is still present
-        assertThat(lines).contains("DataDirectory /tmp/tor");
+        assertThat(config.get("DataDirectory")).containsExactly("/tmp/tor");
     }
 
     @Test
     void overrideKeyNotInBaseIsAddedToOutput() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of("SocksPort", List.of("auto"))));
 
-        List<String> lines = factory.torrcClientConfigLines(
-                Map.of("UseBridges", List.of("1")));
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of("UseBridges", List.of("1")));
 
-        assertThat(lines)
-                .contains("SocksPort auto")
-                .contains("UseBridges 1");
+        assertThat(config.get("SocksPort")).containsExactly("auto");
+        assertThat(config.get("UseBridges")).containsExactly("1");
     }
 
     @Test
     void multipleBridgeOverrideValuesAllAppearInOutput() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of("SocksPort", List.of("auto"))));
 
-        List<String> lines = factory.torrcClientConfigLines(Map.of(
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of(
                 "UseBridges", List.of("1"),
                 "Bridge", List.of("obfs4 192.0.2.1:1234 FP1", "obfs4 192.0.2.2:5678 FP2")
         ));
 
-        assertThat(lines)
-                .contains("Bridge obfs4 192.0.2.1:1234 FP1")
-                .contains("Bridge obfs4 192.0.2.2:5678 FP2")
-                .contains("UseBridges 1");
-        assertThat(lines.stream().filter(l -> l.startsWith("Bridge "))).hasSize(2);
-        assertThat(lines.indexOf("Bridge obfs4 192.0.2.1:1234 FP1"))
-                .isLessThan(lines.indexOf("Bridge obfs4 192.0.2.2:5678 FP2"));
+        assertThat(config.get("Bridge")).containsExactly(
+                "obfs4 192.0.2.1:1234 FP1",
+                "obfs4 192.0.2.2:5678 FP2");
+        assertThat(config.get("UseBridges")).containsExactly("1");
     }
 
     @Test
     void overrideReplacesDisableNetworkWhenExplicitlySet() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of("SocksPort", List.of("auto"))));
 
         // DisableNetwork is put into base config by the factory (value "1") — an override can replace it
-        List<String> lines = factory.torrcClientConfigLines(
-                Map.of(DISABLE_NETWORK, List.of("0")));
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of(DISABLE_NETWORK, List.of("0")));
 
-        assertThat(lines).contains(DISABLE_NETWORK + " 0");
-        assertThat(lines.stream().filter(l -> l.startsWith(DISABLE_NETWORK + " "))).hasSize(1);
+        assertThat(config.get(DISABLE_NETWORK)).containsExactly("0");
     }
 
     @Test
     void createTorrcConfigFileFlowWritesMergedConfigToTorrc() throws IOException {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
-                "SocksPort", "auto",
-                "DataDirectory", "/tmp/tor"
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of(
+                "SocksPort", List.of("auto"),
+                "DataDirectory", List.of("/tmp/tor")
         )));
 
-        List<String> lines = factory.torrcClientConfigLines(Map.of(
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of(
                 "SocksPort", List.of("9999"),
                 "Bridge", List.of("obfs4 192.0.2.1:1234 FP1", "obfs4 192.0.2.2:5678 FP2")
         ));
 
         Path torrcPath = tempDir.resolve("torrc");
-        new TorrcFileGenerator(torrcPath, lines, Set.of()).generate();
+        new TorrcFileGenerator(torrcPath, config, Set.of()).generate();
 
         String torrcContent = Files.readString(torrcPath);
         assertThat(torrcContent)
@@ -162,16 +159,20 @@ class TorrcClientConfigFactoryTest {
         assertThat(torrcContent.lines().filter(l -> l.startsWith("SocksPort "))).hasSize(1);
     }
 
-
     @Test
-    void overrideWithEmptyListRemovesKeyFromOutput() {
-        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
-                "SocksPort", "auto",
-                "DataDirectory", "/tmp/tor"
+    void overrideWithEmptyListRemovesKeyFromOutput() throws IOException {
+        when(mockGenerator.generate()).thenReturn(mutableBaseConfig(Map.of(
+                "SocksPort", List.of("auto"),
+                "DataDirectory", List.of("/tmp/tor")
         )));
-        List<String> lines = factory.torrcClientConfigLines(Map.of("SocksPort", List.of())); // empty list
-        assertThat(lines).doesNotContain("SocksPort auto");
-        assertThat(lines.stream().filter(l -> l.startsWith("SocksPort "))).isEmpty();
-        assertThat(lines).contains("DataDirectory /tmp/tor");
+
+        Map<String, List<String>> config = factory.torrcClientConfigMap(Map.of("SocksPort", List.of())); // empty list
+
+        assertThat(config.get("SocksPort")).isEmpty();
+        assertThat(config.get("DataDirectory")).containsExactly("/tmp/tor");
+
+        Path torrcPath = tempDir.resolve("torrc");
+        new TorrcFileGenerator(torrcPath, config, Set.of()).generate();
+        assertThat(Files.readString(torrcPath)).doesNotContain("SocksPort ");
     }
 }

--- a/network/tor/tor/src/test/java/bisq/network/tor/TorrcClientConfigFactoryTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/TorrcClientConfigFactoryTest.java
@@ -1,0 +1,177 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import bisq.network.tor.common.torrc.TorrcConfigGenerator;
+import bisq.network.tor.common.torrc.TorrcFileGenerator;
+import net.freehaven.tor.control.PasswordDigest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static bisq.network.tor.common.torrc.Torrc.Keys.DISABLE_NETWORK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+class TorrcClientConfigFactoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private TorrcConfigGenerator mockGenerator;
+    private PasswordDigest mockPasswordDigest;
+    private TorrcClientConfigFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        mockGenerator = Mockito.mock(TorrcConfigGenerator.class);
+        mockPasswordDigest = Mockito.mock(PasswordDigest.class);
+
+        // Use doReturn().when() to avoid calling the real method during stub setup.
+        TorrcClientConfigFactory base = new TorrcClientConfigFactory(false, tempDir, mockPasswordDigest);
+        factory = Mockito.spy(base);
+        doReturn(mockGenerator).when(factory).clientTorrcGenerator();
+    }
+
+    @Test
+    void baseConfigLinesAppearsWhenNoOverrides() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
+                "SocksPort", "auto",
+                "DataDirectory", "/tmp/tor"
+        )));
+
+        List<String> lines = factory.torrcClientConfigLines(Map.of());
+
+        assertThat(lines).contains("SocksPort auto", "DataDirectory /tmp/tor");
+    }
+
+    @Test
+    void disableNetworkIsAlwaysAdded() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+
+        List<String> lines = factory.torrcClientConfigLines(Map.of());
+
+        assertThat(lines).contains(DISABLE_NETWORK + " 1");
+    }
+
+    @Test
+    void overrideReplacesBaseConfigKeyWithSameName() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
+                "SocksPort", "auto",
+                "DataDirectory", "/tmp/tor"
+        )));
+
+        List<String> lines = factory.torrcClientConfigLines(Map.of("SocksPort", List.of("9999")));
+
+        assertThat(lines).contains("SocksPort 9999");
+        assertThat(lines).doesNotContain("SocksPort auto");
+        // unrelated base config key is still present
+        assertThat(lines).contains("DataDirectory /tmp/tor");
+    }
+
+    @Test
+    void overrideKeyNotInBaseIsAddedToOutput() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+
+        List<String> lines = factory.torrcClientConfigLines(
+                Map.of("UseBridges", List.of("1")));
+
+        assertThat(lines)
+                .contains("SocksPort auto")
+                .contains("UseBridges 1");
+    }
+
+    @Test
+    void multipleBridgeOverrideValuesAllAppearInOutput() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+
+        List<String> lines = factory.torrcClientConfigLines(Map.of(
+                "UseBridges", List.of("1"),
+                "Bridge", List.of("obfs4 192.0.2.1:1234 FP1", "obfs4 192.0.2.2:5678 FP2")
+        ));
+
+        assertThat(lines)
+                .contains("Bridge obfs4 192.0.2.1:1234 FP1")
+                .contains("Bridge obfs4 192.0.2.2:5678 FP2")
+                .contains("UseBridges 1");
+        assertThat(lines.stream().filter(l -> l.startsWith("Bridge "))).hasSize(2);
+        assertThat(lines.indexOf("Bridge obfs4 192.0.2.1:1234 FP1"))
+                .isLessThan(lines.indexOf("Bridge obfs4 192.0.2.2:5678 FP2"));
+    }
+
+    @Test
+    void overrideReplacesDisableNetworkWhenExplicitlySet() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of("SocksPort", "auto")));
+
+        // DisableNetwork is put into base config by the factory (value "1") — an override can replace it
+        List<String> lines = factory.torrcClientConfigLines(
+                Map.of(DISABLE_NETWORK, List.of("0")));
+
+        assertThat(lines).contains(DISABLE_NETWORK + " 0");
+        assertThat(lines.stream().filter(l -> l.startsWith(DISABLE_NETWORK + " "))).hasSize(1);
+    }
+
+    @Test
+    void createTorrcConfigFileFlowWritesMergedConfigToTorrc() throws IOException {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
+                "SocksPort", "auto",
+                "DataDirectory", "/tmp/tor"
+        )));
+
+        List<String> lines = factory.torrcClientConfigLines(Map.of(
+                "SocksPort", List.of("9999"),
+                "Bridge", List.of("obfs4 192.0.2.1:1234 FP1", "obfs4 192.0.2.2:5678 FP2")
+        ));
+
+        Path torrcPath = tempDir.resolve("torrc");
+        new TorrcFileGenerator(torrcPath, lines, Set.of()).generate();
+
+        String torrcContent = Files.readString(torrcPath);
+        assertThat(torrcContent)
+                .contains("DataDirectory /tmp/tor")
+                .contains("SocksPort 9999")
+                .contains("Bridge obfs4 192.0.2.1:1234 FP1")
+                .contains("Bridge obfs4 192.0.2.2:5678 FP2")
+                .contains(DISABLE_NETWORK + " 1")
+                .doesNotContain("SocksPort auto");
+        assertThat(torrcContent.lines().filter(l -> l.startsWith("SocksPort "))).hasSize(1);
+    }
+
+
+    @Test
+    void overrideWithEmptyListRemovesKeyFromOutput() {
+        when(mockGenerator.generate()).thenReturn(new HashMap<>(Map.of(
+                "SocksPort", "auto",
+                "DataDirectory", "/tmp/tor"
+        )));
+        List<String> lines = factory.torrcClientConfigLines(Map.of("SocksPort", List.of())); // empty list
+        assertThat(lines).doesNotContain("SocksPort auto");
+        assertThat(lines.stream().filter(l -> l.startsWith("SocksPort "))).isEmpty();
+        assertThat(lines).contains("DataDirectory /tmp/tor");
+    }
+}

--- a/network/tor/tor/src/test/java/bisq/network/tor/UseExternalTorResolverTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/UseExternalTorResolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.tor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UseExternalTorResolverTest {
+
+    @Test
+    void whonixAlwaysUsesExternalTor() {
+        boolean result = UseExternalTorResolver.evaluateUseExternalTorValue(
+                true,
+                null,
+                false,
+                "0");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void torSkipLaunchEnvHasHighestPriority() {
+        boolean result = UseExternalTorResolver.evaluateUseExternalTorValue(
+                false,
+                "true",
+                false,
+                "0");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void torSkipLaunchEnvCanDisableExternalTor() {
+        boolean result = UseExternalTorResolver.evaluateUseExternalTorValue(
+                false,
+                "0",
+                true,
+                "1");
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void jvmUseExternalTorOverridesExternalTorConfig() {
+        boolean result = UseExternalTorResolver.evaluateUseExternalTorValue(
+                false,
+                null,
+                true,
+                "0");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void externalTorConfigIsUsedWhenNoHigherPriorityInputIsSet() {
+        boolean result = UseExternalTorResolver.evaluateUseExternalTorValue(
+                false,
+                null,
+                false,
+                "1");
+
+        assertThat(result).isTrue();
+    }
+}

--- a/network/tor/tor/src/test/java/bisq/network/tor/controller/TorControlProtocolTest.java
+++ b/network/tor/tor/src/test/java/bisq/network/tor/controller/TorControlProtocolTest.java
@@ -1,0 +1,78 @@
+package bisq.network.tor.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TorControlProtocolTest {
+
+    @Test
+    void initializeSupportsUnixDomainControlSocket(@TempDir Path tempDir) throws Exception {
+        Path controlSocketPath = tempDir.resolve("tor-control.sock");
+        CountDownLatch commandReceived = new CountDownLatch(1);
+        AtomicReference<String> commandRef = new AtomicReference<>();
+        AtomicReference<Throwable> serverErrorRef = new AtomicReference<>();
+
+        try (ServerSocketChannel serverSocketChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
+            serverSocketChannel.bind(UnixDomainSocketAddress.of(controlSocketPath));
+
+            Thread serverThread = new Thread(() -> acceptSingleCommand(serverSocketChannel,
+                    commandRef,
+                    commandReceived,
+                    serverErrorRef));
+            serverThread.setName("TorControlProtocolTest.server");
+            serverThread.start();
+
+            TorControlProtocol torControlProtocol = new TorControlProtocol();
+            try {
+                torControlProtocol.initialize(controlSocketPath);
+                torControlProtocol.authenticate(new byte[0]);
+
+                assertThat(commandReceived.await(2, TimeUnit.SECONDS)).isTrue();
+                assertThat(commandRef.get()).startsWith("AUTHENTICATE");
+                assertThat(serverErrorRef.get()).isNull();
+            } finally {
+                torControlProtocol.close();
+                serverThread.join(TimeUnit.SECONDS.toMillis(2));
+                assertThat(serverThread.isAlive()).isFalse();
+            }
+        } finally {
+            Files.deleteIfExists(controlSocketPath);
+        }
+    }
+
+    private static void acceptSingleCommand(ServerSocketChannel serverSocketChannel,
+                                            AtomicReference<String> commandRef,
+                                            CountDownLatch commandReceived,
+                                            AtomicReference<Throwable> serverErrorRef) {
+        try (SocketChannel clientChannel = serverSocketChannel.accept();
+             BufferedReader reader = new BufferedReader(new InputStreamReader(
+                     Channels.newInputStream(clientChannel), StandardCharsets.US_ASCII));
+             OutputStream outputStream = Channels.newOutputStream(clientChannel)) {
+            commandRef.set(reader.readLine());
+            outputStream.write("250 OK\r\n".getBytes(StandardCharsets.US_ASCII));
+            outputStream.flush();
+            commandReceived.countDown();
+        } catch (IOException exception) {
+            serverErrorRef.set(exception);
+            commandReceived.countDown();
+        }
+    }
+}


### PR DESCRIPTION
- Solves an issue I had before with the override config, which didn't allow to have multiple `Bridge` directives or similar things
- Fixes the `java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String` issue mentioned in https://github.com/bisq-network/bisq2/issues/4606#issuecomment-4206218568
- Adds support for using a custom torrc file using the new `torrcOverrideFilePath` config
- Same `torrcOverrideFilePath` can now be used for configuring external tor connection details
- Adds support for using a Unix socket for connecting to tor
- Improves `useExternalTor` flag UX by automatically detecting it's tail os and setting the ControlPort to 951
- Improves UX by hard failing rather than failing back to using embedded tor when `useExternalTor` flag is true, which can be very confusing otherwise
- Includes tails and whonix onion-grater configs in the package now
- Adds a new `prepare_tails.sh` for easier setup on tails 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tor overrides now support ordered multi-value directives, can be loaded from an external torrc-style file, and external Tor may use either UNIX-domain sockets or host:port endpoints. Improved control connection detection, cookie-auth handling, and clearer error messages. Tails packaging and a helper script added.

* **Documentation**
  * Config docs updated to add external torrc file option, describe value shapes (string or list) and precedence.

* **Tests**
  * Added tests for parsing, merging, endpoints, socket control, heuristics, and helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->