### PR TITLE
Fix NullPointerException on startup with generic OS locales (C.UTF-8)

### DIFF
--- a/TODO_LOCALE.txt
+++ b/TODO_LOCALE.txt
@@ -1,0 +1,1 @@
+// TODO: Investigate NPE when Locale.getDefault() returns a generic C.UTF-8 locale

--- a/TODO_LOCALE.txt
+++ b/TODO_LOCALE.txt
@@ -1,1 +1,0 @@
-// TODO: Investigate NPE when Locale.getDefault() returns a generic C.UTF-8 locale

--- a/common/src/main/java/bisq/common/locale/LocaleRepository.java
+++ b/common/src/main/java/bisq/common/locale/LocaleRepository.java
@@ -39,7 +39,14 @@ public class LocaleRepository {
 
     static {
         String propertyFileName = "bisq.properties";
-        Locale locale = Locale.getDefault();
+        // Ensure the initial OS locale is safe before we do anything else
+        Locale osLocale = Locale.getDefault();
+        if (osLocale.getCountry().isEmpty() && osLocale.getScript().isEmpty()) {
+            log.warn("OS locale '{}' has no country or script. Falling back to Locale.US", osLocale);
+            osLocale = Locale.US;
+        }
+        Locale locale = osLocale;
+
         try {
             Properties properties = PropertiesReader.getProperties(propertyFileName);
             String language = properties.getProperty("language"); // e.g., "en"
@@ -52,7 +59,8 @@ public class LocaleRepository {
         } catch (IOException e) {
             log.warn("Could not load properties from {}", propertyFileName);
         } finally {
-            setDefaultLocale(locale);
+            // Validate the final locale before setting it as default
+            setDefaultLocale(ensureValidLocale(locale));
         }
     }
 


### PR DESCRIPTION
This PR fixes a crash occurring when the OS locale does not provide a country subtag (common in VPS environments with C.UTF-8 or generic en locales). 

Changes:

Modified LocaleRepository static initializer to detect incomplete OS locales.

Implemented a fallback to Locale.US when country and script are missing.

Ensured ensureValidLocale() is called before setting the default locale.

Validation:
Reproduced the NPE locally using -Duser.country= and verified that the patch correctly applies the fallback and allows the application to boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application language and regional settings handling to ensure robust locale configuration even when system settings are incomplete or unusual. Enhanced fallback mechanisms now ensure consistent behavior across all locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->