### PR TITLE
Improve amount ranges in musig create offer

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
@@ -53,22 +53,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 public class MuSigAmountSelectionController implements Controller {
-    private static final String SLIDER_TRACK_DEFAULT_COLOR = "-bisq-dark-grey-50";
-    private static final String SLIDER_TRACK_MARKER_COLOR = "-bisq2-green";
-    private static final int RANGE_INPUT_TEXT_MAX_LENGTH = 11;
-    private static final int FIXED_INPUT_TEXT_MAX_LENGTH = 18;
-    private static final Map<Integer, Integer> CHAR_WIDTH_MAP = new HashMap<>();
-
-    static {
-        CHAR_WIDTH_MAP.put(10, 28);
-        CHAR_WIDTH_MAP.put(11, 25);
-        CHAR_WIDTH_MAP.put(12, 23);
-        CHAR_WIDTH_MAP.put(13, 21);
-        CHAR_WIDTH_MAP.put(14, 19);
-        CHAR_WIDTH_MAP.put(15, 18);
-        CHAR_WIDTH_MAP.put(16, 17);
-        CHAR_WIDTH_MAP.put(17, 16);
-    }
 
     final MuSigAmountSelectionModel model;
     @Getter
@@ -107,7 +91,7 @@ public class MuSigAmountSelectionController implements Controller {
 
         priceInput = new MuSigPriceInput(serviceProvider.getBondedRolesService().getMarketPriceService());
 
-        model = new MuSigAmountSelectionModel();
+        model = new MuSigAmountSelectionModel(getWidthByNumCharsMap());
         view = new MuSigAmountSelectionView(model,
                 this,
                 maxOrFixedBaseSideAmountDisplay.getRoot(),
@@ -377,8 +361,10 @@ public class MuSigAmountSelectionController implements Controller {
                                     : "muSig.offer.create.amount.description.fixed"
                             , model.getMarket().getQuoteCurrencyCode()));
             updateShouldShowAmounts();
-            maxOrFixedQuoteSideAmountInput.setTextInputMaxCharCount(useRangeAmount ? RANGE_INPUT_TEXT_MAX_LENGTH : FIXED_INPUT_TEXT_MAX_LENGTH);
-            minQuoteSideAmountInput.setTextInputMaxCharCount(RANGE_INPUT_TEXT_MAX_LENGTH);
+            maxOrFixedQuoteSideAmountInput.setTextInputMaxCharCount(useRangeAmount
+                    ? MuSigAmountSelectionModel.RANGE_INPUT_TEXT_MAX_LENGTH
+                    : MuSigAmountSelectionModel.FIXED_INPUT_TEXT_MAX_LENGTH);
+            minQuoteSideAmountInput.setTextInputMaxCharCount(MuSigAmountSelectionModel.RANGE_INPUT_TEXT_MAX_LENGTH);
             applyTextInputPrefWidth();
             deselectAll();
             schedulers.add(UIScheduler.run(this::requestFocusForAmountInput).after(150));
@@ -609,7 +595,7 @@ public class MuSigAmountSelectionController implements Controller {
             return;
         }
         Monetary min = rangeQuoteSideAmount.getMin();
-        Monetary max = model.getMaxAllowedQuoteSideAmount() != null
+        Monetary max = model.getMaxAllowedQuoteSideAmount().get() != null
                 ? model.getMaxAllowedQuoteSideAmount().get()
                 : rangeQuoteSideAmount.getMax();
         if (min == null || max == null) {
@@ -647,14 +633,14 @@ public class MuSigAmountSelectionController implements Controller {
 
         // E.g.: -bisq-dark-grey-50 0%, -bisq-dark-grey-50 30.0%, -bisq2-green 30.0%, -bisq2-green 60.0%, -bisq-dark-grey-50 60.0%, -bisq-dark-grey-50 100%)
         String segments = String.format(
-                SLIDER_TRACK_DEFAULT_COLOR + " 0%%, " +
-                        SLIDER_TRACK_DEFAULT_COLOR + " %1$.1f%%, " +
+                MuSigAmountSelectionModel.SLIDER_TRACK_DEFAULT_COLOR + " 0%%, " +
+                        MuSigAmountSelectionModel.SLIDER_TRACK_DEFAULT_COLOR + " %1$.1f%%, " +
 
-                        SLIDER_TRACK_MARKER_COLOR + " %1$.1f%%, " +
-                        SLIDER_TRACK_MARKER_COLOR + " %2$.1f%%, " +
+                        MuSigAmountSelectionModel.SLIDER_TRACK_MARKER_COLOR + " %1$.1f%%, " +
+                        MuSigAmountSelectionModel.SLIDER_TRACK_MARKER_COLOR + " %2$.1f%%, " +
 
-                        SLIDER_TRACK_DEFAULT_COLOR + " %2$.1f%%, " +
-                        SLIDER_TRACK_DEFAULT_COLOR + " 100%%)",
+                        MuSigAmountSelectionModel.SLIDER_TRACK_DEFAULT_COLOR + " %2$.1f%%, " +
+                        MuSigAmountSelectionModel.SLIDER_TRACK_DEFAULT_COLOR + " 100%%)",
                 leftPercentage, rightPercentage);
         String style = "-track-color: linear-gradient(to right, " + segments + ";";
         model.getSliderTrackStyle().set(style);
@@ -891,11 +877,24 @@ public class MuSigAmountSelectionController implements Controller {
         applyTextInputPrefWidth();
     }
 
-    private static int getFontCharWidth(int charCount) {
+    private int getFontCharWidth(int charCount) {
         if (charCount < 10) {
             return 31;
         } else {
-            return CHAR_WIDTH_MAP.getOrDefault(charCount, 15); // Default to 15 if not found
+            return model.getWidthByNumCharsMap().getOrDefault(charCount, 15); // Default to 15 if not found
         }
+    }
+
+    private static Map<Integer, Integer> getWidthByNumCharsMap() {
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(10, 28);
+        map.put(11, 25);
+        map.put(12, 23);
+        map.put(13, 21);
+        map.put(14, 19);
+        map.put(15, 18);
+        map.put(16, 17);
+        map.put(17, 16);
+        return map;
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
@@ -23,6 +23,7 @@ import bisq.common.market.Market;
 import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
 import bisq.common.monetary.Monetary;
+import bisq.common.monetary.MonetaryRange;
 import bisq.common.monetary.PriceQuote;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.threading.UIScheduler;
@@ -47,6 +48,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 public class MuSigAmountSelectionController implements Controller {
@@ -124,10 +127,9 @@ public class MuSigAmountSelectionController implements Controller {
         maxOrFixedBaseSideAmountFromModelListener = (observable, oldValue, newValue) -> UIThread.runOnNextRenderFrame(this::setMaxOrFixedQuoteFromBase);
         minBaseSideAmountFromModelListener = (observable, oldValue, newValue) -> UIThread.runOnNextRenderFrame(this::setMinQuoteFromBase);
         quoteListener = (observable, oldValue, newValue) -> {
-            model.getMinRangeBaseSideValue().set(null);
-            model.getMaxRangeBaseSideValue().set(null);
-            model.getMinRangeQuoteSideValue().set(null);
-            model.getMaxRangeQuoteSideValue().set(null);
+            model.getRangeBaseSideAmount().set(null);
+            model.getRangeQuoteSideAmount().set(null);
+
             applyInitialRangeValues();
             UIThread.runOnNextRenderFrame(this::applyQuote);
         };
@@ -181,11 +183,6 @@ public class MuSigAmountSelectionController implements Controller {
         model.getSpendOrReceiveString().set(direction.isBuy() ? Res.get("offer.buying") : Res.get("offer.selling"));
     }
 
-    public void setAllowInvertingBaseAndQuoteCurrencies(boolean allowInvertingBaseAndQuoteCurrencies) {
-        model.getAllowInvertingBaseAndQuoteCurrencies().set(allowInvertingBaseAndQuoteCurrencies);
-        model.getBaseAmountSelectionHBoxWidth().set(allowInvertingBaseAndQuoteCurrencies ? model.getAmountBoxWidth() - 10 : model.getAmountBoxWidth());
-    }
-
     public void setTooltip(String tooltip) {
         maxOrFixedBaseSideAmountDisplay.setTooltip(tooltip);
         minBaseSideAmountDisplay.setTooltip(tooltip);
@@ -220,27 +217,17 @@ public class MuSigAmountSelectionController implements Controller {
     }
 
     public void setMaxAllowedLimitation(Monetary maxAllowedLimitation) {
-        model.getMaxQuoteAllowedLimitation().set(maxAllowedLimitation);
+        model.getMaxAllowedQuoteSideAmount().set(maxAllowedLimitation);
         // TODO: this should work for any coin, not just BTC
         Monetary maxAllowedLimitationInBtc = marketPriceService.findMarketPriceQuote(model.getMarket())
                 .map(btcFiatPriceQuote -> btcFiatPriceQuote.toBaseSideMonetary(maxAllowedLimitation)).orElseThrow();
-        model.getMaxBaseAllowedLimitation().set(maxAllowedLimitationInBtc);
+        model.getMaxAllowedBaseSideAmount().set(maxAllowedLimitationInBtc);
     }
 
-    public void setMinMaxRange(Monetary minRangeValue, Monetary maxRangeValue) {
-        // Ensure the minRangeValue is not larger as maxAmount
-        if (minRangeValue.isGreaterThan(maxRangeValue)) {
-            minRangeValue = maxRangeValue;
-            log.warn("minRangeValue was greater than maxRangeValue. We clamp it down to maxRangeValue.");
-        }
-
-//        boolean minRangeValueIsFiat = Asset.isFiat(minRangeValue.getCode());
-//        boolean maxRangeValueIsFiat = Asset.isFiat(maxRangeValue.getCode());
-//        checkArgument(minRangeValueIsFiat && maxRangeValueIsFiat,
-//                "The provided minRangeValue and maxRangeValue must be fiat currencies as useQuoteCurrencyForMinMaxRange is set to true.");
-
-        model.getMinRangeMonetary().set(minRangeValue);
-        model.getMaxRangeMonetary().set(maxRangeValue);
+    public void setQuoteSideTradeAmountLimits(MonetaryRange quoteSideTradeAmountLimits) {
+        checkArgument(quoteSideTradeAmountLimits.getMin().getValue() <= quoteSideTradeAmountLimits.getMax().getValue(),
+                "Min value must not be larger than max value");
+        model.getQuoteSideTradeAmountLimits().set(quoteSideTradeAmountLimits);
         applyInitialRangeValues();
     }
 
@@ -260,8 +247,8 @@ public class MuSigAmountSelectionController implements Controller {
         }
     }
 
-    public void setIsRangeAmountEnabled(boolean isRangeAmountEnabled) {
-        model.getIsRangeAmountEnabled().set(isRangeAmountEnabled);
+    public void setUseRangeAmount(boolean value) {
+        model.getUseRangeAmount().set(value);
     }
 
     public ReadOnlyObjectProperty<PriceQuote> getQuote() {
@@ -272,9 +259,8 @@ public class MuSigAmountSelectionController implements Controller {
         return model.getRightMarkerQuoteSideValue();
     }
 
-    public boolean isUsingInvertedBaseAndQuoteCurrencies() {
-        return model.getAllowInvertingBaseAndQuoteCurrencies().get()
-                && model.getIsDefaultAmountInputBtc().get();
+    public boolean isDefaultAmountInputBtc() {
+        return model.getIsDefaultAmountInputBtc().get();
     }
 
     public void reset() {
@@ -300,10 +286,9 @@ public class MuSigAmountSelectionController implements Controller {
                     .orElse(true));
         }
 
-        model.getMinRangeBaseSideValue().set(null);
-        model.getMaxRangeBaseSideValue().set(null);
-        model.getMinRangeQuoteSideValue().set(null);
-        model.getMaxRangeQuoteSideValue().set(null);
+        model.getRangeBaseSideAmount().set(null);
+        model.getRangeQuoteSideAmount().set(null);
+
         applyInitialRangeValues();
 
         model.getMaxOrFixedQuoteSideAmount().addListener(maxOrFixedQuoteSideAmountFromModelListener);
@@ -334,7 +319,7 @@ public class MuSigAmountSelectionController implements Controller {
 
         subscriptions.add(EasyBind.subscribe(model.getMaxOrFixedQuoteSideAmount(), amount -> {
             // Only apply value from component to slider if we have no focus on the high thumb (max)
-            boolean isMaxOrFixedThumbFocused = model.getIsRangeAmountEnabled().get()
+            boolean isMaxOrFixedThumbFocused = model.getUseRangeAmount().get()
                     ? model.getRangeSliderHighThumbFocus().get()
                     : model.getMaxOrFixedAmountSliderFocus().get();
             if (amount != null && !isMaxOrFixedThumbFocused) {
@@ -344,7 +329,7 @@ public class MuSigAmountSelectionController implements Controller {
 
         subscriptions.add(EasyBind.subscribe(model.getMinQuoteSideAmount(), amount -> {
             // Only apply value from component to slider if we have no focus on the low thumb (min)
-            boolean isMinThumbFocused = model.getIsRangeAmountEnabled().get()
+            boolean isMinThumbFocused = model.getUseRangeAmount().get()
                     ? model.getRangeSliderLowThumbFocus().get()
                     : model.getMinAmountSliderFocus().get();
             if (amount != null && !isMinThumbFocused) {
@@ -378,22 +363,21 @@ public class MuSigAmountSelectionController implements Controller {
 
         subscriptions.add(EasyBind.subscribe(priceInput.getQuote(), quote -> applyInitialRangeValues()));
 
-        subscriptions.add(EasyBind.subscribe(model.getMinRangeMonetary(), value -> applyInitialRangeValues()));
-        subscriptions.add(EasyBind.subscribe(model.getMaxRangeMonetary(), value -> applyInitialRangeValues()));
+        subscriptions.add(EasyBind.subscribe(model.getQuoteSideTradeAmountLimits(), value -> applyInitialRangeValues()));
 
         subscriptions.add(subscribeToAmountValidity(maxOrFixedQuoteSideAmountInput, this::setMaxOrFixedQuoteFromBase));
         subscriptions.add(subscribeToAmountValidity(minQuoteSideAmountInput, this::setMinQuoteFromBase));
         subscriptions.add(subscribeToAmountValidity(invertedMinBaseSideAmountInput, this::setMinBaseFromQuote));
         subscriptions.add(subscribeToAmountValidity(invertedMaxOrFixedBaseSideAmountInput, this::setMaxOrFixedBaseFromQuote));
 
-        subscriptions.add(EasyBind.subscribe(model.getIsRangeAmountEnabled(), isRangeAmountEnabled -> {
+        subscriptions.add(EasyBind.subscribe(model.getUseRangeAmount(), useRangeAmount -> {
             model.getDescription().set(
-                    Res.get(isRangeAmountEnabled
+                    Res.get(useRangeAmount
                                     ? "muSig.offer.create.amount.description.range"
                                     : "muSig.offer.create.amount.description.fixed"
                             , model.getMarket().getQuoteCurrencyCode()));
             updateShouldShowAmounts();
-            maxOrFixedQuoteSideAmountInput.setTextInputMaxCharCount(isRangeAmountEnabled ? RANGE_INPUT_TEXT_MAX_LENGTH : FIXED_INPUT_TEXT_MAX_LENGTH);
+            maxOrFixedQuoteSideAmountInput.setTextInputMaxCharCount(useRangeAmount ? RANGE_INPUT_TEXT_MAX_LENGTH : FIXED_INPUT_TEXT_MAX_LENGTH);
             minQuoteSideAmountInput.setTextInputMaxCharCount(RANGE_INPUT_TEXT_MAX_LENGTH);
             applyTextInputPrefWidth();
             deselectAll();
@@ -458,21 +442,22 @@ public class MuSigAmountSelectionController implements Controller {
     }
 
     double onGetMaxAllowedSliderValue() {
-        return getSliderValue(model.getMaxRangeQuoteSideValue().get().getValue());
+        MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+        if (rangeQuoteSideAmount == null) {
+            return 0;
+        }
+        Monetary maxRangeQuoteSideAmount = rangeQuoteSideAmount.getMax();
+        return getSliderValue(maxRangeQuoteSideAmount.getValue());
     }
 
     void onClickFlipCurrenciesButton() {
-        if (model.getAllowInvertingBaseAndQuoteCurrencies() == null || !model.getAllowInvertingBaseAndQuoteCurrencies().get()) {
-            return;
-        }
-
         boolean currentValue = model.getIsDefaultAmountInputBtc().get();
         model.getIsDefaultAmountInputBtc().set(!currentValue);
         applyNewStyles();
     }
 
     int onGetCalculatedTotalCharCount() {
-        return isUsingInvertedBaseAndQuoteCurrencies()
+        return isDefaultAmountInputBtc()
                 ? getCount(invertedMinBaseSideAmountInput, invertedMaxOrFixedBaseSideAmountInput)
                 : getCount(minQuoteSideAmountInput, maxOrFixedQuoteSideAmountInput);
     }
@@ -485,7 +470,7 @@ public class MuSigAmountSelectionController implements Controller {
     }
 
     private void requestFocusForAmountInput() {
-        if (isUsingInvertedBaseAndQuoteCurrencies()) {
+        if (isDefaultAmountInputBtc()) {
             invertedMaxOrFixedBaseSideAmountInput.requestFocus();
         } else {
             maxOrFixedQuoteSideAmountInput.requestFocus();
@@ -494,7 +479,7 @@ public class MuSigAmountSelectionController implements Controller {
 
     private int getCount(MuSigBigAmountNumberBox minSideAmountInput,
                          MuSigBigAmountNumberBox maxOrFixedSideAmountInput) {
-        int count = model.getIsRangeAmountEnabled().get()
+        int count = model.getUseRangeAmount().get()
                 ? minSideAmountInput.getTextInputLength() + maxOrFixedSideAmountInput.getTextInputLength() + 1 // 1 for the dash
                 : maxOrFixedSideAmountInput.getTextInputLength();
 
@@ -506,10 +491,14 @@ public class MuSigAmountSelectionController implements Controller {
     }
 
     private double getSliderValue(long amountValue) {
-        long min = model.getMinRangeQuoteSideValue().get().getValue();
-        long max = model.getMaxQuoteAllowedLimitation().get() != null
-                ? model.getMaxQuoteAllowedLimitation().get().getValue()
-                : model.getMaxRangeQuoteSideValue().get().getValue();
+        MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+        if (rangeQuoteSideAmount == null) {
+            return 0;
+        }
+        long min = rangeQuoteSideAmount.getMin().getValue();
+        long max = model.getMaxAllowedQuoteSideAmount().get() != null
+                ? model.getMaxAllowedQuoteSideAmount().get().getValue()
+                : rangeQuoteSideAmount.getMax().getValue();
         long base = max - min;
         if (base == 0) {
             return 0;
@@ -520,10 +509,14 @@ public class MuSigAmountSelectionController implements Controller {
     private void initializeQuoteSideAmount(MuSigBigAmountNumberBox quoteSideAmountInput,
                                            MuSigSmallAmountNumberBox smallNumberDisplayBox) {
         PriceQuote priceQuote = priceInput.getQuote().get();
+        MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+        if (rangeQuoteSideAmount == null) {
+            return;
+        }
         if (priceQuote != null) {
-            Monetary minRangeQuoteSideValue = model.getMinRangeQuoteSideValue().get();
-            Monetary maxRangeQuoteSideValue = model.getMaxRangeQuoteSideValue().get();
-            long midValue = minRangeQuoteSideValue.getValue() + (maxRangeQuoteSideValue.getValue() - minRangeQuoteSideValue.getValue()) / 2;
+            Monetary minRangeQuoteSideAmount = rangeQuoteSideAmount.getMin();
+            Monetary maxRangeQuoteSideAmount = rangeQuoteSideAmount.getMax();
+            long midValue = minRangeQuoteSideAmount.getValue() + (maxRangeQuoteSideAmount.getValue() - minRangeQuoteSideAmount.getValue()) / 2;
             Monetary exactAmount = model.getMarket().isCrypto()
                     ? Coin.asBtcFromValue(midValue)
                     : Fiat.fromValue(midValue, priceQuote.getQuoteSideMonetary().getCode()).round(0);
@@ -550,69 +543,60 @@ public class MuSigAmountSelectionController implements Controller {
 
     private void applyInitialRangeValues() {
         PriceQuote priceQuote = priceInput.getQuote().get();
-        if (priceQuote == null) {
+        MonetaryRange quoteSideTradeAmountLimits = model.getQuoteSideTradeAmountLimits().get();
+        if (priceQuote == null || quoteSideTradeAmountLimits == null) {
             return;
         }
 
         if (model.getMarket().isCrypto()) {
-            Monetary minRangeQuoteMonetary = model.getMinRangeMonetary().get();
-            Monetary maxRangeQuoteMonetary = model.getMaxRangeMonetary().get();
+            Monetary minRangeQuoteMonetary = quoteSideTradeAmountLimits.getMin();
+            Monetary maxRangeQuoteMonetary = quoteSideTradeAmountLimits.getMax();
             Monetary minRangeBaseMonetary = priceQuote.toBaseSideMonetary(minRangeQuoteMonetary);
             Monetary maxRangeBaseMonetary = priceQuote.toBaseSideMonetary(maxRangeQuoteMonetary);
 
-            model.getMinRangeBaseSideValue().set(minRangeBaseMonetary);
-            model.getMaxRangeBaseSideValue().set(maxRangeBaseMonetary);
-            model.getMinRangeQuoteSideValue().set(minRangeQuoteMonetary);
-            model.getMaxRangeQuoteSideValue().set(maxRangeQuoteMonetary);
+            model.getRangeBaseSideAmount().set(new MonetaryRange(minRangeBaseMonetary, maxRangeBaseMonetary));
+            model.getRangeQuoteSideAmount().set(new MonetaryRange(minRangeQuoteMonetary, maxRangeQuoteMonetary));
 
-            if (isUsingInvertedBaseAndQuoteCurrencies()) {
+            if (isDefaultAmountInputBtc()) {
                 // Input now is base side
-                model.getMinRangeValueAsString().set(AmountFormatter.formatBaseAmount(minRangeBaseMonetary));
-                model.getMinRangeCodeAsString().set(minRangeBaseMonetary.getCode());
-                model.getMaxRangeCodeAsString().set(maxRangeBaseMonetary.getCode());
-                model.getMaxRangeValueLimitationAsString().set(AmountFormatter.formatBaseAmount(maxRangeBaseMonetary));
+                model.getFormattedMinRangeAmount().set(AmountFormatter.formatBaseAmount(minRangeBaseMonetary));
+                model.getRangeAmountCode().set(minRangeBaseMonetary.getCode());
+                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatBaseAmount(maxRangeBaseMonetary));
             } else {
                 // Input now is quote side
-                model.getMinRangeValueAsString().set(AmountFormatter.formatQuoteAmount(minRangeQuoteMonetary));
-                model.getMinRangeCodeAsString().set(minRangeQuoteMonetary.getCode());
-                model.getMaxRangeCodeAsString().set(maxRangeQuoteMonetary.getCode());
-                model.getMaxRangeValueLimitationAsString().set(AmountFormatter.formatQuoteAmount(maxRangeQuoteMonetary));
+                model.getFormattedMinRangeAmount().set(AmountFormatter.formatQuoteAmount(minRangeQuoteMonetary));
+                model.getRangeAmountCode().set(minRangeQuoteMonetary.getCode());
+                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatQuoteAmount(maxRangeQuoteMonetary));
             }
         } else {
-            Monetary minRangeMonetary = model.getMinRangeMonetary().get();
-            Monetary maxRangeMonetary = model.getMaxRangeMonetary().get();
-            boolean isMinRangeMonetaryFiat = Asset.isFiat(minRangeMonetary.getCode());
-            boolean isMaxRangeMonetaryFiat = Asset.isFiat(maxRangeMonetary.getCode());
+            Monetary minRangeAmount = quoteSideTradeAmountLimits.getMin();
+            Monetary maxRangeAmount = quoteSideTradeAmountLimits.getMax();
+            String code = minRangeAmount.getCode();
+            boolean isFiat = Asset.isFiat(code);
 
-            Monetary minRangeMonetaryAsCoin = !isMinRangeMonetaryFiat ? minRangeMonetary : priceQuote.toBaseSideMonetary(minRangeMonetary);
-            model.getMinRangeBaseSideValue().set(minRangeMonetaryAsCoin);
+            Monetary minRangeBaseSideAmount = !isFiat ? minRangeAmount : priceQuote.toBaseSideMonetary(minRangeAmount);
+            Monetary maxRangeBaseSideAmount = !isFiat ? maxRangeAmount : priceQuote.toBaseSideMonetary(maxRangeAmount);
+            model.getRangeBaseSideAmount().set(new MonetaryRange(minRangeBaseSideAmount, maxRangeBaseSideAmount));
 
-            Monetary maxRangeMonetaryAsCoin = !isMaxRangeMonetaryFiat ? maxRangeMonetary : priceQuote.toBaseSideMonetary(maxRangeMonetary);
-            model.getMaxRangeBaseSideValue().set(maxRangeMonetaryAsCoin);
+            Monetary minRangeQuoteSideAmount = isFiat ? minRangeAmount : priceQuote.toQuoteSideMonetary(minRangeAmount).round(0);
+            Monetary maxRangeQuoteSideAmount = isFiat ? maxRangeAmount : priceQuote.toQuoteSideMonetary(maxRangeAmount).round(0);
+            model.getRangeQuoteSideAmount().set(new MonetaryRange(minRangeQuoteSideAmount, maxRangeQuoteSideAmount));
 
-            Monetary minRangeMonetaryAsFiat = isMinRangeMonetaryFiat ? minRangeMonetary : priceQuote.toQuoteSideMonetary(minRangeMonetary).round(0);
-            model.getMinRangeQuoteSideValue().set(minRangeMonetaryAsFiat);
-
-            Monetary maxRangeMonetaryAsFiat = isMaxRangeMonetaryFiat ? maxRangeMonetary : priceQuote.toQuoteSideMonetary(maxRangeMonetary).round(0);
-            model.getMaxRangeQuoteSideValue().set(maxRangeMonetaryAsFiat);
-
-            if (isUsingInvertedBaseAndQuoteCurrencies()) {
+            if (isDefaultAmountInputBtc()) {
                 // Input now is base side
-                model.getMinRangeValueAsString().set(AmountFormatter.formatBaseAmount(minRangeMonetaryAsCoin));
-                model.getMinRangeCodeAsString().set(minRangeMonetaryAsCoin.getCode());
-                model.getMaxRangeCodeAsString().set(maxRangeMonetaryAsCoin.getCode());
-                model.getMaxRangeValueLimitationAsString().set(AmountFormatter.formatBaseAmount(maxRangeMonetaryAsCoin));
+                model.getFormattedMinRangeAmount().set(AmountFormatter.formatBaseAmount(minRangeBaseSideAmount));
+                model.getRangeAmountCode().set(minRangeBaseSideAmount.getCode());
+                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatBaseAmount(maxRangeBaseSideAmount));
             } else {
                 // Input now is quote side
-                model.getMinRangeValueAsString().set(AmountFormatter.formatQuoteAmount(minRangeMonetaryAsFiat));
-                model.getMinRangeCodeAsString().set(minRangeMonetaryAsFiat.getCode());
-                model.getMaxRangeCodeAsString().set(maxRangeMonetaryAsFiat.getCode());
-                Monetary maxRangeMonetaryLimitationAsFiat = maxRangeMonetaryAsFiat;
-                if (model.getMaxQuoteAllowedLimitation().get() != null) {
-                    Monetary maxQuoteAllowedLimitation = model.getMaxQuoteAllowedLimitation().get();
-                    maxRangeMonetaryLimitationAsFiat = isMaxRangeMonetaryFiat ? maxQuoteAllowedLimitation : priceQuote.toQuoteSideMonetary(maxQuoteAllowedLimitation).round(0);
+                model.getFormattedMinRangeAmount().set(AmountFormatter.formatQuoteAmount(minRangeQuoteSideAmount));
+                model.getRangeAmountCode().set(minRangeQuoteSideAmount.getCode());
+                Monetary maxRangeMonetaryLimitationAsFiat = maxRangeQuoteSideAmount;
+                if (model.getMaxAllowedQuoteSideAmount().get() != null) {
+                    Monetary maxQuoteAllowedLimitation = model.getMaxAllowedQuoteSideAmount().get();
+                    maxRangeMonetaryLimitationAsFiat = isFiat ? maxQuoteAllowedLimitation : priceQuote.toQuoteSideMonetary(maxQuoteAllowedLimitation).round(0);
                 }
-                model.getMaxRangeValueLimitationAsString().set(AmountFormatter.formatQuoteAmount(maxRangeMonetaryLimitationAsFiat));
+                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatQuoteAmount(maxRangeMonetaryLimitationAsFiat));
             }
         }
 
@@ -620,25 +604,29 @@ public class MuSigAmountSelectionController implements Controller {
     }
 
     private void applySliderTrackStyle() {
-        Monetary minRangeMonetary = model.getMinRangeQuoteSideValue().get();
-        Monetary maxRangeMonetary = model.getMaxQuoteAllowedLimitation() != null
-                ? model.getMaxQuoteAllowedLimitation().get()
-                : model.getMaxRangeQuoteSideValue().get();
-        if (minRangeMonetary == null || maxRangeMonetary == null) {
+        MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+        if (rangeQuoteSideAmount == null) {
             return;
         }
-        long minRangeMonetaryValue = minRangeMonetary.getValue();
-        long maxRangeMonetaryValue = maxRangeMonetary.getValue();
+        Monetary min = rangeQuoteSideAmount.getMin();
+        Monetary max = model.getMaxAllowedQuoteSideAmount() != null
+                ? model.getMaxAllowedQuoteSideAmount().get()
+                : rangeQuoteSideAmount.getMax();
+        if (min == null || max == null) {
+            return;
+        }
+        long minRangeMonetaryValue = min.getValue();
+        long maxRangeMonetaryValue = max.getValue();
         double range = maxRangeMonetaryValue - minRangeMonetaryValue;
 
         // If left value is not set we use minRange
         // If left value is set but right value not set we don't show any marker
         Monetary markerQuoteSideValue = model.getLeftMarkerQuoteSideValue();
-        long leftMarkerQuoteSideValue = Optional.ofNullable(markerQuoteSideValue).orElse(minRangeMonetary).getValue();
+        long leftMarkerQuoteSideValue = Optional.ofNullable(markerQuoteSideValue).orElse(min).getValue();
         double left = leftMarkerQuoteSideValue - minRangeMonetaryValue;
         double leftPercentage = range != 0 ? 100 * left / range : 0;
 
-        long rightMarkerQuoteSideValue = Optional.ofNullable(model.getRightMarkerQuoteSideValue()).orElse(minRangeMonetary).getValue();
+        long rightMarkerQuoteSideValue = Optional.ofNullable(model.getRightMarkerQuoteSideValue()).orElse(min).getValue();
         double right = rightMarkerQuoteSideValue - minRangeMonetaryValue;
         double rightPercentage = range != 0 ? 100 * right / range : 0;
 
@@ -674,31 +662,42 @@ public class MuSigAmountSelectionController implements Controller {
 
     private void applySliderValue(double sliderValue,
                                   MuSigBigAmountNumberBox quoteAmountInput,
-                                  MuSigBigAmountNumberBox invertedBaseAmountInput) {
-        if (isUsingInvertedBaseAndQuoteCurrencies()) {
-            if (model.getMinRangeBaseSideValue().get() != null && model.getMaxRangeBaseSideValue().get() != null) {
-                long min = model.getMinRangeBaseSideValue().get().getValue();
-                long max = model.getMaxBaseAllowedLimitation().get() != null
-                        ? model.getMaxBaseAllowedLimitation().get().getValue()
-                        : model.getMaxRangeBaseSideValue().get().getValue();
-                long value = Math.round(sliderValue * (max - min)) + min;
-
-                String baseCurrencyCode = model.getMarket().getBaseCurrencyCode();
-                Monetary exactBaseAmount = Monetary.from(value, baseCurrencyCode);
-                invertedBaseAmountInput.setAmount(exactBaseAmount);
+                                  MuSigBigAmountNumberBox baseAmountInput) {
+        if (isDefaultAmountInputBtc()) {
+            MonetaryRange rangeBaseSideAmount = model.getRangeBaseSideAmount().get();
+            if (rangeBaseSideAmount == null) {
+                return;
             }
+            long min = rangeBaseSideAmount.getMin().getValue();
+            long max;
+            Monetary maxAllowedBaseSideAmount = model.getMaxAllowedBaseSideAmount().get();
+            if (maxAllowedBaseSideAmount != null) {
+                max = maxAllowedBaseSideAmount.getValue();
+            } else {
+                max = rangeBaseSideAmount.getMax().getValue();
+            }
+            long value = Math.round(sliderValue * (max - min)) + min;
+            String baseCurrencyCode = model.getMarket().getBaseCurrencyCode();
+            Monetary baseAmount = Monetary.from(value, baseCurrencyCode);
+            baseAmountInput.setAmount(baseAmount);
         } else {
-            if (model.getMinRangeQuoteSideValue().get() != null && model.getMaxRangeQuoteSideValue().get() != null) {
-                long min = model.getMinRangeQuoteSideValue().get().getValue();
-                long max = model.getMaxQuoteAllowedLimitation().get() != null
-                        ? model.getMaxQuoteAllowedLimitation().get().getValue()
-                        : model.getMaxRangeQuoteSideValue().get().getValue();
-                long value = Math.round(sliderValue * (max - min)) + min;
-
-                String quoteCurrencyCode = model.getMarket().getQuoteCurrencyCode();
-                Monetary exactQuoteAmount = Monetary.from(value, quoteCurrencyCode);
-                quoteAmountInput.setAmount(exactQuoteAmount);
+            MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+            if (rangeQuoteSideAmount == null) {
+                return;
             }
+            long min = rangeQuoteSideAmount.getMin().getValue();
+            long max;
+            Monetary maxAllowedQuoteSideAmount = model.getMaxAllowedQuoteSideAmount().get();
+            if (maxAllowedQuoteSideAmount != null) {
+                max = maxAllowedQuoteSideAmount.getValue();
+            } else {
+                max = rangeQuoteSideAmount.getMax().getValue();
+            }
+            long value = Math.round(sliderValue * (max - min)) + min;
+            String quoteCurrencyCode = model.getMarket().getQuoteCurrencyCode();
+            Monetary quoteAmount = Monetary.from(value, quoteCurrencyCode);
+            quoteAmountInput.setAmount(quoteAmount);
+
         }
     }
 
@@ -769,73 +768,89 @@ public class MuSigAmountSelectionController implements Controller {
             boolean areCurrenciesInverted = model.getIsDefaultAmountInputBtc().get();
             model.getShouldShowMaxOrFixedAmounts().set(!areCurrenciesInverted);
             model.getShouldShowInvertedMaxOrFixedAmounts().set(areCurrenciesInverted);
-            if (model.getIsRangeAmountEnabled() != null) {
-                boolean isRangeAmountEnabled = model.getIsRangeAmountEnabled().get();
-                model.getShouldShowMinAmounts().set(isRangeAmountEnabled && !areCurrenciesInverted);
-                model.getShouldShowInvertedMinAmounts().set(isRangeAmountEnabled && areCurrenciesInverted);
+            if (model.getUseRangeAmount() != null) {
+                boolean useRangeAmount = model.getUseRangeAmount().get();
+                model.getShouldShowMinAmounts().set(useRangeAmount && !areCurrenciesInverted);
+                model.getShouldShowInvertedMinAmounts().set(useRangeAmount && areCurrenciesInverted);
             }
         }
     }
 
     private void updateMaxOrFixedBaseSideAmount(Monetary amount, MuSigAmountNumberBox amountNumberBox) {
-        Monetary minRangeValue = model.getMinRangeBaseSideValue().get();
-        Monetary maxRangeValue = model.getMaxRangeBaseSideValue().get();
-        if (amount != null && amount.getValue() > maxRangeValue.getValue()) {
-            model.getMaxOrFixedBaseSideAmount().set(maxRangeValue);
+        MonetaryRange rangeBaseSideAmount = model.getRangeBaseSideAmount().get();
+        if (rangeBaseSideAmount == null) {
+            return;
+        }
+        Monetary min = rangeBaseSideAmount.getMin();
+        Monetary max = rangeBaseSideAmount.getMax();
+        if (amount != null && amount.getValue() > max.getValue()) {
+            model.getMaxOrFixedBaseSideAmount().set(max);
             setMaxOrFixedQuoteFromBase();
-            amountNumberBox.setAmount(maxRangeValue);
-        } else if (amount != null && amount.getValue() < minRangeValue.getValue()) {
-            model.getMaxOrFixedBaseSideAmount().set(minRangeValue);
+            amountNumberBox.setAmount(max);
+        } else if (amount != null && amount.getValue() < min.getValue()) {
+            model.getMaxOrFixedBaseSideAmount().set(min);
             setMaxOrFixedQuoteFromBase();
-            amountNumberBox.setAmount(minRangeValue);
+            amountNumberBox.setAmount(min);
         } else {
             model.getMaxOrFixedBaseSideAmount().set(amount);
         }
     }
 
     private void updateMinBaseAmount(Monetary amount, MuSigAmountNumberBox amountNumberBox) {
-        Monetary minRangeValue = model.getMinRangeBaseSideValue().get();
-        Monetary maxRangeValue = model.getMaxRangeBaseSideValue().get();
-        if (amount != null && amount.getValue() > maxRangeValue.getValue()) {
-            model.getMinBaseSideAmount().set(maxRangeValue);
+        MonetaryRange rangeBaseSideAmount = model.getRangeBaseSideAmount().get();
+        if (rangeBaseSideAmount == null) {
+            return;
+        }
+        Monetary min = rangeBaseSideAmount.getMin();
+        Monetary max = rangeBaseSideAmount.getMax();
+        if (amount != null && amount.getValue() > max.getValue()) {
+            model.getMinBaseSideAmount().set(max);
             setMinQuoteFromBase();
-            amountNumberBox.setAmount(maxRangeValue);
-        } else if (amount != null && amount.getValue() < minRangeValue.getValue()) {
-            model.getMinBaseSideAmount().set(minRangeValue);
+            amountNumberBox.setAmount(max);
+        } else if (amount != null && amount.getValue() < min.getValue()) {
+            model.getMinBaseSideAmount().set(min);
             setMinQuoteFromBase();
-            amountNumberBox.setAmount(minRangeValue);
+            amountNumberBox.setAmount(min);
         } else {
             model.getMinBaseSideAmount().set(amount);
         }
     }
 
     private void updateMaxOrFixedQuoteSideAmount(Monetary amount, MuSigAmountNumberBox amountNumberBox) {
-        Monetary minRangeValue = model.getMinRangeQuoteSideValue().get();
-        Monetary maxRangeValue = model.getMaxRangeQuoteSideValue().get();
-        if (maxRangeValue != null && amount != null && amount.getValue() > maxRangeValue.getValue()) {
-            model.getMaxOrFixedQuoteSideAmount().set(maxRangeValue);
+        MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+        if (rangeQuoteSideAmount == null) {
+            return;
+        }
+        Monetary min = rangeQuoteSideAmount.getMin();
+        Monetary max = rangeQuoteSideAmount.getMax();
+        if (max != null && amount != null && amount.getValue() > max.getValue()) {
+            model.getMaxOrFixedQuoteSideAmount().set(max);
             setMaxOrFixedBaseFromQuote();
-            amountNumberBox.setAmount(maxRangeValue);
-        } else if (minRangeValue != null && amount != null && amount.getValue() < minRangeValue.getValue()) {
-            model.getMaxOrFixedQuoteSideAmount().set(minRangeValue);
+            amountNumberBox.setAmount(max);
+        } else if (min != null && amount != null && amount.getValue() < min.getValue()) {
+            model.getMaxOrFixedQuoteSideAmount().set(min);
             setMaxOrFixedBaseFromQuote();
-            amountNumberBox.setAmount(minRangeValue);
+            amountNumberBox.setAmount(min);
         } else {
             model.getMaxOrFixedQuoteSideAmount().set(amount);
         }
     }
 
     private void updateMinQuoteSideAmount(Monetary amount, MuSigAmountNumberBox amountNumberBox) {
-        Monetary minRangeValue = model.getMinRangeQuoteSideValue().get();
-        Monetary maxRangeValue = model.getMaxRangeQuoteSideValue().get();
-        if (maxRangeValue != null && amount != null && amount.getValue() > maxRangeValue.getValue()) {
-            model.getMinQuoteSideAmount().set(maxRangeValue);
+        MonetaryRange rangeQuoteSideAmount = model.getRangeQuoteSideAmount().get();
+        if (rangeQuoteSideAmount == null) {
+            return;
+        }
+        Monetary min = rangeQuoteSideAmount.getMin();
+        Monetary max = rangeQuoteSideAmount.getMax();
+        if (max != null && amount != null && amount.getValue() > max.getValue()) {
+            model.getMinQuoteSideAmount().set(max);
             setMinBaseFromQuote();
-            amountNumberBox.setAmount(maxRangeValue);
-        } else if (minRangeValue != null && amount != null && amount.getValue() < minRangeValue.getValue()) {
-            model.getMinQuoteSideAmount().set(minRangeValue);
+            amountNumberBox.setAmount(max);
+        } else if (min != null && amount != null && amount.getValue() < min.getValue()) {
+            model.getMinQuoteSideAmount().set(min);
             setMinBaseFromQuote();
-            amountNumberBox.setAmount(minRangeValue);
+            amountNumberBox.setAmount(min);
         } else {
             model.getMinQuoteSideAmount().set(amount);
         }
@@ -843,7 +858,7 @@ public class MuSigAmountSelectionController implements Controller {
 
     private void applyTextInputPrefWidth() {
         int charCount = onGetCalculatedTotalCharCount();
-        if (isUsingInvertedBaseAndQuoteCurrencies()) {
+        if (isDefaultAmountInputBtc()) {
             applyPrefWidth(charCount, invertedMinBaseSideAmountInput);
             applyPrefWidth(charCount, invertedMaxOrFixedBaseSideAmountInput);
         } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionModel.java
@@ -34,8 +34,16 @@ import javafx.beans.property.StringProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Map;
+
 @Getter
 public class MuSigAmountSelectionModel implements Model {
+    static final String SLIDER_TRACK_DEFAULT_COLOR = "-bisq-dark-grey-50";
+    static final String SLIDER_TRACK_MARKER_COLOR = "-bisq2-green";
+    static final int RANGE_INPUT_TEXT_MAX_LENGTH = 11;
+    static final int FIXED_INPUT_TEXT_MAX_LENGTH = 18;
+
+    private final Map<Integer, Integer> widthByNumCharsMap;
     @Setter
     private Market market = MarketRepository.getDefaultBtcFiatMarket();
     @Setter
@@ -98,6 +106,10 @@ public class MuSigAmountSelectionModel implements Model {
     public final int amountBoxHeight = 120;
     private final BooleanProperty shouldFocusInputTextField = new SimpleBooleanProperty(false);
     private final BooleanProperty shouldApplyNewInputTextFontStyle = new SimpleBooleanProperty(false);
+
+    public MuSigAmountSelectionModel(Map<Integer, Integer> widthByNumCharsMap) {
+        this.widthByNumCharsMap = widthByNumCharsMap;
+    }
 
     void reset() {
         maxOrFixedBaseSideAmount.set(null);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionModel.java
@@ -17,19 +17,17 @@
 
 package bisq.desktop.main.content.mu_sig.offer.components.amount_selection;
 
-import bisq.bisq_easy.BisqEasyTradeAmountLimits;
 import bisq.common.market.Market;
 import bisq.common.market.MarketRepository;
 import bisq.common.monetary.Monetary;
+import bisq.common.monetary.MonetaryRange;
 import bisq.desktop.common.view.Model;
 import bisq.offer.Direction;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -38,61 +36,66 @@ import lombok.Setter;
 
 @Getter
 public class MuSigAmountSelectionModel implements Model {
-    private final double sliderMin = 0;
-    private final double sliderMax = 1;
-    public final int amountBoxWidth = 300;
-    public final int amountBoxHeight = 120;
+    @Setter
+    private Market market = MarketRepository.getDefaultBtcFiatMarket();
+    @Setter
+    private Direction direction = Direction.BUY;
 
-    private final ObjectProperty<Monetary> maxOrFixedBaseSideAmount = new SimpleObjectProperty<>();
-    private final ObjectProperty<Monetary> maxOrFixedQuoteSideAmount = new SimpleObjectProperty<>();
+    // Range
+    private final BooleanProperty useRangeAmount = new SimpleBooleanProperty();
+
+    private final ObjectProperty<MonetaryRange> quoteSideTradeAmountLimits = new SimpleObjectProperty<>();
+
+    private final ObjectProperty<MonetaryRange> rangeBaseSideAmount = new SimpleObjectProperty<>();
+    private final ObjectProperty<MonetaryRange> rangeQuoteSideAmount = new SimpleObjectProperty<>();
+
+    private final ObjectProperty<Monetary> maxAllowedQuoteSideAmount = new SimpleObjectProperty<>();
+    private final ObjectProperty<Monetary> maxAllowedBaseSideAmount = new SimpleObjectProperty<>();
+
+    private final StringProperty formattedMinRangeAmount = new SimpleStringProperty();
+    private final StringProperty rangeAmountCode = new SimpleStringProperty();
+    private final StringProperty formattedMaxAllowedQuoteSideAmount = new SimpleStringProperty();
+
+
+    // Amounts
     private final ObjectProperty<Monetary> minBaseSideAmount = new SimpleObjectProperty<>();
     private final ObjectProperty<Monetary> minQuoteSideAmount = new SimpleObjectProperty<>();
-    private final StringProperty spendOrReceiveString = new SimpleStringProperty();
+    private final ObjectProperty<Monetary> maxOrFixedBaseSideAmount = new SimpleObjectProperty<>();
+    private final ObjectProperty<Monetary> maxOrFixedQuoteSideAmount = new SimpleObjectProperty<>();
 
+
+    // Slider
     private final DoubleProperty maxOrFixedAmountSliderValue = new SimpleDoubleProperty();
     private final DoubleProperty minAmountSliderValue = new SimpleDoubleProperty();
     private final BooleanProperty maxOrFixedAmountSliderFocus = new SimpleBooleanProperty();
     private final BooleanProperty minAmountSliderFocus = new SimpleBooleanProperty();
     private final BooleanProperty rangeSliderLowThumbFocus = new SimpleBooleanProperty();
     private final BooleanProperty rangeSliderHighThumbFocus = new SimpleBooleanProperty();
-    private final BooleanProperty isRangeAmountEnabled = new SimpleBooleanProperty();
 
-    @Setter
-    private ObjectProperty<Monetary> minRangeMonetary = new SimpleObjectProperty<>(BisqEasyTradeAmountLimits.DEFAULT_MIN_BTC_TRADE_AMOUNT);
-    @Setter
-    private ObjectProperty<Monetary> maxRangeMonetary = new SimpleObjectProperty<>(BisqEasyTradeAmountLimits.DEFAULT_MAX_BTC_TRADE_AMOUNT);
-    @Setter
-    private ObjectProperty<Monetary> minRangeBaseSideValue = new SimpleObjectProperty<>();
-    @Setter
-    private ObjectProperty<Monetary> maxRangeBaseSideValue = new SimpleObjectProperty<>();
-    @Setter
-    private ObjectProperty<Monetary> minRangeQuoteSideValue = new SimpleObjectProperty<>();
-    @Setter
-    private ObjectProperty<Monetary> maxRangeQuoteSideValue = new SimpleObjectProperty<>();
-    private final ObjectProperty<Monetary> maxQuoteAllowedLimitation = new SimpleObjectProperty<>();
-    private final ObjectProperty<Monetary> maxBaseAllowedLimitation = new SimpleObjectProperty<>();
     @Setter
     private Monetary leftMarkerQuoteSideValue;
     @Setter
     private Monetary rightMarkerQuoteSideValue;
     private final StringProperty sliderTrackStyle = new SimpleStringProperty();
-    @Setter
-    private Market market = MarketRepository.getDefaultBtcFiatMarket();
-    @Setter
-    private Direction direction = Direction.BUY;
-    private final StringProperty description = new SimpleStringProperty();
-    private final StringProperty minRangeValueAsString = new SimpleStringProperty();
-    private final StringProperty minRangeCodeAsString = new SimpleStringProperty();
-    private final StringProperty maxRangeValueLimitationAsString = new SimpleStringProperty();
-    private final StringProperty maxRangeCodeAsString = new SimpleStringProperty();
-    private final BooleanProperty showRangeAmountSelection = new SimpleBooleanProperty(false);
-    private final BooleanProperty allowInvertingBaseAndQuoteCurrencies = new SimpleBooleanProperty(false);
-    private final IntegerProperty baseAmountSelectionHBoxWidth = new SimpleIntegerProperty(amountBoxWidth);
+
+
+    // Input type
     private final BooleanProperty isDefaultAmountInputBtc = new SimpleBooleanProperty(false);
-    private final BooleanProperty shouldShowMinAmounts = new SimpleBooleanProperty(false);
     private final BooleanProperty shouldShowInvertedMinAmounts = new SimpleBooleanProperty(false);
-    private final BooleanProperty shouldShowMaxOrFixedAmounts = new SimpleBooleanProperty(false);
     private final BooleanProperty shouldShowInvertedMaxOrFixedAmounts = new SimpleBooleanProperty(false);
+    private final BooleanProperty shouldShowMaxOrFixedAmounts = new SimpleBooleanProperty(false);
+    private final BooleanProperty shouldShowMinAmounts = new SimpleBooleanProperty(false);
+    private final BooleanProperty showRangeAmountSelection = new SimpleBooleanProperty(false);
+
+    // Strings
+    private final StringProperty spendOrReceiveString = new SimpleStringProperty();
+    private final StringProperty description = new SimpleStringProperty();
+
+    // Layout
+    private final double sliderMin = 0;
+    private final double sliderMax = 1;
+    public final int amountBoxWidth = 300;
+    public final int amountBoxHeight = 120;
     private final BooleanProperty shouldFocusInputTextField = new SimpleBooleanProperty(false);
     private final BooleanProperty shouldApplyNewInputTextFontStyle = new SimpleBooleanProperty(false);
 
@@ -108,28 +111,22 @@ public class MuSigAmountSelectionModel implements Model {
         minAmountSliderFocus.set(false);
         rangeSliderLowThumbFocus.set(false);
         rangeSliderHighThumbFocus.set(false);
-        isRangeAmountEnabled.set(false);
-        minRangeMonetary.set(BisqEasyTradeAmountLimits.DEFAULT_MIN_BTC_TRADE_AMOUNT);
-        maxRangeMonetary.set(BisqEasyTradeAmountLimits.DEFAULT_MAX_BTC_TRADE_AMOUNT);
-        minRangeBaseSideValue.set(null);
-        maxRangeBaseSideValue.set(null);
-        minRangeQuoteSideValue.set(null);
-        maxRangeQuoteSideValue.set(null);
-        maxQuoteAllowedLimitation.set(null);
-        maxBaseAllowedLimitation.set(null);
+        useRangeAmount.set(false);
+        quoteSideTradeAmountLimits.set(null);
+        rangeBaseSideAmount.set(null);
+        rangeQuoteSideAmount.set(null);
+        maxAllowedQuoteSideAmount.set(null);
+        maxAllowedBaseSideAmount.set(null);
         leftMarkerQuoteSideValue = null;
         rightMarkerQuoteSideValue = null;
         sliderTrackStyle.set(null);
         market = MarketRepository.getDefaultBtcFiatMarket();
         direction = Direction.BUY;
         description.set(null);
-        minRangeValueAsString.set(null);
-        minRangeCodeAsString.set(null);
-        maxRangeValueLimitationAsString.set(null);
-        maxRangeCodeAsString.set(null);
+        formattedMinRangeAmount.set(null);
+        rangeAmountCode.set(null);
+        formattedMaxAllowedQuoteSideAmount.set(null);
         showRangeAmountSelection.set(false);
-        allowInvertingBaseAndQuoteCurrencies.set(false);
-        baseAmountSelectionHBoxWidth.set(amountBoxWidth);
         isDefaultAmountInputBtc.set(false);
         shouldShowMinAmounts.set(false);
         shouldShowInvertedMinAmounts.set(false);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionView.java
@@ -75,7 +75,7 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
     private final ChangeListener<Number> maxOrFixedAmountSliderValueListener, minAmountSliderValueListener;
     private final BisqMenuItem flipCurrenciesButton;
     private final RangeSlider rangeAmountSlider;
-    private Subscription shouldFocusInputTextFieldPin, sliderTrackStylePin, isRangeAmountEnabledPin,
+    private Subscription shouldFocusInputTextFieldPin, sliderTrackStylePin, useRangeAmountPin,
             shouldApplyNewInputTextFontStylePin;
 
     MuSigAmountSelectionView(MuSigAmountSelectionModel model,
@@ -131,6 +131,9 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         baseAmountSelectionHBox = new HBox(minBaseAmountRoot, invertedMinQuoteAmountRoot, baseAmountSeparator,
                 maxOrFixedBaseAmountRoot, invertedMaxOrFixedQuoteAmountRoot);
         baseAmountSelectionHBox.getStyleClass().add("base-amount");
+        baseAmountSelectionHBox.setMinWidth(model.getAmountBoxWidth() - 10);
+        baseAmountSelectionHBox.setMaxWidth(model.getAmountBoxWidth() - 10);
+
 
         flipCurrenciesButton = new BisqMenuItem("flip-fields-arrows-green", "flip-fields-arrows-white");
         flipCurrenciesButton.setTooltip(Res.get("muSig.offer.create.amount.selection.flipCurrenciesButton.tooltip"));
@@ -216,11 +219,11 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
 
     @Override
     protected void onViewAttached() {
-        isRangeAmountEnabledPin = EasyBind.subscribe(model.getIsRangeAmountEnabled(), isRangeAmountEnabled -> {
+        useRangeAmountPin = EasyBind.subscribe(model.getUseRangeAmount(), useRangeAmount -> {
             root.getStyleClass().clear();
             root.getStyleClass().add("amount-selection");
-            root.getStyleClass().add(isRangeAmountEnabled ? "range-amount" : "fixed-amount");
-            VBox.setMargin(sliderIndicators, isRangeAmountEnabled ? SLIDER_INDICATORS_RANGE_MARGIN : SLIDER_INDICATORS_FIXED_MARGIN);
+            root.getStyleClass().add(useRangeAmount ? "range-amount" : "fixed-amount");
+            VBox.setMargin(sliderIndicators, useRangeAmount ? SLIDER_INDICATORS_RANGE_MARGIN : SLIDER_INDICATORS_FIXED_MARGIN);
             applyTextInputFontStyle(true);
         });
         sliderTrackStylePin = EasyBind.subscribe(model.getSliderTrackStyle(), trackStyle -> {
@@ -240,14 +243,14 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         fixedAmountSlider.valueProperty().addListener(maxOrFixedAmountSliderValueListener);
         model.getMaxOrFixedAmountSliderFocus().bind(fixedAmountSlider.focusedProperty());
         description.textProperty().bind(model.getDescription());
-        minRangeValue.textProperty().bind(model.getMinRangeValueAsString());
-        minRangeCode.textProperty().bind(model.getMinRangeCodeAsString());
-        maxRangeValue.textProperty().bind(model.getMaxRangeValueLimitationAsString());
-        maxRangeCode.textProperty().bind(model.getMaxRangeCodeAsString());
-        quoteAmountSeparator.visibleProperty().bind(model.getIsRangeAmountEnabled());
-        quoteAmountSeparator.managedProperty().bind(model.getIsRangeAmountEnabled());
-        baseAmountSeparator.visibleProperty().bind(model.getIsRangeAmountEnabled());
-        baseAmountSeparator.managedProperty().bind(model.getIsRangeAmountEnabled());
+        minRangeValue.textProperty().bind(model.getFormattedMinRangeAmount());
+        minRangeCode.textProperty().bind(model.getRangeAmountCode());
+        maxRangeValue.textProperty().bind(model.getFormattedMaxAllowedQuoteSideAmount());
+        maxRangeCode.textProperty().bind(model.getRangeAmountCode());
+        quoteAmountSeparator.visibleProperty().bind(model.getUseRangeAmount());
+        quoteAmountSeparator.managedProperty().bind(model.getUseRangeAmount());
+        baseAmountSeparator.visibleProperty().bind(model.getUseRangeAmount());
+        baseAmountSeparator.managedProperty().bind(model.getUseRangeAmount());
         minQuoteAmountRoot.visibleProperty().bind(model.getShouldShowMinAmounts());
         minQuoteAmountRoot.managedProperty().bind(model.getShouldShowMinAmounts());
         minBaseAmountRoot.visibleProperty().bind(model.getShouldShowMinAmounts());
@@ -256,14 +259,10 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         invertedMinQuoteAmountRoot.managedProperty().bind(model.getShouldShowInvertedMinAmounts());
         invertedMinBaseAmountRoot.visibleProperty().bind(model.getShouldShowInvertedMinAmounts());
         invertedMinBaseAmountRoot.managedProperty().bind(model.getShouldShowInvertedMinAmounts());
-        rangeAmountSlider.visibleProperty().bind(model.getIsRangeAmountEnabled());
-        rangeAmountSlider.managedProperty().bind(model.getIsRangeAmountEnabled());
-        fixedAmountSlider.visibleProperty().bind(model.getIsRangeAmountEnabled().not());
-        fixedAmountSlider.managedProperty().bind(model.getIsRangeAmountEnabled().not());
-        flipCurrenciesButton.visibleProperty().bind(model.getAllowInvertingBaseAndQuoteCurrencies());
-        flipCurrenciesButton.managedProperty().bind(model.getAllowInvertingBaseAndQuoteCurrencies());
-        baseAmountSelectionHBox.minWidthProperty().bind(model.getBaseAmountSelectionHBoxWidth());
-        baseAmountSelectionHBox.maxWidthProperty().bind(model.getBaseAmountSelectionHBoxWidth());
+        rangeAmountSlider.visibleProperty().bind(model.getUseRangeAmount());
+        rangeAmountSlider.managedProperty().bind(model.getUseRangeAmount());
+        fixedAmountSlider.visibleProperty().bind(model.getUseRangeAmount().not());
+        fixedAmountSlider.managedProperty().bind(model.getUseRangeAmount().not());
         maxOrFixedBaseAmountRoot.visibleProperty().bind(model.getShouldShowMaxOrFixedAmounts());
         maxOrFixedBaseAmountRoot.managedProperty().bind(model.getShouldShowMaxOrFixedAmounts());
         maxOrFixedQuoteAmountRoot.visibleProperty().bind(model.getShouldShowMaxOrFixedAmounts());
@@ -286,7 +285,7 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
 
     @Override
     protected void onViewDetached() {
-        isRangeAmountEnabledPin.unsubscribe();
+        useRangeAmountPin.unsubscribe();
         sliderTrackStylePin.unsubscribe();
         shouldFocusInputTextFieldPin.unsubscribe();
         shouldApplyNewInputTextFontStylePin.unsubscribe();
@@ -321,10 +320,6 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         rangeAmountSlider.managedProperty().unbind();
         fixedAmountSlider.visibleProperty().unbind();
         fixedAmountSlider.managedProperty().unbind();
-        flipCurrenciesButton.visibleProperty().unbind();
-        flipCurrenciesButton.managedProperty().unbind();
-        baseAmountSelectionHBox.minWidthProperty().unbind();
-        baseAmountSelectionHBox.maxWidthProperty().unbind();
         maxOrFixedBaseAmountRoot.visibleProperty().unbind();
         maxOrFixedBaseAmountRoot.managedProperty().unbind();
         maxOrFixedQuoteAmountRoot.visibleProperty().unbind();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/amount_and_price/amount/MuSigCreateOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/amount_and_price/amount/MuSigCreateOfferAmountController.java
@@ -23,6 +23,7 @@ import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.market.Market;
 import bisq.common.monetary.Fiat;
 import bisq.common.monetary.Monetary;
+import bisq.common.monetary.MonetaryRange;
 import bisq.common.monetary.PriceQuote;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Browser;
@@ -59,12 +60,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static bisq.mu_sig.MuSigTradeAmountLimits.DEFAULT_MIN_USD_TRADE_AMOUNT;
 import static bisq.mu_sig.MuSigTradeAmountLimits.MAX_USD_TRADE_AMOUNT;
 import static bisq.mu_sig.MuSigTradeAmountLimits.MAX_USD_TRADE_AMOUNT_WITHOUT_REPUTATION;
+import static bisq.mu_sig.MuSigTradeAmountLimits.MIN_USD_TRADE_AMOUNT;
 import static bisq.mu_sig.MuSigTradeAmountLimits.withTolerance;
 import static bisq.presentation.formatters.AmountFormatter.formatQuoteAmountWithCode;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class MuSigCreateOfferAmountController implements Controller {
@@ -180,7 +180,6 @@ public class MuSigCreateOfferAmountController implements Controller {
 
     @Override
     public void onActivate() {
-        amountSelectionController.setAllowInvertingBaseAndQuoteCurrencies(true);
         model.getShouldShowWarningIcon().set(false);
         applyQuoteSideMinMaxRange();
 
@@ -238,13 +237,13 @@ public class MuSigCreateOfferAmountController implements Controller {
 
         isRangeAmountEnabledPin = EasyBind.subscribe(model.getIsRangeAmountEnabled(), isRangeAmountEnabled -> {
             applyAmountSpec();
-            amountSelectionController.setIsRangeAmountEnabled(isRangeAmountEnabled);
+            amountSelectionController.setUseRangeAmount(isRangeAmountEnabled);
         });
         applyAmountSpec();
 
         areBaseAndQuoteCurrenciesInvertedPin = EasyBind.subscribe(amountSelectionController.getIsDefaultAmountInputBtc(), isDefaultAmountInputBtc -> {
             String quoteCode = model.getPriceQuote().get().getMarket().getQuoteCurrencyCode();
-            model.getPriceTooltip().set(amountSelectionController.isUsingInvertedBaseAndQuoteCurrencies()
+            model.getPriceTooltip().set(amountSelectionController.isDefaultAmountInputBtc()
                     ? Res.get("muSig.offer.wizard.amount.quoteSide.tooltip.fiatAmount.selectedPrice", quoteCode)
                     : Res.get("muSig.offer.wizard.amount.baseSide.tooltip.btcAmount.selectedPrice"));
         });
@@ -319,7 +318,9 @@ public class MuSigCreateOfferAmountController implements Controller {
 
         if (model.getIsRangeAmountEnabled().get()) {
             Long minAmount = getAmountValue(amountSelectionController.getMinBaseSideAmount());
-            checkNotNull(minAmount);
+            if (minAmount == null) {
+                return;
+            }
             if (maxOrFixAmount.compareTo(minAmount) < 0) {
                 amountSelectionController.setMinBaseSideAmount(amountSelectionController.getMaxOrFixedBaseSideAmount().get());
                 minAmount = getAmountValue(amountSelectionController.getMinBaseSideAmount());
@@ -430,14 +431,16 @@ public class MuSigCreateOfferAmountController implements Controller {
     private void applyQuoteSideMinMaxRange() {
         Market market = model.getMarket();
 
+        Monetary minRangeValue = market.isCrypto()
+                ? MarketBasedAmountConversion.usdToBtc(marketPriceService, MIN_USD_TRADE_AMOUNT).orElseThrow()
+                : MarketBasedAmountConversion.usdToFiat(marketPriceService, market, MIN_USD_TRADE_AMOUNT)
+                .orElseThrow().round(0);
+
         Monetary maxRangeValue = market.isCrypto()
                 ? MarketBasedAmountConversion.usdToBtc(marketPriceService, MAX_USD_TRADE_AMOUNT).orElseThrow()
                 : MarketBasedAmountConversion.usdToFiat(marketPriceService, market, MAX_USD_TRADE_AMOUNT)
                 .orElseThrow().round(0);
-        Monetary minRangeValue = market.isCrypto()
-                ? MarketBasedAmountConversion.usdToBtc(marketPriceService, DEFAULT_MIN_USD_TRADE_AMOUNT).orElseThrow()
-                : MarketBasedAmountConversion.usdToFiat(marketPriceService, market, DEFAULT_MIN_USD_TRADE_AMOUNT)
-                .orElseThrow().round(0);
+
         applyMaxAmountBasedOnReputation();
 
         Fiat defaultUsdAmount = MAX_USD_TRADE_AMOUNT_WITHOUT_REPUTATION.multiply(2);
@@ -456,7 +459,7 @@ public class MuSigCreateOfferAmountController implements Controller {
 
         if (isBuyer) {
             //model.getShouldShowAmountLimitInfo().set(true);
-            amountSelectionController.setMinMaxRange(minRangeValue, maxRangeValue);
+            amountSelectionController.setQuoteSideTradeAmountLimits(new MonetaryRange(minRangeValue, maxRangeValue));
         } else {
             boolean hasNotReachedAmountLimit = reputationBasedMaxAmount.getValue() < maxRangeValue.getValue();
             //model.getShouldShowAmountLimitInfo().set(hasNotReachedAmountLimit);
@@ -466,7 +469,7 @@ public class MuSigCreateOfferAmountController implements Controller {
             if (reputationBasedMaxAmount.getValue() < maxRangeValue.getValue()) {
                 maxRangeValue = reputationBasedMaxAmount;
             }
-            amountSelectionController.setMinMaxRange(minRangeValue, maxRangeValue);
+            amountSelectionController.setQuoteSideTradeAmountLimits(new MonetaryRange(minRangeValue, maxRangeValue));
         }
 
         if (isBuyer) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/take_offer/amount/MuSigTakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/take_offer/amount/MuSigTakeOfferAmountController.java
@@ -21,6 +21,7 @@ import bisq.bisq_easy.BisqEasyTradeAmountLimits;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.market.Market;
 import bisq.common.monetary.Monetary;
+import bisq.common.monetary.MonetaryRange;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Browser;
 import bisq.desktop.common.utils.KeyHandlerUtil;
@@ -106,7 +107,6 @@ public class MuSigTakeOfferAmountController implements Controller {
 
     @Override
     public void onActivate() {
-        amountSelectionController.setAllowInvertingBaseAndQuoteCurrencies(true);
         applyQuoteSideMinMaxRange();
         baseSideAmountPin = EasyBind.subscribe(amountSelectionController.getMaxOrFixedBaseSideAmount(),
                 amount -> {
@@ -188,7 +188,7 @@ public class MuSigTakeOfferAmountController implements Controller {
 
         amountSelectionController.setMaxAllowedLimitation(offersQuoteSideMaxOrFixedAmount);
         amountSelectionController.setRightMarkerQuoteSideValue(maxAmount);
-        amountSelectionController.setMinMaxRange(minRangeValue, maxAmount);
+        amountSelectionController.setQuoteSideTradeAmountLimits(new MonetaryRange(minRangeValue, maxAmount));
 
         boolean isBuyer = muSigOffer.getTakersDisplayDirection().isBuy();
         if (isBuyer) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/trade_limits/simulation/MuSigTradeLimitsSimulationController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/trade_limits/simulation/MuSigTradeLimitsSimulationController.java
@@ -97,7 +97,7 @@ public class MuSigTradeLimitsSimulationController implements Controller {
 
     private void applySelectFiatPaymentRail(FiatPaymentRail fiatPaymentRail) {
         model.getSelectedFiatPaymentRail().set(fiatPaymentRail);
-        String maxTradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimit(fiatPaymentRail);
+        String maxTradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimitInUsd(fiatPaymentRail);
         model.getFiatPaymentRailMaxLimit().set(Res.get("muSig.trade.limits.simulation.fiatRail.maxLimit", maxTradeLimit));
         updateLimits();
     }
@@ -108,7 +108,7 @@ public class MuSigTradeLimitsSimulationController implements Controller {
             return;
         }
 
-        double maxTradeLimit = MuSigTradeAmountLimits.getMaxTradeLimit(fiatPaymentRail).getValue() / 10000d;
+        double maxTradeLimit = MuSigTradeAmountLimits.getMaxTradeLimitInUsd(fiatPaymentRail).getValue() / 10000d;
         // We use 10% of max limit as default limit
         double defaultTradeLimit = maxTradeLimit * 0.1;    // 250-1000
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/AccountDetails.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/AccountDetails.java
@@ -160,7 +160,7 @@ public abstract class AccountDetails<A extends Account<?, ?>, R extends PaymentR
     }
 
     protected Label addTradeLimitInfo() {
-        String maxTradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimit(account.getPaymentMethod().getPaymentRail());
+        String maxTradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimitInUsd(account.getPaymentMethod().getPaymentRail());
         return addDescriptionAndValue(Res.get("paymentAccounts.tradeLimit"), maxTradeLimit);
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/crypto_accounts/create/summary/details/SummaryDetails.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/crypto_accounts/create/summary/details/SummaryDetails.java
@@ -80,7 +80,7 @@ public class SummaryDetails<P extends CryptoAssetAccountPayload> extends GridPan
     protected void addRestrictions(P accountPayload) {
         CryptoPaymentRail paymentRail = accountPayload.getPaymentMethod().getPaymentRail();
 
-        String tradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimit(paymentRail);
+        String tradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimitInUsd(paymentRail);
         String restrictions = Res.get("paymentAccounts.summary.tradeLimit", tradeLimit) + " / " +
                 Res.get("paymentAccounts.summary.tradeDuration", paymentRail.getTradeDuration().getDisplayString());
         addDescriptionAndValue(Res.get("paymentAccounts.restrictions"), restrictions);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/summary/details/AccountDetailsGridPane.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/create/summary/details/AccountDetailsGridPane.java
@@ -59,7 +59,7 @@ public abstract class AccountDetailsGridPane<A extends AccountPayload<?>, R exte
     protected abstract void addDetails(A accountPayload);
 
     protected void addRestrictions(R fiatPaymentRail) {
-        String maxTradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimit(fiatPaymentRail);
+        String maxTradeLimit = MuSigTradeAmountLimits.getFormattedMaxTradeLimitInUsd(fiatPaymentRail);
         String restrictions = Res.get("paymentAccounts.summary.tradeLimit", maxTradeLimit) + " / " +
                 Res.get("paymentAccounts.summary.tradeDuration", fiatPaymentRail.getTradeDuration().getDisplayString());
         addDescriptionAndValue(Res.get("paymentAccounts.restrictions"), restrictions);

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
@@ -53,7 +53,7 @@ import static bisq.bonded_roles.market_price.MarketBasedAmountConversion.usdToFi
 
 @Slf4j
 public class MuSigTradeAmountLimits {
-    public static final Fiat DEFAULT_MIN_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10, "USD");
+    public static final Fiat MIN_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10, "USD");
 
 
     /* --------------------------------------------------------------------- */
@@ -62,16 +62,16 @@ public class MuSigTradeAmountLimits {
 
     public static final Fiat MAX_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10000, "USD");
 
-    public static Fiat getMaxTradeLimit(PaymentRail paymentRail) {
-        return getMaxTradeLimit(paymentRail, MAX_USD_TRADE_AMOUNT);
+    public static Fiat getMaxTradeLimitInUsd(PaymentRail paymentRail) {
+        return getMaxTradeLimitInUsd(paymentRail, MAX_USD_TRADE_AMOUNT);
     }
 
-    public static String getFormattedMaxTradeLimit(PaymentRail paymentRail) {
-        Fiat maxTradeLimit = getMaxTradeLimit(paymentRail);
+    public static String getFormattedMaxTradeLimitInUsd(PaymentRail paymentRail) {
+        Fiat maxTradeLimit = getMaxTradeLimitInUsd(paymentRail);
         return AmountFormatter.formatQuoteAmount(maxTradeLimit);
     }
 
-    public static Fiat getMaxTradeLimit(PaymentRail paymentRail, Fiat maxTradeLimitByProtocol) {
+    public static Fiat getMaxTradeLimitInUsd(PaymentRail paymentRail, Fiat maxTradeLimitByProtocol) {
         if (paymentRail instanceof FiatPaymentRail fiatPaymentRail) {
             switch (fiatPaymentRail.getChargebackRisk()) {
                 case VERY_LOW -> {
@@ -111,7 +111,7 @@ public class MuSigTradeAmountLimits {
 
     public static Optional<Monetary> getMinQuoteSideTradeAmount(MarketPriceService marketPriceService, Market market) {
         return marketPriceService.findMarketPriceQuote(MarketRepository.getUSDBitcoinMarket())
-                .map(priceQuote -> priceQuote.toBaseSideMonetary(DEFAULT_MIN_USD_TRADE_AMOUNT))
+                .map(priceQuote -> priceQuote.toBaseSideMonetary(MIN_USD_TRADE_AMOUNT))
                 .flatMap(defaultMinBtcTradeAmount -> marketPriceService.findMarketPriceQuote(market)
                         .map(priceQuote -> priceQuote.toQuoteSideMonetary(defaultMinBtcTradeAmount)));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified amount selection and range handling for clearer UI behavior and more consistent slider/input limits.
  * Standardized trade limit displays to use USD-based calculations across account and offer screens.
  * Streamlined range toggle and input layout (including fixed sizing) for more predictable interactions.

* **Bug Fixes**
  * Improved null-safety around range values to prevent unexpected slider/input issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->