### PR TITLE
Better storage persistence 

### DIFF
--- a/common/src/main/java/bisq/common/proto/NetworkStorageWhiteList.java
+++ b/common/src/main/java/bisq/common/proto/NetworkStorageWhiteList.java
@@ -48,6 +48,7 @@ public class NetworkStorageWhiteList {
                         resolver.getClass().getSimpleName().startsWith("BisqEasyMediationRequest")) ||
                         (protoTypeName.equals("support.MediatorsResponse") &&
                                 resolver.getClass().getSimpleName().startsWith("BisqEasyMediatorsResponse"))) {
+                    classNames.add(className);
                     log.debug("resolver and protoTypeName do not match because of backwards compatibility. protoTypeName={} resolver={}",
                             protoTypeName, resolver.getClass().getSimpleName());
                 } else {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/MetaData.java
@@ -26,6 +26,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Meta data for storage properties per DistributedData
@@ -53,6 +54,8 @@ public final class MetaData implements NetworkProto {
     public static final int DEFAULT_PRIORITY = 0;
     public static final int HIGH_PRIORITY = 1;
     public static final int HIGHEST_PRIORITY = 2;
+
+    private static final Pattern CLASS_NAME_PATTERN = Pattern.compile("^[A-Z][A-Za-z0-9_$]*$");
 
     // How long data are kept in the storage map
     private final long ttl;
@@ -91,6 +94,9 @@ public final class MetaData implements NetworkProto {
     @Override
     public void verify() {
         NetworkDataValidation.validateText(className, 50);
+        if (!CLASS_NAME_PATTERN.matcher(className).matches()) {
+            throw new IllegalArgumentException("Invalid className");
+        }
     }
 
     @Override

--- a/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageService.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/storage/StorageService.java
@@ -414,6 +414,9 @@ public class StorageService {
     /* --------------------------------------------------------------------- */
 
     public CompletableFuture<AuthenticatedDataStorageService> getOrCreateAuthenticatedDataStore(String storeKey) {
+        if (isStoreKeyNotAllowed(storeKey)) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Unsupported storeKey"));
+        }
         if (!authenticatedDataStores.containsKey(storeKey)) {
             AuthenticatedDataStorageService storageService = new AuthenticatedDataStorageService(persistenceService,
                     pruneExpiredEntriesService,
@@ -455,6 +458,9 @@ public class StorageService {
     }
 
     public CompletableFuture<MailboxDataStorageService> getOrCreateMailboxDataStore(String storeKey) {
+        if (isStoreKeyNotAllowed(storeKey)) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Unsupported storeKey"));
+        }
         if (!mailboxStores.containsKey(storeKey)) {
             MailboxDataStorageService storageService = new MailboxDataStorageService(persistenceService,
                     pruneExpiredEntriesService,
@@ -498,6 +504,9 @@ public class StorageService {
     }
 
     public CompletableFuture<AppendOnlyDataStorageService> getOrCreateAppendOnlyDataStore(String storeKey) {
+        if (isStoreKeyNotAllowed(storeKey)) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Unsupported storeKey"));
+        }
         if (!appendOnlyDataStores.containsKey(storeKey)) {
             AppendOnlyDataStorageService storageService = new AppendOnlyDataStorageService(persistenceService,
                     APPEND_ONLY_DATA_STORE.getStoreName(),
@@ -610,6 +619,11 @@ public class StorageService {
     private Stream<DataStorageService<? extends DataRequest>> getStoreByFileName(String storeKey) {
         return getAllStores()
                 .filter(store -> storeKey.equals(store.getStoreKey()));
+    }
+
+    private static boolean isStoreKeyNotAllowed(String storeKey) {
+        Set<String> allowed = NetworkStorageWhiteList.getClassNames();
+        return !allowed.isEmpty() && !allowed.contains(storeKey);
     }
 
     private Set<String> getExistingStoreKeys(Path dirPath) {

--- a/persistence/src/main/java/bisq/persistence/Persistence.java
+++ b/persistence/src/main/java/bisq/persistence/Persistence.java
@@ -46,7 +46,12 @@ public class Persistence<T extends PersistableStore<T>> {
     public Persistence(Path directoryPath, String fileName, MaxBackupSize maxBackupSize, RestoreService restoreService) {
         this.fileName = fileName;
         String storageFileName = StringUtils.camelCaseToSnakeCase(fileName);
-        storePath = directoryPath.resolve(storageFileName + EXTENSION);
+        Path resolved = directoryPath.resolve(storageFileName + EXTENSION).normalize();
+        Path baseDir = directoryPath.normalize();
+        if (!resolved.startsWith(baseDir)) {
+            throw new IllegalArgumentException("Invalid storage path");
+        }
+        storePath = resolved;
         var storeFileManager = new PersistableStoreFileManager(storePath, maxBackupSize);
         persistableStoreReaderWriter = new PersistableStoreReaderWriter<>(storeFileManager, restoreService);
     }


### PR DESCRIPTION
- Enforce a strict identifier format for MetaData.className.
- Restrict StorageService.getOrCreate* to store keys present in NetworkStorageWhiteList, with a permissive fallback when the list is empty so unit-test bootstrapping is not affected.