### PR TITLE
Move chat message pruning to callers

### DIFF
--- a/support/src/main/java/bisq/support/arbitration/mu_sig/MuSigArbitrationRequest.java
+++ b/support/src/main/java/bisq/support/arbitration/mu_sig/MuSigArbitrationRequest.java
@@ -28,6 +28,7 @@ import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.SerializedSizeExceededException;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.ByteString;
@@ -38,6 +39,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,9 +47,6 @@ import java.util.stream.Collectors;
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
-import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
-import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 @Getter
@@ -87,7 +86,7 @@ public final class MuSigArbitrationRequest implements
         this.mediationResultSignature = mediationResultSignature.clone();
         this.requester = requester;
         this.peer = peer;
-        this.chatMessages = maybePrune(chatMessages);
+        this.chatMessages = new ArrayList<>(chatMessages);
         this.arbitratorNetworkId = arbitratorNetworkId;
 
         Collections.sort(this.chatMessages);
@@ -98,17 +97,14 @@ public final class MuSigArbitrationRequest implements
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
         NetworkDataValidation.validateECSignature(mediationResultSignature);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
-                "Serialized arbitration request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        if (getValueBuilder(false).build().getSerializedSize() > MAX_SERIALIZED_SIZE) {
+            throw new SerializedSizeExceededException(
+                    "Serialized arbitration request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        }
     }
 
     @Override
     public bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
-    }
-
-    private bisq.support.protobuf.MuSigArbitrationRequest.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
-                                                                                  boolean serializeForHash) {
         return bisq.support.protobuf.MuSigArbitrationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -180,12 +176,4 @@ public final class MuSigArbitrationRequest implements
         return requester.getPublicKey();
     }
 
-    private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
-                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
-                MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
-                log,
-                tradeId);
-    }
 }

--- a/support/src/main/java/bisq/support/dispute/ChatMessagePruning.java
+++ b/support/src/main/java/bisq/support/dispute/ChatMessagePruning.java
@@ -18,15 +18,17 @@
 package bisq.support.dispute;
 
 import bisq.chat.ChatMessage;
-import org.slf4j.Logger;
+import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.function.ToIntFunction;
+import java.util.function.Function;
 
+@Slf4j
 public final class ChatMessagePruning {
-    public static final int MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES = 18_000;
+    private static final int MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES = 18_000;
     // Leave headroom for AEAD authentication tag (16 bytes) added by the
     // confidential transport on top of the serialized payload, so that the
     // resulting ciphertext stays within the transport's 20_000-byte limit.
@@ -35,31 +37,50 @@ public final class ChatMessagePruning {
     private ChatMessagePruning() {
     }
 
-    public static <M extends ChatMessage> List<M> prune(List<M> chatMessages,
-                                                        int maxTotalTextBytes,
-                                                        int maxSerializedSize,
-                                                        ToIntFunction<List<M>> serializedSizeSupplier,
-                                                        Logger log,
-                                                        String tradeId) {
+    public static <M extends ChatMessage, R> R createWithMaybePrunedMessages(List<M> chatMessages,
+                                                                             String tradeId,
+                                                                             Function<List<M>, R> messageFactory) {
+        List<M> candidateMessages = pruneByTotalTextBytes(chatMessages);
+        while (true) {
+            try {
+                R message = messageFactory.apply(new ArrayList<>(candidateMessages));
+                logIfPruned(chatMessages.size(), candidateMessages.size(), tradeId);
+                return message;
+            } catch (SerializedSizeExceededException e) {
+                if (candidateMessages.isEmpty()) {
+                    throw e;
+                }
+                candidateMessages.remove(0);
+            }
+        }
+    }
+
+    private static <M extends ChatMessage> List<M> pruneByTotalTextBytes(List<M> chatMessages) {
         int totalTextBytes = 0;
         List<M> result = new ArrayList<>();
-        for (M message : chatMessages) {
-            totalTextBytes += message.getTextOrNA().getBytes(StandardCharsets.UTF_8).length;
-            if (totalTextBytes >= maxTotalTextBytes) {
+        for (int i = chatMessages.size() - 1; i >= 0; i--) {
+            M message = chatMessages.get(i);
+            int messageTextBytes = message.getTextOrNA().getBytes(StandardCharsets.UTF_8).length;
+            if (totalTextBytes + messageTextBytes >= MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES) {
                 break;
             }
+            totalTextBytes += messageTextBytes;
             result.add(message);
         }
-        while (!result.isEmpty() && serializedSizeSupplier.applyAsInt(result) > maxSerializedSize) {
-            result.removeLast();
-        }
-        if (result.size() != chatMessages.size()) {
-            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalTextBytes={}",
-                    tradeId,
-                    result.size(),
-                    chatMessages.size() - result.size(),
-                    maxTotalTextBytes);
-        }
+        Collections.reverse(result);
         return result;
     }
+
+    private static void logIfPruned(int originalSize,
+                                    int resultSize,
+                                    String tradeId) {
+        if (resultSize != originalSize) {
+            log.warn("chatMessages pruned for trade {}: kept={}, dropped={}, maxTotalTextBytes={}",
+                    tradeId,
+                    resultSize,
+                    originalSize - resultSize,
+                    MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES);
+        }
+    }
+
 }

--- a/support/src/main/java/bisq/support/dispute/SerializedSizeExceededException.java
+++ b/support/src/main/java/bisq/support/dispute/SerializedSizeExceededException.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.dispute;
+
+public class SerializedSizeExceededException extends IllegalArgumentException {
+    public SerializedSizeExceededException(String message) {
+        super(message);
+    }
+}

--- a/support/src/main/java/bisq/support/mediation/MuSigDisputeCaseDataMessage.java
+++ b/support/src/main/java/bisq/support/mediation/MuSigDisputeCaseDataMessage.java
@@ -25,6 +25,7 @@ import bisq.network.p2p.message.ExternalNetworkMessage;
 import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.SerializedSizeExceededException;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -34,6 +35,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,9 +43,6 @@ import java.util.stream.Collectors;
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
-import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
-import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 @Getter
@@ -63,7 +62,7 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
         this.tradeId = tradeId;
         this.senderUserProfile = senderUserProfile;
         this.contractHash = contractHash.clone();
-        this.chatMessages = maybePrune(chatMessages);
+        this.chatMessages = new ArrayList<>(chatMessages);
 
         Collections.sort(this.chatMessages);
         verify();
@@ -73,17 +72,14 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
         NetworkDataValidation.validateHash(contractHash);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
-                "Serialized dispute case data size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        if (getValueBuilder(false).build().getSerializedSize() > MAX_SERIALIZED_SIZE) {
+            throw new SerializedSizeExceededException(
+                    "Serialized dispute case data size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        }
     }
 
     @Override
     public bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
-    }
-
-    private bisq.support.protobuf.MuSigDisputeCaseDataMessage.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
-                                                                                       boolean serializeForHash) {
         return bisq.support.protobuf.MuSigDisputeCaseDataMessage.newBuilder()
                 .setTradeId(tradeId)
                 .setSenderUserProfile(senderUserProfile.toProto(serializeForHash))
@@ -129,12 +125,4 @@ public final class MuSigDisputeCaseDataMessage implements MailboxMessage, Extern
         return contractHash.clone();
     }
 
-    private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
-                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
-                MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
-                log,
-                tradeId);
-    }
 }

--- a/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequest.java
@@ -27,6 +27,7 @@ import bisq.network.p2p.message.ExternalNetworkMessage;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.SerializedSizeExceededException;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.EqualsAndHashCode;
@@ -34,6 +35,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -42,9 +44,6 @@ import java.util.stream.Collectors;
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
-import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
-import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 @Getter
@@ -81,7 +80,7 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
         this.requester = requester;
         this.peer = peer;
         this.mediatorNetworkId = mediatorNetworkId;
-        this.chatMessages = maybePrune(chatMessages);
+        this.chatMessages = new ArrayList<>(chatMessages);
 
         // We need to sort deterministically as the data is used in the proof of work check
         Collections.sort(this.chatMessages);
@@ -92,8 +91,10 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
     @Override
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
-                "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        if (getValueBuilder(false).build().getSerializedSize() > MAX_SERIALIZED_SIZE) {
+            throw new SerializedSizeExceededException(
+                    "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        }
     }
 
     /**
@@ -102,11 +103,6 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
 
     @Override
     public bisq.support.protobuf.MediationRequest.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
-    }
-
-    private bisq.support.protobuf.MediationRequest.Builder getValueBuilder(List<BisqEasyOpenTradeMessage> chatMessages,
-                                                                           boolean serializeForHash) {
         bisq.support.protobuf.MediationRequest.Builder builder = bisq.support.protobuf.MediationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -179,12 +175,4 @@ public final class BisqEasyMediationRequest implements MailboxMessage, ExternalN
         return getCostFactor(0.25, 0.5);
     }
 
-    private List<BisqEasyOpenTradeMessage> maybePrune(List<BisqEasyOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
-                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
-                MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
-                log,
-                tradeId);
-    }
 }

--- a/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequestService.java
+++ b/support/src/main/java/bisq/support/mediation/bisq_easy/BisqEasyMediationRequestService.java
@@ -34,6 +34,7 @@ import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.confidential.ConfidentialMessageService;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.user.UserService;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
@@ -132,12 +133,15 @@ public class BisqEasyMediationRequestService implements Service, ConfidentialMes
         UserProfile peer = channel.getPeer();
         UserProfile mediator = channel.getMediator().orElseThrow();
         NetworkId mediatorNetworkId = mediator.getNetworkId();
-        BisqEasyMediationRequest bisqEasyMediationRequest = new BisqEasyMediationRequest(channel.getTradeId(),
-                contract,
-                myUserIdentity.getUserProfile(),
-                peer,
+        BisqEasyMediationRequest bisqEasyMediationRequest = ChatMessagePruning.createWithMaybePrunedMessages(
                 new ArrayList<>(channel.getChatMessages()),
-                Optional.of(mediatorNetworkId));
+                channel.getTradeId(),
+                chatMessages -> new BisqEasyMediationRequest(channel.getTradeId(),
+                        contract,
+                        myUserIdentity.getUserProfile(),
+                        peer,
+                        chatMessages,
+                        Optional.of(mediatorNetworkId)));
         networkService.confidentialSend(bisqEasyMediationRequest,
                 mediatorNetworkId,
                 myUserIdentity.getNetworkIdWithKeyPair());

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequest.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationRequest.java
@@ -28,6 +28,7 @@ import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
 import bisq.network.p2p.services.confidential.ack.AckRequestingMessage;
 import bisq.network.p2p.services.data.storage.MetaData;
 import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import bisq.support.dispute.SerializedSizeExceededException;
 import bisq.user.profile.UserProfile;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.EqualsAndHashCode;
@@ -36,6 +37,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,9 +45,6 @@ import java.util.stream.Collectors;
 import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
 import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
 import static bisq.support.dispute.ChatMessagePruning.MAX_SERIALIZED_SIZE;
-import static bisq.support.dispute.ChatMessagePruning.MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES;
-import static bisq.support.dispute.ChatMessagePruning.prune;
-import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 @Getter
@@ -80,7 +79,7 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
         this.contract = contract;
         this.requester = requester;
         this.peer = peer;
-        this.chatMessages = maybePrune(chatMessages);
+        this.chatMessages = new ArrayList<>(chatMessages);
         this.mediatorNetworkId = mediatorNetworkId;
 
         // We need to sort deterministically as the data is used in the proof of work check
@@ -92,8 +91,10 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
     @Override
     public void verify() {
         NetworkDataValidation.validateTradeId(tradeId);
-        checkArgument(getValueBuilder(chatMessages, false).build().getSerializedSize() <= MAX_SERIALIZED_SIZE,
-                "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        if (getValueBuilder(false).build().getSerializedSize() > MAX_SERIALIZED_SIZE) {
+            throw new SerializedSizeExceededException(
+                    "Serialized mediation request size must not exceed " + MAX_SERIALIZED_SIZE + " bytes");
+        }
     }
 
     /**
@@ -102,11 +103,6 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
 
     @Override
     public bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(boolean serializeForHash) {
-        return getValueBuilder(chatMessages, serializeForHash);
-    }
-
-    private bisq.support.protobuf.MuSigMediationRequest.Builder getValueBuilder(List<MuSigOpenTradeMessage> chatMessages,
-                                                                                boolean serializeForHash) {
         return bisq.support.protobuf.MuSigMediationRequest.newBuilder()
                 .setTradeId(tradeId)
                 .setContract(contract.toProto(serializeForHash))
@@ -175,12 +171,4 @@ public final class MuSigMediationRequest implements MailboxMessage, ExternalNetw
         return requester.getPublicKey();
     }
 
-    private List<MuSigOpenTradeMessage> maybePrune(List<MuSigOpenTradeMessage> chatMessages) {
-        return prune(chatMessages,
-                MAX_TOTAL_CHAT_MESSAGES_TEXT_BYTES,
-                MAX_SERIALIZED_SIZE,
-                messages -> getValueBuilder(messages, false).build().getSerializedSize(),
-                log,
-                tradeId);
-    }
 }

--- a/support/src/test/java/bisq/support/dispute/ChatMessagePruningTest.java
+++ b/support/src/test/java/bisq/support/dispute/ChatMessagePruningTest.java
@@ -24,93 +24,64 @@ import bisq.chat.reactions.ChatMessageReaction;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.network.p2p.services.data.storage.MetaData;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ChatMessagePruningTest {
     @Test
-    void prune_keepsAllMessages_whenUnderBothLimits() {
-        TestChatMessage first = new TestChatMessage("1", "hello", 10);
-        TestChatMessage second = new TestChatMessage("2", "world", 20);
+    void createWithMaybePrunedMessages_keepsNewestMessages_whenTextBytesExceedLimit() {
+        TestChatMessage first = new TestChatMessage("1", "x".repeat(17_999), 10);
+        TestChatMessage second = new TestChatMessage("2", "middle", 20);
+        TestChatMessage third = new TestChatMessage("3", "new", 30);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
-                List.of(first, second),
-                100,
-                100,
-                messages -> messages.size() * 10,
-                LoggerFactory.getLogger(ChatMessagePruningTest.class),
-                "trade-1");
+        List<TestChatMessage> result = ChatMessagePruning.createWithMaybePrunedMessages(
+                List.of(first, second, third),
+                "trade-text-prune",
+                ArrayList::new);
 
-        assertThat(result).containsExactly(first, second);
+        assertThat(result).containsExactly(second, third);
     }
 
     @Test
-    void prune_usesUtf8ByteLengthForTheHeuristic() {
-        TestChatMessage first = new TestChatMessage("1", "🙂", 10);
-        TestChatMessage second = new TestChatMessage("2", "ok", 20);
-
-        List<TestChatMessage> result = ChatMessagePruning.prune(
-                List.of(first, second),
-                5,
-                100,
-                messages -> 0,
-                LoggerFactory.getLogger(ChatMessagePruningTest.class),
-                "trade-2");
-
-        assertThat(result).containsExactly(first);
-    }
-
-    @Test
-    void prune_dropsMessage_whenUtf8ByteLengthHitsTheLimitExactly() {
-        TestChatMessage first = new TestChatMessage("1", "🙂", 10);
-        TestChatMessage second = new TestChatMessage("2", "ok", 20);
-
-        List<TestChatMessage> result = ChatMessagePruning.prune(
-                List.of(first, second),
-                4,
-                100,
-                messages -> 0,
-                LoggerFactory.getLogger(ChatMessagePruningTest.class),
-                "trade-equal-boundary");
-
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void prune_trimsFromTheEnd_whenSerializedSizeStillExceedsLimit() {
+    void createWithMaybePrunedMessages_removesOldestMessage_whenSerializedSizeStillExceedsLimit() {
         TestChatMessage first = new TestChatMessage("1", "aa", 10);
         TestChatMessage second = new TestChatMessage("2", "bb", 20);
         TestChatMessage third = new TestChatMessage("3", "cc", 30);
+        AtomicInteger attempts = new AtomicInteger();
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
+        List<TestChatMessage> result = ChatMessagePruning.createWithMaybePrunedMessages(
                 List.of(first, second, third),
-                100,
-                25,
-                messages -> messages.size() * 10,
-                LoggerFactory.getLogger(ChatMessagePruningTest.class),
-                "trade-3");
+                "trade-size-prune",
+                messages -> {
+                    attempts.incrementAndGet();
+                    if (messages.size() > 2) {
+                        throw new SerializedSizeExceededException("too large");
+                    }
+                    return new ArrayList<>(messages);
+                });
 
-        assertThat(result).containsExactly(first, second);
+        assertThat(result).containsExactly(second, third);
+        assertThat(attempts).hasValue(2);
     }
 
     @Test
-    void prune_returnsEmpty_whenFirstMessageAlreadyReachesTextLimit() {
-        TestChatMessage first = new TestChatMessage("1", "🙂🙂🙂", 10);
-        TestChatMessage second = new TestChatMessage("2", "ok", 20);
+    void createWithMaybePrunedMessages_rethrows_whenRequestWithNoMessagesIsStillTooLarge() {
+        TestChatMessage message = new TestChatMessage("1", "aa", 10);
 
-        List<TestChatMessage> result = ChatMessagePruning.prune(
-                List.of(first, second),
-                4,
-                100,
-                messages -> 0,
-                LoggerFactory.getLogger(ChatMessagePruningTest.class),
-                "trade-4");
-
-        assertThat(result).isEmpty();
+        assertThatThrownBy(() -> ChatMessagePruning.createWithMaybePrunedMessages(
+                List.of(message),
+                "trade-too-large",
+                messages -> {
+                    throw new SerializedSizeExceededException("too large");
+                }))
+                .isInstanceOf(SerializedSizeExceededException.class)
+                .hasMessage("too large");
     }
 
     private static final class TestChatMessage extends ChatMessage {

--- a/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
+++ b/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediatorServiceTest.java
@@ -34,7 +34,6 @@ import bisq.common.network.TransportType;
 import bisq.common.network.clear_net_address_types.LocalHostAddressTypeFacade;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.i18n.Res;
-import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
@@ -89,8 +88,6 @@ class MuSigMediatorServiceTest {
                 .thenReturn(persistence);
         when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
         when(persistence.getStorePath()).thenReturn(Path.of("build/test/musig-mediator-service"));
-
-        NetworkService networkService = mock(NetworkService.class);
 
         ChatService chatService = mock(ChatService.class);
         MuSigOpenTradeChannelService openTradeChannelService = mock(MuSigOpenTradeChannelService.class);
@@ -227,24 +224,17 @@ class MuSigMediatorServiceTest {
     private MuSigMediationRequest createMediationRequest(String tradeId,
                                                          UserProfile requester,
                                                          UserProfile peer) {
+        UserProfile mediator = createUserProfile(19000);
         return new MuSigMediationRequest(
                 tradeId,
-                createContract(requester, peer, "offer-" + tradeId,
+                createContract(requester, peer, mediator, "offer-" + tradeId,
                         createNationalBankPayload("taker-" + tradeId, "DE" + tradeId.substring(tradeId.length() - 2) + "1"),
                         createNationalBankPayload("maker-" + tradeId, "DE" + tradeId.substring(tradeId.length() - 2) + "2")),
                 requester,
                 peer,
                 List.of(),
-                null
+                mediator.getNetworkId()
         );
-    }
-
-    private MuSigContract createContract(UserProfile maker,
-                                         UserProfile taker,
-                                         String offerId,
-                                         AccountPayload<?> takerPayloadForHash,
-                                         AccountPayload<?> makerPayloadForHash) {
-        return createContractWithMediator(maker, taker, Optional.empty(), offerId, takerPayloadForHash, List.of(makerPayloadForHash));
     }
 
     private MuSigContract createContract(UserProfile maker,
@@ -334,5 +324,4 @@ class MuSigMediatorServiceTest {
                 Optional.empty()
         );
     }
-
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/arbitration/MuSigTraderArbitrationService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/arbitration/MuSigTraderArbitrationService.java
@@ -30,6 +30,7 @@ import bisq.i18n.Res;
 import bisq.identity.Identity;
 import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.support.arbitration.mu_sig.MuSigArbitrationRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.trade.MuSigDisputeState;
@@ -104,16 +105,21 @@ public class MuSigTraderArbitrationService {
 
         NetworkId arbitratorNetworkId = arbitrator.getNetworkId();
 
-        MuSigArbitrationRequest muSigArbitrationRequest = new MuSigArbitrationRequest(tradeId,
-                contract,
-                mediationResult,
-                mediationResultSignature,
-                userProfileService.findUserProfile(myIdentity.getId()).orElseThrow(),
-                userProfileService
-                        .findUserProfile(peer.getNetworkId().getId())
-                        .orElseThrow(),
+        UserProfile requester = userProfileService.findUserProfile(myIdentity.getId()).orElseThrow();
+        UserProfile peerUserProfile = userProfileService
+                .findUserProfile(peer.getNetworkId().getId())
+                .orElseThrow();
+        MuSigArbitrationRequest muSigArbitrationRequest = ChatMessagePruning.createWithMaybePrunedMessages(
                 new ArrayList<>(channel.getChatMessages()),
-                arbitratorNetworkId);
+                tradeId,
+                chatMessages -> new MuSigArbitrationRequest(tradeId,
+                        contract,
+                        mediationResult,
+                        mediationResultSignature,
+                        requester,
+                        peerUserProfile,
+                        chatMessages,
+                        arbitratorNetworkId));
         networkService.confidentialSend(muSigArbitrationRequest,
                 arbitratorNetworkId,
                 myIdentity.getNetworkIdWithKeyPair());

--- a/trade/src/main/java/bisq/trade/mu_sig/mediation/MuSigTraderMediationService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/mediation/MuSigTraderMediationService.java
@@ -32,6 +32,7 @@ import bisq.i18n.Res;
 import bisq.identity.Identity;
 import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
+import bisq.support.dispute.ChatMessagePruning;
 import bisq.support.mediation.MuSigDisputeCaseDataMessage;
 import bisq.support.mediation.mu_sig.MuSigDisputeCasePaymentDetailsResponse;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
@@ -107,12 +108,17 @@ public class MuSigTraderMediationService {
 
         NetworkId mediatorNetworkId = mediator.getNetworkId();
 
-        MuSigMediationRequest muSigMediationRequest = new MuSigMediationRequest(tradeId,
-                contract,
-                userProfileService.findUserProfile(myIdentity.getId()).orElseThrow(),
-                userProfileService.findUserProfile(peer.getNetworkId().getId()).orElseThrow(),
+        UserProfile requester = userProfileService.findUserProfile(myIdentity.getId()).orElseThrow();
+        UserProfile peerUserProfile = userProfileService.findUserProfile(peer.getNetworkId().getId()).orElseThrow();
+        MuSigMediationRequest muSigMediationRequest = ChatMessagePruning.createWithMaybePrunedMessages(
                 new ArrayList<>(channel.getChatMessages()),
-                mediatorNetworkId);
+                tradeId,
+                chatMessages -> new MuSigMediationRequest(tradeId,
+                        contract,
+                        requester,
+                        peerUserProfile,
+                        chatMessages,
+                        mediatorNetworkId));
         networkService.confidentialSend(muSigMediationRequest,
                 mediatorNetworkId,
                 myIdentity.getNetworkIdWithKeyPair());
@@ -141,14 +147,18 @@ public class MuSigTraderMediationService {
                                            Identity myIdentity,
                                            UserProfile mediator,
                                            MuSigContract contract) {
-        MuSigDisputeCaseDataMessage message = new MuSigDisputeCaseDataMessage(
-                tradeId,
-                userProfileService.findUserProfile(myIdentity.getId()).orElseThrow(),
-                ContractService.getContractHash(contract),
+        UserProfile senderUserProfile = userProfileService.findUserProfile(myIdentity.getId()).orElseThrow();
+        byte[] contractHash = ContractService.getContractHash(contract);
+        MuSigDisputeCaseDataMessage message = ChatMessagePruning.createWithMaybePrunedMessages(
                 muSigOpenTradeChannelService.findChannelByTradeId(tradeId)
                         .map(channel -> new ArrayList<>(channel.getChatMessages()))
-                        .orElseGet(ArrayList::new)
-        );
+                        .orElseGet(ArrayList::new),
+                tradeId,
+                chatMessages -> new MuSigDisputeCaseDataMessage(
+                        tradeId,
+                        senderUserProfile,
+                        contractHash,
+                        chatMessages));
         networkService.confidentialSend(message,
                 mediator.getNetworkId(),
                 myIdentity.getNetworkIdWithKeyPair());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of large chat messages in dispute and mediation processes; messages are now automatically pruned to comply with size constraints.
  * Enhanced error reporting when message payloads exceed size limits with a dedicated exception mechanism.

* **Refactor**
  * Centralized chat message pruning logic across dispute and mediation services for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->