### PR TITLE
Prune mediation request chat by payload size

### DIFF
--- a/support/src/main/java/bisq/support/arbitration/mu_sig/MuSigArbitrationRequest.java
+++ b/support/src/main/java/bisq/support/arbitration/mu_sig/MuSigArbitrationRequest.java
@@ -44,6 +44,9 @@ import java.util.stream.Collectors;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
+import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
+import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -95,11 +98,17 @@ public final class MuSigArbitrationRequest implements
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
         NetworkDataValidation.validateECSignature(mediationResultSignature);
-        checkArgument(chatMessages.size() < 1000);
+        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+                "Serialized arbitration request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
     @Override
     public bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(boolean serializeForHash) {
+        return getValueBuilder(chatMessages, serializeForHash);
+    }
+
+    private bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
+                                                                                  boolean serializeForHash) {
         return bisq.support.protobuf.MuSigArbitrationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -172,19 +181,11 @@ public final class MuSigArbitrationRequest implements
     }
 
     private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        StringBuilder sb = new StringBuilder();
-        List<MuSigOpenTradeMessage> result = chatMessages.stream()
-                .filter(message -> {
-                    sb.append(message.getTextOrNA());
-                    return sb.toString().length() < 10_000;
-                })
-                .collect(Collectors.toList());
-        if (result.size() != chatMessages.size()) {
-            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalChars=10000",
-                    tradeId,
-                    result.size(),
-                    chatMessages.size() - result.size());
-        }
-        return result;
+        return prune(chatMessages,
+                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
+                MAX_SERIALIZED_SIZE,
+                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                log,
+                tradeId);
     }
 }

--- a/support/src/main/java/bisq/support/dispute/ChatMessagePruning.java
+++ b/support/src/main/java/bisq/support/dispute/ChatMessagePruning.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.dispute;
+
+import bisq.chat.ChatMessage;
+import org.slf4j.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.ToIntFunction;
+
+public final class ChatMessagePruning {
+    public static final int MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES = 18_000;
+    // Leave headroom for AEAD authentication tag (16 bytes) added by the
+    // confidential transport on top of the serialized payload, so that the
+    // resulting ciphertext stays within the transport's 20_000-byte limit.
+    public static final int MAX_SERIALIZED_SIZE = 20_000 - 16;
+
+    private ChatMessagePruning() {
+    }
+
+    public static <M extends ChatMessage> List<M> prune(List<M> chatMessages,
+                                                        int maxTotalTextBytes,
+                                                        int maxSerializedSize,
+                                                        ToIntFunction<List<M>> serializedSizeSupplier,
+                                                        Logger log,
+                                                        String tradeId) {
+        int totalTextBytes = 0;
+        List<M> result = new ArrayList<>();
+        for (M message : chatMessages) {
+            totalTextBytes += message.getTextOrNA().getBytes(StandardCharsets.UTF_8).length;
+            if (totalTextBytes >= maxTotalTextBytes) {
+                break;
+            }
+            result.add(message);
+        }
+        while (!result.isEmpty() && serializedSizeSupplier.applyAsInt(result) > maxSerializedSize) {
+            result.removeLast();
+        }
+        if (result.size() != chatMessages.size()) {
+            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalTextBytes={}",
+                    tradeId,
+                    result.size(),
+                    chatMessages.size() - result.size(),
+                    maxTotalTextBytes);
+        }
+        return result;
+    }
+}

--- a/support/src/main/java/bisq/support/mediation/MuSigDisputeCaseDataMessage.java
+++ b/support/src/main/java/bisq/support/mediation/MuSigDisputeCaseDataMessage.java
@@ -40,6 +40,9 @@ import java.util.stream.Collectors;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
+import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
+import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -70,11 +73,17 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
         NetworkDataValidation.validateHash(contractHash);
-        checkArgument(chatMessages.size() < 1000);
+        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+                "Serialized dispute case data size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
     @Override
     public bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(boolean serializeForHash) {
+        return getValueBuilder(chatMessages, serializeForHash);
+    }
+
+    private bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
+                                                                                       boolean serializeForHash) {
         return bisq.support.protobuf.MuSigDisputeCaseDataMessage.newBuilder()
                 .setTradeId(tradeId)
                 .setSenderUserProfile(senderUserProfile.toProto(serializeForHash))
@@ -121,19 +130,11 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
     }
 
     private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        StringBuilder sb = new StringBuilder();
-        List<MuSigOpenTradeMessage> result = chatMessages.stream()
-                .filter(message -> {
-                    sb.append(message.getTextOrNA());
-                    return sb.length() < 10_000;
-                })
-                .collect(Collectors.toList());
-        if (result.size() != chatMessages.size()) {
-            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalChars=10000",
-                    tradeId,
-                    result.size(),
-                    chatMessages.size() - result.size());
-        }
-        return result;
+        return prune(chatMessages,
+                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
+                MAX_SERIALIZED_SIZE,
+                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                log,
+                tradeId);
     }
 }

--- a/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequest.java
@@ -39,7 +39,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static bisq.network.p2p.services.data.storage.MetaData.*;
+import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
+import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
+import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -76,8 +80,8 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
         this.contract = contract;
         this.requester = requester;
         this.peer = peer;
-        this.chatMessages = maybePrune(chatMessages);
         this.mediatorNetworkId = mediatorNetworkId;
+        this.chatMessages = maybePrune(chatMessages);
 
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.chatMessages);
@@ -88,7 +92,8 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
     @Override
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
-        checkArgument(chatMessages.size() < 1000);
+        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+                "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
     /**
@@ -97,6 +102,11 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
 
     @Override
     public bisq.support.protobuf.MediationRequest.Builder getValueBuilder(boolean serializeForHash) {
+        return getValueBuilder(chatMessages, serializeForHash);
+    }
+
+    private bisq.support.protobuf.MediationRequest.Builder getValueBuilder(List<BisqEasyOpenTradeMessage> chatMessages,
+                                                                           boolean serializeForHash) {
         bisq.support.protobuf.MediationRequest.Builder builder = bisq.support.protobuf.MediationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -170,19 +180,11 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
     }
 
     private List<BisqEasyOpenTradeMessage> maybePrune(List<BisqEasyOpenTradeMessage> chatMessages) {
-        StringBuilder sb = new StringBuilder();
-        List<BisqEasyOpenTradeMessage> result = chatMessages.stream()
-                .filter(message -> {
-                    sb.append(message.getTextOrNA());
-                    return sb.toString().length() < 10_000;
-                })
-                .collect(Collectors.toList());
-        if (result.size() != chatMessages.size()) {
-            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalChars=10000",
-                    tradeId,
-                    result.size(),
-                    chatMessages.size() - result.size());
-        }
-        return result;
+        return prune(chatMessages,
+                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
+                MAX_SERIALIZED_SIZE,
+                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                log,
+                tradeId);
     }
 }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequest.java
@@ -42,6 +42,9 @@ import java.util.stream.Collectors;
 
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
+import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
+import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -89,7 +92,8 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
     @Override
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
-        checkArgument(chatMessages.size() < 1000);
+        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+                "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
     /**
@@ -98,6 +102,11 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
 
     @Override
     public bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(boolean serializeForHash) {
+        return getValueBuilder(chatMessages, serializeForHash);
+    }
+
+    private bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
+                                                                                boolean serializeForHash) {
         return bisq.support.protobuf.MuSigMediationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -167,19 +176,11 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
     }
 
     private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        StringBuilder sb = new StringBuilder();
-        List<MuSigOpenTradeMessage> result = chatMessages.stream()
-                .filter(message -> {
-                    sb.append(message.getTextOrNA());
-                    return sb.toString().length() < 10_000;
-                })
-                .collect(Collectors.toList());
-        if (result.size() != chatMessages.size()) {
-            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalChars=10000",
-                    tradeId,
-                    result.size(),
-                    chatMessages.size() - result.size());
-        }
-        return result;
+        return prune(chatMessages,
+                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
+                MAX_SERIALIZED_SIZE,
+                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                log,
+                tradeId);
     }
 }

--- a/support/src/test/java/bisq/support/dispute/ChatMessagePruningTest.java
+++ b/support/src/test/java/bisq/support/dispute/ChatMessagePruningTest.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.dispute;
+
+import bisq.chat.ChatChannelDomain;
+import bisq.chat.ChatMessage;
+import bisq.chat.ChatMessageType;
+import bisq.chat.reactions.ChatMessageReaction;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.network.p2p.services.data.storage.MetaData;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatMessagePruningTest {
+    @Test
+    void prune_keepsAllMessages_whenUnderBothLimits() {
+        TestChatMessage first = new TestChatMessage("1", "hello", 10);
+        TestChatMessage second = new TestChatMessage("2", "world", 20);
+
+        List<TestChatMessage> result = ChatMessagePruning.prune(
+                List.of(first, second),
+                100,
+                100,
+                messages -> messages.size() * 10,
+                LoggerFactory.getLogger(ChatMessagePruningTest.class),
+                "trade-1");
+
+        assertThat(result).containsExactly(first, second);
+    }
+
+    @Test
+    void prune_usesUtf8ByteLengthForTheHeuristic() {
+        TestChatMessage first = new TestChatMessage("1", "🙂", 10);
+        TestChatMessage second = new TestChatMessage("2", "ok", 20);
+
+        List<TestChatMessage> result = ChatMessagePruning.prune(
+                List.of(first, second),
+                5,
+                100,
+                messages -> 0,
+                LoggerFactory.getLogger(ChatMessagePruningTest.class),
+                "trade-2");
+
+        assertThat(result).containsExactly(first);
+    }
+
+    @Test
+    void prune_dropsMessage_whenUtf8ByteLengthHitsTheLimitExactly() {
+        TestChatMessage first = new TestChatMessage("1", "🙂", 10);
+        TestChatMessage second = new TestChatMessage("2", "ok", 20);
+
+        List<TestChatMessage> result = ChatMessagePruning.prune(
+                List.of(first, second),
+                4,
+                100,
+                messages -> 0,
+                LoggerFactory.getLogger(ChatMessagePruningTest.class),
+                "trade-equal-boundary");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void prune_trimsFromTheEnd_whenSerializedSizeStillExceedsLimit() {
+        TestChatMessage first = new TestChatMessage("1", "aa", 10);
+        TestChatMessage second = new TestChatMessage("2", "bb", 20);
+        TestChatMessage third = new TestChatMessage("3", "cc", 30);
+
+        List<TestChatMessage> result = ChatMessagePruning.prune(
+                List.of(first, second, third),
+                100,
+                25,
+                messages -> messages.size() * 10,
+                LoggerFactory.getLogger(ChatMessagePruningTest.class),
+                "trade-3");
+
+        assertThat(result).containsExactly(first, second);
+    }
+
+    @Test
+    void prune_returnsEmpty_whenFirstMessageAlreadyReachesTextLimit() {
+        TestChatMessage first = new TestChatMessage("1", "🙂🙂🙂", 10);
+        TestChatMessage second = new TestChatMessage("2", "ok", 20);
+
+        List<TestChatMessage> result = ChatMessagePruning.prune(
+                List.of(first, second),
+                4,
+                100,
+                messages -> 0,
+                LoggerFactory.getLogger(ChatMessagePruningTest.class),
+                "trade-4");
+
+        assertThat(result).isEmpty();
+    }
+
+    private static final class TestChatMessage extends ChatMessage {
+        private static final MetaData META_DATA = new MetaData(1_000, 1, TestChatMessage.class.getSimpleName());
+
+        private TestChatMessage(String id, String text, long date) {
+            super(id,
+                    ChatChannelDomain.SUPPORT,
+                    "channel",
+                    "author",
+                    Optional.of(text),
+                    Optional.empty(),
+                    date,
+                    false,
+                    ChatMessageType.TEXT);
+        }
+
+        @Override
+        public void verify() {
+        }
+
+        @Override
+        public bisq.chat.protobuf.ChatMessage.Builder getBuilder(boolean serializeForHash) {
+            return getChatMessageBuilder(serializeForHash)
+                    .setCommonPublicChatMessage(bisq.chat.protobuf.CommonPublicChatMessage.newBuilder().build());
+        }
+
+        @Override
+        protected MetaData getMetaData() {
+            return META_DATA;
+        }
+
+        @Override
+        public <R extends ChatMessageReaction> ObservableSet<R> getChatMessageReactions() {
+            return new ObservableSet<>();
+        }
+
+        @Override
+        public boolean addChatMessageReaction(ChatMessageReaction reaction) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of message sizes in arbitration and mediation requests to prevent oversized submissions, replacing count-based limits with serialization constraints.

* **Improvements**
  * Enhanced message pruning logic to more consistently handle and enforce size limits across dispute and mediation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->