### PR TITLE
Chore/sync unsync commits from mobile active branch

### DIFF
--- a/account/src/main/java/bisq/account/payment_method/TradeDuration.java
+++ b/account/src/main/java/bisq/account/payment_method/TradeDuration.java
@@ -34,14 +34,20 @@ public enum TradeDuration {
     DAYS_8(8, TimeUnit.DAYS);
 
     private final long time;
-    private final String displayString;
+    private final long duration;
+    private final TimeUnit unit;
 
     TradeDuration(long duration, TimeUnit unit) {
+        this.duration = duration;
+        this.unit = unit;
         this.time = unit.toMillis(duration);
+    }
+
+    public String getDisplayString() {
         if (unit == TimeUnit.HOURS) {
-            this.displayString = Res.get("temporal.hour.*", (int) duration);
+            return Res.get("temporal.hour.*", (int) duration);
         } else {
-            this.displayString = Res.get("temporal.day.*", (int) duration);
+            return Res.get("temporal.day.*", (int) duration);
         }
     }
 }

--- a/account/src/test/java/bisq/account/payment_method/TradeDurationTest.java
+++ b/account/src/test/java/bisq/account/payment_method/TradeDurationTest.java
@@ -1,0 +1,20 @@
+package bisq.account.payment_method;
+
+import bisq.i18n.Res;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class TradeDurationTest {
+
+    @Test
+    void displayStringUsesActiveLanguageTag() {
+        Res.setAndApplyLanguageTag("en");
+        String english = TradeDuration.DAYS_4.getDisplayString();
+
+        Res.setAndApplyLanguageTag("es");
+        String spanish = TradeDuration.DAYS_4.getDisplayString();
+
+        assertNotEquals(english, spanish);
+    }
+}

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("bisq:bonded-roles")
     implementation("bisq:settings")
     implementation("bisq:burningman")
+    implementation("bisq:mu-sig")
     implementation("bisq:user")
     implementation("bisq:chat")
     implementation("bisq:support")

--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -38,7 +38,7 @@ import bisq.api.rest_api.endpoints.devices.DevicesRestApi;
 import bisq.api.rest_api.endpoints.explorer.ExplorerRestApi;
 import bisq.api.rest_api.endpoints.market_price.MarketPriceRestApi;
 import bisq.api.rest_api.endpoints.offers.OfferbookRestApi;
-import bisq.api.rest_api.endpoints.payment_accounts.FiatPaymentAccountsRestApi;
+import bisq.api.rest_api.endpoints.payment_accounts.UserDefinedPaymentAccountsRestApi;
 import bisq.api.rest_api.endpoints.payment_accounts.PaymentAccountsRestApi;
 import bisq.api.rest_api.endpoints.reputation.ReputationRestApi;
 import bisq.api.rest_api.endpoints.settings.SettingsRestApi;
@@ -172,7 +172,7 @@ public class ApiService implements Service {
         AlertNotificationsRestApi alertNotificationsRestApi = new AlertNotificationsRestApi(alertNotificationsService);
         TradeRestrictingAlertRestApi tradeRestrictingAlertRestApi = new TradeRestrictingAlertRestApi(bondedRolesService.getAlertService());
         PaymentAccountsRestApi paymentAccountsRestApi = new PaymentAccountsRestApi(accountService);
-        FiatPaymentAccountsRestApi fiatPaymentAccountsRestApi = new FiatPaymentAccountsRestApi(accountService);
+        UserDefinedPaymentAccountsRestApi userDefinedPaymentAccountsRestApi = new UserDefinedPaymentAccountsRestApi(accountService);
         UserProfileRestApi userProfileRestApi = new UserProfileRestApi(
                 userService.getUserProfileService(),
                 supportedService.getModerationRequestService(),
@@ -199,7 +199,7 @@ public class ApiService implements Service {
                     tradeRestrictingAlertRestApi,
                     explorerRestApi,
                     paymentAccountsRestApi,
-                    fiatPaymentAccountsRestApi,
+                    userDefinedPaymentAccountsRestApi,
                     reputationRestApi,
                     userProfileRestApi,
                     devicesRestApi);

--- a/api/src/main/java/bisq/api/dto/DtoMappings.java
+++ b/api/src/main/java/bisq/api/dto/DtoMappings.java
@@ -17,23 +17,13 @@
 
 package bisq.api.dto;
 
-import bisq.account.accounts.Account;
-import bisq.account.accounts.AccountOrigin;
-import bisq.account.accounts.fiat.UserDefinedFiatAccount;
-import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
-import bisq.account.timestamp.KeyType;
 import bisq.account.payment_method.BitcoinPaymentMethod;
-import bisq.account.payment_method.PaymentMethod;
-import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.account.payment_method.BitcoinPaymentMethodSpec;
 import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.account.payment_method.PaymentMethodSpecUtil;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
 import bisq.account.protocol_type.TradeProtocolType;
-import bisq.api.dto.account.UserDefinedFiatAccountDto;
-import bisq.api.dto.account.UserDefinedFiatAccountPayloadDto;
-import bisq.api.dto.account.fiat.FiatAccountDto;
 import bisq.api.dto.account.protocol_type.TradeProtocolTypeDto;
 import bisq.api.dto.chat.ChatChannelDomainDto;
 import bisq.api.dto.chat.ChatMessageTypeDto;
@@ -1128,108 +1118,6 @@ public class DtoMappings {
                     settingsService.getNumDaysAfterRedactingTradeData().get(),
                     settingsService.getUseAnimations().get()
             );
-        }
-    }
-
-    // paymentaccount
-    public static class UserDefinedFiatAccountMapping {
-        // toBisq2Model method not implemented, as we get accountName, accountData props for account creation calls
-
-        public static UserDefinedFiatAccountDto fromBisq2Model(UserDefinedFiatAccount account) {
-            return new UserDefinedFiatAccountDto(
-                    account.getAccountName(),
-                    new UserDefinedFiatAccountPayloadDto(
-                            account.getAccountPayload().getAccountData()
-                    )
-            );
-        }
-    }
-
-    /**
-     * Mapping for polymorphic fiat accounts.
-     * Supports all FiatPaymentRail types through the FiatAccountDto interface.
-     */
-    public static class FiatAccountMapping {
-        public static final int MIN_ACCOUNT_NAME_LENGTH = 2;
-        public static final int MAX_ACCOUNT_NAME_LENGTH = 20;
-
-        /**
-         * Convert a FiatAccountDto to a Bisq2 Account model.
-         * Currently only supports CUSTOM (UserDefinedFiatAccount).
-         * TODO: Add support for other fiat account types (SEPA, Revolut, Zelle, etc.)
-         */
-        public static Account<? extends PaymentMethod<?>, ?> toBisq2Model(FiatAccountDto dto) {
-            if (dto == null) {
-                throw new IllegalArgumentException("FiatAccountDto cannot be null");
-            }
-
-            String accountName = dto.accountName();
-            if (accountName == null || accountName.trim().isEmpty()) {
-                throw new IllegalArgumentException("Account name is required");
-            }
-            String trimmedName = accountName.trim();
-            if (trimmedName.length() < MIN_ACCOUNT_NAME_LENGTH || trimmedName.length() > MAX_ACCOUNT_NAME_LENGTH) {
-                throw new IllegalArgumentException(
-                        "Account name must be between " + MIN_ACCOUNT_NAME_LENGTH +
-                                " and " + MAX_ACCOUNT_NAME_LENGTH + " characters");
-            }
-
-            return switch (dto.paymentRail()) {
-                case CUSTOM -> {
-                    if (dto instanceof bisq.api.dto.account.fiat.UserDefinedFiatAccountDto userDefinedDto) {
-                        bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto payloadDto = userDefinedDto.accountPayload();
-                        UserDefinedFiatAccountPayload payload = new UserDefinedFiatAccountPayload(
-                                bisq.common.util.StringUtils.createUid(),
-                                payloadDto.accountData()
-                        );
-                        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-                        KeyType keyType = KeyType.EC;
-                        yield new UserDefinedFiatAccount(
-                                bisq.common.util.StringUtils.createUid(),
-                                System.currentTimeMillis(),
-                                userDefinedDto.accountName(),
-                                payload,
-                                keyPair,
-                                keyType,
-                                AccountOrigin.BISQ2_NEW
-                        );
-                    }
-                    throw new IllegalArgumentException("Expected UserDefinedFiatAccountDto for CUSTOM payment rail");
-                }
-                // TODO: Add cases for other payment rails when implemented:
-                // case SEPA -> { ... }
-                // case REVOLUT -> { ... }
-                // case ZELLE -> { ... }
-                default -> throw new IllegalArgumentException("Unsupported payment rail: " + dto.paymentRail());
-            };
-        }
-
-        /**
-         * Convert a Bisq2 Account model to a FiatAccountDto.
-         * Currently only supports UserDefinedFiatAccount.
-         * TODO: Add support for other fiat account types (SEPA, Revolut, Zelle, etc.)
-         */
-        public static FiatAccountDto fromBisq2Model(Account<? extends PaymentMethod<?>, ?> account) {
-            if (account == null) {
-                throw new IllegalArgumentException("Account cannot be null");
-            }
-
-            if (account instanceof UserDefinedFiatAccount userDefinedAccount) {
-                return new bisq.api.dto.account.fiat.UserDefinedFiatAccountDto(
-                        userDefinedAccount.getAccountName(),
-                        FiatPaymentRail.CUSTOM,
-                        new bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto(
-                                userDefinedAccount.getAccountPayload().getAccountData()
-                        )
-                );
-            }
-
-            // TODO: Add conversions for other account types when implemented:
-            // if (account instanceof SepaAccount sepaAccount) { ... }
-            // if (account instanceof RevolutAccount revolutAccount) { ... }
-            // if (account instanceof ZelleAccount zelleAccount) { ... }
-
-            throw new IllegalArgumentException("Unsupported account type: " + account.getClass().getSimpleName());
         }
     }
 

--- a/api/src/main/java/bisq/api/dto/account/AccountMetadataDto.java
+++ b/api/src/main/java/bisq/api/dto/account/AccountMetadataDto.java
@@ -1,0 +1,6 @@
+package bisq.api.dto.account;
+
+public record AccountMetadataDto(String creationDate,
+                                 String tradeLimitInfo,
+                                 String tradeDuration) {
+}

--- a/api/src/main/java/bisq/api/dto/account/PaymentAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/PaymentAccountDto.java
@@ -15,9 +15,12 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.api.dto.account.fiat;
+package bisq.api.dto.account;
 
-import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.api.dto.account.crypto.MoneroAccountDto;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountDto;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
+import bisq.api.dto.account.fiat.ZelleAccountDto;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -35,19 +38,20 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     visible = true
 )
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = UserDefinedFiatAccountDto.class, name = "CUSTOM")
-    // TODO: Add more when implemented:
-    // @JsonSubTypes.Type(value = SepaAccountDto.class, name = "SEPA"),
-    // @JsonSubTypes.Type(value = RevolutAccountDto.class, name = "REVOLUT"),
-    // @JsonSubTypes.Type(value = ZelleAccountDto.class, name = "ZELLE"),
+        // Fiat
+        @JsonSubTypes.Type(value = UserDefinedFiatAccountDto.class, name = "CUSTOM"),
+        @JsonSubTypes.Type(value = ZelleAccountDto.class, name = "ZELLE"),
+        // Crypto
+        @JsonSubTypes.Type(value = MoneroAccountDto.class, name = "MONERO"),
+        @JsonSubTypes.Type(value = OtherCryptoAssetAccountDto.class, name = "OTHER_CRYPTO_ASSET")
 })
-public sealed interface FiatAccountDto 
-        permits UserDefinedFiatAccountDto {
-    // TODO: Add more permitted types when implemented:
-    // permits UserDefinedFiatAccountDto, SepaAccountDto, RevolutAccountDto, ZelleAccountDto, etc.
-    
+public interface PaymentAccountDto {
     String accountName();
-    FiatPaymentRail paymentRail();
-    FiatAccountPayloadDto accountPayload();
+
+    PaymentRailDto paymentRail();
+
+    PaymentAccountPayloadDto accountPayload();
+
+    Long creationDate();
 }
 

--- a/api/src/main/java/bisq/api/dto/account/PaymentAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/PaymentAccountDto.java
@@ -52,6 +52,10 @@ public interface PaymentAccountDto {
 
     PaymentAccountPayloadDto accountPayload();
 
-    Long creationDate();
+    String creationDate();
+
+    String tradeLimitInfo();
+
+    String tradeDuration();
 }
 

--- a/api/src/main/java/bisq/api/dto/account/PaymentAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/PaymentAccountPayloadDto.java
@@ -15,15 +15,12 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.api.dto.account.fiat;
+package bisq.api.dto.account;
 
 /**
- * Base interface for all fiat payment account payload DTOs.
- * Each fiat payment rail type (CUSTOM, SEPA, REVOLUT, etc.) will have its own implementation.
+ * Base interface for all payment account payload DTOs.
+ * Both fiat and crypto payment account types provide their own concrete payload implementations.
  */
-public sealed interface FiatAccountPayloadDto 
-        permits UserDefinedFiatAccountPayloadDto {
-    // TODO: Add more permitted types when implemented:
-    // permits UserDefinedFiatAccountPayloadDto, SepaAccountPayloadDto, RevolutAccountPayloadDto, etc.
+public interface PaymentAccountPayloadDto {
 }
 

--- a/api/src/main/java/bisq/api/dto/account/PaymentRailDto.java
+++ b/api/src/main/java/bisq/api/dto/account/PaymentRailDto.java
@@ -1,0 +1,4 @@
+package bisq.api.dto.account;
+
+public interface PaymentRailDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountDto.java
@@ -1,7 +1,0 @@
-package bisq.api.dto.account;
-
-public record UserDefinedFiatAccountDto(
-    String accountName,
-    UserDefinedFiatAccountPayloadDto accountPayload
-) { }
-

--- a/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/UserDefinedFiatAccountPayloadDto.java
@@ -1,5 +1,0 @@
-package bisq.api.dto.account;
-
-public record UserDefinedFiatAccountPayloadDto(
-        String accountData
-) { }

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoAssetAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoAssetAccountPayloadDto.java
@@ -5,7 +5,7 @@ import bisq.api.dto.account.PaymentAccountPayloadDto;
 import java.util.Optional;
 
 public interface CryptoAssetAccountPayloadDto extends PaymentAccountPayloadDto {
-    String currencyCode();
+    String currencyName();
 
     String address();
 

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoAssetAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoAssetAccountPayloadDto.java
@@ -1,0 +1,21 @@
+package bisq.api.dto.account.crypto;
+
+import bisq.api.dto.account.PaymentAccountPayloadDto;
+
+import java.util.Optional;
+
+public interface CryptoAssetAccountPayloadDto extends PaymentAccountPayloadDto {
+    String currencyCode();
+
+    String address();
+
+    boolean isInstant();
+
+    Optional<Boolean> isAutoConf();
+
+    Optional<Integer> autoConfNumConfirmations();
+
+    Optional<Long> autoConfMaxTradeAmount();
+
+    Optional<String> autoConfExplorerUrls();
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentMethodDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentMethodDto.java
@@ -3,6 +3,7 @@ package bisq.api.dto.account.crypto;
 public record CryptoPaymentMethodDto(
         String code,
         String name,
-        String category
+        String category,
+        boolean supportAutoConf
 ) {
 }

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentMethodDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentMethodDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.crypto;
+
+public record CryptoPaymentMethodDto(
+        String code,
+        String name,
+        String category
+) {
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentRailDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/CryptoPaymentRailDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.crypto;
+
+import bisq.api.dto.account.PaymentRailDto;
+
+public enum CryptoPaymentRailDto implements PaymentRailDto {
+    MONERO,
+    OTHER_CRYPTO_ASSET
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountDto.java
@@ -6,7 +6,9 @@ public record MoneroAccountDto(
         String accountName,
         CryptoPaymentRailDto paymentRail,
         MoneroAccountPayloadDto accountPayload,
-        Long creationDate
+        String creationDate,
+        String tradeLimitInfo,
+        String tradeDuration
 ) implements PaymentAccountDto {
 
     public MoneroAccountDto {
@@ -17,7 +19,9 @@ public record MoneroAccountDto(
 
     public MoneroAccountDto(String accountName,
                             MoneroAccountPayloadDto accountPayload,
-                            Long creationDate) {
-        this(accountName, CryptoPaymentRailDto.MONERO, accountPayload, creationDate);
+                            String creationDate,
+                            String tradeLimitInfo,
+                            String tradeDuration) {
+        this(accountName, CryptoPaymentRailDto.MONERO, accountPayload, creationDate, tradeLimitInfo, tradeDuration);
     }
 }

--- a/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountDto.java
@@ -1,0 +1,23 @@
+package bisq.api.dto.account.crypto;
+
+import bisq.api.dto.account.PaymentAccountDto;
+
+public record MoneroAccountDto(
+        String accountName,
+        CryptoPaymentRailDto paymentRail,
+        MoneroAccountPayloadDto accountPayload,
+        Long creationDate
+) implements PaymentAccountDto {
+
+    public MoneroAccountDto {
+        if (paymentRail != CryptoPaymentRailDto.MONERO) {
+            throw new IllegalArgumentException("paymentRail must be MONERO");
+        }
+    }
+
+    public MoneroAccountDto(String accountName,
+                            MoneroAccountPayloadDto accountPayload,
+                            Long creationDate) {
+        this(accountName, CryptoPaymentRailDto.MONERO, accountPayload, creationDate);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountPayloadDto.java
@@ -3,7 +3,6 @@ package bisq.api.dto.account.crypto;
 import java.util.Optional;
 
 public record MoneroAccountPayloadDto(
-        String currencyCode,
         String address,
         boolean isInstant,
         Optional<Boolean> isAutoConf,
@@ -15,6 +14,7 @@ public record MoneroAccountPayloadDto(
         Optional<String> privateViewKey,
         Optional<String> subAddress,
         Optional<Integer> accountIndex,
-        Optional<Integer> initialSubAddressIndex
+        Optional<Integer> initialSubAddressIndex,
+        String currencyName
 ) implements CryptoAssetAccountPayloadDto {
 }

--- a/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/MoneroAccountPayloadDto.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.account.crypto;
+
+import java.util.Optional;
+
+public record MoneroAccountPayloadDto(
+        String currencyCode,
+        String address,
+        boolean isInstant,
+        Optional<Boolean> isAutoConf,
+        Optional<Integer> autoConfNumConfirmations,
+        Optional<Long> autoConfMaxTradeAmount,
+        Optional<String> autoConfExplorerUrls,
+        boolean useSubAddresses,
+        Optional<String> mainAddress,
+        Optional<String> privateViewKey,
+        Optional<String> subAddress,
+        Optional<Integer> accountIndex,
+        Optional<Integer> initialSubAddressIndex
+) implements CryptoAssetAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountDto.java
@@ -6,7 +6,9 @@ public record OtherCryptoAssetAccountDto(
         String accountName,
         CryptoPaymentRailDto paymentRail,
         OtherCryptoAssetAccountPayloadDto accountPayload,
-        Long creationDate
+        String creationDate,
+        String tradeLimitInfo,
+        String tradeDuration
 ) implements PaymentAccountDto {
 
     public OtherCryptoAssetAccountDto {
@@ -17,7 +19,9 @@ public record OtherCryptoAssetAccountDto(
 
     public OtherCryptoAssetAccountDto(String accountName,
                                       OtherCryptoAssetAccountPayloadDto accountPayload,
-                                      Long creationDate) {
-        this(accountName, CryptoPaymentRailDto.OTHER_CRYPTO_ASSET, accountPayload, creationDate);
+                                      String creationDate,
+                                      String tradeLimitInfo,
+                                      String tradeDuration) {
+        this(accountName, CryptoPaymentRailDto.OTHER_CRYPTO_ASSET, accountPayload, creationDate, tradeLimitInfo, tradeDuration);
     }
 }

--- a/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountDto.java
@@ -1,0 +1,23 @@
+package bisq.api.dto.account.crypto;
+
+import bisq.api.dto.account.PaymentAccountDto;
+
+public record OtherCryptoAssetAccountDto(
+        String accountName,
+        CryptoPaymentRailDto paymentRail,
+        OtherCryptoAssetAccountPayloadDto accountPayload,
+        Long creationDate
+) implements PaymentAccountDto {
+
+    public OtherCryptoAssetAccountDto {
+        if (paymentRail != CryptoPaymentRailDto.OTHER_CRYPTO_ASSET) {
+            throw new IllegalArgumentException("paymentRail must be OTHER_CRYPTO_ASSET");
+        }
+    }
+
+    public OtherCryptoAssetAccountDto(String accountName,
+                                      OtherCryptoAssetAccountPayloadDto accountPayload,
+                                      Long creationDate) {
+        this(accountName, CryptoPaymentRailDto.OTHER_CRYPTO_ASSET, accountPayload, creationDate);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountPayloadDto.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 public record OtherCryptoAssetAccountPayloadDto(
         String currencyCode,
+        String currencyName,
         String address,
         boolean isInstant,
         Optional<Boolean> isAutoConf,

--- a/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/crypto/OtherCryptoAssetAccountPayloadDto.java
@@ -1,0 +1,14 @@
+package bisq.api.dto.account.crypto;
+
+import java.util.Optional;
+
+public record OtherCryptoAssetAccountPayloadDto(
+        String currencyCode,
+        String address,
+        boolean isInstant,
+        Optional<Boolean> isAutoConf,
+        Optional<Integer> autoConfNumConfirmations,
+        Optional<Long> autoConfMaxTradeAmount,
+        Optional<String> autoConfExplorerUrls
+) implements CryptoAssetAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentAccountPayloadDto.java
@@ -1,0 +1,13 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.api.dto.account.PaymentAccountPayloadDto;
+
+public interface FiatPaymentAccountPayloadDto extends PaymentAccountPayloadDto {
+    FiatPaymentMethodChargebackRiskDto chargebackRisk();
+
+    String paymentMethodName();
+
+    String currency();
+
+    String country();
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodChargebackRiskDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodChargebackRiskDto.java
@@ -1,0 +1,8 @@
+package bisq.api.dto.account.fiat;
+
+public enum FiatPaymentMethodChargebackRiskDto {
+    VERY_LOW,
+    LOW,
+    MEDIUM,
+    MODERATE
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodDto.java
@@ -21,7 +21,6 @@ public record FiatPaymentMethodDto(
         FiatPaymentRailDto paymentRail,
         String name,
         String supportedCurrencyCodes,
-        String supportedNameAndCodes,
         String countryNames,
         FiatPaymentMethodChargebackRiskDto chargebackRisk
 ) {

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentMethodDto.java
@@ -17,10 +17,12 @@
 
 package bisq.api.dto.account.fiat;
 
-import bisq.api.dto.account.PaymentAccountPayloadDto;
-
-public record UserDefinedFiatAccountPayloadDto(
-        String accountData
-) implements PaymentAccountPayloadDto {
+public record FiatPaymentMethodDto(
+        FiatPaymentRailDto paymentRail,
+        String name,
+        String supportedCurrencyCodes,
+        String supportedNameAndCodes,
+        String countryNames,
+        FiatPaymentMethodChargebackRiskDto chargebackRisk
+) {
 }
-

--- a/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentRailDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/FiatPaymentRailDto.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ */
+
+package bisq.api.dto.account.fiat;
+
+import bisq.api.dto.account.PaymentRailDto;
+
+public enum FiatPaymentRailDto implements PaymentRailDto {
+    ACH_TRANSFER,
+    ADVANCED_CASH,
+    ALI_PAY,
+    AMAZON_GIFT_CARD,
+    BIZUM,
+    CASH_BY_MAIL,
+    CASH_DEPOSIT,
+    CUSTOM,
+    DOMESTIC_WIRE_TRANSFER,
+    F2F,
+    FASTER_PAYMENTS,
+    HAL_CASH,
+    IMPS,
+    INTERAC_E_TRANSFER,
+    MERCADO_PAGO,
+    MONESE,
+    MONEY_BEAM,
+    MONEY_GRAM,
+    NATIONAL_BANK,
+    NEFT,
+    PAY_ID,
+    PAYSERA,
+    PERFECT_MONEY,
+    PIN_4,
+    PIX,
+    PROMPT_PAY,
+    REVOLUT,
+    SAME_BANK,
+    SATISPAY,
+    SBP,
+    SEPA,
+    SEPA_INSTANT,
+    STRIKE,
+    SWIFT,
+    SWISH,
+    UPHOLD,
+    UPI,
+    US_POSTAL_MONEY_ORDER,
+    WECHAT_PAY,
+    WISE,
+    WISE_USD,
+    ZELLE
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountDto.java
@@ -17,11 +17,25 @@
 
 package bisq.api.dto.account.fiat;
 
-import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.api.dto.account.PaymentAccountDto;
 
 public record UserDefinedFiatAccountDto(
     String accountName,
-    FiatPaymentRail paymentRail,
-    UserDefinedFiatAccountPayloadDto accountPayload
-) implements FiatAccountDto { }
+    FiatPaymentRailDto paymentRail,
+    UserDefinedFiatAccountPayloadDto accountPayload,
+    Long creationDate
+) implements PaymentAccountDto {
+
+    public UserDefinedFiatAccountDto {
+        if (paymentRail != FiatPaymentRailDto.CUSTOM) {
+            throw new IllegalArgumentException("paymentRail must be CUSTOM");
+        }
+    }
+
+    public UserDefinedFiatAccountDto(String accountName,
+                                     UserDefinedFiatAccountPayloadDto accountPayload,
+                                     Long creationDate) {
+        this(accountName, FiatPaymentRailDto.CUSTOM, accountPayload, creationDate);
+    }
+}
 

--- a/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountDto.java
@@ -23,7 +23,9 @@ public record UserDefinedFiatAccountDto(
     String accountName,
     FiatPaymentRailDto paymentRail,
     UserDefinedFiatAccountPayloadDto accountPayload,
-    Long creationDate
+    String creationDate,
+    String tradeLimitInfo,
+    String tradeDuration
 ) implements PaymentAccountDto {
 
     public UserDefinedFiatAccountDto {
@@ -34,8 +36,10 @@ public record UserDefinedFiatAccountDto(
 
     public UserDefinedFiatAccountDto(String accountName,
                                      UserDefinedFiatAccountPayloadDto accountPayload,
-                                     Long creationDate) {
-        this(accountName, FiatPaymentRailDto.CUSTOM, accountPayload, creationDate);
+                                     String creationDate,
+                                     String tradeLimitInfo,
+                                     String tradeDuration) {
+        this(accountName, FiatPaymentRailDto.CUSTOM, accountPayload, creationDate, tradeLimitInfo, tradeDuration);
     }
 }
 

--- a/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/UserDefinedFiatAccountPayloadDto.java
@@ -17,10 +17,12 @@
 
 package bisq.api.dto.account.fiat;
 
-import bisq.api.dto.account.PaymentAccountPayloadDto;
-
 public record UserDefinedFiatAccountPayloadDto(
+        FiatPaymentMethodChargebackRiskDto chargebackRisk,
+        String currency,
+        String paymentMethodName,
+        String country,
         String accountData
-) implements PaymentAccountPayloadDto {
+) implements FiatPaymentAccountPayloadDto {
 }
 

--- a/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountDto.java
@@ -1,0 +1,23 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.api.dto.account.PaymentAccountDto;
+
+public record ZelleAccountDto(
+        String accountName,
+        FiatPaymentRailDto paymentRail,
+        ZelleAccountPayloadDto accountPayload,
+        Long creationDate
+) implements PaymentAccountDto {
+
+    public ZelleAccountDto {
+        if (paymentRail != FiatPaymentRailDto.ZELLE) {
+            throw new IllegalArgumentException("paymentRail must be ZELLE");
+        }
+    }
+
+    public ZelleAccountDto(String accountName,
+                           ZelleAccountPayloadDto accountPayload,
+                           Long creationDate) {
+        this(accountName, FiatPaymentRailDto.ZELLE, accountPayload, creationDate);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountDto.java
@@ -6,7 +6,9 @@ public record ZelleAccountDto(
         String accountName,
         FiatPaymentRailDto paymentRail,
         ZelleAccountPayloadDto accountPayload,
-        Long creationDate
+        String creationDate,
+        String tradeLimitInfo,
+        String tradeDuration
 ) implements PaymentAccountDto {
 
     public ZelleAccountDto {
@@ -17,7 +19,9 @@ public record ZelleAccountDto(
 
     public ZelleAccountDto(String accountName,
                            ZelleAccountPayloadDto accountPayload,
-                           Long creationDate) {
-        this(accountName, FiatPaymentRailDto.ZELLE, accountPayload, creationDate);
+                           String creationDate,
+                           String tradeLimitInfo,
+                           String tradeDuration) {
+        this(accountName, FiatPaymentRailDto.ZELLE, accountPayload, creationDate, tradeLimitInfo, tradeDuration);
     }
 }

--- a/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountPayloadDto.java
@@ -1,0 +1,9 @@
+package bisq.api.dto.account.fiat;
+
+import bisq.api.dto.account.PaymentAccountPayloadDto;
+
+public record ZelleAccountPayloadDto(
+        String holderName,
+        String emailOrMobileNr
+) implements PaymentAccountPayloadDto {
+}

--- a/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountPayloadDto.java
+++ b/api/src/main/java/bisq/api/dto/account/fiat/ZelleAccountPayloadDto.java
@@ -1,9 +1,11 @@
 package bisq.api.dto.account.fiat;
 
-import bisq.api.dto.account.PaymentAccountPayloadDto;
-
 public record ZelleAccountPayloadDto(
+        FiatPaymentMethodChargebackRiskDto chargebackRisk,
+        String paymentMethodName,
+        String currency,
+        String country,
         String holderName,
         String emailOrMobileNr
-) implements PaymentAccountPayloadDto {
+) implements FiatPaymentAccountPayloadDto {
 }

--- a/api/src/main/java/bisq/api/dto/mappings/account/PaymentAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/PaymentAccountDtoMapping.java
@@ -1,0 +1,96 @@
+package bisq.api.dto.mappings.account;
+
+import bisq.account.accounts.Account;
+import bisq.account.accounts.crypto.MoneroAccount;
+import bisq.account.accounts.crypto.OtherCryptoAssetAccount;
+import bisq.account.accounts.fiat.UserDefinedFiatAccount;
+import bisq.account.accounts.fiat.ZelleAccount;
+import bisq.account.payment_method.PaymentMethod;
+import bisq.api.dto.account.PaymentAccountDto;
+import bisq.api.dto.account.crypto.MoneroAccountDto;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountDto;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
+import bisq.api.dto.account.fiat.ZelleAccountDto;
+import bisq.api.dto.mappings.account.crypto.MoneroAccountDtoMapping;
+import bisq.api.dto.mappings.account.crypto.OtherCryptoAssetAccountDtoMapping;
+import bisq.api.dto.mappings.account.fiat.UserDefinedFiatAccountDtoMapping;
+import bisq.api.dto.mappings.account.fiat.ZelleAccountDtoMapping;
+
+import static bisq.api.dto.account.crypto.CryptoPaymentRailDto.MONERO;
+import static bisq.api.dto.account.crypto.CryptoPaymentRailDto.OTHER_CRYPTO_ASSET;
+import static bisq.api.dto.account.fiat.FiatPaymentRailDto.CUSTOM;
+import static bisq.api.dto.account.fiat.FiatPaymentRailDto.ZELLE;
+
+public class PaymentAccountDtoMapping {
+
+    public static Account<? extends PaymentMethod<?>, ?> toBisq2Model(PaymentAccountDto dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("PaymentAccountDto cannot be null");
+        }
+
+        return switch (dto.paymentRail()) {
+            // Fiat
+            case CUSTOM -> {
+                if (dto instanceof UserDefinedFiatAccountDto userDefinedDto) {
+                    yield UserDefinedFiatAccountDtoMapping.toBisq2Model(userDefinedDto);
+                }
+                throw new IllegalArgumentException("Expected UserDefinedFiatAccountDto for CUSTOM payment rail");
+            }
+            case ZELLE -> {
+                if (dto instanceof ZelleAccountDto zelleDto) {
+                    yield ZelleAccountDtoMapping.toBisq2Model(zelleDto);
+                }
+                throw new IllegalArgumentException("Expected ZelleAccountDto for ZELLE payment rail");
+            }
+            // Crypto
+            case MONERO -> {
+                if (dto instanceof MoneroAccountDto moneroDto) {
+                    yield MoneroAccountDtoMapping.toBisq2Model(moneroDto);
+                }
+                throw new IllegalArgumentException("Expected MoneroAccountDto for MONERO payment rail");
+            }
+            case OTHER_CRYPTO_ASSET -> {
+                if (dto instanceof OtherCryptoAssetAccountDto otherCryptoDto) {
+                    yield OtherCryptoAssetAccountDtoMapping.toBisq2Model(otherCryptoDto);
+                }
+                throw new IllegalArgumentException("Expected OtherCryptoAssetAccountDto for OTHER_CRYPTO_ASSET payment rail");
+            }
+            // TODO: Add cases for additional payment rails when implemented:
+            // case SEPA -> { ... }
+            // case REVOLUT -> { ... }
+            default -> throw new IllegalArgumentException("Unsupported payment rail: " + dto.paymentRail());
+        };
+    }
+
+    /**
+     * Convert a Bisq2 Account model to a PaymentAccountDto.
+     * Currently supports:
+     * - Fiat: UserDefinedFiatAccount, ZelleAccount
+     * - Crypto: MoneroAccount, OtherCryptoAssetAccount
+     * TODO: Add support for additional account types as they are implemented.
+     */
+    public static PaymentAccountDto fromBisq2Model(Account<? extends PaymentMethod<?>, ?> account) {
+        if (account == null) {
+            throw new IllegalArgumentException("Account cannot be null");
+        }
+
+        if (account instanceof UserDefinedFiatAccount userDefinedAccount) {
+            return UserDefinedFiatAccountDtoMapping.fromBisq2Model(userDefinedAccount);
+        }
+        if (account instanceof ZelleAccount zelleAccount) {
+            return ZelleAccountDtoMapping.fromBisq2Model(zelleAccount);
+        }
+        if (account instanceof MoneroAccount moneroAccount) {
+            return MoneroAccountDtoMapping.fromBisq2Model(moneroAccount);
+        }
+        if (account instanceof OtherCryptoAssetAccount otherCryptoAssetAccount) {
+            return OtherCryptoAssetAccountDtoMapping.fromBisq2Model(otherCryptoAssetAccount);
+        }
+
+        // TODO: Add conversions for other account types when implemented:
+        // if (account instanceof SepaAccount sepaAccount) { ... }
+        // if (account instanceof RevolutAccount revolutAccount) { ... }
+
+        throw new IllegalArgumentException("Unsupported account type: " + account.getClass().getSimpleName());
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/PaymentAccountKeyMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/PaymentAccountKeyMapping.java
@@ -1,0 +1,18 @@
+package bisq.api.dto.mappings.account;
+
+import bisq.account.timestamp.KeyType;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public final class PaymentAccountKeyMapping {
+    private PaymentAccountKeyMapping() {
+    }
+
+    public static KeyData createDefault() {
+        return new KeyData(KeyGeneration.generateDefaultEcKeyPair(), KeyType.EC);
+    }
+
+    public record KeyData(KeyPair keyPair, KeyType keyType) {
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/PaymentAccountMetadataDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/PaymentAccountMetadataDtoMapping.java
@@ -1,0 +1,19 @@
+package bisq.api.dto.mappings.account;
+
+import bisq.account.accounts.Account;
+import bisq.account.payment_method.PaymentMethod;
+import bisq.api.dto.account.AccountMetadataDto;
+import bisq.mu_sig.MuSigTradeAmountLimits;
+import bisq.presentation.formatters.DateFormatter;
+
+public final class PaymentAccountMetadataDtoMapping {
+    private PaymentAccountMetadataDtoMapping() {
+    }
+
+    public static AccountMetadataDto mapAccountMetadata(Account<? extends PaymentMethod<?>, ?> account) {
+        String tradeLimitInfo = MuSigTradeAmountLimits.getFormattedMaxTradeLimitInUsd(account.getPaymentMethod().getPaymentRail());
+        String creationDate = DateFormatter.formatDate(account.getCreationDate());
+        String tradeDuration = account.getPaymentMethod().getPaymentRail().getTradeDuration().getDisplayString();
+        return new AccountMetadataDto(creationDate, tradeLimitInfo, tradeDuration);
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/crypto/CryptoPaymentMethodDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/crypto/CryptoPaymentMethodDtoMapping.java
@@ -1,0 +1,14 @@
+package bisq.api.dto.mappings.account.crypto;
+
+import bisq.account.payment_method.crypto.CryptoPaymentMethod;
+import bisq.api.dto.account.crypto.CryptoPaymentMethodDto;
+
+public class CryptoPaymentMethodDtoMapping {
+    public static CryptoPaymentMethodDto fromBisq2Model(CryptoPaymentMethod paymentMethod) {
+        return new CryptoPaymentMethodDto(
+                paymentMethod.getCode(),
+                paymentMethod.getName(),
+                paymentMethod.getPaymentRail().name()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/crypto/CryptoPaymentMethodDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/crypto/CryptoPaymentMethodDtoMapping.java
@@ -2,13 +2,15 @@ package bisq.api.dto.mappings.account.crypto;
 
 import bisq.account.payment_method.crypto.CryptoPaymentMethod;
 import bisq.api.dto.account.crypto.CryptoPaymentMethodDto;
+import bisq.common.asset.CryptoAssetRepository;
 
 public class CryptoPaymentMethodDtoMapping {
     public static CryptoPaymentMethodDto fromBisq2Model(CryptoPaymentMethod paymentMethod) {
         return new CryptoPaymentMethodDto(
                 paymentMethod.getCode(),
                 paymentMethod.getName(),
-                paymentMethod.getPaymentRail().name()
+                paymentMethod.getPaymentRail().name(),
+                CryptoAssetRepository.isAutoConfSupported(paymentMethod.getCode())
         );
     }
 }

--- a/api/src/main/java/bisq/api/dto/mappings/account/crypto/MoneroAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/crypto/MoneroAccountDtoMapping.java
@@ -3,13 +3,12 @@ package bisq.api.dto.mappings.account.crypto;
 import bisq.account.accounts.AccountOrigin;
 import bisq.account.accounts.crypto.MoneroAccount;
 import bisq.account.accounts.crypto.MoneroAccountPayload;
-import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.AccountMetadataDto;
 import bisq.api.dto.account.crypto.MoneroAccountDto;
 import bisq.api.dto.account.crypto.MoneroAccountPayloadDto;
+import bisq.api.dto.mappings.account.PaymentAccountKeyMapping;
+import bisq.api.dto.mappings.account.PaymentAccountMetadataDtoMapping;
 import bisq.common.util.StringUtils;
-import bisq.security.keys.KeyGeneration;
-
-import java.security.KeyPair;
 
 public class MoneroAccountDtoMapping {
     public static MoneroAccount toBisq2Model(MoneroAccountDto dto) {
@@ -29,25 +28,25 @@ public class MoneroAccountDtoMapping {
                 payloadDto.accountIndex(),
                 payloadDto.initialSubAddressIndex()
         );
-        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-        KeyType keyType = KeyType.EC;
+        PaymentAccountKeyMapping.KeyData keyData = PaymentAccountKeyMapping.createDefault();
         return new MoneroAccount(
                 StringUtils.createUid(),
                 System.currentTimeMillis(),
                 dto.accountName(),
                 payload,
-                keyPair,
-                keyType,
+                keyData.keyPair(),
+                keyData.keyType(),
                 AccountOrigin.BISQ2_NEW
         );
     }
 
     public static MoneroAccountDto fromBisq2Model(MoneroAccount account) {
+        AccountMetadataDto accountMetadata = PaymentAccountMetadataDtoMapping.mapAccountMetadata(account);
+
         MoneroAccountPayload payload = account.getAccountPayload();
         return new MoneroAccountDto(
                 account.getAccountName(),
                 new MoneroAccountPayloadDto(
-                        payload.getCurrencyCode(),
                         payload.getAddress(),
                         payload.isInstant(),
                         payload.getIsAutoConf(),
@@ -59,9 +58,12 @@ public class MoneroAccountDtoMapping {
                         payload.getPrivateViewKey(),
                         payload.getSubAddress(),
                         payload.getAccountIndex(),
-                        payload.getInitialSubAddressIndex()
+                        payload.getInitialSubAddressIndex(),
+                        payload.getPaymentMethod().getDisplayString()
                 ),
-                account.getCreationDate()
+                accountMetadata.creationDate(),
+                accountMetadata.tradeLimitInfo(),
+                accountMetadata.tradeDuration()
         );
     }
 }

--- a/api/src/main/java/bisq/api/dto/mappings/account/crypto/MoneroAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/crypto/MoneroAccountDtoMapping.java
@@ -1,0 +1,67 @@
+package bisq.api.dto.mappings.account.crypto;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.crypto.MoneroAccount;
+import bisq.account.accounts.crypto.MoneroAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.crypto.MoneroAccountDto;
+import bisq.api.dto.account.crypto.MoneroAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class MoneroAccountDtoMapping {
+    public static MoneroAccount toBisq2Model(MoneroAccountDto dto) {
+        MoneroAccountPayloadDto payloadDto = dto.accountPayload();
+        MoneroAccountPayload payload = new MoneroAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.address(),
+                payloadDto.isInstant(),
+                payloadDto.isAutoConf(),
+                payloadDto.autoConfNumConfirmations(),
+                payloadDto.autoConfMaxTradeAmount(),
+                payloadDto.autoConfExplorerUrls(),
+                payloadDto.useSubAddresses(),
+                payloadDto.mainAddress(),
+                payloadDto.privateViewKey(),
+                payloadDto.subAddress(),
+                payloadDto.accountIndex(),
+                payloadDto.initialSubAddressIndex()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new MoneroAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static MoneroAccountDto fromBisq2Model(MoneroAccount account) {
+        MoneroAccountPayload payload = account.getAccountPayload();
+        return new MoneroAccountDto(
+                account.getAccountName(),
+                new MoneroAccountPayloadDto(
+                        payload.getCurrencyCode(),
+                        payload.getAddress(),
+                        payload.isInstant(),
+                        payload.getIsAutoConf(),
+                        payload.getAutoConfNumConfirmations(),
+                        payload.getAutoConfMaxTradeAmount(),
+                        payload.getAutoConfExplorerUrls(),
+                        payload.isUseSubAddresses(),
+                        payload.getMainAddress(),
+                        payload.getPrivateViewKey(),
+                        payload.getSubAddress(),
+                        payload.getAccountIndex(),
+                        payload.getInitialSubAddressIndex()
+                ),
+                account.getCreationDate()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/crypto/OtherCryptoAssetAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/crypto/OtherCryptoAssetAccountDtoMapping.java
@@ -3,13 +3,12 @@ package bisq.api.dto.mappings.account.crypto;
 import bisq.account.accounts.AccountOrigin;
 import bisq.account.accounts.crypto.OtherCryptoAssetAccount;
 import bisq.account.accounts.crypto.OtherCryptoAssetAccountPayload;
-import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.AccountMetadataDto;
 import bisq.api.dto.account.crypto.OtherCryptoAssetAccountDto;
 import bisq.api.dto.account.crypto.OtherCryptoAssetAccountPayloadDto;
+import bisq.api.dto.mappings.account.PaymentAccountKeyMapping;
+import bisq.api.dto.mappings.account.PaymentAccountMetadataDtoMapping;
 import bisq.common.util.StringUtils;
-import bisq.security.keys.KeyGeneration;
-
-import java.security.KeyPair;
 
 public class OtherCryptoAssetAccountDtoMapping {
     public static OtherCryptoAssetAccount toBisq2Model(OtherCryptoAssetAccountDto dto) {
@@ -24,25 +23,27 @@ public class OtherCryptoAssetAccountDtoMapping {
                 payloadDto.autoConfMaxTradeAmount(),
                 payloadDto.autoConfExplorerUrls()
         );
-        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-        KeyType keyType = KeyType.EC;
+        PaymentAccountKeyMapping.KeyData keyData = PaymentAccountKeyMapping.createDefault();
         return new OtherCryptoAssetAccount(
                 StringUtils.createUid(),
                 System.currentTimeMillis(),
                 dto.accountName(),
                 payload,
-                keyPair,
-                keyType,
+                keyData.keyPair(),
+                keyData.keyType(),
                 AccountOrigin.BISQ2_NEW
         );
     }
 
     public static OtherCryptoAssetAccountDto fromBisq2Model(OtherCryptoAssetAccount account) {
+        AccountMetadataDto accountMetadata = PaymentAccountMetadataDtoMapping.mapAccountMetadata(account);
+
         OtherCryptoAssetAccountPayload payload = account.getAccountPayload();
         return new OtherCryptoAssetAccountDto(
                 account.getAccountName(),
                 new OtherCryptoAssetAccountPayloadDto(
                         payload.getCurrencyCode(),
+                        payload.getPaymentMethod().getDisplayString(),
                         payload.getAddress(),
                         payload.isInstant(),
                         payload.getIsAutoConf(),
@@ -50,7 +51,9 @@ public class OtherCryptoAssetAccountDtoMapping {
                         payload.getAutoConfMaxTradeAmount(),
                         payload.getAutoConfExplorerUrls()
                 ),
-                account.getCreationDate()
+                accountMetadata.creationDate(),
+                accountMetadata.tradeLimitInfo(),
+                accountMetadata.tradeDuration()
         );
     }
 }

--- a/api/src/main/java/bisq/api/dto/mappings/account/crypto/OtherCryptoAssetAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/crypto/OtherCryptoAssetAccountDtoMapping.java
@@ -1,0 +1,56 @@
+package bisq.api.dto.mappings.account.crypto;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.crypto.OtherCryptoAssetAccount;
+import bisq.account.accounts.crypto.OtherCryptoAssetAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountDto;
+import bisq.api.dto.account.crypto.OtherCryptoAssetAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class OtherCryptoAssetAccountDtoMapping {
+    public static OtherCryptoAssetAccount toBisq2Model(OtherCryptoAssetAccountDto dto) {
+        OtherCryptoAssetAccountPayloadDto payloadDto = dto.accountPayload();
+        OtherCryptoAssetAccountPayload payload = new OtherCryptoAssetAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.currencyCode(),
+                payloadDto.address(),
+                payloadDto.isInstant(),
+                payloadDto.isAutoConf(),
+                payloadDto.autoConfNumConfirmations(),
+                payloadDto.autoConfMaxTradeAmount(),
+                payloadDto.autoConfExplorerUrls()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new OtherCryptoAssetAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static OtherCryptoAssetAccountDto fromBisq2Model(OtherCryptoAssetAccount account) {
+        OtherCryptoAssetAccountPayload payload = account.getAccountPayload();
+        return new OtherCryptoAssetAccountDto(
+                account.getAccountName(),
+                new OtherCryptoAssetAccountPayloadDto(
+                        payload.getCurrencyCode(),
+                        payload.getAddress(),
+                        payload.isInstant(),
+                        payload.getIsAutoConf(),
+                        payload.getAutoConfNumConfirmations(),
+                        payload.getAutoConfMaxTradeAmount(),
+                        payload.getAutoConfExplorerUrls()
+                ),
+                account.getCreationDate()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatAccountPayloadCurrencyMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatAccountPayloadCurrencyMapping.java
@@ -1,0 +1,24 @@
+package bisq.api.dto.mappings.account.fiat;
+
+import bisq.account.accounts.AccountPayload;
+import bisq.account.accounts.MultiCurrencyAccountPayload;
+import bisq.account.accounts.SelectableCurrencyAccountPayload;
+import bisq.account.accounts.SingleCurrencyAccountPayload;
+import bisq.common.asset.FiatCurrencyRepository;
+
+public class FiatAccountPayloadCurrencyMapping {
+    public static String toDisplayString(AccountPayload<?> accountPayload) {
+        return switch (accountPayload) {
+            case MultiCurrencyAccountPayload multiCurrencyAccountPayload ->
+                    FiatCurrencyRepository.getCodeAndDisplayNames(multiCurrencyAccountPayload.getSelectedCurrencyCodes());
+            case SelectableCurrencyAccountPayload selectableCurrencyAccountPayload ->
+                    FiatCurrencyRepository.getCodeAndDisplayName(selectableCurrencyAccountPayload.getSelectedCurrencyCode());
+            case SingleCurrencyAccountPayload singleCurrencyAccountPayload ->
+                    FiatCurrencyRepository.getCodeAndDisplayName(singleCurrencyAccountPayload.getCurrencyCode());
+            case null, default -> {
+                String type = accountPayload != null ? accountPayload.getClass().getSimpleName() : "null";
+                throw new UnsupportedOperationException("accountPayload of unexpected type: " + type);
+            }
+        };
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentMethodDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentMethodDtoMapping.java
@@ -7,12 +7,13 @@ import bisq.common.locale.Country;
 import bisq.common.locale.CountryRepository;
 import bisq.i18n.Res;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
-public class FiatPaymentMethodMapping {
+public class FiatPaymentMethodDtoMapping {
     public static FiatPaymentMethodDto fromBisq2Model(FiatPaymentMethod paymentMethod) {
-        java.util.List<Country> supportedCountries = paymentMethod.getSupportedCountries();
-        java.util.List<String> countryCodes = supportedCountries.stream()
+        List<Country> supportedCountries = paymentMethod.getSupportedCountries();
+        List<String> countryCodes = supportedCountries.stream()
                 .map(Country::getCode)
                 .sorted()
                 .toList();
@@ -24,7 +25,7 @@ public class FiatPaymentMethodMapping {
                 .collect(Collectors.joining(", "));
 
         return new FiatPaymentMethodDto(
-                FiatPaymentRailMapping.fromBisq2Model(paymentMethod.getPaymentRail()),
+                FiatPaymentRailDtoMapping.fromBisq2Model(paymentMethod.getPaymentRail()),
                 paymentMethod.getShortDisplayString(),
                 paymentMethod.getSupportedCurrencyCodesAsDisplayString(),
                 paymentMethod.getSupportedCurrencyDisplayNameAndCodeAsDisplayString(),

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentMethodDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentMethodDtoMapping.java
@@ -19,8 +19,8 @@ public class FiatPaymentMethodDtoMapping {
                 .toList();
         String countryNames = CountryRepository.matchesAllCountries(countryCodes)
                 ? Res.get("paymentAccounts.allCountries")
-                : supportedCountries.stream()
-                .map(Country::getName)
+                : countryCodes.stream()
+                .map(CountryRepository::getLocalizedCountryDisplayString)
                 .sorted()
                 .collect(Collectors.joining(", "));
 
@@ -28,7 +28,6 @@ public class FiatPaymentMethodDtoMapping {
                 FiatPaymentRailDtoMapping.fromBisq2Model(paymentMethod.getPaymentRail()),
                 paymentMethod.getShortDisplayString(),
                 paymentMethod.getSupportedCurrencyCodesAsDisplayString(),
-                paymentMethod.getSupportedCurrencyDisplayNameAndCodeAsDisplayString(),
                 countryNames,
                 FiatPaymentMethodChargebackRiskDto.valueOf(paymentMethod.getPaymentRail().getChargebackRisk().name())
         );

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentMethodMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentMethodMapping.java
@@ -1,0 +1,35 @@
+package bisq.api.dto.mappings.account.fiat;
+
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.api.dto.account.fiat.FiatPaymentMethodChargebackRiskDto;
+import bisq.api.dto.account.fiat.FiatPaymentMethodDto;
+import bisq.common.locale.Country;
+import bisq.common.locale.CountryRepository;
+import bisq.i18n.Res;
+
+import java.util.stream.Collectors;
+
+public class FiatPaymentMethodMapping {
+    public static FiatPaymentMethodDto fromBisq2Model(FiatPaymentMethod paymentMethod) {
+        java.util.List<Country> supportedCountries = paymentMethod.getSupportedCountries();
+        java.util.List<String> countryCodes = supportedCountries.stream()
+                .map(Country::getCode)
+                .sorted()
+                .toList();
+        String countryNames = CountryRepository.matchesAllCountries(countryCodes)
+                ? Res.get("paymentAccounts.allCountries")
+                : supportedCountries.stream()
+                .map(Country::getName)
+                .sorted()
+                .collect(Collectors.joining(", "));
+
+        return new FiatPaymentMethodDto(
+                FiatPaymentRailMapping.fromBisq2Model(paymentMethod.getPaymentRail()),
+                paymentMethod.getShortDisplayString(),
+                paymentMethod.getSupportedCurrencyCodesAsDisplayString(),
+                paymentMethod.getSupportedCurrencyDisplayNameAndCodeAsDisplayString(),
+                countryNames,
+                FiatPaymentMethodChargebackRiskDto.valueOf(paymentMethod.getPaymentRail().getChargebackRisk().name())
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentRailDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentRailDtoMapping.java
@@ -3,7 +3,7 @@ package bisq.api.dto.mappings.account.fiat;
 import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.api.dto.account.fiat.FiatPaymentRailDto;
 
-public class FiatPaymentRailMapping {
+public class FiatPaymentRailDtoMapping {
     public static FiatPaymentRail toBisq2Model(FiatPaymentRailDto value) {
         if (value == null) {
             return null;

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentRailMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/FiatPaymentRailMapping.java
@@ -1,0 +1,20 @@
+package bisq.api.dto.mappings.account.fiat;
+
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.api.dto.account.fiat.FiatPaymentRailDto;
+
+public class FiatPaymentRailMapping {
+    public static FiatPaymentRail toBisq2Model(FiatPaymentRailDto value) {
+        if (value == null) {
+            return null;
+        }
+        return FiatPaymentRail.valueOf(value.name());
+    }
+
+    public static FiatPaymentRailDto fromBisq2Model(FiatPaymentRail value) {
+        if (value == null) {
+            return null;
+        }
+        return FiatPaymentRailDto.valueOf(value.name());
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/UserDefinedFiatAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/UserDefinedFiatAccountDtoMapping.java
@@ -1,0 +1,43 @@
+package bisq.api.dto.mappings.account.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.UserDefinedFiatAccount;
+import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class UserDefinedFiatAccountDtoMapping {
+    public static UserDefinedFiatAccount toBisq2Model(UserDefinedFiatAccountDto dto) {
+        UserDefinedFiatAccountPayloadDto payloadDto = dto.accountPayload();
+        UserDefinedFiatAccountPayload payload = new UserDefinedFiatAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.accountData()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new UserDefinedFiatAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static UserDefinedFiatAccountDto fromBisq2Model(UserDefinedFiatAccount account) {
+        return new UserDefinedFiatAccountDto(
+                account.getAccountName(),
+                new UserDefinedFiatAccountPayloadDto(
+                        account.getAccountPayload().getAccountData()
+                ),
+                account.getCreationDate()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/UserDefinedFiatAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/UserDefinedFiatAccountDtoMapping.java
@@ -3,13 +3,13 @@ package bisq.api.dto.mappings.account.fiat;
 import bisq.account.accounts.AccountOrigin;
 import bisq.account.accounts.fiat.UserDefinedFiatAccount;
 import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
-import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.AccountMetadataDto;
+import bisq.api.dto.account.fiat.FiatPaymentMethodChargebackRiskDto;
 import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
 import bisq.api.dto.account.fiat.UserDefinedFiatAccountPayloadDto;
+import bisq.api.dto.mappings.account.PaymentAccountKeyMapping;
+import bisq.api.dto.mappings.account.PaymentAccountMetadataDtoMapping;
 import bisq.common.util.StringUtils;
-import bisq.security.keys.KeyGeneration;
-
-import java.security.KeyPair;
 
 public class UserDefinedFiatAccountDtoMapping {
     public static UserDefinedFiatAccount toBisq2Model(UserDefinedFiatAccountDto dto) {
@@ -18,26 +18,36 @@ public class UserDefinedFiatAccountDtoMapping {
                 StringUtils.createUid(),
                 payloadDto.accountData()
         );
-        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-        KeyType keyType = KeyType.EC;
+        PaymentAccountKeyMapping.KeyData keyData = PaymentAccountKeyMapping.createDefault();
         return new UserDefinedFiatAccount(
                 StringUtils.createUid(),
                 System.currentTimeMillis(),
                 dto.accountName(),
                 payload,
-                keyPair,
-                keyType,
+                keyData.keyPair(),
+                keyData.keyType(),
                 AccountOrigin.BISQ2_NEW
         );
     }
 
     public static UserDefinedFiatAccountDto fromBisq2Model(UserDefinedFiatAccount account) {
+        AccountMetadataDto accountMetadata = PaymentAccountMetadataDtoMapping.mapAccountMetadata(account);
+        FiatPaymentMethodChargebackRiskDto chargebackRisk = FiatPaymentMethodChargebackRiskDto.valueOf(account.getPaymentMethod().getPaymentRail().getChargebackRisk().name());
+
+        String currency = FiatAccountPayloadCurrencyMapping.toDisplayString(account.getAccountPayload());
+
         return new UserDefinedFiatAccountDto(
                 account.getAccountName(),
                 new UserDefinedFiatAccountPayloadDto(
+                        chargebackRisk,
+                        currency,
+                        account.getPaymentMethod().getShortDisplayString(),
+                        null,
                         account.getAccountPayload().getAccountData()
                 ),
-                account.getCreationDate()
+                accountMetadata.creationDate(),
+                accountMetadata.tradeLimitInfo(),
+                accountMetadata.tradeDuration()
         );
     }
 }

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/ZelleAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/ZelleAccountDtoMapping.java
@@ -3,13 +3,14 @@ package bisq.api.dto.mappings.account.fiat;
 import bisq.account.accounts.AccountOrigin;
 import bisq.account.accounts.fiat.ZelleAccount;
 import bisq.account.accounts.fiat.ZelleAccountPayload;
-import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.AccountMetadataDto;
+import bisq.api.dto.account.fiat.FiatPaymentMethodChargebackRiskDto;
 import bisq.api.dto.account.fiat.ZelleAccountDto;
 import bisq.api.dto.account.fiat.ZelleAccountPayloadDto;
+import bisq.api.dto.mappings.account.PaymentAccountKeyMapping;
+import bisq.api.dto.mappings.account.PaymentAccountMetadataDtoMapping;
+import bisq.common.locale.CountryRepository;
 import bisq.common.util.StringUtils;
-import bisq.security.keys.KeyGeneration;
-
-import java.security.KeyPair;
 
 public class ZelleAccountDtoMapping {
     public static ZelleAccount toBisq2Model(ZelleAccountDto dto) {
@@ -19,27 +20,37 @@ public class ZelleAccountDtoMapping {
                 payloadDto.holderName(),
                 payloadDto.emailOrMobileNr()
         );
-        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-        KeyType keyType = KeyType.EC;
+        PaymentAccountKeyMapping.KeyData keyData = PaymentAccountKeyMapping.createDefault();
         return new ZelleAccount(
                 StringUtils.createUid(),
                 System.currentTimeMillis(),
                 dto.accountName(),
                 payload,
-                keyPair,
-                keyType,
+                keyData.keyPair(),
+                keyData.keyType(),
                 AccountOrigin.BISQ2_NEW
         );
     }
 
     public static ZelleAccountDto fromBisq2Model(ZelleAccount account) {
+        AccountMetadataDto accountMetadata = PaymentAccountMetadataDtoMapping.mapAccountMetadata(account);
+        FiatPaymentMethodChargebackRiskDto chargebackRisk = FiatPaymentMethodChargebackRiskDto.valueOf(account.getPaymentMethod().getPaymentRail().getChargebackRisk().name());
+
+        String currency = FiatAccountPayloadCurrencyMapping.toDisplayString(account.getAccountPayload());
+
         return new ZelleAccountDto(
                 account.getAccountName(),
                 new ZelleAccountPayloadDto(
+                        chargebackRisk,
+                        account.getPaymentMethod().getShortDisplayString(),
+                        currency,
+                        CountryRepository.getNameByCode(account.getCountry().getCode()),
                         account.getAccountPayload().getHolderName(),
                         account.getAccountPayload().getEmailOrMobileNr()
                 ),
-                account.getCreationDate()
+                accountMetadata.creationDate(),
+                accountMetadata.tradeLimitInfo(),
+                accountMetadata.tradeDuration()
         );
     }
 }

--- a/api/src/main/java/bisq/api/dto/mappings/account/fiat/ZelleAccountDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/account/fiat/ZelleAccountDtoMapping.java
@@ -1,0 +1,45 @@
+package bisq.api.dto.mappings.account.fiat;
+
+import bisq.account.accounts.AccountOrigin;
+import bisq.account.accounts.fiat.ZelleAccount;
+import bisq.account.accounts.fiat.ZelleAccountPayload;
+import bisq.account.timestamp.KeyType;
+import bisq.api.dto.account.fiat.ZelleAccountDto;
+import bisq.api.dto.account.fiat.ZelleAccountPayloadDto;
+import bisq.common.util.StringUtils;
+import bisq.security.keys.KeyGeneration;
+
+import java.security.KeyPair;
+
+public class ZelleAccountDtoMapping {
+    public static ZelleAccount toBisq2Model(ZelleAccountDto dto) {
+        ZelleAccountPayloadDto payloadDto = dto.accountPayload();
+        ZelleAccountPayload payload = new ZelleAccountPayload(
+                StringUtils.createUid(),
+                payloadDto.holderName(),
+                payloadDto.emailOrMobileNr()
+        );
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        KeyType keyType = KeyType.EC;
+        return new ZelleAccount(
+                StringUtils.createUid(),
+                System.currentTimeMillis(),
+                dto.accountName(),
+                payload,
+                keyPair,
+                keyType,
+                AccountOrigin.BISQ2_NEW
+        );
+    }
+
+    public static ZelleAccountDto fromBisq2Model(ZelleAccount account) {
+        return new ZelleAccountDto(
+                account.getAccountName(),
+                new ZelleAccountPayloadDto(
+                        account.getAccountPayload().getHolderName(),
+                        account.getAccountPayload().getEmailOrMobileNr()
+                ),
+                account.getCreationDate()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
@@ -11,7 +11,7 @@ import bisq.api.rest_api.endpoints.explorer.ExplorerRestApi;
 import bisq.api.rest_api.endpoints.market_price.MarketPriceRestApi;
 import bisq.api.rest_api.endpoints.offers.OfferbookRestApi;
 import bisq.api.rest_api.endpoints.trade_restricting_alert.TradeRestrictingAlertRestApi;
-import bisq.api.rest_api.endpoints.payment_accounts.FiatPaymentAccountsRestApi;
+import bisq.api.rest_api.endpoints.payment_accounts.UserDefinedPaymentAccountsRestApi;
 import bisq.api.rest_api.endpoints.payment_accounts.PaymentAccountsRestApi;
 import bisq.api.rest_api.endpoints.reputation.ReputationRestApi;
 import bisq.api.rest_api.endpoints.alert_notifications.AlertNotificationsRestApi;
@@ -40,7 +40,7 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
                                  TradeRestrictingAlertRestApi tradeRestrictingAlertRestApi,
                                  ExplorerRestApi explorerRestApi,
                                  PaymentAccountsRestApi paymentAccountsRestApi,
-                                 FiatPaymentAccountsRestApi fiatPaymentAccountsRestApi,
+                                 UserDefinedPaymentAccountsRestApi userDefinedPaymentAccountsRestApi,
                                  ReputationRestApi reputationRestApi,
                                  UserProfileRestApi userProfileRestApi,
                                  DevicesRestApi devicesRestApi) {
@@ -60,7 +60,7 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
         register(TradeRestrictingAlertRestApi.class);
         register(ExplorerRestApi.class);
         register(PaymentAccountsRestApi.class);
-        register(FiatPaymentAccountsRestApi.class);
+        register(UserDefinedPaymentAccountsRestApi.class);
         register(ReputationRestApi.class);
         register(UserProfileRestApi.class);
         register(DevicesRestApi.class);
@@ -78,7 +78,7 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
                 bind(tradeRestrictingAlertRestApi).to(TradeRestrictingAlertRestApi.class);
                 bind(explorerRestApi).to(ExplorerRestApi.class);
                 bind(paymentAccountsRestApi).to(PaymentAccountsRestApi.class);
-                bind(fiatPaymentAccountsRestApi).to(FiatPaymentAccountsRestApi.class);
+                bind(userDefinedPaymentAccountsRestApi).to(UserDefinedPaymentAccountsRestApi.class);
                 bind(reputationRestApi).to(ReputationRestApi.class);
                 bind(userProfileRestApi).to(UserProfileRestApi.class);
                 bind(devicesRestApi).to(DevicesRestApi.class);

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/AddFiatAccountRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/AddFiatAccountRequest.java
@@ -17,7 +17,8 @@
 
 package bisq.api.rest_api.endpoints.payment_accounts;
 
-import bisq.api.dto.account.fiat.FiatAccountDto;
+import bisq.api.dto.account.PaymentAccountDto;
 
-public record AddFiatAccountRequest(FiatAccountDto account) { }
+public record AddFiatAccountRequest(PaymentAccountDto account) {
+}
 

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountChangeRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountChangeRequest.java
@@ -17,7 +17,7 @@
 
 package bisq.api.rest_api.endpoints.payment_accounts;
 
-import bisq.api.dto.account.UserDefinedFiatAccountDto;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
 
 import javax.annotation.Nullable;
 

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
@@ -1,36 +1,24 @@
-/*
- * This file is part of Bisq.
- *
- * Bisq is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * Bisq is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
- * License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
- */
-
 package bisq.api.rest_api.endpoints.payment_accounts;
 
 import bisq.account.AccountService;
 import bisq.account.accounts.Account;
-import bisq.account.accounts.AccountOrigin;
-import bisq.account.accounts.fiat.UserDefinedFiatAccount;
-import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
+import bisq.account.accounts.crypto.CryptoAssetAccount;
 import bisq.account.payment_method.PaymentMethod;
-import bisq.account.timestamp.KeyType;
-import bisq.common.util.StringUtils;
-import bisq.api.dto.DtoMappings;
-import bisq.api.dto.account.UserDefinedFiatAccountDto;
+import bisq.account.payment_method.crypto.CryptoPaymentMethodUtil;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentRailUtil;
+import bisq.api.dto.account.PaymentAccountDto;
+import bisq.api.dto.account.crypto.CryptoPaymentMethodDto;
+import bisq.api.dto.account.fiat.FiatPaymentMethodDto;
+import bisq.api.dto.mappings.account.PaymentAccountDtoMapping;
+import bisq.api.dto.mappings.account.crypto.CryptoPaymentMethodDtoMapping;
+import bisq.api.dto.mappings.account.fiat.FiatPaymentMethodMapping;
 import bisq.api.rest_api.endpoints.RestApiBase;
-import bisq.security.keys.KeyGeneration;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,28 +27,26 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import java.security.KeyPair;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Path("/payment-accounts")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Payment Accounts API", description = "API for managing user payment accounts. Right now UserDefinedFiatAccount")
+@Tag(name = "Payment Accounts API", description = "API for retrieving fiat and crypto payment accounts.")
 public class PaymentAccountsRestApi extends RestApiBase {
     private final AccountService accountService;
 
@@ -71,52 +57,26 @@ public class PaymentAccountsRestApi extends RestApiBase {
     @GET
     @Operation(
             summary = "Get payment accounts",
-            description = "Retrieve all the payment accounts (only UserDefinedFiatAccount)",
+            description = "Retrieve fiat and crypto payment accounts",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Payment accounts retrieved successfully",
-                            content = @Content(schema = @Schema(implementation = UserDefinedFiatAccountDto.class))),
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = PaymentAccountDto.class))
+                            )),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
     public Response getPaymentAccounts() {
         try {
-            List<UserDefinedFiatAccountDto> userAccounts = accountService.getAccountByNameMap().values().stream()
-                    .filter(account -> account instanceof UserDefinedFiatAccount)
-                    .map(account -> (UserDefinedFiatAccount) account)
-                    .map(DtoMappings.UserDefinedFiatAccountMapping::fromBisq2Model)
-                    .collect(Collectors.toList());
+            var accounts = accountService.getAccounts();
 
-            return buildOkResponse(userAccounts);
-        } catch (Exception e) {
-            log.error("Failed to retrieve payment accounts", e);
-            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
-        }
-    }
+            List<PaymentAccountDto> paymentAccounts = accounts.stream()
+                    .filter(account -> isFiatAccount(account) || isCryptoAccount(account))
+                    .map(PaymentAccountDtoMapping::fromBisq2Model)
+                    .toList();
 
-    @GET
-    @Operation(
-            summary = "Get selected payment account",
-            description = "Get selected payment account (only UserDefinedFiatAccount)",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Selected payment account retrieved successfully",
-                            content = @Content(schema = @Schema(implementation = UserDefinedFiatAccountDto.class))),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
-            }
-    )
-    @Path("/selected")
-    public Response getSelectedPaymentAccount() {
-        try {
-            if (accountService.findSelectedAccount().isPresent()) {
-                Account<? extends PaymentMethod<?>, ?> account = accountService.findSelectedAccount().get();
-                if (account instanceof UserDefinedFiatAccount castedAccount) {
-                    UserDefinedFiatAccountDto userAccount = DtoMappings.UserDefinedFiatAccountMapping.fromBisq2Model(castedAccount);
-                    return buildOkResponse(userAccount);
-                } else {
-                    return buildNoContentResponse();
-                }
-            }
-
-            return buildNoContentResponse();
+            return buildOkResponse(paymentAccounts);
         } catch (Exception e) {
             log.error("Failed to retrieve payment accounts", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
@@ -126,35 +86,70 @@ public class PaymentAccountsRestApi extends RestApiBase {
     @POST
     @Operation(
             summary = "Add new payment account",
-            description = "Add new payment account (only UserDefinedFiatAccount)",
+            description = "Create a new fiat or crypto payment account.",
             requestBody = @RequestBody(
-                    description = "",
-                    content = @Content(schema = @Schema(implementation = AddAccountRequest.class))
+                    description = "Payment account details",
+                    content = @Content(
+                            schema = @Schema(implementation = PaymentAccountDto.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Zelle account",
+                                            value = "{\n  \"accountName\": \"My Zelle Account\",\n  \"paymentRail\": \"ZELLE\",\n  \"accountPayload\": {\n    \"holderName\": \"John Doe\",\n    \"emailOrMobileNr\": \"john.doe@example.com\"\n  }\n}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "ACH transfer account",
+                                            value = "{\n  \"accountName\": \"My Ach Account\",\n  \"paymentRail\": \"ACH_TRANSFER\",\n  \"accountPayload\": {\n    \"holderName\": \"John Doe\",\n    \"holderAddress\": \"Some Address\",\n    \"bankName\": \"Bank of Test\",\n    \"routingNr\": \"123456789\",\n    \"accountNr\": \"000123456789\",\n    \"bankAccountType\": \"CHECKING\"\n  }\n}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "Monero account",
+                                            value = "{\n  \"accountName\": \"My Monero Account\",\n  \"paymentRail\": \"MONERO\",\n  \"accountPayload\": {\n    \"currencyCode\": \"XMR\",\n    \"address\": \"84f....\",\n    \"isInstant\": false,\n    \"isAutoConf\": false,\n    \"autoConfNumConfirmations\": 1,\n    \"autoConfMaxTradeAmount\": 100000,\n    \"autoConfExplorerUrls\": \"https://xmrchain.net\",\n    \"useSubAddresses\": false,\n    \"mainAddress\": null,\n    \"privateViewKey\": null,\n    \"subAddress\": null,\n    \"accountIndex\": null,\n    \"initialSubAddressIndex\": null\n  }\n}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "Other crypto account",
+                                            value = "{\n  \"accountName\": \"My LTC Account\",\n  \"paymentRail\": \"OTHER_CRYPTO_ASSET\",\n  \"accountPayload\": {\n    \"currencyCode\": \"LTC\",\n    \"address\": \"ltc1....\",\n    \"isInstant\": false,\n    \"isAutoConf\": false,\n    \"autoConfNumConfirmations\": 1,\n    \"autoConfMaxTradeAmount\": 100000,\n    \"autoConfExplorerUrls\": \"https://blockchair.com/litecoin\"\n  }\n}"
+                                    )
+                            }
+                    )
             ),
             responses = {
-                    @ApiResponse(responseCode = "201", description = "",
-                            content = @Content(schema = @Schema(example = ""))),
+                    @ApiResponse(responseCode = "201", description = "Payment account created successfully",
+                            content = @Content(schema = @Schema(implementation = PaymentAccountDto.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid input"),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
+                    @ApiResponse(responseCode = "409", description = "Payment account already exists"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error"),
+                    @ApiResponse(responseCode = "503", description = "Request timed out")
             }
     )
-    public void addAccount(AddAccountRequest request, @Suspended AsyncResponse asyncResponse) {
+    public void addAccount(@Valid PaymentAccountDto request,
+                           @Suspended AsyncResponse asyncResponse) {
         asyncResponse.setTimeout(10, TimeUnit.SECONDS);
-        asyncResponse.setTimeoutHandler(response -> {
-            response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out"));
-        });
+        asyncResponse.setTimeoutHandler(response ->
+                response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out")));
         try {
-            KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
-            KeyType keyType = KeyType.EC;
-            UserDefinedFiatAccountPayload accountPayload = new UserDefinedFiatAccountPayload(StringUtils.createUid(), request.accountData());
-            accountService.addPaymentAccount(new UserDefinedFiatAccount(StringUtils.createUid(),
-                    System.currentTimeMillis(),
-                    request.accountName(),
-                    accountPayload,
-                    keyPair,
-                    keyType,
-                    AccountOrigin.BISQ2_NEW));
-            asyncResponse.resume(buildResponse(Response.Status.CREATED, new AddAccountResponse(request.accountName())));
+            if (request == null) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account data is required"));
+                return;
+            }
+
+            try {
+                Account<? extends PaymentMethod<?>, ?> account = PaymentAccountDtoMapping.toBisq2Model(request);
+                if (!accountService.addPaymentAccount(account)) {
+                    asyncResponse.resume(buildErrorResponse(Response.Status.CONFLICT,
+                            "Payment account already exists: " + request.accountName()));
+                    return;
+                }
+
+                Optional<Account<? extends PaymentMethod<?>, ?>> createdAccount = accountService.findAccount(account.getAccountName());
+                if (createdAccount.isEmpty()) {
+                    asyncResponse.resume(buildErrorResponse("Account was created but could not be loaded"));
+                    return;
+                }
+
+                PaymentAccountDto createdAccountDto = PaymentAccountDtoMapping.fromBisq2Model(createdAccount.get());
+                asyncResponse.resume(buildResponse(Response.Status.CREATED, createdAccountDto));
+            } catch (IllegalArgumentException e) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()));
+            }
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
@@ -162,21 +157,21 @@ public class PaymentAccountsRestApi extends RestApiBase {
 
     @DELETE
     @Operation(
-            summary = "Delete Payment account",
-            description = "Delete Payment account",
+            summary = "Delete payment account",
+            description = "Delete a payment account by account name (fiat or crypto)",
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Offer successfully deleted"),
-                    @ApiResponse(responseCode = "400", description = "Invalid input"),
-                    @ApiResponse(responseCode = "404", description = "Offer or user identity not found"),
+                    @ApiResponse(responseCode = "204", description = "Payment account successfully deleted"),
+                    @ApiResponse(responseCode = "400", description = "Account name is required"),
+                    @ApiResponse(responseCode = "404", description = "Account not found"),
                     @ApiResponse(responseCode = "500", description = "Internal server error"),
                     @ApiResponse(responseCode = "503", description = "Request timed out")
             }
     )
-    public void removeAccount(@QueryParam("accountName") String accountName, @Suspended AsyncResponse asyncResponse) {
+    public void removeAccount(@QueryParam("accountName") String accountName,
+                              @Suspended AsyncResponse asyncResponse) {
         asyncResponse.setTimeout(10, TimeUnit.SECONDS);
-        asyncResponse.setTimeoutHandler(response -> {
-            response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out"));
-        });
+        asyncResponse.setTimeoutHandler(response ->
+                response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out")));
         try {
             if (accountName == null || accountName.trim().isEmpty()) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account name is required"));
@@ -184,56 +179,75 @@ public class PaymentAccountsRestApi extends RestApiBase {
             }
 
             Optional<Account<? extends PaymentMethod<?>, ?>> result = accountService.findAccount(accountName);
-            if (result.isPresent()) {
-                Account<? extends PaymentMethod<?>, ?> toRemove = result.get();
-                accountService.removePaymentAccount(toRemove);
-                asyncResponse.resume(buildNoContentResponse());
-            } else {
-                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found"));
+            if (result.isEmpty()) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.NOT_FOUND, "Payment account not found"));
+                return;
             }
+
+            accountService.removePaymentAccount(result.get());
+            asyncResponse.resume(buildNoContentResponse());
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
     }
 
-    @PATCH
+    @GET
+    @Path("/payment-methods/fiat")
     @Operation(
-            summary = "Update selected payment account",
-            description = "Update selected payment account (only UserDefinedFiatAccount)",
-            requestBody = @RequestBody(
-                    description = "The setting key and value to be updated",
-                    required = true,
-                    content = @Content(schema = @Schema(implementation = PaymentAccountChangeRequest.class))
-            ),
+            summary = "Get fiat payment methods",
+            description = "Retrieve all available fiat payment methods as displayed by the desktop payment method selection",
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Selected payment account set successfully"),
-                    @ApiResponse(responseCode = "400", description = "Invalid input data"),
+                    @ApiResponse(responseCode = "200", description = "Fiat payment methods retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = FiatPaymentMethodDto.class, type = "array"))),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
-    @Path("/selected")
-    public Response setSelectedPaymentAccount(@Valid PaymentAccountChangeRequest request) {
+    @SuppressWarnings("deprecation")
+    public Response getFiatPaymentMethods() {
         try {
-            UserDefinedFiatAccountDto account = request.selectedAccount();
-            if (account != null) {
-                Optional<Account<? extends PaymentMethod<?>, ?>> result = accountService.findAccount(account.accountName());
-                if (result.isPresent()) {
-                    Account<? extends PaymentMethod<?>, ?> foundAccount = result.get();
-                    if (foundAccount instanceof UserDefinedFiatAccount castedAccount) {
-                        accountService.setSelectedAccount(castedAccount);
-                    } else {
-                        return buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found");
-                    }
-                } else {
-                    return buildErrorResponse(Response.Status.BAD_REQUEST, "Payment account not found");
-                }
-            }
-
-            log.info("Updated selected payment account from request: {}", request);
-            return Response.noContent().build();
+            List<FiatPaymentMethodDto> items = FiatPaymentRailUtil.getPaymentRails().stream()
+                    .filter(rail -> rail != FiatPaymentRail.CUSTOM)
+                    .filter(rail -> rail != FiatPaymentRail.CASH_APP)
+                    .map(FiatPaymentMethod::fromPaymentRail)
+                    .map(FiatPaymentMethodMapping::fromBisq2Model)
+                    .sorted(Comparator.comparing(FiatPaymentMethodDto::name, String.CASE_INSENSITIVE_ORDER))
+                    .toList();
+            return buildOkResponse(items);
         } catch (Exception e) {
-            log.error("Error updating select payment account", e);
+            log.error("Failed to retrieve fiat payment methods", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
         }
+    }
+
+    @GET
+    @Path("/payment-methods/crypto")
+    @Operation(
+            summary = "Get crypto payment methods",
+            description = "Retrieve all available crypto payment methods",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Crypto payment methods retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = CryptoPaymentMethodDto.class, type = "array"))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getCryptoPaymentMethods() {
+        try {
+            List<CryptoPaymentMethodDto> items = CryptoPaymentMethodUtil.getPaymentMethods().stream()
+                    .filter(e -> !e.getCode().equals("BTC"))
+                    .map(CryptoPaymentMethodDtoMapping::fromBisq2Model)
+                    .toList();
+            return buildOkResponse(items);
+        } catch (Exception e) {
+            log.error("Failed to retrieve crypto payment methods", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    private boolean isFiatAccount(Account<? extends PaymentMethod<?>, ?> account) {
+        return account.getPaymentMethod() instanceof FiatPaymentMethod;
+    }
+
+    public boolean isCryptoAccount(Account<? extends PaymentMethod<?>, ?> account) {
+        return account instanceof CryptoAssetAccount;
     }
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/PaymentAccountsRestApi.java
@@ -13,7 +13,7 @@ import bisq.api.dto.account.crypto.CryptoPaymentMethodDto;
 import bisq.api.dto.account.fiat.FiatPaymentMethodDto;
 import bisq.api.dto.mappings.account.PaymentAccountDtoMapping;
 import bisq.api.dto.mappings.account.crypto.CryptoPaymentMethodDtoMapping;
-import bisq.api.dto.mappings.account.fiat.FiatPaymentMethodMapping;
+import bisq.api.dto.mappings.account.fiat.FiatPaymentMethodDtoMapping;
 import bisq.api.rest_api.endpoints.RestApiBase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -209,7 +209,7 @@ public class PaymentAccountsRestApi extends RestApiBase {
                     .filter(rail -> rail != FiatPaymentRail.CUSTOM)
                     .filter(rail -> rail != FiatPaymentRail.CASH_APP)
                     .map(FiatPaymentMethod::fromPaymentRail)
-                    .map(FiatPaymentMethodMapping::fromBisq2Model)
+                    .map(FiatPaymentMethodDtoMapping::fromBisq2Model)
                     .sorted(Comparator.comparing(FiatPaymentMethodDto::name, String.CASE_INSENSITIVE_ORDER))
                     .toList();
             return buildOkResponse(items);

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/SaveFiatAccountRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/SaveFiatAccountRequest.java
@@ -17,7 +17,8 @@
 
 package bisq.api.rest_api.endpoints.payment_accounts;
 
-import bisq.api.dto.account.fiat.FiatAccountDto;
+import bisq.api.dto.account.PaymentAccountDto;
 
-public record SaveFiatAccountRequest(FiatAccountDto account) { }
+public record SaveFiatAccountRequest(PaymentAccountDto account) {
+}
 

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/SetSelectedFiatAccountRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/SetSelectedFiatAccountRequest.java
@@ -17,12 +17,12 @@
 
 package bisq.api.rest_api.endpoints.payment_accounts;
 
-import bisq.api.dto.account.fiat.FiatAccountDto;
+import bisq.api.dto.account.PaymentAccountDto;
 
 import javax.annotation.Nullable;
 
 public record SetSelectedFiatAccountRequest(
-        @Nullable FiatAccountDto selectedAccount
+        @Nullable PaymentAccountDto selectedAccount
 ) {
 }
 

--- a/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/UserDefinedPaymentAccountsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/payment_accounts/UserDefinedPaymentAccountsRestApi.java
@@ -19,10 +19,12 @@ package bisq.api.rest_api.endpoints.payment_accounts;
 
 import bisq.account.AccountService;
 import bisq.account.accounts.Account;
+import bisq.account.accounts.fiat.UserDefinedFiatAccount;
 import bisq.account.payment_method.PaymentMethod;
-import bisq.account.payment_method.fiat.FiatPaymentMethod;
-import bisq.api.dto.DtoMappings;
-import bisq.api.dto.account.fiat.FiatAccountDto;
+import bisq.api.dto.account.PaymentAccountDto;
+import bisq.api.dto.account.fiat.UserDefinedFiatAccountDto;
+import bisq.api.dto.mappings.account.PaymentAccountDtoMapping;
+import bisq.api.dto.mappings.account.fiat.UserDefinedFiatAccountDtoMapping;
 import bisq.api.rest_api.endpoints.RestApiBase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -31,7 +33,15 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
@@ -41,38 +51,40 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
+/*
+ * Temporary REST API for fiat-only account management.
+ * This endpoint is planned to be removed once MuSig is enabled and the client
+ * migrates to PaymentAccountsRestApi, which accepts both fiat and crypto accounts.
+ */
 @Slf4j
 @Path("/payment-accounts/fiat")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@Tag(name = "Fiat Payment Accounts API", description = "API for managing fiat payment accounts. Supports all FiatPaymentRail types including CUSTOM (user-defined), SEPA, REVOLUT, ZELLE, and more.")
-public class FiatPaymentAccountsRestApi extends RestApiBase {
+@Tag(name = "User-Defined Fiat Payment Accounts API", description = "API for managing user-defined fiat payment accounts (CUSTOM rail only).")
+public class UserDefinedPaymentAccountsRestApi extends RestApiBase {
     private final AccountService accountService;
 
-    public FiatPaymentAccountsRestApi(AccountService accountService) {
+    public UserDefinedPaymentAccountsRestApi(AccountService accountService) {
         this.accountService = accountService;
     }
 
     @GET
     @Operation(
-            summary = "Get fiat payment accounts",
-            description = "Retrieve all fiat payment accounts",
+            summary = "Get user-defined fiat payment accounts",
+            description = "Retrieve all user-defined fiat payment accounts (CUSTOM rail only)",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Fiat payment accounts retrieved successfully",
-                            content = @Content(schema = @Schema(implementation = FiatAccountDto.class, type = "array"))),
+                    @ApiResponse(responseCode = "200", description = "User-defined fiat payment accounts retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = PaymentAccountDto.class, type = "array"))),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
-    public Response getPaymentAccounts() {
+    public Response getUserDefinedPaymentAccounts() {
         try {
-            List<FiatAccountDto> accounts = accountService.getAccounts().stream()
-                    .filter(this::isFiatAccount)
+            List<PaymentAccountDto> accounts = accountService.getAccounts().stream()
+                    .filter(this::isUserDefinedAccount)
                     .map(this::convertToDto)
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .collect(Collectors.toList());
+                    .toList();
 
             return buildOkResponse(accounts);
         } catch (Exception e) {
@@ -82,31 +94,23 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
     }
 
     /**
-     * Check if account is a fiat payment account
+     * Check if account is a user-defined fiat payment account.
      */
-    private boolean isFiatAccount(Account<? extends PaymentMethod<?>, ?> account) {
-        return account.getPaymentMethod() instanceof FiatPaymentMethod;
+    private boolean isUserDefinedAccount(Account<? extends PaymentMethod<?>, ?> account) {
+        return account instanceof UserDefinedFiatAccount;
     }
 
-    /**
-     * Convert account to DTO. Returns Optional.empty() for unsupported account types.
-     */
-    private Optional<FiatAccountDto> convertToDto(Account<? extends PaymentMethod<?>, ?> account) {
-        try {
-            return Optional.of(DtoMappings.FiatAccountMapping.fromBisq2Model(account));
-        } catch (IllegalArgumentException e) {
-            log.warn("Unsupported account type: {}", account.getClass().getSimpleName());
-            return Optional.empty();
-        }
+    private PaymentAccountDto convertToDto(Account<? extends PaymentMethod<?>, ?> account) {
+        return PaymentAccountDtoMapping.fromBisq2Model(account);
     }
 
     @GET
     @Operation(
-            summary = "Get selected fiat payment account",
-            description = "Get the currently selected fiat payment account",
+            summary = "Get selected user-defined fiat payment account",
+            description = "Get the currently selected user-defined fiat payment account",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Selected fiat payment account retrieved successfully",
-                            content = @Content(schema = @Schema(implementation = FiatAccountDto.class))),
+                    @ApiResponse(responseCode = "200", description = "Selected user-defined fiat payment account retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = PaymentAccountDto.class))),
                     @ApiResponse(responseCode = "204", description = "No account selected"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
@@ -115,13 +119,11 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
     public Response getSelectedPaymentAccount() {
         try {
             Optional<Account<? extends PaymentMethod<?>, ?>> selectedAccount = accountService.findSelectedAccount();
-            if (selectedAccount.isEmpty() || !isFiatAccount(selectedAccount.get())) {
+            if (selectedAccount.isEmpty() || !isUserDefinedAccount(selectedAccount.get())) {
                 return buildNoContentResponse();
             }
 
-            return convertToDto(selectedAccount.get())
-                    .map(this::buildOkResponse)
-                    .orElse(buildNoContentResponse());
+            return buildOkResponse(convertToDto(selectedAccount.get()));
         } catch (Exception e) {
             log.error("Failed to retrieve selected payment account", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
@@ -130,16 +132,16 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
     @POST
     @Operation(
-            summary = "Add new fiat payment account",
-            description = "Create a new fiat payment account. The payment rail type is specified in the request body.",
+            summary = "Add new user-defined fiat payment account",
+            description = "Create a new user-defined fiat payment account (CUSTOM rail only).",
             requestBody = @RequestBody(
-                    description = "Fiat account details including payment rail type, account name, and payload",
+                    description = "User-defined fiat account details (must be UserDefinedFiatAccountDto / CUSTOM)",
                     content = @Content(schema = @Schema(implementation = AddFiatAccountRequest.class))
             ),
             responses = {
-                    @ApiResponse(responseCode = "201", description = "Fiat payment account created successfully",
-                            content = @Content(schema = @Schema(implementation = FiatAccountDto.class))),
-                    @ApiResponse(responseCode = "400", description = "Invalid input or unsupported payment rail"),
+                    @ApiResponse(responseCode = "201", description = "User-defined fiat payment account created successfully",
+                            content = @Content(schema = @Schema(implementation = PaymentAccountDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid input or unsupported account type"),
                     @ApiResponse(responseCode = "500", description = "Internal server error"),
                     @ApiResponse(responseCode = "503", description = "Request timed out")
             }
@@ -151,21 +153,26 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
             response.resume(buildResponse(Response.Status.SERVICE_UNAVAILABLE, "Request timed out"));
         });
         try {
-            FiatAccountDto accountDto = request.account();
+            PaymentAccountDto accountDto = request.account();
             if (accountDto == null) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account data is required"));
                 return;
             }
+            if (!(accountDto instanceof UserDefinedFiatAccountDto userDefinedDto)) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST,
+                        "Account must be of type UserDefinedFiatAccountDto"));
+                return;
+            }
 
             try {
-                Account<? extends PaymentMethod<?>, ?> account = DtoMappings.FiatAccountMapping.toBisq2Model(accountDto);
+                UserDefinedFiatAccount account = UserDefinedFiatAccountDtoMapping.toBisq2Model(userDefinedDto);
                 accountService.addPaymentAccount(account);
             } catch (IllegalArgumentException e) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()));
                 return;
             }
 
-            asyncResponse.resume(buildResponse(Response.Status.CREATED, accountDto));
+            asyncResponse.resume(buildResponse(Response.Status.CREATED, userDefinedDto));
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
@@ -173,11 +180,11 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
     @DELETE
     @Operation(
-            summary = "Delete fiat payment account",
-            description = "Delete a fiat payment account by account name (provided as query parameter)",
+            summary = "Delete user-defined fiat payment account",
+            description = "Delete a user-defined fiat payment account by account name (provided as query parameter)",
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Fiat payment account successfully deleted"),
-                    @ApiResponse(responseCode = "400", description = "Account is not a fiat payment account"),
+                    @ApiResponse(responseCode = "204", description = "User-defined fiat payment account successfully deleted"),
+                    @ApiResponse(responseCode = "400", description = "Account is not a user-defined fiat payment account"),
                     @ApiResponse(responseCode = "404", description = "Account not found"),
                     @ApiResponse(responseCode = "500", description = "Internal server error"),
                     @ApiResponse(responseCode = "503", description = "Request timed out")
@@ -203,8 +210,8 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
             Account<? extends PaymentMethod<?>, ?> toRemove = result.get();
 
-            if (!isFiatAccount(toRemove)) {
-                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account is not a fiat payment account"));
+            if (!isUserDefinedAccount(toRemove)) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account is not a user-defined fiat payment account"));
                 return;
             }
 
@@ -217,17 +224,17 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
     @PUT
     @Operation(
-            summary = "Update fiat payment account",
-            description = "Update an existing fiat payment account by replacing it with new data. The account name to update is provided as a query parameter.",
+            summary = "Update user-defined fiat payment account",
+            description = "Update an existing user-defined fiat payment account by replacing it with new data. The account name to update is provided as a query parameter.",
             requestBody = @RequestBody(
-                    description = "Updated fiat account details including payment rail type, account name, and payload",
+                    description = "Updated user-defined fiat account details (must be UserDefinedFiatAccountDto / CUSTOM)",
                     required = true,
                     content = @Content(schema = @Schema(implementation = SaveFiatAccountRequest.class))
             ),
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Fiat payment account updated successfully"),
-                    @ApiResponse(responseCode = "400", description = "Invalid input data or unsupported payment rail"),
-                    @ApiResponse(responseCode = "404", description = "Fiat payment account not found"),
+                    @ApiResponse(responseCode = "204", description = "User-defined fiat payment account updated successfully"),
+                    @ApiResponse(responseCode = "400", description = "Invalid input data or unsupported account type"),
+                    @ApiResponse(responseCode = "404", description = "User-defined fiat payment account not found"),
                     @ApiResponse(responseCode = "500", description = "Internal server error"),
                     @ApiResponse(responseCode = "503", description = "Request timed out")
             }
@@ -245,9 +252,14 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
                 return;
             }
 
-            FiatAccountDto accountDto = request.account();
+            PaymentAccountDto accountDto = request.account();
             if (accountDto == null) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account data is required"));
+                return;
+            }
+            if (!(accountDto instanceof UserDefinedFiatAccountDto userDefinedDto)) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST,
+                        "Account must be of type UserDefinedFiatAccountDto"));
                 return;
             }
 
@@ -259,13 +271,13 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
             Account<? extends PaymentMethod<?>, ?> existingAccount = result.get();
 
-            if (!isFiatAccount(existingAccount)) {
-                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account is not a fiat payment account"));
+            if (!isUserDefinedAccount(existingAccount)) {
+                asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, "Account is not a user-defined fiat payment account"));
                 return;
             }
 
             try {
-                Account<? extends PaymentMethod<?>, ?> newAccount = DtoMappings.FiatAccountMapping.toBisq2Model(accountDto);
+                UserDefinedFiatAccount newAccount = UserDefinedFiatAccountDtoMapping.toBisq2Model(userDefinedDto);
                 accountService.updatePaymentAccount(accountName, newAccount);
             } catch (IllegalArgumentException e) {
                 asyncResponse.resume(buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage()));
@@ -281,15 +293,15 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
     @PATCH
     @Operation(
-            summary = "Set selected fiat payment account",
-            description = "Set the currently selected fiat payment account. Pass null or omit selectedAccount to unselect.",
+            summary = "Set selected user-defined fiat payment account",
+            description = "Set the currently selected user-defined fiat payment account. Pass null or omit selectedAccount to unselect.",
             requestBody = @RequestBody(
-                    description = "The fiat payment account to set as selected. Pass null to unselect.",
+                    description = "The user-defined fiat payment account to set as selected. Pass null to unselect.",
                     required = false,
                     content = @Content(schema = @Schema(implementation = SetSelectedFiatAccountRequest.class))
             ),
             responses = {
-                    @ApiResponse(responseCode = "204", description = "Selected fiat payment account set successfully"),
+                    @ApiResponse(responseCode = "204", description = "Selected user-defined fiat payment account set successfully"),
                     @ApiResponse(responseCode = "400", description = "Invalid input data"),
                     @ApiResponse(responseCode = "404", description = "Payment account not found"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -298,8 +310,12 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
     @Path("/selected")
     public Response setSelectedPaymentAccount(@Valid SetSelectedFiatAccountRequest request) {
         try {
-            FiatAccountDto accountDto = request.selectedAccount();
+            PaymentAccountDto accountDto = request.selectedAccount();
             if (accountDto != null) {
+                if (!(accountDto instanceof UserDefinedFiatAccountDto)) {
+                    return buildErrorResponse(Response.Status.BAD_REQUEST,
+                            "Account must be of type UserDefinedFiatAccountDto");
+                }
                 Optional<Account<? extends PaymentMethod<?>, ?>> result = accountService.findAccount(accountDto.accountName());
                 if (result.isEmpty()) {
                     return buildErrorResponse(Response.Status.NOT_FOUND, "Payment account not found");
@@ -307,8 +323,8 @@ public class FiatPaymentAccountsRestApi extends RestApiBase {
 
                 Account<? extends PaymentMethod<?>, ?> foundAccount = result.get();
 
-                if (!isFiatAccount(foundAccount)) {
-                    return buildErrorResponse(Response.Status.BAD_REQUEST, "Account is not a fiat payment account");
+                if (!isUserDefinedAccount(foundAccount)) {
+                    return buildErrorResponse(Response.Status.BAD_REQUEST, "Account is not a user-defined fiat payment account");
                 }
 
                 accountService.setSelectedAccount(foundAccount);

--- a/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesDto.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesDto.java
@@ -46,4 +46,5 @@ public class TradePropertiesDto {
     public Optional<String> peersErrorMessage = Optional.empty();
     public Optional<String> peersErrorStackTrace = Optional.empty();
     public Optional<TradeProtocolFailureDto> peersTradeProtocolFailure = Optional.empty();
+    public Optional<Long> tradeCompletedDate = Optional.empty();
 }

--- a/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/trades/TradePropertiesWebSocketService.java
@@ -76,6 +76,7 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
                 pins.add(observePeersErrorMessage(bisqEasyTrade, tradeId));
                 pins.add(observePeersErrorStackTrace(bisqEasyTrade, tradeId));
                 pins.add(observePeersTradeProtocolFailure(bisqEasyTrade, tradeId));
+                pins.add(observeTradeCompletedDate(bisqEasyTrade, tradeId));
             }
 
             @Override
@@ -207,6 +208,16 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
         });
     }
 
+    private Pin observeTradeCompletedDate(BisqEasyTrade bisqEasyTrade, String tradeId) {
+        return bisqEasyTrade.tradeCompletedDateObservable().addObserver(value -> {
+            if (value.isPresent()) {
+                var data = new TradePropertiesDto();
+                data.tradeCompletedDate = value;
+                send(Map.of(tradeId, data));
+            }
+        });
+    }
+
     @Override
     public CompletableFuture<Boolean> shutdown() {
         if (tradesPin != null) {
@@ -234,6 +245,7 @@ public class TradePropertiesWebSocketService extends BaseWebSocketService {
                     data.peersErrorMessage = Optional.ofNullable(bisqEasyTrade.getPeersErrorMessage());
                     data.peersErrorStackTrace = Optional.ofNullable(bisqEasyTrade.getPeersErrorStackTrace());
                     data.peersTradeProtocolFailure = Optional.ofNullable(DtoMappings.TradeProtocolFailureMapping.fromBisq2Model(bisqEasyTrade.getPeersTradeProtocolFailure()));
+                    data.tradeCompletedDate = bisqEasyTrade.getTradeCompletedDate();
                     return Map.of(bisqEasyTrade.getId(), data);
                 })
                 .collect(Collectors.toList());

--- a/apps/api-app/build.gradle.kts
+++ b/apps/api-app/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("bisq:bonded-roles")
     implementation("bisq:settings")
     implementation("bisq:burningman")
+    implementation("bisq:mu-sig")
     implementation("bisq:user")
     implementation("bisq:chat")
     implementation("bisq:support")

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/details/FiatAccountDetails.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/accounts/fiat_accounts/details/FiatAccountDetails.java
@@ -22,6 +22,7 @@ import bisq.account.accounts.fiat.CountryBasedAccount;
 import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.account.timestamp.AccountTimestampService;
 import bisq.common.data.Triple;
+import bisq.common.locale.CountryRepository;
 import bisq.desktop.main.content.user.accounts.AccountDetails;
 import bisq.i18n.Res;
 import javafx.scene.control.Label;
@@ -41,7 +42,7 @@ public abstract class FiatAccountDetails<A extends Account<?, ?>> extends Accoun
 
         if (account instanceof CountryBasedAccount<?> countryBasedAccount) {
             Triple<Text, Label, VBox> currencyTriple = getDescriptionValueVBoxTriple(Res.get("paymentAccounts.country"),
-                    countryBasedAccount.getCountry().getName());
+                    CountryRepository.getNameByCode(countryBasedAccount.getCountry().getCode()));
             gridPane.add(currencyTriple.getThird(), 2, rowIndex);
         }
     }

--- a/common/src/main/java/bisq/common/asset/CryptoAsset.java
+++ b/common/src/main/java/bisq/common/asset/CryptoAsset.java
@@ -17,19 +17,15 @@
 
 package bisq.common.asset;
 
-
 import bisq.common.validation.Validation;
 import bisq.common.validation.crypto.CryptoAddressValidationRepository;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.Set;
-
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public final class CryptoAsset extends DigitalAsset {
-    private static final Set<String> SUPPORT_AUTO_CONF_CODES = Set.of("XMR");
 
     @Getter
     private transient final Validation addressValidation;
@@ -44,7 +40,7 @@ public final class CryptoAsset extends DigitalAsset {
     public CryptoAsset(String code, String name) {
         super(code, name);
         this.addressValidation = CryptoAddressValidationRepository.getValidation(code);
-        supportAutoConf = SUPPORT_AUTO_CONF_CODES.contains(code);
+        supportAutoConf = CryptoAssetRepository.isAutoConfSupported(code);
     }
 
     @Override

--- a/common/src/main/java/bisq/common/asset/CryptoAssetRepository.java
+++ b/common/src/main/java/bisq/common/asset/CryptoAssetRepository.java
@@ -23,9 +23,12 @@ import lombok.Setter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class CryptoAssetRepository {
+    private static final Set<String> AUTO_CONF_SUPPORTED_CODES = Set.of("XMR");
+
     public static final CryptoAsset BITCOIN = new CryptoAsset("BTC", "Bitcoin");
     public static final CryptoAsset XMR = new CryptoAsset("XMR", "Monero");
     public static final CryptoAsset BSQ = new CryptoAsset("BSQ", "BSQ");
@@ -74,5 +77,9 @@ public class CryptoAssetRepository {
 
     public static List<CryptoAsset> getCryptoAssets() {
         return CRYPTO_ASSETS;
+    }
+
+    public static boolean isAutoConfSupported(String code) {
+        return AUTO_CONF_SUPPORTED_CODES.contains(code);
     }
 }

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -34,7 +34,6 @@ import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,9 +58,8 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
     // Wrapper for stateObservable which is not handled as generic in Fsm
     private final transient Observable<BisqEasyTradeState> tradeState = new Observable<>();
 
-    @Setter
-    @Getter
-    private Optional<Long> tradeCompletedDate = Optional.empty();
+    @EqualsAndHashCode.Exclude
+    private final Observable<Optional<Long>> tradeCompletedDate = new Observable<>(Optional.empty());
 
     public BisqEasyTrade(BisqEasyContract contract,
                          boolean isBuyer,
@@ -116,7 +114,7 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
         Optional.ofNullable(bitcoinPaymentData.get()).ifPresent(builder::setBitcoinPaymentData);
         Optional.ofNullable(paymentProof.get()).ifPresent(builder::setPaymentProof);
         Optional.ofNullable(interruptTradeInitiator.get()).ifPresent(e -> builder.setInterruptTradeInitiator(e.toProtoEnum()));
-        tradeCompletedDate.ifPresent(builder::setTradeCompletedDate);
+        getTradeCompletedDate().ifPresent(builder::setTradeCompletedDate);
         return builder;
     }
 
@@ -175,5 +173,17 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
 
     public ReadOnlyObservable<BisqEasyTradeState> tradeStateObservable() {
         return tradeState;
+    }
+
+    public Optional<Long> getTradeCompletedDate() {
+        return tradeCompletedDate.get();
+    }
+
+    public void setTradeCompletedDate(Optional<Long> value) {
+        tradeCompletedDate.set(value);
+    }
+
+    public ReadOnlyObservable<Optional<Long>> tradeCompletedDateObservable() {
+        return tradeCompletedDate;
     }
 }


### PR DESCRIPTION
## Sync for-mobile-based-on-2.1.10 unmerged commits to main

  - #4588: crypto and fiat rest api + dto/mappings                                                                              
  - #4603: musig payment accounts dto models and mappings                                                                       
  - #4650: FiatPaymentMethodDto                                                                                                 
  - #4680: BisqEasyTrade.tradeCompletedDate observable + WS event      
  - #4696: Update crypto account model                                                                                          
                                                                                                                                
  Adaptation notes:
  
While the cherry-pick renamed FiatPaymentAccountsRestApi → UserDefinedPaymentAccountsRestApi).           
                   
  - #4603: 1-line fixup squashed in — the `getFormattedMaxTradeLimit` method was                                                
    renamed to `getFormattedMaxTradeLimitInUsd` on main after the cherry-pick was                                               
    authored.                                                                                                                   
  - #4696: CryptoAsset conflict resolved — preserved both main's `final` modifier                                               
    (added in 83fcdb953a) and the cherry-pick's delegation to                                                                   
    CryptoAssetRepository.isAutoConfSupported. 