### PR TITLE
Improve trade export to csv #4532

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/OpenTradesUtils.java
@@ -33,29 +33,35 @@ public class OpenTradesUtils {
             long quoteSideAmount = contract.getQuoteSideAmount();
             String formattedBaseAmount = AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(baseSideAmount));
             String formattedQuoteAmount = AmountFormatter.formatQuoteAmountWithCode(Fiat.from(quoteSideAmount, quoteCurrencyCode));
+            String formattedPrice = AmountFormatter.formatQuoteAmountWithCode(trade.getPriceQuote().getQuoteSideMonetary());
             String paymentProof = Optional.ofNullable(trade.getPaymentProof().get()).orElseGet(() -> Res.get("data.na"));
             String bitcoinPaymentData = Optional.ofNullable(trade.getBitcoinPaymentData().get()).orElseGet(() -> Res.get("data.na"));
             String bitcoinMethod = contract.getBaseSidePaymentMethodSpec().getDisplayString();
             String fiatMethod = contract.getQuoteSidePaymentMethodSpec().getDisplayString();
             String paymentMethod = bitcoinMethod + " / " + fiatMethod;
+
             List<String> headers = List.of(
                     Res.get("bisqEasy.openTrades.table.tradeId"),
                     Res.get("bisqEasy.openTrades.table.baseAmount"),
                     Res.get("bisqEasy.openTrades.csv.quoteAmount", quoteCurrencyCode),
+                    Res.get("bisqEasy.openTrades.table.price"),
                     Res.get("bisqEasy.openTrades.csv.txIdOrPreimage"),
                     Res.get("bisqEasy.openTrades.csv.receiverAddressOrInvoice"),
                     Res.get("bisqEasy.openTrades.csv.paymentMethod")
             );
+
             List<List<String>> tradeData = List.of(
                     List.of(
                             tradeId,
                             formattedBaseAmount,
                             formattedQuoteAmount,
+                            formattedPrice,
                             paymentProof,
                             bitcoinPaymentData,
                             paymentMethod
                     )
             );
+
             String csv = Csv.toCsv(headers, tradeData);
             String initialFileName = "BisqEasy-trade-" + trade.getShortId() + ".csv";
             FileChooserUtil.saveFile(scene, initialFileName)
@@ -72,9 +78,9 @@ public class OpenTradesUtils {
     }
 
     public static void requestMediation(BisqEasyOpenTradeChannel channel,
-                                         BisqEasyContract contract,
-                                         BisqEasyMediationRequestService bisqEasyMediationRequestService,
-                                         BisqEasyOpenTradeChannelService channelService) {
+                                        BisqEasyContract contract,
+                                        BisqEasyMediationRequestService bisqEasyMediationRequestService,
+                                        BisqEasyOpenTradeChannelService channelService) {
         Optional<UserProfile> mediator = channel.getMediator();
         if (mediator.isPresent()) {
             new Popup().headline(Res.get("bisqEasy.mediation.request.confirm.headline"))


### PR DESCRIPTION
his PR adds the missing Price column to the Bisq Easy CSV export functionality.
I have used the standard AmountFormatter to ensure the currency formatting matches the rest of the application's UI.
Variable Extraction: Added price extraction logic using trade.getPriceQuote().getQuoteSideMonetary().
Formatting: Implemented AmountFormatter.formatQuoteAmountWithCode to ensure the price is exported with the correct currency symbol and decimal precision.
CSV Header: Included the localized header bisqEasy.openTrades.table.price in the CSV header list.
Data Injection: Inserted the formatted price value into the corresponding position within the exported data structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade exports now include a price column in CSV format for enhanced data visibility.
* **Refactor**
  * Code formatting and indentation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->