### PR TITLE
chore/bring_connect_expire_revoke_sessions

### DIFF
--- a/api/src/main/java/bisq/api/access/ApiAccessService.java
+++ b/api/src/main/java/bisq/api/access/ApiAccessService.java
@@ -54,6 +54,25 @@ public class ApiAccessService {
         return new PairingResponse(clientId, clientSecret, sessionToken.getSessionId(), expiresAt);
     }
 
+    /**
+     * Revokes a paired client by invalidating all its active sessions and removing
+     * its stored profile and permissions. After revocation the client can no longer
+     * authenticate and must go through the pairing flow again.
+     *
+     * @param clientId The client ID to revoke
+     * @return {@code true} if the client was found and revoked; {@code false} if not found
+     */
+    public boolean revokeClient(String clientId) {
+        boolean removed = pairingService.revokeClientProfile(clientId);
+        sessionService.removeSessionByClientId(clientId);
+        if (removed) {
+            log.info("Revoked client {}", clientId);
+        } else {
+            log.warn("Client profile not found for {}, but session was still invalidated", clientId);
+        }
+        return removed;
+    }
+
     public SessionResponse requestSession(String clientId, String clientSecret) throws InvalidSessionRequestException {
         ClientProfile clientProfile = pairingService.findClientProfile(clientId)
                 .orElseThrow(() -> new InvalidSessionRequestException("No client profile found for Client ID"));

--- a/api/src/main/java/bisq/api/access/pairing/PairingService.java
+++ b/api/src/main/java/bisq/api/access/pairing/PairingService.java
@@ -125,6 +125,16 @@ public class PairingService {
         return Optional.ofNullable(apiAccessStoreService.getClientProfileByIdMap().get(id));
     }
 
+    /**
+     * Removes the client profile and associated permissions for the given client ID.
+     *
+     * @param clientId The client ID to revoke
+     * @return {@code true} if the profile was found and removed; {@code false} if not found
+     */
+    public boolean revokeClientProfile(String clientId) {
+        return apiAccessStoreService.removeClientProfile(clientId);
+    }
+
     private boolean isExpired(PairingCode pairingCode) {
         return Instant.now().isAfter(pairingCode.getExpiresAt());
     }

--- a/api/src/main/java/bisq/api/access/persistence/ApiAccessStoreService.java
+++ b/api/src/main/java/bisq/api/access/persistence/ApiAccessStoreService.java
@@ -62,4 +62,21 @@ public class ApiAccessStoreService extends RateLimitedPersistenceClient<ApiAcces
         persistableStore.getPermissionsByClientId().put(clientId, permissions);
         persist();
     }
+
+    /**
+     * Removes the client profile and associated permissions for the given client ID.
+     * Both removals are applied atomically under a lock and persisted in a single
+     * {@link #persist()} call.
+     *
+     * @param clientId The client ID to remove
+     * @return {@code true} if a profile was present and removed; {@code false} if the client was not found
+     */
+    public boolean removeClientProfile(String clientId) {
+        synchronized (persistableStore) {
+            boolean removed = persistableStore.getClientProfileByIdMap().remove(clientId) != null;
+            persistableStore.getPermissionsByClientId().remove(clientId);
+            persist();
+            return removed;
+        }
+    }
 }

--- a/api/src/main/java/bisq/api/access/session/SessionService.java
+++ b/api/src/main/java/bisq/api/access/session/SessionService.java
@@ -57,4 +57,14 @@ public class SessionService {
     public void remove(String sessionId) {
         sessionTokenBySessionIdMap.remove(sessionId);
     }
+
+    /**
+     * Removes all active sessions belonging to the given client.
+     * Called during client revocation to immediately invalidate any live session.
+     *
+     * @param clientId The client ID whose sessions should be invalidated
+     */
+    public void removeSessionByClientId(String clientId) {
+        sessionTokenBySessionIdMap.values().removeIf(token -> clientId.equals(token.getClientId()));
+    }
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/access/AccessApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/access/AccessApi.java
@@ -30,14 +30,17 @@ import bisq.api.dto.access.session.SessionRequestDto;
 import bisq.api.dto.access.session.SessionResponseDto;
 import bisq.api.rest_api.endpoints.RestApiBase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -67,12 +70,12 @@ public class AccessApi extends RestApiBase {
             summary = "Request API client pairing",
             description = """
                     Performs pairing of an API client.
-                    
+
                     The client submits a signed pairing request containing:
                     - protocol version
                     - pairing code identifier (from QR code)
                     - client name
-                    
+
                     On success, client credentials and a short-lived session ID are returned.
                     """
     )
@@ -136,10 +139,10 @@ public class AccessApi extends RestApiBase {
             description = """
                     Creates a new short-lived session for a client using a
                     client identifier and shared client secret.
-                    
+
                     This endpoint is intentionally unauthenticated and is used during
                     initial client bootstrap or re-sessioning.
-                    
+
                     If the credentials are valid, a new session ID is issued together
                     with its expiration timestamp. The session ID must be supplied in
                     subsequent authenticated requests.
@@ -189,6 +192,38 @@ public class AccessApi extends RestApiBase {
         } catch (Exception e) {
             log.error("Unexpected error during session request", e);
             return buildErrorResponse("Session request failed");
+        }
+    }
+
+    @DELETE
+    @Path("/clients/{clientId}")
+    @Operation(
+            summary = "Revoke a paired client",
+            description = """
+                    Revokes a previously paired API client.
+
+                    All active sessions for the client are immediately invalidated and
+                    the client profile is removed from persistent storage. The client
+                    can no longer authenticate and must pair again via QR code to regain
+                    access.
+                    """
+    )
+    @ApiResponse(responseCode = "204", description = "Client successfully revoked")
+    @ApiResponse(responseCode = "404", description = "Client not found")
+    @ApiResponse(responseCode = "500", description = "Unexpected internal server error")
+    public Response revokeClient(
+            @Parameter(description = "The client ID to revoke", required = true)
+            @PathParam("clientId") String clientId
+    ) {
+        try {
+            boolean revoked = apiAccessService.revokeClient(clientId);
+            if (!revoked) {
+                return buildNotFoundResponse("Client not found: " + clientId);
+            }
+            return buildNoContentResponse();
+        } catch (Exception e) {
+            log.error("Unexpected error during client revocation for clientId={}", clientId, e);
+            return buildErrorResponse("Client revocation failed");
         }
     }
 }

--- a/api/src/main/java/bisq/api/web_socket/WebSocketConnectionHandler.java
+++ b/api/src/main/java/bisq/api/web_socket/WebSocketConnectionHandler.java
@@ -97,6 +97,30 @@ public class WebSocketConnectionHandler extends WebSocketApplication implements 
         }, executor);
     }
 
+    /**
+     * Closes the WebSocket connection for a specific client.
+     * Called after revoking a client profile to force immediate disconnection.
+     *
+     * @param clientId The client ID whose connection should be closed
+     */
+    public void disconnectClient(String clientId) {
+        getWebSockets().stream()
+                .filter(webSocket -> {
+                    if (webSocket instanceof DefaultWebSocket defaultWebSocket) {
+                        HttpServletRequest request = defaultWebSocket.getUpgradeRequest();
+                        if (request != null) {
+                            String wsClientId = request.getHeader(Headers.CLIENT_ID);
+                            return clientId.equals(wsClientId);
+                        }
+                    }
+                    return false;
+                })
+                .forEach(webSocket -> {
+                    log.info("Disconnecting revoked client: {}", clientId);
+                    webSocket.close();
+                });
+    }
+
     private void updateWebsocketClients() {
         try {
             websocketClients.setAll(getWebSockets().stream().map(webSocket -> {

--- a/api/src/main/java/bisq/api/web_socket/WebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/WebSocketService.java
@@ -103,6 +103,10 @@ public class WebSocketService implements Service {
         return webSocketConnectionHandler.getWebsocketClients();
     }
 
+    public void disconnectClient(String clientId) {
+        webSocketConnectionHandler.disconnectClient(clientId);
+    }
+
     public ReadOnlyObservable<State> getState() {
         return state;
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/bisq_connect/BisqConnectController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/bisq_connect/BisqConnectController.java
@@ -20,6 +20,7 @@ package bisq.desktop.main.content.settings.bisq_connect;
 import bisq.api.ApiService;
 import bisq.api.access.pairing.PairingCode;
 import bisq.api.access.pairing.PairingService;
+import bisq.api.access.session.SessionService;
 import bisq.api.web_socket.WebSocketService;
 import bisq.common.observable.Pin;
 import bisq.desktop.ServiceProvider;
@@ -51,6 +52,7 @@ public class BisqConnectController implements Controller {
     private final BisqConnectModel model;
     private final Optional<WebSocketService> optionalWebSocketService;
     private final PairingService pairingService;
+    private final SessionService sessionService;
     private final Set<Pin> pins = new HashSet<>();
     private final DontShowAgainService dontShowAgainService;
     private final ApiService apiService;
@@ -61,6 +63,7 @@ public class BisqConnectController implements Controller {
         apiService = serviceProvider.getApiService();
         optionalWebSocketService = apiService.getWebSocketService();
         pairingService = apiService.getPairingService();
+        sessionService = apiService.getSessionService();
         dontShowAgainService = serviceProvider.getDontShowAgainService();
 
         ApiConfigController apiConfigController = new ApiConfigController(serviceProvider);
@@ -117,6 +120,37 @@ public class BisqConnectController implements Controller {
             model.getQrCodeImage().set(null);
             new Popup().error(e).show();
         }
+    }
+
+    void onRevokeClient(BisqConnectView.ClientListItem item) {
+        new Popup().warning(Res.get("settings.bisqConnect.clients.revoke.confirm", item.getClientName()))
+                .actionButtonText(Res.get("settings.bisqConnect.clients.revoke"))
+                .onAction(() -> {
+                    item.getClientId().ifPresent(clientId -> {
+                        boolean profileRemoved = pairingService.revokeClientProfile(clientId);
+                        // Always clean up session and WebSocket regardless of profile removal result.
+                        // The profile may have been already removed but the session/connection is still active.
+                        sessionService.removeSessionByClientId(clientId);
+                        optionalWebSocketService.ifPresent(ws -> ws.disconnectClient(clientId));
+                        if (profileRemoved) {
+                            log.info("Revoked client {} ({})", item.getClientName(), clientId);
+                        } else {
+                            log.warn("Client profile not found for {}, but session/connection cleaned up", clientId);
+                        }
+                    });
+                })
+                .secondaryActionButtonText(Res.get("settings.bisqConnect.clients.expireSession"))
+                .onSecondaryAction(() -> {
+                    item.getClientId().ifPresent(clientId -> {
+                        sessionService.removeSessionByClientId(clientId);
+                        // Close the WebSocket to force the client to reconnect.
+                        // Unlike revoke, the client profile is preserved — so the mobile app
+                        // can call requestSession() with its stored credentials and auto-recover.
+                        optionalWebSocketService.ifPresent(ws -> ws.disconnectClient(clientId));
+                        log.info("Expired session and disconnected client {} ({})", item.getClientName(), clientId);
+                    });
+                })
+                .show();
     }
 
     private void applyPairingCode(PairingCode pairingCode) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/bisq_connect/BisqConnectView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/settings/bisq_connect/BisqConnectView.java
@@ -42,6 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import java.util.Optional;
+
 @Slf4j
 public class BisqConnectView extends View<VBox, BisqConnectModel, BisqConnectController> {
     private final Label webSocketServerStateLabel, pairingCodeExpiryInfo;
@@ -208,18 +210,27 @@ public class BisqConnectView extends View<VBox, BisqConnectModel, BisqConnectCon
                 .title(Res.get("settings.bisqConnect.clients.userAgent"))
                 .valueSupplier(ClientListItem::getUserAgent)
                 .build());
+        clientsTable.getColumns().add(new BisqTableColumn.Builder<ClientListItem>()
+                .value(Res.get("settings.bisqConnect.clients.revoke"))
+                .defaultCellFactory(BisqTableColumn.DefaultCellFactory.BUTTON)
+                .actionHandler(controller::onRevokeClient)
+                .isVisibleFunction(item -> item.getClientId().isPresent())
+                .includeForCsv(false)
+                .isSortable(false)
+                .fixWidth(150)
+                .build());
     }
 
     @Getter
     @EqualsAndHashCode
     static class ClientListItem {
-        private final WebSocketClient webSocketClient;
+        private final Optional<String> clientId;
         private final String clientName;
         private final String clientAddress;
         private final String userAgent;
 
         ClientListItem(WebSocketClient webSocketClient, PairingService pairingService) {
-            this.webSocketClient = webSocketClient;
+            this.clientId = webSocketClient.getClientId();
             clientName = webSocketClient.getClientId()
                     .flatMap(pairingService::findClientProfile)
                     .map(ClientProfile::getClientName)

--- a/i18n/src/main/resources/settings.properties
+++ b/i18n/src/main/resources/settings.properties
@@ -186,6 +186,9 @@ settings.bisqConnect.clients.headline=Connected clients
 settings.bisqConnect.clients.clientName=Client name
 settings.bisqConnect.clients.address=Client address
 settings.bisqConnect.clients.userAgent=User agent
+settings.bisqConnect.clients.revoke=Revoke
+settings.bisqConnect.clients.revoke.confirm=Choose an action for client ''{0}'':\n\n\u2022 Revoke: Permanently removes the client. It will need to pair again.\n\u2022 Invalidate session: Invalidates the current session. The client should reconnect automatically.
+settings.bisqConnect.clients.expireSession=Invalidate session
 
 settings.backup.headline=Backup settings
 settings.backup.totalMaxBackupSizeInMB.description=Max. size in MB for automatic backups


### PR DESCRIPTION
 - cherry picks https://github.com/bisq-network/bisq2/pull/4604 into main
 - implement revoke and disconnect connected device (bisq connect) both on Desktop UI and API
 - add the possibility to just expire current session (this forces a reconnect but it will be able to reconnect without repairing
 - apply CRAI suggestions
 - apply reviewer suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to revoke connected API clients from settings with two options: revoke (removes all permissions and sessions) or invalidate session only.
  * Revoked clients are immediately disconnected from active connections.

* **Internationalization**
  * Added UI strings for client revocation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->