### PR TITLE
Add trade amount limits in USD

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
@@ -31,6 +31,7 @@ import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.main.content.mu_sig.offer.components.MuSigPriceInput;
 import bisq.i18n.Res;
+import bisq.mu_sig.MuSigTradeAmountLimits;
 import bisq.offer.Direction;
 import bisq.presentation.formatters.AmountFormatter;
 import bisq.settings.CookieKey;
@@ -179,6 +180,7 @@ public class MuSigAmountSelectionController implements Controller {
             return;
         }
         model.setMarket(market);
+
         maxOrFixedBaseSideAmountDisplay.setSelectedMarket(market);
         invertedMaxOrFixedBaseSideAmountInput.setSelectedMarket(market);
         maxOrFixedQuoteSideAmountInput.setSelectedMarket(market);
@@ -194,6 +196,8 @@ public class MuSigAmountSelectionController implements Controller {
         model.getMinQuoteSideAmount().set(null);
         model.getMaxOrFixedBaseSideAmount().set(null);
         model.getMinBaseSideAmount().set(null);
+
+        updateShowTradeAmountLimitInUsd();
     }
 
     public void setDescription(String description) {
@@ -377,7 +381,7 @@ public class MuSigAmountSelectionController implements Controller {
             } else {
                 settingsService.setCookie(CookieKey.MU_SIG_OTHER_MARKET_IS_DEFAULT_AMOUNT_INPUT_BTC, isDefaultAmountInputBtc);
             }
-
+            updateShowTradeAmountLimitInUsd();
             updateShouldShowAmounts();
             applyInitialRangeValues();
             schedulers.add(UIScheduler.run(this::requestFocusForAmountInput).after(150));
@@ -533,6 +537,8 @@ public class MuSigAmountSelectionController implements Controller {
         if (priceQuote == null || quoteSideTradeAmountLimits == null) {
             return;
         }
+        model.getFormattedMinTradeAmountLimitInUsd().set(AmountFormatter.formatAmount(MuSigTradeAmountLimits.MIN_USD_TRADE_AMOUNT, true));
+        model.getFormattedMaxTradeAmountLimitInUsd().set(AmountFormatter.formatAmount(MuSigTradeAmountLimits.MAX_USD_TRADE_AMOUNT, true));
 
         if (model.getMarket().isCrypto()) {
             Monetary minRangeQuoteMonetary = quoteSideTradeAmountLimits.getMin();
@@ -545,14 +551,14 @@ public class MuSigAmountSelectionController implements Controller {
 
             if (isDefaultAmountInputBtc()) {
                 // Input now is base side
-                model.getFormattedMinRangeAmount().set(AmountFormatter.formatBaseAmount(minRangeBaseMonetary));
-                model.getRangeAmountCode().set(minRangeBaseMonetary.getCode());
-                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatBaseAmount(maxRangeBaseMonetary));
+                model.getFormattedMinTradeAmountLimit().set(AmountFormatter.formatBaseAmount(minRangeBaseMonetary));
+                model.getTradeAmountLimitCode().set(minRangeBaseMonetary.getCode());
+                model.getFormattedMaxTradeAmountLimit().set(AmountFormatter.formatBaseAmount(maxRangeBaseMonetary));
             } else {
                 // Input now is quote side
-                model.getFormattedMinRangeAmount().set(AmountFormatter.formatQuoteAmount(minRangeQuoteMonetary));
-                model.getRangeAmountCode().set(minRangeQuoteMonetary.getCode());
-                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatQuoteAmount(maxRangeQuoteMonetary));
+                model.getFormattedMinTradeAmountLimit().set(AmountFormatter.formatQuoteAmount(minRangeQuoteMonetary));
+                model.getTradeAmountLimitCode().set(minRangeQuoteMonetary.getCode());
+                model.getFormattedMaxTradeAmountLimit().set(AmountFormatter.formatQuoteAmount(maxRangeQuoteMonetary));
             }
         } else {
             Monetary minRangeAmount = quoteSideTradeAmountLimits.getMin();
@@ -570,19 +576,19 @@ public class MuSigAmountSelectionController implements Controller {
 
             if (isDefaultAmountInputBtc()) {
                 // Input now is base side
-                model.getFormattedMinRangeAmount().set(AmountFormatter.formatBaseAmount(minRangeBaseSideAmount));
-                model.getRangeAmountCode().set(minRangeBaseSideAmount.getCode());
-                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatBaseAmount(maxRangeBaseSideAmount));
+                model.getFormattedMinTradeAmountLimit().set(AmountFormatter.formatBaseAmount(minRangeBaseSideAmount));
+                model.getTradeAmountLimitCode().set(minRangeBaseSideAmount.getCode());
+                model.getFormattedMaxTradeAmountLimit().set(AmountFormatter.formatBaseAmount(maxRangeBaseSideAmount));
             } else {
                 // Input now is quote side
-                model.getFormattedMinRangeAmount().set(AmountFormatter.formatQuoteAmount(minRangeQuoteSideAmount));
-                model.getRangeAmountCode().set(minRangeQuoteSideAmount.getCode());
+                model.getFormattedMinTradeAmountLimit().set(AmountFormatter.formatQuoteAmount(minRangeQuoteSideAmount));
+                model.getTradeAmountLimitCode().set(minRangeQuoteSideAmount.getCode());
                 Monetary maxRangeMonetaryLimitationAsFiat = maxRangeQuoteSideAmount;
                 if (model.getMaxAllowedQuoteSideAmount().get() != null) {
                     Monetary maxQuoteAllowedLimitation = model.getMaxAllowedQuoteSideAmount().get();
                     maxRangeMonetaryLimitationAsFiat = isFiat ? maxQuoteAllowedLimitation : priceQuote.toQuoteSideMonetary(maxQuoteAllowedLimitation).round(0);
                 }
-                model.getFormattedMaxAllowedQuoteSideAmount().set(AmountFormatter.formatQuoteAmount(maxRangeMonetaryLimitationAsFiat));
+                model.getFormattedMaxTradeAmountLimit().set(AmountFormatter.formatQuoteAmount(maxRangeMonetaryLimitationAsFiat));
             }
         }
 
@@ -839,6 +845,12 @@ public class MuSigAmountSelectionController implements Controller {
             amountNumberBox.setAmount(min);
         } else {
             model.getMinQuoteSideAmount().set(amount);
+        }
+    }
+
+    private void updateShowTradeAmountLimitInUsd() {
+        if (model.getMarket() != null) {
+            model.getShowTradeAmountLimitInUsd().set(model.getIsDefaultAmountInputBtc().get() || !model.getMarket().isUsdMarket());
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionModel.java
@@ -60,9 +60,12 @@ public class MuSigAmountSelectionModel implements Model {
     private final ObjectProperty<Monetary> maxAllowedQuoteSideAmount = new SimpleObjectProperty<>();
     private final ObjectProperty<Monetary> maxAllowedBaseSideAmount = new SimpleObjectProperty<>();
 
-    private final StringProperty formattedMinRangeAmount = new SimpleStringProperty();
-    private final StringProperty rangeAmountCode = new SimpleStringProperty();
-    private final StringProperty formattedMaxAllowedQuoteSideAmount = new SimpleStringProperty();
+    private final StringProperty formattedMinTradeAmountLimit = new SimpleStringProperty();
+    private final StringProperty formattedMaxTradeAmountLimit = new SimpleStringProperty();
+    private final StringProperty formattedMinTradeAmountLimitInUsd = new SimpleStringProperty();
+    private final StringProperty formattedMaxTradeAmountLimitInUsd = new SimpleStringProperty();
+    private final StringProperty tradeAmountLimitCode = new SimpleStringProperty();
+    private final BooleanProperty showTradeAmountLimitInUsd = new SimpleBooleanProperty();
 
 
     // Amounts
@@ -135,9 +138,12 @@ public class MuSigAmountSelectionModel implements Model {
         market = MarketRepository.getDefaultBtcFiatMarket();
         direction = Direction.BUY;
         description.set(null);
-        formattedMinRangeAmount.set(null);
-        rangeAmountCode.set(null);
-        formattedMaxAllowedQuoteSideAmount.set(null);
+        formattedMinTradeAmountLimit.set(null);
+        formattedMaxTradeAmountLimit.set(null);
+        tradeAmountLimitCode.set(null);
+        formattedMinTradeAmountLimitInUsd.set(null);
+        formattedMaxTradeAmountLimitInUsd.set(null);
+        showTradeAmountLimitInUsd.set(false);
         showRangeAmountSelection.set(false);
         isDefaultAmountInputBtc.set(false);
         shouldShowMinAmounts.set(false);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionView.java
@@ -47,6 +47,7 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
     @SuppressWarnings("UnnecessaryUnicodeEscape")
     private static final String EN_DASH_SYMBOL = "\u2013"; // Unicode for "–"
     private static final Map<Integer, String> CHAR_COUNT_FONT_STYLE_MAP = new HashMap<>();
+
     static {
         CHAR_COUNT_FONT_STYLE_MAP.put(9, "input-text-9");
         CHAR_COUNT_FONT_STYLE_MAP.put(10, "input-text-10");
@@ -66,12 +67,14 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
     }
 
     private final Slider fixedAmountSlider;
-    private final Label minRangeValue, maxRangeValue, minRangeCode, maxRangeCode, description, quoteAmountSeparator,
+    private final Label minTradeAmountLimitValue, maxTradeAmountLimitValue, minTradeAmountLimitCode, maxTradeAmountLimitCode,
+            minTradeAmountLimitInUsdValue, maxTradeAmountLimitInUsdValue,
+            description, quoteAmountSeparator,
             baseAmountSeparator;
     private final Region selectionLine;
     private final Pane minQuoteAmountRoot, minBaseAmountRoot, invertedMinQuoteAmountRoot, invertedMinBaseAmountRoot,
             maxOrFixedBaseAmountRoot, maxOrFixedQuoteAmountRoot, invertedMaxOrFixedQuoteAmountRoot, invertedMaxOrFixedBaseAmountRoot;
-    private final HBox quoteAmountSelectionHBox, baseAmountSelectionHBox, sliderIndicators;
+    private final HBox quoteAmountSelectionHBox, tradeAmountLimitsBox, tradeAmountLimitsInUsdBox;
     private final ChangeListener<Number> maxOrFixedAmountSliderValueListener, minAmountSliderValueListener;
     private final BisqMenuItem flipCurrenciesButton;
     private final RangeSlider rangeAmountSlider;
@@ -128,7 +131,7 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         invertedMinQuoteAmountRoot.getStyleClass().add("min-base-amount");
         maxOrFixedBaseAmountRoot.getStyleClass().add("max-or-fixed-base-amount");
         invertedMaxOrFixedQuoteAmountRoot.getStyleClass().add("max-or-fixed-base-amount");
-        baseAmountSelectionHBox = new HBox(minBaseAmountRoot, invertedMinQuoteAmountRoot, baseAmountSeparator,
+        HBox baseAmountSelectionHBox = new HBox(minBaseAmountRoot, invertedMinQuoteAmountRoot, baseAmountSeparator,
                 maxOrFixedBaseAmountRoot, invertedMaxOrFixedQuoteAmountRoot);
         baseAmountSelectionHBox.getStyleClass().add("base-amount");
         baseAmountSelectionHBox.setMinWidth(model.getAmountBoxWidth() - 10);
@@ -184,22 +187,40 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         rangeAmountSlider.setMax(model.getSliderMax());
         rangeAmountSlider.getStyleClass().add("amount-range-slider");
 
-        minRangeValue = new Label();
-        minRangeValue.getStyleClass().add("range-value");
-        minRangeCode = new Label();
-        minRangeCode.getStyleClass().add("range-code");
-        HBox minRangeValueAndCodeHBox = new HBox(2, minRangeValue, minRangeCode);
-        minRangeValueAndCodeHBox.setAlignment(Pos.BASELINE_LEFT);
+        minTradeAmountLimitValue = new Label();
+        minTradeAmountLimitValue.getStyleClass().add("range-value");
+        minTradeAmountLimitCode = new Label();
+        minTradeAmountLimitCode.getStyleClass().add("range-code");
+        HBox minTradeAmountLimitBox = new HBox(2, minTradeAmountLimitValue, minTradeAmountLimitCode);
+        minTradeAmountLimitBox.setAlignment(Pos.BASELINE_LEFT);
 
-        maxRangeValue = new Label();
-        maxRangeValue.getStyleClass().add("range-value");
-        maxRangeCode = new Label();
-        maxRangeCode.getStyleClass().add("range-code");
-        HBox maxRangeValueAndCodeHBox = new HBox(2, maxRangeValue, maxRangeCode);
-        maxRangeValueAndCodeHBox.setAlignment(Pos.BASELINE_RIGHT);
+        maxTradeAmountLimitValue = new Label();
+        maxTradeAmountLimitValue.getStyleClass().add("range-value");
+        maxTradeAmountLimitCode = new Label();
+        maxTradeAmountLimitCode.getStyleClass().add("range-code");
+        HBox maxTradeAmountLimitBox = new HBox(2, maxTradeAmountLimitValue, maxTradeAmountLimitCode);
+        maxTradeAmountLimitBox.setAlignment(Pos.BASELINE_RIGHT);
 
-        sliderIndicators = new HBox(minRangeValueAndCodeHBox, Spacer.fillHBox(), maxRangeValueAndCodeHBox);
-        VBox sliderBox = new VBox(2, fixedAmountSlider, rangeAmountSlider, sliderIndicators);
+        // limits in USD
+        minTradeAmountLimitInUsdValue = new Label();
+        minTradeAmountLimitInUsdValue.getStyleClass().add("range-value-secondary");
+        Label minTradeAmountLimitInUsdCode = new Label("USD");
+        minTradeAmountLimitInUsdCode.getStyleClass().add("range-code-secondary");
+        HBox minTradeAmountLimitInUsdBox = new HBox(2, minTradeAmountLimitInUsdValue, minTradeAmountLimitInUsdCode);
+        minTradeAmountLimitInUsdBox.setAlignment(Pos.BASELINE_LEFT);
+
+        maxTradeAmountLimitInUsdValue = new Label();
+        maxTradeAmountLimitInUsdValue.getStyleClass().add("range-value-secondary");
+        Label maxTradeAmountLimitInUsdCode = new Label("USD");
+        maxTradeAmountLimitInUsdCode.getStyleClass().add("range-code-secondary");
+        HBox maxTradeAmountLimitInUsdBox = new HBox(2, maxTradeAmountLimitInUsdValue, maxTradeAmountLimitInUsdCode);
+        maxTradeAmountLimitInUsdBox.setAlignment(Pos.BASELINE_RIGHT);
+
+        tradeAmountLimitsBox = new HBox(minTradeAmountLimitBox, Spacer.fillHBox(), maxTradeAmountLimitBox);
+        tradeAmountLimitsInUsdBox = new HBox(minTradeAmountLimitInUsdBox, Spacer.fillHBox(), maxTradeAmountLimitInUsdBox);
+        tradeAmountLimitsInUsdBox.setOpacity(0.5);
+
+        VBox sliderBox = new VBox(2, fixedAmountSlider, rangeAmountSlider, tradeAmountLimitsBox, tradeAmountLimitsInUsdBox);
         sliderBox.setMaxWidth(model.getAmountBoxWidth() + 40);
 
         VBox.setMargin(sliderBox, new Insets(30, 0, 0, 0));
@@ -223,7 +244,7 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
             root.getStyleClass().clear();
             root.getStyleClass().add("amount-selection");
             root.getStyleClass().add(useRangeAmount ? "range-amount" : "fixed-amount");
-            VBox.setMargin(sliderIndicators, useRangeAmount ? SLIDER_INDICATORS_RANGE_MARGIN : SLIDER_INDICATORS_FIXED_MARGIN);
+            VBox.setMargin(tradeAmountLimitsBox, useRangeAmount ? SLIDER_INDICATORS_RANGE_MARGIN : SLIDER_INDICATORS_FIXED_MARGIN);
             applyTextInputFontStyle(true);
         });
         sliderTrackStylePin = EasyBind.subscribe(model.getSliderTrackStyle(), trackStyle -> {
@@ -243,10 +264,18 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         fixedAmountSlider.valueProperty().addListener(maxOrFixedAmountSliderValueListener);
         model.getMaxOrFixedAmountSliderFocus().bind(fixedAmountSlider.focusedProperty());
         description.textProperty().bind(model.getDescription());
-        minRangeValue.textProperty().bind(model.getFormattedMinRangeAmount());
-        minRangeCode.textProperty().bind(model.getRangeAmountCode());
-        maxRangeValue.textProperty().bind(model.getFormattedMaxAllowedQuoteSideAmount());
-        maxRangeCode.textProperty().bind(model.getRangeAmountCode());
+
+        minTradeAmountLimitValue.textProperty().bind(model.getFormattedMinTradeAmountLimit());
+        minTradeAmountLimitCode.textProperty().bind(model.getTradeAmountLimitCode());
+        maxTradeAmountLimitValue.textProperty().bind(model.getFormattedMaxTradeAmountLimit());
+        maxTradeAmountLimitCode.textProperty().bind(model.getTradeAmountLimitCode());
+
+        minTradeAmountLimitInUsdValue.textProperty().bind(model.getFormattedMinTradeAmountLimitInUsd());
+        maxTradeAmountLimitInUsdValue.textProperty().bind(model.getFormattedMaxTradeAmountLimitInUsd());
+
+        tradeAmountLimitsInUsdBox.visibleProperty().bind(model.getShowTradeAmountLimitInUsd());
+        tradeAmountLimitsInUsdBox.managedProperty().bind(model.getShowTradeAmountLimitInUsd());
+
         quoteAmountSeparator.visibleProperty().bind(model.getUseRangeAmount());
         quoteAmountSeparator.managedProperty().bind(model.getUseRangeAmount());
         baseAmountSeparator.visibleProperty().bind(model.getUseRangeAmount());
@@ -300,10 +329,18 @@ public class MuSigAmountSelectionView extends View<VBox, MuSigAmountSelectionMod
         fixedAmountSlider.valueProperty().removeListener(maxOrFixedAmountSliderValueListener);
         model.getMaxOrFixedAmountSliderFocus().unbind();
         description.textProperty().unbind();
-        minRangeValue.textProperty().unbind();
-        minRangeCode.textProperty().unbind();
-        maxRangeValue.textProperty().unbind();
-        maxRangeCode.textProperty().unbind();
+
+        minTradeAmountLimitValue.textProperty().unbind();
+        minTradeAmountLimitCode.textProperty().unbind();
+        maxTradeAmountLimitValue.textProperty().unbind();
+        maxTradeAmountLimitCode.textProperty().unbind();
+
+        minTradeAmountLimitInUsdValue.textProperty().unbind();
+        maxTradeAmountLimitInUsdValue.textProperty().unbind();
+
+        tradeAmountLimitsInUsdBox.visibleProperty().unbind();
+        tradeAmountLimitsInUsdBox.managedProperty().unbind();
+
         quoteAmountSeparator.visibleProperty().unbind();
         quoteAmountSeparator.managedProperty().unbind();
         baseAmountSeparator.visibleProperty().unbind();

--- a/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
+++ b/apps/desktop/desktop/src/main/resources/css/bisq_easy.css
@@ -1171,6 +1171,8 @@
 
 .amount-selection .range-value,
 .amount-selection .range-code,
+.amount-selection .range-value-secondary,
+.amount-selection .range-code-secondary,
 .bisq-easy-trade-wizard-price-step .range-value {
     -fx-font-family: "IBM Plex Sans Light";
     -fx-text-fill: -bisq-mid-grey-20;
@@ -1183,6 +1185,14 @@
 
 .amount-selection .range-code {
     -fx-font-size: 0.7em;
+}
+
+.amount-selection .range-value-secondary {
+    -fx-font-size: 1em;
+}
+
+.amount-selection .range-code-secondary {
+    -fx-font-size: 0.63em;
 }
 
 .bisq-easy-trade-wizard-amount-step,

--- a/common/src/main/java/bisq/common/market/Market.java
+++ b/common/src/main/java/bisq/common/market/Market.java
@@ -150,4 +150,8 @@ public final class Market implements NetworkProto, PersistableProto, Comparable<
     public String getRelevantCodeAndDisplayName() {
         return getRelevantCurrencyCode() + " (" + getRelevantCurrencyDisplayName() + ")";
     }
+
+    public boolean isUsdMarket() {
+        return isBtcFiatMarket() && getQuoteCurrencyCode().equalsIgnoreCase("USD");
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added USD-denominated trade amount limits display for fiat currency markets, enabling users to see trade limits in their local currency equivalent.

* **Refactor**
  * Restructured the amount selection interface to display trade amount limits instead of range amounts.
  * Implemented secondary displays for USD equivalents of trade limits in applicable market scenarios.

* **Style**
  * Updated styling for trade amount limit displays and secondary labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->