### PR TITLE
feat: implement QRcode in text for pairing code

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -42,4 +42,5 @@ dependencies {
     implementation(libs.bundles.websocket.libs)
     implementation(libs.bouncycastle)
     implementation(libs.bouncycastle.pkix)
+    implementation(libs.zxing.core)
 }

--- a/api/src/main/java/bisq/api/access/pairing/PairingService.java
+++ b/api/src/main/java/bisq/api/access/pairing/PairingService.java
@@ -20,6 +20,7 @@ package bisq.api.access.pairing;
 import bisq.api.ApiConfig;
 import bisq.api.access.identity.ClientProfile;
 import bisq.api.access.pairing.qr.PairingQrCodeGenerator;
+import bisq.api.access.pairing.qr.TextQrCodeRenderer;
 import bisq.api.access.permissions.Permission;
 import bisq.api.access.permissions.PermissionMapping;
 import bisq.api.access.permissions.PermissionService;
@@ -168,7 +169,13 @@ public class PairingService {
     private void writePairingQrCodeToDataDir(String pairingQrCode) {
         try {
             Path path = appDataDirPath.resolve("pairing_qr_code.txt");
-            FileMutatorUtils.writeToPath(pairingQrCode, path);
+            StringBuilder content = new StringBuilder(pairingQrCode);
+            try {
+                content.append("\n\n\n").append(TextQrCodeRenderer.render(pairingQrCode));
+            } catch (Exception e) {
+                log.warn("Failed to render text QR code", e);
+            }
+            FileMutatorUtils.writeToPath(content.toString(), path);
             log.info("Pairing QR code written to {}", path);
         } catch (IOException e) {
             log.error("Error at write pairing QR code to disk at {}", appDataDirPath.resolve("pairing_qr_code.txt"), e);

--- a/api/src/main/java/bisq/api/access/pairing/qr/TextQrCodeRenderer.java
+++ b/api/src/main/java/bisq/api/access/pairing/qr/TextQrCodeRenderer.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.pairing.qr;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.WriterException;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
+
+import java.util.Map;
+
+public class TextQrCodeRenderer {
+    private static final char FULL = '\u2588';   // █ both rows on
+    private static final char UPPER = '\u2580';  // ▀ upper only
+    private static final char LOWER = '\u2584';  // ▄ lower only
+    private static final char EMPTY = ' ';
+
+    public static String render(String data) throws WriterException {
+        Map<EncodeHintType, Object> hints = Map.of(
+                EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.M,
+                EncodeHintType.MARGIN, 1);
+        BitMatrix matrix = new QRCodeWriter().encode(data, BarcodeFormat.QR_CODE, 0, 0, hints);
+        int width = matrix.getWidth();
+        int height = matrix.getHeight();
+        StringBuilder sb = new StringBuilder(width * (height / 2 + 1));
+        for (int y = 0; y < height; y += 2) {
+            for (int x = 0; x < width; x++) {
+                boolean top = matrix.get(x, y);
+                boolean bottom = y + 1 < height && matrix.get(x, y + 1);
+                sb.append(top && bottom ? FULL : top ? UPPER : bottom ? LOWER : EMPTY);
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -174,6 +174,7 @@ tukaani = { module = 'org.tukaani:xz', version.ref = 'tukaani-lib' }
 typesafe-config = { module = 'com.typesafe:config', version.ref = 'typesafe-config-lib' }
 
 zxing = { module = 'com.google.zxing:javase', version.ref = 'zxing-lib' }
+zxing-core = { module = 'com.google.zxing:core', version.ref = 'zxing-lib' }
 
 # Defines groups of libs that are commonly used together
 # Referenced in dependencies block as 'implementation libs.bundles.i2p'


### PR DESCRIPTION
adds a QR code in text format to the generated `pairing_qr_code.txt` for convenience