### PR TITLE
feature/http_request_service_support_post_request

### DIFF
--- a/bonded-roles/src/main/java/bisq/bonded_roles/explorer/ExplorerService.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/explorer/ExplorerService.java
@@ -22,6 +22,7 @@ import bisq.common.json.JsonMapperProvider;
 import bisq.common.network.TransportType;
 import bisq.common.threading.ExecutorFactory;
 import bisq.network.NetworkService;
+import bisq.network.http.HttpRequest;
 import bisq.network.http.HttpRequestService;
 import bisq.network.http.HttpRequestServiceConfig;
 import bisq.network.http.HttpRequestUrlProvider;
@@ -59,17 +60,17 @@ public class ExplorerService extends HttpRequestService<ExplorerService.RequestD
     }
 
     @Override
-    protected String getParam(HttpRequestUrlProvider provider, RequestData requestData) {
+    protected HttpRequest buildRequest(HttpRequestUrlProvider provider, RequestData requestData) {
         if (provider instanceof Provider explorerServiceProvider) {
             String apiPath = explorerServiceProvider.getApiPath();
             if (requestData instanceof TxRequestData txRequestData) {
                 String txPath = explorerServiceProvider.getTxPath();
                 String txId = txRequestData.getTxId();
-                return apiPath + "/" + txPath + "/" + txId;
+                return HttpRequest.get(apiPath + "/" + txPath + "/" + txId);
             } else if (requestData instanceof AddressRequestData addressRequestData) {
                 String addressPath = explorerServiceProvider.getAddressPath();
                 String address = addressRequestData.getAddress();
-                return apiPath + "/" + addressPath + "/" + address;
+                return HttpRequest.get(apiPath + "/" + addressPath + "/" + address);
             } else {
                 throw new IllegalArgumentException("requestData of unsupported type. requestData = " + requestData);
             }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/market_price/MarketPriceRequestService.java
@@ -27,6 +27,7 @@ import bisq.common.threading.ExecutorFactory;
 import bisq.common.timer.Scheduler;
 import bisq.common.util.MathUtils;
 import bisq.network.NetworkService;
+import bisq.network.http.HttpRequest;
 import bisq.network.http.HttpRequestService;
 import bisq.network.http.HttpRequestServiceConfig;
 import bisq.network.http.HttpRequestUrlProvider;
@@ -130,8 +131,8 @@ public class MarketPriceRequestService extends HttpRequestService<Void, Map<Mark
     }
 
     @Override
-    protected String getParam(HttpRequestUrlProvider provider, Void requestData) {
-        return provider.getApiPath();
+    protected HttpRequest buildRequest(HttpRequestUrlProvider provider, Void requestData) {
+        return HttpRequest.get(provider.getApiPath());
     }
 
     Map<Market, MarketPrice> loadStaticDevMarketPrice() {

--- a/bonded-roles/src/main/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClient.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClient.java
@@ -21,21 +21,18 @@ import bisq.common.data.Pair;
 import bisq.common.json.JsonMapperProvider;
 import bisq.common.threading.ExecutorFactory;
 import bisq.network.NetworkService;
-import bisq.network.http.BaseHttpClient;
+import bisq.network.http.HttpRequest;
 import bisq.network.http.HttpRequestService;
 import bisq.network.http.HttpRequestServiceConfig;
 import bisq.network.http.HttpRequestUrlProvider;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 
 @Slf4j
-public class MobileNotificationRelayClient extends HttpRequestService<MobileNotificationRelayClient.RequestData, String> {
+public class MobileNotificationRelayClient extends HttpRequestService<MobileNotificationRelayClient.RequestData, Boolean> {
 
     private static ExecutorService getExecutorService() {
         return ExecutorFactory.newCachedThreadPool(MobileNotificationRelayClient.class.getSimpleName(),
@@ -51,65 +48,52 @@ public class MobileNotificationRelayClient extends HttpRequestService<MobileNoti
     }
 
     @Override
-    protected String parseResult(String json) {
-        return json;
+    protected Boolean parseResult(String json) {
+        // The relay v1 endpoint signals success with a 2xx response — anything
+        // non-2xx surfaces as HttpException upstream, never reaches this method.
+        // TODO: if the relay starts returning structured JSON (e.g.
+        // {"success": false, "reason": "..."} with a 200), parse it here so we
+        // don't silently report success on a logical failure.
+        // Logged at DEBUG: relay responses are small acks today, but future
+        // relay versions may include diagnostic data referencing tokens or
+        // operator details — keep INFO output free of raw response bodies.
+        log.debug("Relay v1 response: {}", json);
+        return true;
     }
 
     @Override
-    protected String getParam(HttpRequestUrlProvider provider, RequestData requestData) {
-        String params = provider.getApiPath() + "?" +
-                "isAndroid=" + requestData.isAndroid() +
-                "&token=" + requestData.getDeviceToken() +
-                "&msg=" + requestData.getEncryptedMessage();
-        if (requestData.isMutableContent()) {
-            params += "&mutableContent=true";
-        }
-        return params;
+    protected HttpRequest buildRequest(HttpRequestUrlProvider provider, RequestData requestData) {
+        // POST /v1/{platform}/device/{token} with JSON body containing the
+        // Base64-encoded encrypted payload. Avoids the hex-encoding round-trip
+        // of the legacy GET /relay endpoint which corrupts binary ciphertext.
+        String platformPath = requestData.isAndroid() ? "/v1/fcm/device/" : "/v1/apns/device/";
+        String path = platformPath + requestData.deviceToken();
+        // Device tokens are an installation identifier — redact from logs.
+        String logPath = platformPath + "<redacted>";
+        String body = buildJsonBody(requestData.encryptedMessage(), true, requestData.mutableContent());
+        // Push delivery is best-effort and 5xx from FCM/APNS is typically
+        // transient. We accept at-least-once semantics: a rare duplicate
+        // banner is preferable to a silent drop. Note: neither FCM
+        // collapse_key nor APNS apns-collapse-id / apns-id dedupes
+        // already-delivered notifications — they only collapse while the
+        // device is offline.
+        return HttpRequest.post(path,
+                logPath,
+                body,
+                new Pair<>("Content-Type", "application/json"),
+                true);
     }
 
     /**
-     * Sends a push notification via the relay's v1 POST endpoint.
-     * Uses POST /v1/apns/device/{token} or /v1/fcm/device/{token} with a JSON body
-     * containing the Base64-encoded encrypted payload. This avoids the hex encoding
-     * round-trip of the legacy GET /relay endpoint which corrupts binary ciphertext.
+     * Sends a push notification via the relay's v1 POST endpoint, using the
+     * full {@link HttpRequestService} pipeline (provider failover, retry,
+     * timeout, lifecycle).
      */
     public CompletableFuture<Boolean> sendToRelayServer(boolean isAndroid,
                                                         String deviceToken,
                                                         String encryptedBase64,
                                                         boolean mutableContent) {
-        if (noProviderAvailable) {
-            return CompletableFuture.failedFuture(new RuntimeException("No relay provider available"));
-        }
-
-        HttpRequestUrlProvider provider = selectedProvider.get();
-        if (provider == null) {
-            return CompletableFuture.failedFuture(new RuntimeException("No relay provider selected"));
-        }
-
-        String platformPath = isAndroid ? "/v1/fcm/device/" : "/v1/apns/device/";
-        String baseUrl = provider.getBaseUrl().replaceAll("/+$", "");
-        String fullUrl = baseUrl + platformPath + deviceToken;
-        String jsonBody = buildJsonBody(encryptedBase64, true, mutableContent);
-
-        return CompletableFuture.supplyAsync(() -> {
-            BaseHttpClient client = networkService.getHttpClient(
-                    fullUrl, userAgent, provider.getTransportType());
-            try {
-                log.info("Sending push notification via POST to {}", provider.getBaseUrl() + platformPath + "...");
-                String response = client.post(jsonBody,
-                        Optional.of(new Pair<>("Content-Type", "application/json")));
-                log.info("Relay v1 response: {}", response);
-                return true;
-            } catch (Exception e) {
-                throw new CompletionException(e);
-            } finally {
-                try {
-                    client.shutdown();
-                } catch (Exception e) {
-                    log.warn("Failed to shut down HTTP client", e);
-                }
-            }
-        }, executorService);
+        return request(new RequestData(isAndroid, deviceToken, encryptedBase64, mutableContent));
     }
 
     static String buildJsonBody(String encryptedBase64, boolean isUrgent, boolean isMutableContent) {
@@ -123,19 +107,9 @@ public class MobileNotificationRelayClient extends HttpRequestService<MobileNoti
         }
     }
 
-    @Getter
-    public static class RequestData {
-        private final boolean isAndroid;
-        private final String deviceToken;
-        private final String encryptedMessage;
-        private final boolean mutableContent;
-
-        public RequestData(boolean isAndroid, String deviceToken, String encryptedMessage, boolean mutableContent) {
-            this.isAndroid = isAndroid;
-            this.deviceToken = deviceToken;
-            this.encryptedMessage = encryptedMessage;
-            this.mutableContent = mutableContent;
-        }
+    public record RequestData(boolean isAndroid,
+                              String deviceToken,
+                              String encryptedMessage,
+                              boolean mutableContent) {
     }
-
 }

--- a/bonded-roles/src/test/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClientTest.java
+++ b/bonded-roles/src/test/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClientTest.java
@@ -17,15 +17,38 @@
 
 package bisq.bonded_roles.mobile_notification_relay;
 
+import bisq.common.network.TransportType;
+import bisq.network.NetworkService;
+import bisq.network.http.HttpRequest;
+import bisq.network.http.HttpRequestServiceConfig;
+import bisq.network.http.HttpRequestUrlProvider;
+import bisq.network.http.utils.HttpMethod;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MobileNotificationRelayClientTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final List<TestableRelayClient> openedClients = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        // Each newClient() spins up an executor inside the parent service.
+        // Without explicit shutdown the threads linger, which adds up across
+        // CI runs.
+        openedClients.forEach(c -> c.shutdown().join());
+        openedClients.clear();
+    }
 
     @Test
     void buildJsonBody_withAllFields() throws Exception {
@@ -65,5 +88,102 @@ class MobileNotificationRelayClientTest {
 
         JsonNode node = objectMapper.readTree(json);
         assertThat(node.get("encrypted").asText()).isEqualTo(base64);
+    }
+
+    @Test
+    void buildRequest_androidTargetsFcmPath() throws Exception {
+        TestableRelayClient client = newClient();
+
+        HttpRequest req = client.publicBuildRequest(stubProvider(),
+                new MobileNotificationRelayClient.RequestData(true, "tok-123", "ZW5jcnlwdGVk", false));
+
+        assertThat(req.method()).isEqualTo(HttpMethod.POST);
+        assertThat(req.path()).isEqualTo("/v1/fcm/device/tok-123");
+        assertThat(req.body()).isPresent();
+        JsonNode body = objectMapper.readTree(req.body().orElseThrow());
+        assertThat(body.get("encrypted").asText()).isEqualTo("ZW5jcnlwdGVk");
+        assertThat(body.get("isMutableContent").asBoolean()).isFalse();
+        assertThat(req.header()).isPresent();
+        assertThat(req.header().orElseThrow().getFirst()).isEqualTo("Content-Type");
+        assertThat(req.header().orElseThrow().getSecond()).isEqualTo("application/json");
+    }
+
+    @Test
+    void buildRequest_iosTargetsApnsPath() throws Exception {
+        TestableRelayClient client = newClient();
+
+        HttpRequest req = client.publicBuildRequest(stubProvider(),
+                new MobileNotificationRelayClient.RequestData(false, "ios-tok", "Ym9keQ==", true));
+
+        assertThat(req.path()).isEqualTo("/v1/apns/device/ios-tok");
+        JsonNode body = objectMapper.readTree(req.body().orElseThrow());
+        assertThat(body.get("isMutableContent").asBoolean()).isTrue();
+    }
+
+    @Test
+    void buildRequest_redactsDeviceTokenFromLogPath() {
+        TestableRelayClient client = newClient();
+
+        HttpRequest req = client.publicBuildRequest(stubProvider(),
+                new MobileNotificationRelayClient.RequestData(true, "secret-token-abc", "x", false));
+
+        assertThat(req.path())
+                .as("real path carries the token over the wire")
+                .endsWith("secret-token-abc");
+        assertThat(req.logPath())
+                .as("logPath must not contain the device token")
+                .doesNotContain("secret-token-abc")
+                .isEqualTo("/v1/fcm/device/<redacted>");
+    }
+
+    @Test
+    void buildRequest_optsIntoServerErrorRetry() {
+        TestableRelayClient client = newClient();
+
+        HttpRequest req = client.publicBuildRequest(stubProvider(),
+                new MobileNotificationRelayClient.RequestData(true, "tok", "x", false));
+
+        // Push delivery is best-effort and 5xx from FCM/APNS is typically transient,
+        // so we opt into at-least-once semantics: a rare duplicate banner beats a silent drop.
+        assertThat(req.retryOnServerError()).isTrue();
+    }
+
+    @Test
+    void parseResult_reportsSuccess_whenAnyBodyReceived() {
+        TestableRelayClient client = newClient();
+
+        assertThat(client.publicParseResult("any-body")).isTrue();
+        assertThat(client.publicParseResult("")).isTrue();
+    }
+
+    private TestableRelayClient newClient() {
+        NetworkService networkService = mock(NetworkService.class);
+        when(networkService.getSupportedTransportTypes()).thenReturn(Set.of(TransportType.CLEAR));
+        HttpRequestServiceConfig conf = new HttpRequestServiceConfig(60L,
+                Set.of(stubProvider()),
+                Set.of());
+        TestableRelayClient client = new TestableRelayClient(conf, networkService);
+        openedClients.add(client);
+        return client;
+    }
+
+    private static HttpRequestUrlProvider stubProvider() {
+        return new HttpRequestUrlProvider("https://relay.example/", "operator", "/legacy", TransportType.CLEAR);
+    }
+
+    /** Exposes the protected hooks so unit tests don't need network IO. */
+    private static final class TestableRelayClient extends MobileNotificationRelayClient {
+        TestableRelayClient(HttpRequestServiceConfig conf, NetworkService networkService) {
+            super(conf, networkService);
+        }
+
+        HttpRequest publicBuildRequest(HttpRequestUrlProvider provider,
+                                       MobileNotificationRelayClient.RequestData data) {
+            return buildRequest(provider, data);
+        }
+
+        Boolean publicParseResult(String json) {
+            return parseResult(json);
+        }
     }
 }

--- a/network/network/src/main/java/bisq/network/NetworkService.java
+++ b/network/network/src/main/java/bisq/network/NetworkService.java
@@ -444,11 +444,17 @@ public class NetworkService extends RateLimitedPersistenceClient<NetworkServiceS
     // Getters
     /* --------------------------------------------------------------------- */
 
-    public BaseHttpClient getHttpClient(String url, String userAgent, TransportType transportType) {
+    /**
+     * @param logUrl Redacted variant of {@code url} used for log statements
+     *               and exception messages emitted by the returned client.
+     *               Pass the same value as {@code url} when nothing in the
+     *               URL is sensitive.
+     */
+    public BaseHttpClient getHttpClient(String url, String logUrl, String userAgent, TransportType transportType) {
         if (Objects.requireNonNull(transportType) == TransportType.TOR) {
-            return httpClientsByTransport.getHttpClient(url, userAgent, transportType, serviceNodesByTransport.getSocksProxy(transportType), socks5ProxyAddress);
+            return httpClientsByTransport.getHttpClient(url, logUrl, userAgent, transportType, serviceNodesByTransport.getSocksProxy(transportType), socks5ProxyAddress);
         }
-        return httpClientsByTransport.getHttpClient(url, userAgent, transportType);
+        return httpClientsByTransport.getHttpClient(url, logUrl, userAgent, transportType);
     }
 
     public Map<TransportType, Observable<Node.State>> getDefaultNodeStateByTransportType() {

--- a/network/network/src/main/java/bisq/network/http/BaseHttpClient.java
+++ b/network/network/src/main/java/bisq/network/http/BaseHttpClient.java
@@ -31,13 +31,22 @@ import java.util.Optional;
 @Slf4j
 public abstract class BaseHttpClient implements HttpClient {
     public final String baseUrl;
+    /**
+     * Redacted variant of {@link #baseUrl} used for log statements and
+     * exception messages. Subclasses MUST log {@code logBaseUrl} (never
+     * {@code baseUrl}) so that secrets in the path — device tokens, session
+     * ids, etc. — never reach log files. When the caller has nothing to
+     * redact, it can pass the same value as {@code baseUrl}.
+     */
+    public final String logBaseUrl;
     public final String userAgent;
     protected final String uid;
 
     public boolean hasPendingRequest;
 
-    public BaseHttpClient(String baseUrl, String userAgent) {
+    public BaseHttpClient(String baseUrl, String logBaseUrl, String userAgent) {
         this.baseUrl = baseUrl;
+        this.logBaseUrl = logBaseUrl;
         this.userAgent = userAgent;
 
         uid = StringUtils.createUid();
@@ -61,6 +70,11 @@ public abstract class BaseHttpClient implements HttpClient {
     @Override
     public String getBaseUrl() {
         return baseUrl;
+    }
+
+    @Override
+    public String getLogBaseUrl() {
+        return logBaseUrl;
     }
 
     protected abstract String doRequest(String param,

--- a/network/network/src/main/java/bisq/network/http/ClearNetHttpClient.java
+++ b/network/network/src/main/java/bisq/network/http/ClearNetHttpClient.java
@@ -43,12 +43,12 @@ public class ClearNetHttpClient extends BaseHttpClient {
     private Proxy proxy;
     private HttpURLConnection connection;
 
-    public ClearNetHttpClient(String baseUrl, String userAgent) {
-        super(baseUrl, userAgent);
+    public ClearNetHttpClient(String baseUrl, String logBaseUrl, String userAgent) {
+        super(baseUrl, logBaseUrl, userAgent);
     }
 
-    public ClearNetHttpClient(String baseUrl, String userAgent, Proxy proxy) {
-        super(baseUrl, userAgent);
+    public ClearNetHttpClient(String baseUrl, String logBaseUrl, String userAgent, Proxy proxy) {
+        super(baseUrl, logBaseUrl, userAgent);
         this.proxy = proxy;
     }
 
@@ -91,7 +91,15 @@ public class ClearNetHttpClient extends BaseHttpClient {
         hasPendingRequest = true;
 
         long ts = System.currentTimeMillis();
-        log.debug("requestWithoutProxy: URL={}, param={}, httpMethod={}", baseUrl, param, httpMethod);
+        // Safe-to-log representation of param. For POST 'param' is the request
+        // body (may contain plaintext payload), so log only its size. For GET
+        // 'param' is the path; current callers do not embed secrets there, but
+        // sensitive GET paths should be redacted by the caller via the
+        // descriptor's logPath before reaching this layer.
+        String safeParam = httpMethod == HttpMethod.POST
+                ? "[body " + param.length() + " chars]"
+                : param;
+        log.debug("requestWithoutProxy: URL={}, param={}, httpMethod={}", logBaseUrl, safeParam, httpMethod);
         String spec = httpMethod == HttpMethod.GET ? baseUrl + "/" + param : baseUrl;
         try {
             URL url = new URI(spec).toURL();
@@ -117,8 +125,8 @@ public class ClearNetHttpClient extends BaseHttpClient {
             if (isSuccess(responseCode)) {
                 String response = inputStreamToString(connection.getInputStream());
                 log.debug("Response from {} with param {} took {} ms. Data size:{}, response: {}",
-                        baseUrl,
-                        param,
+                        logBaseUrl,
+                        safeParam,
                         System.currentTimeMillis() - ts,
                         StringUtils.fromBytes(response.getBytes().length),
                         StringUtils.truncate(response, 100));
@@ -132,20 +140,23 @@ public class ClearNetHttpClient extends BaseHttpClient {
                 log.info("Received errorMsg '{}' with responseCode {} from {}. Response took: {} ms. param: {}",
                         error,
                         responseCode,
-                        baseUrl,
+                        logBaseUrl,
                         System.currentTimeMillis() - ts,
-                        param);
+                        safeParam);
                 throw new HttpException(error, responseCode);
             } else {
                 log.info("Response with responseCode {} from {}. Response took: {} ms. param: {}",
                         responseCode,
-                        baseUrl,
+                        logBaseUrl,
                         System.currentTimeMillis() - ts,
-                        param);
+                        safeParam);
                 throw new HttpException("Request failed", responseCode);
             }
         } catch (Exception e) {
-            String message = "Request to " + baseUrl + "/" + param + " failed with error: " + ExceptionUtil.getRootCauseMessage(e);
+            // For POST the URL is already complete in logBaseUrl; for GET param
+            // is the path so we append it to form the full request target.
+            String requestTarget = httpMethod == HttpMethod.GET ? logBaseUrl + "/" + param : logBaseUrl;
+            String message = "Request to " + requestTarget + " failed with error: " + ExceptionUtil.getRootCauseMessage(e);
             throw new IOException(message, e);
         } finally {
             try {

--- a/network/network/src/main/java/bisq/network/http/HttpClient.java
+++ b/network/network/src/main/java/bisq/network/http/HttpClient.java
@@ -30,6 +30,14 @@ public interface HttpClient {
 
     String getBaseUrl();
 
+    /**
+     * Variant of {@link #getBaseUrl()} that is safe to write to log files.
+     * Identical to {@link #getBaseUrl()} unless the caller built the client
+     * with a redacted form (e.g. when the path embeds device tokens, session
+     * ids, or other sensitive segments).
+     */
+    String getLogBaseUrl();
+
     boolean hasPendingRequest();
 
     CompletableFuture<Boolean> shutdown();

--- a/network/network/src/main/java/bisq/network/http/HttpClientsByTransport.java
+++ b/network/network/src/main/java/bisq/network/http/HttpClientsByTransport.java
@@ -44,13 +44,21 @@ public class HttpClientsByTransport {
         this.configByTransportType = configByTransportType;
     }
 
+    /**
+     * @param logUrl Redacted variant of {@code url} used for log statements
+     *               and exception messages. Pass the same value as {@code url}
+     *               when there is nothing to redact (e.g. provider URL with no
+     *               sensitive path segments).
+     */
     public BaseHttpClient getHttpClient(String url,
+                                        String logUrl,
                                         String userAgent,
                                         TransportType transportType) {
-        return getHttpClient(url, userAgent, transportType, Optional.empty(), Optional.empty());
+        return getHttpClient(url, logUrl, userAgent, transportType, Optional.empty(), Optional.empty());
     }
 
     public BaseHttpClient getHttpClient(String url,
+                                        String logUrl,
                                         String userAgent,
                                         TransportType transportType,
                                         Optional<Socks5Proxy> socksProxy,
@@ -61,17 +69,17 @@ public class HttpClientsByTransport {
                         .map(Socks5ProxyProvider::new)
                         .orElseGet(() -> socksProxy.map(Socks5ProxyProvider::new)
                                 .orElseThrow(() -> new RuntimeException("No socks5ProxyAddress provided and no Tor socksProxy available.")));
-                yield new TorHttpClient(url, userAgent, socks5ProxyProvider);
+                yield new TorHttpClient(url, logUrl, userAgent, socks5ProxyProvider);
             }
 
             case I2P -> {
                 I2PTransportService.Config config = (I2PTransportService.Config) configByTransportType.get(TransportType.I2P);
                 Address address = new ClearnetAddress(config.getHttpProxyHost(), config.getHttpProxyPort());
                 Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(address.getHost(), address.getPort()));
-                yield new ClearNetHttpClient(url, userAgent, proxy);
+                yield new ClearNetHttpClient(url, logUrl, userAgent, proxy);
             }
 
-            case CLEAR -> new ClearNetHttpClient(url, userAgent);
+            case CLEAR -> new ClearNetHttpClient(url, logUrl, userAgent);
         };
     }
 }

--- a/network/network/src/main/java/bisq/network/http/HttpRequest.java
+++ b/network/network/src/main/java/bisq/network/http/HttpRequest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.http;
+
+import bisq.common.data.Pair;
+import bisq.network.http.utils.HttpMethod;
+
+import java.util.Optional;
+
+/**
+ * Descriptor for a single HTTP request issued by {@link HttpRequestService}.
+ * Subclasses build one of these in {@code buildRequest(provider, requestData)}.
+ *
+ * <p>Use the static factories {@link #get(String)}, {@link #get(String, Pair)},
+ * {@link #post(String, String, Pair, boolean)}, or
+ * {@link #post(String, String, String, Pair, boolean)} rather than the canonical
+ * constructor — they encode the safe defaults for each method.
+ *
+ * <p><b>{@code logPath}</b> — the path string the framework writes to INFO logs.
+ * If your real {@code path} embeds secrets or PII (device tokens, session
+ * identifiers, user-provided opaque data), pass a redacted {@code logPath} via
+ * {@link #post(String, String, String, Pair, boolean)} (the structural portion
+ * of the path, e.g. {@code "/v1/fcm/device/<redacted>"}). The framework never
+ * inspects {@code logPath} — it is purely for log hygiene.
+ */
+public record HttpRequest(HttpMethod method,
+                          String path,
+                          String logPath,
+                          Optional<String> body,
+                          Optional<Pair<String, String>> header,
+                          boolean retryOnServerError) {
+
+    public static HttpRequest get(String path) {
+        return new HttpRequest(HttpMethod.GET, path, path, Optional.empty(), Optional.empty(), true);
+    }
+
+    public static HttpRequest get(String path, Pair<String, String> header) {
+        return new HttpRequest(HttpMethod.GET, path, path, Optional.empty(), Optional.of(header), true);
+    }
+
+    /**
+     * Build a POST descriptor. The {@code path} is also used in INFO logs;
+     * use {@link #post(String, String, String, Pair, boolean)} when the path
+     * contains secrets or PII.
+     *
+     * @param retryOnServerError set to {@code true} ONLY when the server-side
+     *                           operation is idempotent (duplicate execution
+     *                           is harmless). See {@link HttpRequestService}
+     *                           class JavaDoc for the full retry matrix.
+     */
+    public static HttpRequest post(String path,
+                                   String body,
+                                   Pair<String, String> header,
+                                   boolean retryOnServerError) {
+        return new HttpRequest(HttpMethod.POST, path, path, Optional.of(body), Optional.of(header), retryOnServerError);
+    }
+
+    /**
+     * Build a POST descriptor with a redacted log path. Use this overload when
+     * the real {@code path} contains a device token, session id, or any value
+     * that should not appear in INFO logs.
+     */
+    public static HttpRequest post(String path,
+                                   String logPath,
+                                   String body,
+                                   Pair<String, String> header,
+                                   boolean retryOnServerError) {
+        return new HttpRequest(HttpMethod.POST, path, logPath, Optional.of(body), Optional.of(header), retryOnServerError);
+    }
+}

--- a/network/network/src/main/java/bisq/network/http/HttpRequestService.java
+++ b/network/network/src/main/java/bisq/network/http/HttpRequestService.java
@@ -19,7 +19,6 @@ package bisq.network.http;
 
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
-import bisq.common.data.Pair;
 import bisq.common.network.TransportType;
 import bisq.common.observable.Observable;
 import bisq.common.threading.ExecutorFactory;
@@ -28,6 +27,7 @@ import bisq.common.util.ExceptionUtil;
 import bisq.i18n.Res;
 import bisq.network.NetworkService;
 import bisq.network.http.utils.HttpException;
+import bisq.network.http.utils.HttpMethod;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +45,52 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+/**
+ * Base service that issues HTTP requests with provider failover, retry, timeout,
+ * and HTTP-client lifecycle management. Subclasses implement {@link #buildRequest}
+ * to describe a single call (method, path, optional body, optional header) and
+ * {@link #parseResult} to decode the response body.
+ *
+ * <h2>Request methods</h2>
+ * Both {@code GET} and {@code POST} are supported. The active method is encoded
+ * in the {@link HttpRequest} descriptor returned by {@link #buildRequest}.
+ *
+ * <h2>Retry &amp; failover semantics</h2>
+ * The pipeline classifies failures into two buckets:
+ * <ul>
+ *   <li><b>Transport-level</b> — the request was never delivered to the server
+ *       (busy client, connection refused, DNS, TLS handshake, etc.). These are
+ *       <i>always</i> retried against the next provider, for both GET and POST.
+ *       Retrying is safe because the server has no state to duplicate.</li>
+ *   <li><b>Server-level</b> — the server received the request and either
+ *       responded with 5xx / 408 / 429, or the framework timeout fired after the
+ *       request was sent. For these, retry is gated on the request method:
+ *       <ul>
+ *         <li>{@code GET}: always retried (idempotent by HTTP contract).</li>
+ *         <li>{@code POST}: retried only when the descriptor declares
+ *             {@code retryOnServerError = true}. The default is {@code false}.
+ *             Set it to {@code true} only when the server-side operation is
+ *             idempotent — a 5xx response means the side effect <i>may</i>
+ *             have been applied, and a blind retry would duplicate it.</li>
+ *       </ul></li>
+ * </ul>
+ *
+ * <p>4xx responses (other than 408 and 429) bypass retry entirely and are
+ * propagated to the caller as a {@link CompletionException} — these indicate
+ * caller error, not transient failure.
+ *
+ * <h2>Lifecycle</h2>
+ * The service owns the underlying {@link BaseHttpClient}: callers do not need
+ * to manage {@code shutdown()} per request. {@link #shutdown()} drains the
+ * executor and the most recently used client.
+ *
+ * <h2>Logging</h2>
+ * The framework logs the resolved request URL at INFO. It uses the descriptor's
+ * {@link HttpRequest#logPath()} (defaults to {@code path}) for the path portion.
+ * Subclasses whose paths contain device tokens, session identifiers, or other
+ * sensitive values MUST pass a redacted {@code logPath} when constructing the
+ * descriptor — the framework will not redact {@code path} on its own.
+ */
 @Slf4j
 public abstract class HttpRequestService<T, R> implements Service {
     private static class ProviderFailoverException extends RuntimeException {
@@ -121,7 +167,11 @@ public abstract class HttpRequestService<T, R> implements Service {
 
     protected abstract R parseResult(String json) throws JsonProcessingException;
 
-    protected abstract String getParam(HttpRequestUrlProvider provider, T requestData);
+    /**
+     * Describe the HTTP call for the given provider and request data.
+     * See {@link HttpRequest#get(String)} / {@link HttpRequest#post(String, String, bisq.common.data.Pair, boolean)}.
+     */
+    protected abstract HttpRequest buildRequest(HttpRequestUrlProvider provider, T requestData);
 
     public String getSelectedProviderBaseUrl() {
         return Optional.ofNullable(selectedProvider.get()).map(HttpRequestUrlProvider::getBaseUrl).orElse(Res.get("data.na"));
@@ -152,7 +202,7 @@ public abstract class HttpRequestService<T, R> implements Service {
                 });
     }
 
-    private CompletableFuture<R> request(T request, AtomicInteger recursionDepth) {
+    private CompletableFuture<R> request(T requestData, AtomicInteger recursionDepth) {
         if (noProviderAvailable) {
             return CompletableFuture.failedFuture(new RuntimeException("No provider available"));
         }
@@ -161,11 +211,30 @@ public abstract class HttpRequestService<T, R> implements Service {
         }
 
         HttpRequestUrlProvider providerForThisRequest = checkNotNull(selectedProvider.get(), "Selected provider must not be null.");
+        HttpRequest httpRequest = buildRequest(providerForThisRequest, requestData);
         try {
             return CompletableFuture.supplyAsync(() -> {
-                        BaseHttpClient client = networkService.getHttpClient(providerForThisRequest.getBaseUrl(), userAgent, providerForThisRequest.getTransportType());
+                        // For POST the path is appended to the http-client baseUrl when the
+                        // client is constructed, since BaseHttpClient.post(param, header) treats
+                        // 'param' as the body. TODO: refactor BaseHttpClient.post to accept
+                        // (path, body, header) so the API is symmetric with get(path, header).
+                        String clientBaseUrl = httpRequest.method() == HttpMethod.POST
+                                ? joinUrl(providerForThisRequest.getBaseUrl(), httpRequest.path())
+                                : providerForThisRequest.getBaseUrl();
+                        // Redacted variant for logs/exceptions — keeps device tokens, session
+                        // ids etc. out of log files even when the underlying HTTP client logs
+                        // its baseUrl on errors. Equals clientBaseUrl when nothing is redacted.
+                        String clientLogBaseUrl = httpRequest.method() == HttpMethod.POST
+                                ? loggableUrl(providerForThisRequest, httpRequest)
+                                : providerForThisRequest.getBaseUrl();
+                        BaseHttpClient client = networkService.getHttpClient(
+                                clientBaseUrl,
+                                clientLogBaseUrl,
+                                userAgent,
+                                providerForThisRequest.getTransportType());
 
                         if (client.hasPendingRequest()) {
+                            // Transport-level: request was never sent. Always safe to retry.
                             boolean shouldRetry = shouldRetry(recursionDepth, providerForThisRequest, false);
                             if (shouldRetry) {
                                 log.warn("Client had a pending request. We retry the request with new provider {}", selectedProvider.get().getBaseUrl());
@@ -180,16 +249,17 @@ public abstract class HttpRequestService<T, R> implements Service {
                         httpClient = Optional.of(client);
 
                         long requestedAt = System.currentTimeMillis();
-                        String param = getParam(providerForThisRequest, request);
                         try {
-                            log.info("Start Http request to {}", client.getBaseUrl() + "/" + param);
+                            log.info("Start Http {} request to {}",
+                                    httpRequest.method(),
+                                    loggableUrl(providerForThisRequest, httpRequest));
 
-                            String json = client.get(param, Optional.of(new Pair<>("User-Agent", userAgent)));
+                            String json = execute(client, httpRequest);
 
                             long receivedAt = System.currentTimeMillis();
                             String sinceLastResponse = timeSinceLastResponse == 0 ? "" : "Time since last response: " + (receivedAt - timeSinceLastResponse) / 1000 + " sec";
                             log.info("Received response from {} after {} ms. {}",
-                                    client.getBaseUrl(), receivedAt - requestedAt, sinceLastResponse);
+                                    client.getLogBaseUrl(), receivedAt - requestedAt, sinceLastResponse);
                             timeSinceLastResponse = receivedAt;
 
                             R result = parseResult(json);
@@ -207,15 +277,23 @@ public abstract class HttpRequestService<T, R> implements Service {
 
                             Throwable rootCause = ExceptionUtil.getRootCause(e);
                             log.warn("Encountered exception during HTTP request to provider {}", providerForThisRequest.getBaseUrl(), rootCause);
+
+                            // Distinguish HTTP responses from transport-level failures.
+                            // HTTP responses came back from the server (4xx/5xx) — server-level.
+                            // Anything else (IOException at connect/DNS/TLS, etc.) means the
+                            // request was never delivered — transport-level, always retriable.
                             if (rootCause instanceof HttpException httpException) {
                                 int responseCode = httpException.getResponseCode();
-                                // If not server error we pass the error to the client
-                                // 408 (Request Timeout) and 429 (Too Many Requests) are usually transient
-                                // and should rotate to another provider.
                                 if (responseCode < 500 && responseCode != 408 && responseCode != 429) {
+                                    // 4xx (other than 408 / 429): caller error, never retry.
+                                    throw new CompletionException(e);
+                                }
+                                // 5xx / 408 / 429: retry only if the method allows it.
+                                if (!isServerErrorRetryAllowed(httpRequest)) {
                                     throw new CompletionException(e);
                                 }
                             }
+                            // else: transport-level failure → fall through to retry path.
 
                             boolean shouldRetry = shouldRetry(recursionDepth, providerForThisRequest, true);
                             if (shouldRetry) {
@@ -230,6 +308,11 @@ public abstract class HttpRequestService<T, R> implements Service {
                         if (ExceptionUtil.getRootCause(throwable) instanceof TimeoutException) {
                             log.warn("Request to provider {} timed out after {} seconds",
                                     providerForThisRequest.getBaseUrl(), conf.getTimeoutInSeconds());
+                            if (!isServerErrorRetryAllowed(httpRequest)) {
+                                return CompletableFuture.failedFuture(new RuntimeException(
+                                        "Timeout. Non-idempotent POST — not retrying. Provider=" + providerForThisRequest.getBaseUrl(),
+                                        throwable));
+                            }
                             boolean shouldRetry = shouldRetry(recursionDepth, providerForThisRequest, true);
                             Exception exception = shouldRetry
                                     ? new ProviderFailoverException("Timeout. Retrying with next provider " + selectedProvider.get().getBaseUrl(), recursionDepth)
@@ -242,6 +325,43 @@ public abstract class HttpRequestService<T, R> implements Service {
             log.error("Executor rejected request task.", e);
             return CompletableFuture.failedFuture(e);
         }
+    }
+
+    private String execute(BaseHttpClient client, HttpRequest httpRequest) throws Exception {
+        return switch (httpRequest.method()) {
+            case GET -> client.get(httpRequest.path(), httpRequest.header());
+            case POST -> client.post(
+                    httpRequest.body().orElseThrow(() -> new IllegalStateException("POST request must carry a body")),
+                    httpRequest.header());
+        };
+    }
+
+    /**
+     * Server-level retry is allowed for GET (idempotent by HTTP contract) or for
+     * POST when the descriptor opts in via {@code retryOnServerError = true}.
+     */
+    static boolean isServerErrorRetryAllowed(HttpRequest httpRequest) {
+        return httpRequest.method() == HttpMethod.GET || httpRequest.retryOnServerError();
+    }
+
+    /**
+     * Joins {@code base} and {@code path} into a single URL with exactly one
+     * separating slash, regardless of trailing slash on {@code base} or leading
+     * slash on {@code path}.
+     */
+    static String joinUrl(String base, String path) {
+        String trimmedBase = base.replaceAll("/+$", "");
+        String normalizedPath = path.startsWith("/") ? path : "/" + path;
+        return trimmedBase + normalizedPath;
+    }
+
+    /**
+     * Build the URL string used for INFO logging. Honours the descriptor's
+     * {@link HttpRequest#logPath()} so subclasses can redact sensitive path
+     * segments (device tokens, session ids, etc.) before they hit log files.
+     */
+    static String loggableUrl(HttpRequestUrlProvider provider, HttpRequest httpRequest) {
+        return joinUrl(provider.getBaseUrl(), httpRequest.logPath());
     }
 
     private boolean shouldRetry(AtomicInteger recursionDepth,

--- a/network/network/src/main/java/bisq/network/http/ReferenceTimeService.java
+++ b/network/network/src/main/java/bisq/network/http/ReferenceTimeService.java
@@ -114,8 +114,8 @@ public class ReferenceTimeService extends HttpRequestService<Void, Long> {
     }
 
     @Override
-    protected String getParam(HttpRequestUrlProvider provider, Void requestData) {
-        return provider.getApiPath();
+    protected HttpRequest buildRequest(HttpRequestUrlProvider provider, Void requestData) {
+        return HttpRequest.get(provider.getApiPath());
     }
 
     public CompletableFuture<Long> request() {

--- a/network/network/src/main/java/bisq/network/http/TorHttpClient.java
+++ b/network/network/src/main/java/bisq/network/http/TorHttpClient.java
@@ -51,8 +51,8 @@ public class TorHttpClient extends BaseHttpClient {
     private CloseableHttpClient closeableHttpClient;
     private volatile boolean shutdownStarted;
 
-    public TorHttpClient(String baseUrl, String userAgent, Socks5ProxyProvider socks5ProxyProvider) {
-        super(baseUrl, userAgent);
+    public TorHttpClient(String baseUrl, String logBaseUrl, String userAgent, Socks5ProxyProvider socks5ProxyProvider) {
+        super(baseUrl, logBaseUrl, userAgent);
         this.socks5ProxyProvider = socks5ProxyProvider;
     }
 
@@ -97,7 +97,15 @@ public class TorHttpClient extends BaseHttpClient {
         Socks5Proxy socks5Proxy = socks5ProxyProvider.getSocks5Proxy();
 
         long ts = System.currentTimeMillis();
-        log.debug("doRequestWithProxy: baseUrl={}, param={}, httpMethod={}", baseUrl, param, httpMethod);
+        // Safe-to-log representation of param. For POST 'param' is the request
+        // body (may contain plaintext payload), so log only its size. For GET
+        // 'param' is the path; current callers do not embed secrets there, but
+        // sensitive GET paths should be redacted by the caller via the
+        // descriptor's logPath before reaching this layer.
+        String safeParam = httpMethod == HttpMethod.POST
+                ? "[body " + param.length() + " chars]"
+                : param;
+        log.debug("doRequestWithProxy: baseUrl={}, param={}, httpMethod={}", logBaseUrl, safeParam, httpMethod);
 
         InetSocketAddress socksAddress = new InetSocketAddress(socks5Proxy.getInetAddress(), socks5Proxy.getPort());
         // Use this to test with system-wide Tor proxy, or change port for another proxy.
@@ -142,23 +150,23 @@ public class TorHttpClient extends BaseHttpClient {
                 int statusCode = response.getCode();
                 if (isSuccess(statusCode)) {
                     log.debug("Response from {} took {} ms. Data size:{}, response: {}, param: {}",
-                            baseUrl,
+                            logBaseUrl,
                             System.currentTimeMillis() - ts,
                             StringUtils.fromBytes(responseString.getBytes().length),
                             StringUtils.truncate(response, 2000),
-                            param);
+                            safeParam);
                     return responseString;
                 }
                 log.info("Received errorMsg '{}' with statusCode {} from {}. Response took: {} ms. param: {}",
                         responseString,
                         statusCode,
-                        baseUrl,
+                        logBaseUrl,
                         System.currentTimeMillis() - ts,
-                        param);
+                        safeParam);
                 throw new RuntimeException(responseString);
             });
         } catch (Throwable t) {
-            String message = "Error at doRequestWithProxy with url " + baseUrl + " and param " + param +
+            String message = "Error at doRequestWithProxy with url " + logBaseUrl + " and param " + safeParam +
                     ". Throwable=" + t.getMessage();
             throw new IOException(message, t);
         } finally {

--- a/network/network/src/test/java/bisq/network/http/HttpRequestTest.java
+++ b/network/network/src/test/java/bisq/network/http/HttpRequestTest.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.http;
+
+import bisq.common.data.Pair;
+import bisq.network.http.utils.HttpMethod;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpRequestTest {
+
+    @Test
+    void get_factoryProducesGetWithRetryOnServerErrorTrue() {
+        HttpRequest req = HttpRequest.get("api/path");
+
+        assertThat(req.method()).isEqualTo(HttpMethod.GET);
+        assertThat(req.path()).isEqualTo("api/path");
+        assertThat(req.logPath()).isEqualTo("api/path");
+        assertThat(req.body()).isEmpty();
+        assertThat(req.header()).isEmpty();
+        assertThat(req.retryOnServerError()).isTrue();
+    }
+
+    @Test
+    void get_withHeader_attachesHeader() {
+        Pair<String, String> header = new Pair<>("X-Foo", "bar");
+
+        HttpRequest req = HttpRequest.get("api/path", header);
+
+        assertThat(req.method()).isEqualTo(HttpMethod.GET);
+        assertThat(req.header()).contains(header);
+    }
+
+    @Test
+    void post_factoryRequiresExplicitRetryFlagAndBody() {
+        Pair<String, String> header = new Pair<>("Content-Type", "application/json");
+
+        HttpRequest req = HttpRequest.post("v1/push", "{\"a\":1}", header, false);
+
+        assertThat(req.method()).isEqualTo(HttpMethod.POST);
+        assertThat(req.path()).isEqualTo("v1/push");
+        assertThat(req.logPath())
+                .as("logPath defaults to path when caller does not redact")
+                .isEqualTo("v1/push");
+        assertThat(req.body()).contains("{\"a\":1}");
+        assertThat(req.header()).contains(header);
+        assertThat(req.retryOnServerError()).isFalse();
+    }
+
+    @Test
+    void post_canOptIntoServerErrorRetryForIdempotentEndpoints() {
+        HttpRequest req = HttpRequest.post("v1/push", "body",
+                new Pair<>("Content-Type", "application/json"), true);
+
+        assertThat(req.retryOnServerError()).isTrue();
+    }
+
+    @Test
+    void post_withLogPath_usesRedactedPathInLogPathField() {
+        HttpRequest req = HttpRequest.post("/v1/fcm/device/abc-123",
+                "/v1/fcm/device/<redacted>",
+                "body",
+                new Pair<>("Content-Type", "application/json"),
+                true);
+
+        assertThat(req.path())
+                .as("real path still carries the token for the wire")
+                .isEqualTo("/v1/fcm/device/abc-123");
+        assertThat(req.logPath())
+                .as("logPath does not leak the token")
+                .isEqualTo("/v1/fcm/device/<redacted>")
+                .doesNotContain("abc-123");
+    }
+
+    @Test
+    void serverErrorRetry_alwaysAllowedForGet() {
+        HttpRequest get = HttpRequest.get("path");
+
+        assertThat(HttpRequestService.isServerErrorRetryAllowed(get)).isTrue();
+    }
+
+    @Test
+    void serverErrorRetry_postOptOutDeniesRetry() {
+        HttpRequest post = HttpRequest.post("path", "body",
+                new Pair<>("Content-Type", "application/json"), false);
+
+        assertThat(HttpRequestService.isServerErrorRetryAllowed(post)).isFalse();
+    }
+
+    @Test
+    void serverErrorRetry_postOptInAllowsRetry() {
+        HttpRequest post = HttpRequest.post("path", "body",
+                new Pair<>("Content-Type", "application/json"), true);
+
+        assertThat(HttpRequestService.isServerErrorRetryAllowed(post)).isTrue();
+    }
+
+    @Test
+    void joinUrl_collapsesDoubleSlashWhenBaseEndsWithSlashAndPathStartsWithSlash() {
+        assertThat(HttpRequestService.joinUrl("https://relay.example/", "/v1/x"))
+                .isEqualTo("https://relay.example/v1/x");
+    }
+
+    @Test
+    void joinUrl_addsSlashWhenBaseHasNoTrailingSlashAndPathHasNoLeadingSlash() {
+        assertThat(HttpRequestService.joinUrl("https://relay.example", "v1/x"))
+                .isEqualTo("https://relay.example/v1/x");
+    }
+
+    @Test
+    void joinUrl_normalizesMultipleTrailingSlashesOnBase() {
+        assertThat(HttpRequestService.joinUrl("https://relay.example///", "/v1/x"))
+                .isEqualTo("https://relay.example/v1/x");
+    }
+}


### PR DESCRIPTION
 - resolves #4690 
 - Introduce HttpRequest descriptor (method, path, body, header, retr…yOnServerError, logPath) and replace the GET-only getParam() hook with buildRequest().
 - MobileNotificationRelayClient now uses the full pipeline (failover, retry, timeout, lifecycle) instead of bypassing it.       - POST 5xx retry is opt-in per descriptor; transport-level failures (connect/DNS/TLS) always retry regardless of method, restoring failover for unreachable providers. URL joining is normalized and device tokens are redacted from INFO logs via descriptor logPath.
 - added unit tests
 - tested with mobile relay circuit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized HTTP request descriptor for standardized request handling and redacted logging.

* **Refactor**
  * Unified request building and execution across services with clearer retry behavior for safe vs. non-safe operations.
  * Mobile notification relay rewritten to use the unified HTTP pipeline and simplified public API, improving reliability.

* **Tests**
  * Added tests for request construction, redaction, retry policies, and notification relay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->