### PR TITLE
BisqEasyTrade.tradeCompletedDate: Made into a observable and sent via WS

### DIFF
--- a/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesDto.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesDto.java
@@ -46,4 +46,5 @@ public class TradePropertiesDto {
     public Optional<String> peersErrorMessage = Optional.empty();
     public Optional<String> peersErrorStackTrace = Optional.empty();
     public Optional<TradeProtocolFailureDto> peersTradeProtocolFailure = Optional.empty();
+    public Optional<Long> tradeCompletedDate = Optional.empty();
 }

--- a/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesWebSocketService.java
@@ -76,6 +76,7 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
                 pins.add(observePeersErrorMessage(bisqEasyTrade, tradeId));
                 pins.add(observePeersErrorStackTrace(bisqEasyTrade, tradeId));
                 pins.add(observePeersTradeProtocolFailure(bisqEasyTrade, tradeId));
+                pins.add(observeTradeCompletedDate(bisqEasyTrade, tradeId));
             }
 
             @Override
@@ -207,6 +208,16 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
         });
     }
 
+    private Pin observeTradeCompletedDate(BisqEasyTrade bisqEasyTrade, String tradeId) {
+        return bisqEasyTrade.tradeCompletedDateObservable().addObserver(value -> {
+            if (value.isPresent()) {
+                var data = new TradePropertiesDto();
+                data.tradeCompletedDate = value;
+                send(Map.of(tradeId, data));
+            }
+        });
+    }
+
     @Override
     public CompletableFuture<Boolean> shutdown() {
         if (tradesPin != null) {
@@ -234,6 +245,7 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
                     data.peersErrorMessage = Optional.ofNullable(bisqEasyTrade.getPeersErrorMessage());
                     data.peersErrorStackTrace = Optional.ofNullable(bisqEasyTrade.getPeersErrorStackTrace());
                     data.peersTradeProtocolFailure = Optional.ofNullable(DtoMappings.TradeProtocolFailureMapping.fromBisq2Model(bisqEasyTrade.getPeersTradeProtocolFailure()));
+                    data.tradeCompletedDate = bisqEasyTrade.getTradeCompletedDate();
                     return Map.of(bisqEasyTrade.getId(), data);
                 })
                 .collect(Collectors.toList());

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -34,7 +34,6 @@ import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,9 +58,8 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
     // Wrapper for stateObservable which is not handled as generic in Fsm
     private final transient Observable<BisqEasyTradeState> tradeState = new Observable<>();
 
-    @Setter
-    @Getter
-    private Optional<Long> tradeCompletedDate = Optional.empty();
+    @EqualsAndHashCode.Exclude
+    private final Observable<Optional<Long>> tradeCompletedDate = new Observable<>(Optional.empty());
 
     public BisqEasyTrade(BisqEasyContract contract,
                          boolean isBuyer,
@@ -116,7 +114,7 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
         Optional.ofNullable(bitcoinPaymentData.get()).ifPresent(builder::setBitcoinPaymentData);
         Optional.ofNullable(paymentProof.get()).ifPresent(builder::setPaymentProof);
         Optional.ofNullable(interruptTradeInitiator.get()).ifPresent(e -> builder.setInterruptTradeInitiator(e.toProtoEnum()));
-        tradeCompletedDate.ifPresent(builder::setTradeCompletedDate);
+        getTradeCompletedDate().ifPresent(builder::setTradeCompletedDate);
         return builder;
     }
 
@@ -175,5 +173,17 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
 
     public ReadOnlyObservable<BisqEasyTradeState> tradeStateObservable() {
         return tradeState;
+    }
+
+    public Optional<Long> getTradeCompletedDate() {
+        return tradeCompletedDate.get();
+    }
+
+    public void setTradeCompletedDate(Optional<Long> value) {
+        tradeCompletedDate.set(value);
+    }
+
+    public ReadOnlyObservable<Optional<Long>> tradeCompletedDateObservable() {
+        return tradeCompletedDate;
     }
 }


### PR DESCRIPTION
 - Contributes to https://github.com/bisq-network/bisq-mobile/issues/419
 - BisqEasyTrade.tradeCompletedDate is made into an observable and sent via ws on change
 - For mobile app to calculate trade duration

Required for https://github.com/bisq-network/bisq-mobile/pull/1374




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade completion timestamps are now included in WebSocket payloads for existing trades returned in batch responses.
  * WebSocket now delivers real-time updates when a trade is completed, allowing clients to receive immediate completion notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->