### PR TITLE
Use explicit serialized size checks for chat pruning

### DIFF
--- a/support/src/main/java/bisq/support/arbitration/mu_sig/MuSigArbitrationRequest.java
+++ b/support/src/main/java/bisq/support/arbitration/mu_sig/MuSigArbitrationRequest.java
@@ -28,6 +28,7 @@ import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.ByteString;
@@ -46,7 +47,6 @@ import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
 import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -87,8 +87,15 @@ public final class MuSigArbitrationRequest implements
         this.mediationResultSignature = mediationResultSignature.clone();
         this.requester = requester;
         this.peer = peer;
-        this.chatMessages = maybePrune(chatMessages);
         this.arbitratorNetworkId = arbitratorNetworkId;
+        this.chatMessages = maybePrune(tradeId,
+                contract,
+                muSigMediationResult,
+                this.mediationResultSignature,
+                requester,
+                peer,
+                arbitratorNetworkId,
+                chatMessages);
 
         Collections.sort(this.chatMessages);
         verify();
@@ -98,17 +105,39 @@ public final class MuSigArbitrationRequest implements
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
         NetworkDataValidation.validateECSignature(mediationResultSignature);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+        checkArgument(getSerializedSize(tradeId,
+                        contract,
+                        muSigMediationResult,
+                        mediationResultSignature,
+                        requester,
+                        peer,
+                        arbitratorNetworkId,
+                        chatMessages) <= MAX_SERIALIZED_SIZE,
                 "Serialized arbitration request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
     @Override
     public bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
+        return getValueBuilder(tradeId,
+                contract,
+                muSigMediationResult,
+                mediationResultSignature,
+                requester,
+                peer,
+                arbitratorNetworkId,
+                chatMessages,
+                serializeForHash);
     }
 
-    private bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
-                                                                                  boolean serializeForHash) {
+    private static bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(String tradeId,
+                                                                                         MuSigContract contract,
+                                                                                         MuSigMediationResult muSigMediationResult,
+                                                                                         byte[] mediationResultSignature,
+                                                                                         UserProfile requester,
+                                                                                         UserProfile peer,
+                                                                                         NetworkId arbitratorNetworkId,
+                                                                                         List<MuSigOpenTradeMessage> chatMessages,
+                                                                                         boolean serializeForHash) {
         return bisq.support.protobuf.MuSigArbitrationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -120,6 +149,27 @@ public final class MuSigArbitrationRequest implements
                         .map(e -> e.toValueProto(serializeForHash))
                         .collect(Collectors.toList()))
                 .setArbitratorNetworkId(arbitratorNetworkId.toProto(serializeForHash));
+    }
+
+    private static int getSerializedSize(String tradeId,
+                                         MuSigContract contract,
+                                         MuSigMediationResult muSigMediationResult,
+                                         byte[] mediationResultSignature,
+                                         UserProfile requester,
+                                         UserProfile peer,
+                                         NetworkId arbitratorNetworkId,
+                                         List<MuSigOpenTradeMessage> chatMessages) {
+        return getValueBuilder(tradeId,
+                contract,
+                muSigMediationResult,
+                mediationResultSignature,
+                requester,
+                peer,
+                arbitratorNetworkId,
+                chatMessages,
+                false)
+                .build()
+                .getSerializedSize();
     }
 
     @Override
@@ -180,11 +230,25 @@ public final class MuSigArbitrationRequest implements
         return requester.getPublicKey();
     }
 
-    private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
+    private static List<MuSigOpenTradeMessage> maybePrune(String tradeId,
+                                                          MuSigContract contract,
+                                                          MuSigMediationResult muSigMediationResult,
+                                                          byte[] mediationResultSignature,
+                                                          UserProfile requester,
+                                                          UserProfile peer,
+                                                          NetworkId arbitratorNetworkId,
+                                                          List<MuSigOpenTradeMessage> chatMessages) {
+        return ChatMessagePruning.maybePrune(chatMessages,
                 MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
                 MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                messages -> getSerializedSize(tradeId,
+                        contract,
+                        muSigMediationResult,
+                        mediationResultSignature,
+                        requester,
+                        peer,
+                        arbitratorNetworkId,
+                        messages),
                 log,
                 tradeId);
     }

--- a/support/src/main/java/bisq/support/dispute/ChatMessagePruning.java
+++ b/support/src/main/java/bisq/support/dispute/ChatMessagePruning.java
@@ -35,12 +35,12 @@ public final class ChatMessagePruning {
     private ChatMessagePruning() {
     }
 
-    public static <M extends ChatMessage> List<M> prune(List<M> chatMessages,
-                                                        int maxTotalTextBytes,
-                                                        int maxSerializedSize,
-                                                        ToIntFunction<List<M>> serializedSizeSupplier,
-                                                        Logger log,
-                                                        String tradeId) {
+    public static <M extends ChatMessage> List<M> maybePrune(List<M> chatMessages,
+                                                             int maxTotalTextBytes,
+                                                             int maxSerializedSize,
+                                                             ToIntFunction<List<M>> serializedSizeSupplier,
+                                                             Logger log,
+                                                             String tradeId) {
         int totalTextBytes = 0;
         List<M> result = new ArrayList<>();
         for (M message : chatMessages) {

--- a/support/src/main/java/bisq/support/mediation/MuSigDisputeCaseDataMessage.java
+++ b/support/src/main/java/bisq/support/mediation/MuSigDisputeCaseDataMessage.java
@@ -25,6 +25,7 @@ import bisq.network.p2p.message.ExternalNetworkMessage;
 import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -42,7 +43,6 @@ import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
 import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -63,7 +63,7 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
         this.tradeId = tradeId;
         this.senderUserProfile = senderUserProfile;
         this.contractHash = contractHash.clone();
-        this.chatMessages = maybePrune(chatMessages);
+        this.chatMessages = maybePrune(tradeId, senderUserProfile, this.contractHash, chatMessages);
 
         Collections.sort(this.chatMessages);
         verify();
@@ -73,17 +73,20 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
         NetworkDataValidation.validateHash(contractHash);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+        checkArgument(getSerializedSize(tradeId, senderUserProfile, contractHash, chatMessages) <= MAX_SERIALIZED_SIZE,
                 "Serialized dispute case data size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
     @Override
     public bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
+        return getValueBuilder(tradeId, senderUserProfile, contractHash, chatMessages, serializeForHash);
     }
 
-    private bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
-                                                                                       boolean serializeForHash) {
+    private static bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(String tradeId,
+                                                                                             UserProfile senderUserProfile,
+                                                                                             byte[] contractHash,
+                                                                                             List<MuSigOpenTradeMessage> chatMessages,
+                                                                                             boolean serializeForHash) {
         return bisq.support.protobuf.MuSigDisputeCaseDataMessage.newBuilder()
                 .setTradeId(tradeId)
                 .setSenderUserProfile(senderUserProfile.toProto(serializeForHash))
@@ -91,6 +94,15 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
                 .addAllChatMessages(chatMessages.stream()
                         .map(message -> message.toValueProto(serializeForHash))
                         .collect(Collectors.toList()));
+    }
+
+    private static int getSerializedSize(String tradeId,
+                                         UserProfile senderUserProfile,
+                                         byte[] contractHash,
+                                         List<MuSigOpenTradeMessage> chatMessages) {
+        return getValueBuilder(tradeId, senderUserProfile, contractHash, chatMessages, false)
+                .build()
+                .getSerializedSize();
     }
 
     public static MuSigDisputeCaseDataMessage fromProto(bisq.support.protobuf.MuSigDisputeCaseDataMessage proto) {
@@ -129,11 +141,14 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
         return contractHash.clone();
     }
 
-    private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
+    private static List<MuSigOpenTradeMessage> maybePrune(String tradeId,
+                                                          UserProfile senderUserProfile,
+                                                          byte[] contractHash,
+                                                          List<MuSigOpenTradeMessage> chatMessages) {
+        return ChatMessagePruning.maybePrune(chatMessages,
                 MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
                 MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                messages -> getSerializedSize(tradeId, senderUserProfile, contractHash, messages),
                 log,
                 tradeId);
     }

--- a/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequest.java
@@ -27,6 +27,7 @@ import bisq.network.p2p.message.ExternalNetworkMessage;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.EqualsAndHashCode;
@@ -43,7 +44,6 @@ import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
 import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -81,7 +81,7 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
         this.requester = requester;
         this.peer = peer;
         this.mediatorNetworkId = mediatorNetworkId;
-        this.chatMessages = maybePrune(chatMessages);
+        this.chatMessages = maybePrune(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages);
 
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.chatMessages);
@@ -92,7 +92,7 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
     @Override
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+        checkArgument(getSerializedSize(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages) <= MAX_SERIALIZED_SIZE,
                 "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
@@ -102,11 +102,16 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
 
     @Override
     public bisq.support.protobuf.MediationRequest.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
+        return getValueBuilder(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages, serializeForHash);
     }
 
-    private bisq.support.protobuf.MediationRequest.Builder getValueBuilder(List<BisqEasyOpenTradeMessage> chatMessages,
-                                                                           boolean serializeForHash) {
+    private static bisq.support.protobuf.MediationRequest.Builder getValueBuilder(String tradeId,
+                                                                                  BisqEasyContract contract,
+                                                                                  UserProfile requester,
+                                                                                  UserProfile peer,
+                                                                                  Optional<NetworkId> mediatorNetworkId,
+                                                                                  List<BisqEasyOpenTradeMessage> chatMessages,
+                                                                                  boolean serializeForHash) {
         bisq.support.protobuf.MediationRequest.Builder builder = bisq.support.protobuf.MediationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -115,8 +120,19 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
                 .addAllChatMessages(chatMessages.stream()
                         .map(e -> e.toValueProto(serializeForHash))
                         .collect(Collectors.toList()));
-        mediatorNetworkId.ifPresent(mediatorNetworkId -> builder.setMediatorNetworkId(mediatorNetworkId.toProto(serializeForHash)));
+        mediatorNetworkId.ifPresent(networkId -> builder.setMediatorNetworkId(networkId.toProto(serializeForHash)));
         return builder;
+    }
+
+    private static int getSerializedSize(String tradeId,
+                                         BisqEasyContract contract,
+                                         UserProfile requester,
+                                         UserProfile peer,
+                                         Optional<NetworkId> mediatorNetworkId,
+                                         List<BisqEasyOpenTradeMessage> chatMessages) {
+        return getValueBuilder(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages, false)
+                .build()
+                .getSerializedSize();
     }
 
     @Override
@@ -179,11 +195,16 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
         return getCostFactor(0.25, 0.5);
     }
 
-    private List<BisqEasyOpenTradeMessage> maybePrune(List<BisqEasyOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
+    private static List<BisqEasyOpenTradeMessage> maybePrune(String tradeId,
+                                                             BisqEasyContract contract,
+                                                             UserProfile requester,
+                                                             UserProfile peer,
+                                                             Optional<NetworkId> mediatorNetworkId,
+                                                             List<BisqEasyOpenTradeMessage> chatMessages) {
+        return ChatMessagePruning.maybePrune(chatMessages,
                 MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
                 MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                messages -> getSerializedSize(tradeId, contract, requester, peer, mediatorNetworkId, messages),
                 log,
                 tradeId);
     }

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequest.java
@@ -28,6 +28,7 @@ import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.EqualsAndHashCode;
@@ -44,7 +45,6 @@ import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
 import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
@@ -80,8 +80,8 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
         this.contract = contract;
         this.requester = requester;
         this.peer = peer;
-        this.chatMessages = maybePrune(chatMessages);
         this.mediatorNetworkId = mediatorNetworkId;
+        this.chatMessages = maybePrune(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages);
 
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.chatMessages);
@@ -92,7 +92,7 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
     @Override
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
+        checkArgument(getSerializedSize(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages) <= MAX_SERIALIZED_SIZE,
                 "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
     }
 
@@ -102,11 +102,16 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
 
     @Override
     public bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
+        return getValueBuilder(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages, serializeForHash);
     }
 
-    private bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
-                                                                                boolean serializeForHash) {
+    private static bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(String tradeId,
+                                                                                       MuSigContract contract,
+                                                                                       UserProfile requester,
+                                                                                       UserProfile peer,
+                                                                                       NetworkId mediatorNetworkId,
+                                                                                       List<MuSigOpenTradeMessage> chatMessages,
+                                                                                       boolean serializeForHash) {
         return bisq.support.protobuf.MuSigMediationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -116,6 +121,17 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
                 .addAllChatMessages(chatMessages.stream()
                         .map(e -> e.toValueProto(serializeForHash))
                         .collect(Collectors.toList()));
+    }
+
+    private static int getSerializedSize(String tradeId,
+                                         MuSigContract contract,
+                                         UserProfile requester,
+                                         UserProfile peer,
+                                         NetworkId mediatorNetworkId,
+                                         List<MuSigOpenTradeMessage> chatMessages) {
+        return getValueBuilder(tradeId, contract, requester, peer, mediatorNetworkId, chatMessages, false)
+                .build()
+                .getSerializedSize();
     }
 
     @Override
@@ -175,11 +191,16 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
         return requester.getPublicKey();
     }
 
-    private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
+    private static List<MuSigOpenTradeMessage> maybePrune(String tradeId,
+                                                          MuSigContract contract,
+                                                          UserProfile requester,
+                                                          UserProfile peer,
+                                                          NetworkId mediatorNetworkId,
+                                                          List<MuSigOpenTradeMessage> chatMessages) {
+        return ChatMessagePruning.maybePrune(chatMessages,
                 MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
                 MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
+                messages -> getSerializedSize(tradeId, contract, requester, peer, mediatorNetworkId, messages),
                 log,
                 tradeId);
     }

--- a/support/src/test/java/bisq/support/dispute/ChatMessagePruningTest.java
+++ b/support/src/test/java/bisq/support/dispute/ChatMessagePruningTest.java
@@ -23,9 +23,11 @@ import bisq.chat.ChatMessageType;
 import bisq.chat.reactions.ChatMessageReaction;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.network.p2p.services.data.storage.MetaData;
+import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,11 +35,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ChatMessagePruningTest {
     @Test
-    void prune_keepsAllMessages_whenUnderBothLimits() {
+    void maybePrune_keepsAllMessages_whenUnderBothLimits() {
         TestChatMessage first = new TestChatMessage("1", "hello", 10);
         TestChatMessage second = new TestChatMessage("2", "world", 20);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
+        List<TestChatMessage> result = ChatMessagePruning.maybePrune(
                 List.of(first, second),
                 100,
                 100,
@@ -49,11 +51,11 @@ class ChatMessagePruningTest {
     }
 
     @Test
-    void prune_usesUtf8ByteLengthForTheHeuristic() {
+    void maybePrune_usesUtf8ByteLengthForTheHeuristic() {
         TestChatMessage first = new TestChatMessage("1", "🙂", 10);
         TestChatMessage second = new TestChatMessage("2", "ok", 20);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
+        List<TestChatMessage> result = ChatMessagePruning.maybePrune(
                 List.of(first, second),
                 5,
                 100,
@@ -65,11 +67,11 @@ class ChatMessagePruningTest {
     }
 
     @Test
-    void prune_dropsMessage_whenUtf8ByteLengthHitsTheLimitExactly() {
+    void maybePrune_dropsMessage_whenUtf8ByteLengthHitsTheLimitExactly() {
         TestChatMessage first = new TestChatMessage("1", "🙂", 10);
         TestChatMessage second = new TestChatMessage("2", "ok", 20);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
+        List<TestChatMessage> result = ChatMessagePruning.maybePrune(
                 List.of(first, second),
                 4,
                 100,
@@ -81,12 +83,12 @@ class ChatMessagePruningTest {
     }
 
     @Test
-    void prune_trimsFromTheEnd_whenSerializedSizeStillExceedsLimit() {
+    void maybePrune_trimsFromTheEnd_whenSerializedSizeStillExceedsLimit() {
         TestChatMessage first = new TestChatMessage("1", "aa", 10);
         TestChatMessage second = new TestChatMessage("2", "bb", 20);
         TestChatMessage third = new TestChatMessage("3", "cc", 30);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
+        List<TestChatMessage> result = ChatMessagePruning.maybePrune(
                 List.of(first, second, third),
                 100,
                 25,
@@ -98,11 +100,11 @@ class ChatMessagePruningTest {
     }
 
     @Test
-    void prune_returnsEmpty_whenFirstMessageAlreadyReachesTextLimit() {
+    void maybePrune_returnsEmpty_whenFirstMessageAlreadyReachesTextLimit() {
         TestChatMessage first = new TestChatMessage("1", "🙂🙂🙂", 10);
         TestChatMessage second = new TestChatMessage("2", "ok", 20);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
+        List<TestChatMessage> result = ChatMessagePruning.maybePrune(
                 List.of(first, second),
                 4,
                 100,
@@ -111,6 +113,66 @@ class ChatMessagePruningTest {
                 "trade-4");
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void maybePrune_usesRealRequestSerializedSizeSupplierWithContextFields() {
+        TestChatMessage first = new TestChatMessage("1", "aa", 10);
+        TestChatMessage second = new TestChatMessage("2", "bb", 20);
+        int maxSerializedSize = getMediationRequestSerializedSize(List.of(first));
+
+        List<TestChatMessage> result = ChatMessagePruning.maybePrune(
+                List.of(first, second),
+                100,
+                maxSerializedSize,
+                ChatMessagePruningTest::getMediationRequestSerializedSize,
+                LoggerFactory.getLogger(ChatMessagePruningTest.class),
+                "trade-real-request-size");
+
+        assertThat(getMediationRequestSerializedSize(List.of(first, second))).isGreaterThan(maxSerializedSize);
+        assertThat(result).containsExactly(first);
+        assertThat(getMediationRequestSerializedSize(result)).isLessThanOrEqualTo(maxSerializedSize);
+    }
+
+    private static int getMediationRequestSerializedSize(List<TestChatMessage> chatMessages) {
+        return bisq.support.protobuf.MediationRequest.newBuilder()
+                .setTradeId("trade-real-request-size")
+                .setContract(bisq.contract.protobuf.Contract.newBuilder()
+                        .setTakeOfferDate(1)
+                        .build())
+                .setRequester(createUserProfile("requester"))
+                .setPeer(createUserProfile("peer"))
+                .setMediatorNetworkId(createNetworkId("mediator"))
+                .addAllChatMessages(chatMessages.stream()
+                        .map(message -> message.<bisq.chat.protobuf.ChatMessage>unsafeToProto(false))
+                        .toList())
+                .build()
+                .getSerializedSize();
+    }
+
+    private static bisq.user.protobuf.UserProfile createUserProfile(String id) {
+        return bisq.user.protobuf.UserProfile.newBuilder()
+                .setNickName(id + "-" + createString(1_000))
+                .setNetworkId(createNetworkId(id))
+                .setTerms(createString(1_000))
+                .setStatement(createString(1_000))
+                .setApplicationVersion("1.0.0")
+                .build();
+    }
+
+    private static bisq.network.identity.protobuf.NetworkId createNetworkId(String id) {
+        return bisq.network.identity.protobuf.NetworkId.newBuilder()
+                .setPubKey(bisq.security.protobuf.PubKey.newBuilder()
+                        .setKeyId(id + "-" + createString(1_000))
+                        .setPublicKey(ByteString.copyFrom(new byte[1_000]))
+                        .build())
+                .build();
+    }
+
+    private static String createString(int length) {
+        char[] chars = new char[length];
+        Arrays.fill(chars, 'x');
+        return new String(chars);
     }
 
     private static final class TestChatMessage extends ChatMessage {

--- a/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
+++ b/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
@@ -34,7 +34,6 @@ import bisq.common.network.TransportType;
 import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.i18n.Res;
-import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
@@ -89,8 +88,6 @@ class MuSigMediatorServiceTest {
                 .thenReturn(persistence);
         when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(persistence.getStorePath()).thenReturn(Path.of("build/test/musig-mediator-service"));
-
-        NetworkService networkService = mock(NetworkService.class);
 
         ChatService chatService = mock(ChatService.class);
         MuSigOpenTradeChannelService openTradeChannelService = mock(MuSigOpenTradeChannelService.class);
@@ -227,24 +224,17 @@ class MuSigMediatorServiceTest {
     private MuSigMediationRequest createMediationRequest(String tradeId,
                                                          UserProfile requester,
                                                          UserProfile peer) {
+        UserProfile mediator = createUserProfile(19000);
         return new MuSigMediationRequest(
                 tradeId,
-                createContract(requester, peer, "offer-" + tradeId,
+                createContract(requester, peer, mediator, "offer-" + tradeId,
                         createNationalBankPayload("taker-" + tradeId, "DE" + tradeId.substring(tradeId.length() - 2) + "1"),
                         createNationalBankPayload("maker-" + tradeId, "DE" + tradeId.substring(tradeId.length() - 2) + "2")),
                 requester,
                 peer,
                 List.of(),
-                null
+                mediator.getNetworkId()
         );
-    }
-
-    private MuSigContract createContract(UserProfile maker,
-                                         UserProfile taker,
-                                         String offerId,
-                                         AccountPayload<?> takerPayloadForHash,
-                                         AccountPayload<?> makerPayloadForHash) {
-        return createContractWithMediator(maker, taker, Optional.empty(), offerId, takerPayloadForHash, List.of(makerPayloadForHash));
     }
 
     private MuSigContract createContract(UserProfile maker,
@@ -334,5 +324,4 @@ class MuSigMediatorServiceTest {
                 Optional.empty()
         );
     }
-
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chat message validation and pruning logic to use full request context for more accurate message size estimation and handling.

* **Tests**
  * Updated test suite to reflect refactored message pruning mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->