### PR TITLE
Add release artifact GPG signing task

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/GpgSignReleaseArtifactsTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/GpgSignReleaseArtifactsTask.kt
@@ -36,7 +36,7 @@ abstract class GpgSignReleaseArtifactsTask : DefaultTask() {
         val releaseDir = getReleaseDir()
         val gpgUser = getRequiredValue(gpgUser, "Missing required -PgpgUser=<key-id-email-or-fingerprint>. You can also use -PbisqGpgUser=<key-id-email-or-fingerprint> or BISQ_GPG_USER.")
         val expectedFingerprint = normalizeFingerprint(
-                getRequiredValue(expectedFingerprint, "Missing expected GPG fingerprint. Use -PgpgFingerprint=<fingerprint> or BISQ_GPG_FINGERPRINT.")
+                getRequiredValue(expectedFingerprint, "Missing expected GPG fingerprint. Use -PgpgFingerprint=<fingerprint>, -PbisqGpgFingerprint=<fingerprint>, or BISQ_GPG_FINGERPRINT.")
         )
 
         val releaseDirFiles = releaseDir.listFiles()

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/GpgSignReleaseArtifactsTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/GpgSignReleaseArtifactsTask.kt
@@ -1,0 +1,193 @@
+package bisq.gradle.packaging
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.Locale
+
+abstract class GpgSignReleaseArtifactsTask : DefaultTask() {
+
+    @get:Input
+    abstract val releaseDirPath: Property<String>
+
+    @get:Input
+    abstract val gpgUser: Property<String>
+
+    @get:Input
+    abstract val expectedFingerprint: Property<String>
+
+    @get:Input
+    abstract val gpgExecutable: Property<String>
+
+    @get:Input
+    abstract val artifactExtensions: ListProperty<String>
+
+    init {
+        outputs.upToDateWhen { false }
+    }
+
+    @TaskAction
+    fun run() {
+        val releaseDir = getReleaseDir()
+        val gpgUser = getRequiredValue(gpgUser, "Missing required -PgpgUser=<key-id-email-or-fingerprint>. You can also use -PbisqGpgUser=<key-id-email-or-fingerprint> or BISQ_GPG_USER.")
+        val expectedFingerprint = normalizeFingerprint(
+                getRequiredValue(expectedFingerprint, "Missing expected GPG fingerprint. Use -PgpgFingerprint=<fingerprint> or BISQ_GPG_FINGERPRINT.")
+        )
+
+        val releaseDirFiles = releaseDir.listFiles()
+                ?: throw GradleException("Cannot list release directory: $releaseDir. Check that it is readable.")
+
+        val artifacts = releaseDirFiles
+                .filter(::isSignableArtifact)
+                .sortedBy(File::getName)
+
+        if (artifacts.isEmpty()) {
+            throw GradleException("No release artifacts found to sign in $releaseDir")
+        }
+
+        logger.lifecycle("Signing ${artifacts.size} release artifact(s) in ${releaseDir.absolutePath}")
+        artifacts.forEach { artifact ->
+            val signatureFile = File(artifact.parentFile, "${artifact.name}.asc")
+            signArtifact(gpgExecutable.get(), gpgUser, artifact, signatureFile)
+            verifySignature(gpgExecutable.get(), expectedFingerprint, artifact, signatureFile)
+            logger.lifecycle("Signed and verified ${artifact.name} -> ${signatureFile.name}")
+        }
+    }
+
+    private fun getReleaseDir(): File {
+        val rawReleaseDir = getRequiredValue(releaseDirPath, "Missing required -Pbisq.release.dir=<directory> or -PreleaseDir=<directory>.")
+        val releaseDir = project.file(rawReleaseDir.trim())
+        if (!releaseDir.isDirectory) {
+            throw GradleException("Release directory is not a directory: $releaseDir")
+        }
+        return releaseDir
+    }
+
+    private fun getRequiredValue(property: Property<String>, message: String): String {
+        val value = property.orNull
+        if (value == null || value.trim().isEmpty()) {
+            throw GradleException(message)
+        }
+        return value.trim()
+    }
+
+    private fun isSignableArtifact(candidate: File): Boolean {
+        if (!candidate.isFile || candidate.name.startsWith(".") || candidate.name.endsWith(".asc")) {
+            return false
+        }
+
+        val lowerName = candidate.name.lowercase(Locale.ROOT)
+        return artifactExtensions.get().any { extension ->
+            lowerName.endsWith(".${extension.lowercase(Locale.ROOT)}")
+        }
+    }
+
+    private fun signArtifact(gpgExecutable: String,
+                             gpgUser: String,
+                             artifact: File,
+                             signatureFile: File) {
+        val signResult = execResult(listOf(
+                gpgExecutable,
+                "--yes",
+                "--digest-algo", "SHA256",
+                "--local-user", gpgUser,
+                "--output", signatureFile.absolutePath,
+                "--detach-sig",
+                "--armor",
+                artifact.absolutePath
+        ))
+        if (signResult.exitValue != 0) {
+            throw GradleException("Failed to sign ${artifact.name}: ${signResult.failureDetails()}")
+        }
+        if (!signatureFile.isFile || signatureFile.length() == 0L) {
+            throw GradleException("GPG did not create a non-empty signature file for ${artifact.name}: $signatureFile")
+        }
+    }
+
+    private fun verifySignature(gpgExecutable: String,
+                                expectedFingerprint: String,
+                                artifact: File,
+                                signatureFile: File) {
+        val verifyResult = execResult(listOf(
+                gpgExecutable,
+                "--status-fd", "1",
+                "--verify",
+                signatureFile.absolutePath,
+                artifact.absolutePath
+        ))
+        if (verifyResult.exitValue != 0) {
+            throw GradleException("Failed to verify ${signatureFile.name}: ${verifyResult.failureDetails()}")
+        }
+
+        val validSigFingerprints = parseValidSigFingerprints(verifyResult.stdout)
+        if (!validSigFingerprints.contains(expectedFingerprint)) {
+            throw GradleException(
+                    "Signature ${signatureFile.name} was valid, but not from expected fingerprint $expectedFingerprint. " +
+                            "VALIDSIG fingerprints: ${validSigFingerprints.joinToString()}"
+            )
+        }
+    }
+
+    private fun parseValidSigFingerprints(statusOutput: String): Set<String> {
+        return statusOutput.lineSequence()
+                .filter { it.startsWith("[GNUPG:] VALIDSIG ") }
+                .flatMap { line ->
+                    val tokens = line.split(Regex("\\s+"))
+                    // GnuPG emits the signing-key fingerprint first and, for subkey signatures, the primary-key
+                    // fingerprint as the last field. Accept either so release operators can pin the primary key.
+                    listOfNotNull(tokens.getOrNull(2), tokens.lastOrNull())
+                }
+                .mapNotNull(::normalizeFingerprintOrNull)
+                .toSet()
+    }
+
+    private fun normalizeFingerprint(fingerprint: String): String {
+        val normalizedFingerprint = fingerprint.replace(Regex("\\s+"), "")
+                .uppercase(Locale.ROOT)
+        if (!normalizedFingerprint.matches(Regex("[0-9A-F]{40}"))) {
+            throw GradleException("Expected a full 40-character GPG fingerprint, got: $fingerprint")
+        }
+        return normalizedFingerprint
+    }
+
+    private fun normalizeFingerprintOrNull(fingerprint: String): String? {
+        val normalizedFingerprint = fingerprint.replace(Regex("\\s+"), "")
+                .uppercase(Locale.ROOT)
+        return if (normalizedFingerprint.matches(Regex("[0-9A-F]{40}"))) {
+            normalizedFingerprint
+        } else {
+            null
+        }
+    }
+
+    private fun execResult(commandLine: List<String>): ExecResult {
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val result = project.exec {
+            commandLine(commandLine)
+            standardOutput = stdout
+            errorOutput = stderr
+            isIgnoreExitValue = true
+        }
+        return ExecResult(
+                result.exitValue,
+                stdout.toString(Charsets.UTF_8.name()),
+                stderr.toString(Charsets.UTF_8.name())
+        )
+    }
+
+    private data class ExecResult(val exitValue: Int,
+                                  val stdout: String,
+                                  val stderr: String) {
+        fun failureDetails(): String =
+                listOf(stderr, stdout)
+                        .filter { it.trim().isNotEmpty() }
+                        .joinToString("\n")
+                        .trim()
+    }
+}

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/GpgSignReleaseArtifactsTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/GpgSignReleaseArtifactsTask.kt
@@ -50,12 +50,18 @@ abstract class GpgSignReleaseArtifactsTask : DefaultTask() {
             throw GradleException("No release artifacts found to sign in $releaseDir")
         }
 
-        logger.lifecycle("Signing ${artifacts.size} release artifact(s) in ${releaseDir.absolutePath}")
+        logger.lifecycle("Processing ${artifacts.size} release artifact(s) in ${releaseDir.absolutePath}")
         artifacts.forEach { artifact ->
             val signatureFile = File(artifact.parentFile, "${artifact.name}.asc")
-            signArtifact(gpgExecutable.get(), gpgUser, artifact, signatureFile)
-            verifySignature(gpgExecutable.get(), expectedFingerprint, artifact, signatureFile)
-            logger.lifecycle("Signed and verified ${artifact.name} -> ${signatureFile.name}")
+            if (signatureFile.exists()) {
+                verifyExistingSignatureFile(signatureFile)
+                verifySignature(gpgExecutable.get(), expectedFingerprint, artifact, signatureFile)
+                logger.lifecycle("Verified existing signature ${signatureFile.name}")
+            } else {
+                signArtifact(gpgExecutable.get(), gpgUser, artifact, signatureFile)
+                verifySignature(gpgExecutable.get(), expectedFingerprint, artifact, signatureFile)
+                logger.lifecycle("Signed and verified ${artifact.name} -> ${signatureFile.name}")
+            }
         }
     }
 
@@ -93,7 +99,6 @@ abstract class GpgSignReleaseArtifactsTask : DefaultTask() {
                              signatureFile: File) {
         val signResult = execResult(listOf(
                 gpgExecutable,
-                "--yes",
                 "--digest-algo", "SHA256",
                 "--local-user", gpgUser,
                 "--output", signatureFile.absolutePath,
@@ -106,6 +111,15 @@ abstract class GpgSignReleaseArtifactsTask : DefaultTask() {
         }
         if (!signatureFile.isFile || signatureFile.length() == 0L) {
             throw GradleException("GPG did not create a non-empty signature file for ${artifact.name}: $signatureFile")
+        }
+    }
+
+    private fun verifyExistingSignatureFile(signatureFile: File) {
+        if (!signatureFile.isFile) {
+            throw GradleException("Existing signature path is not a file: $signatureFile")
+        }
+        if (signatureFile.length() == 0L) {
+            throw GradleException("Existing signature file is empty: $signatureFile")
         }
     }
 

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -106,6 +106,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         releaseBinariesTaskFactory.registerCopyMaintainerPublicKeysTask()
         releaseBinariesTaskFactory.registerCopySigningPublicKeyTask()
         releaseBinariesTaskFactory.registerMergeOsSpecificJarHashesTask(extension.version)
+        releaseBinariesTaskFactory.registerSignReleaseArtifactsTask()
     }
 
     private fun getHashFileForOs(project: Project, extension: PackagingPluginExtension): Provider<RegularFile> {

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/ReleaseBinariesTaskFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/ReleaseBinariesTaskFactory.kt
@@ -11,6 +11,7 @@ import org.gradle.kotlin.dsl.register
 class ReleaseBinariesTaskFactory(private val project: Project) {
     companion object {
         private const val MAINTAINER_PUBLIC_KEY_DIRECTORY: String = "maintainer_public_keys"
+        private const val DEFAULT_SIGNING_KEY_FINGERPRINT: String = "B493319106CC3D1F252E19CBF806F422E222AA02"
     }
 
     private val releaseDir: Provider<Directory> = project.layout.buildDirectory.dir("packaging/release")
@@ -103,5 +104,41 @@ class ReleaseBinariesTaskFactory(private val project: Project) {
             hashFiles.setFrom(files)
             outputFile.set(mergedShaFile)
         }
+    }
+
+    fun registerSignReleaseArtifactsTask() {
+        val releaseDirPath = project.providers.gradleProperty("bisq.release.dir")
+                .orElse(project.providers.gradleProperty("releaseDir"))
+                .orElse("")
+        val gpgUser = project.providers.gradleProperty("gpgUser")
+                .orElse(project.providers.gradleProperty("bisqGpgUser"))
+                .orElse(project.providers.environmentVariable("BISQ_GPG_USER"))
+                .orElse("")
+        val expectedFingerprint = project.providers.gradleProperty("gpgFingerprint")
+                .orElse(project.providers.gradleProperty("bisqGpgFingerprint"))
+                .orElse(project.providers.environmentVariable("BISQ_GPG_FINGERPRINT"))
+                .orElse(DEFAULT_SIGNING_KEY_FINGERPRINT)
+        val gpgExecutable = project.providers.gradleProperty("gpgExecutable")
+                .orElse(project.providers.environmentVariable("GPG_EXECUTABLE"))
+                .orElse(project.providers.provider { resolveGpgExecutable() })
+
+        project.tasks.register<GpgSignReleaseArtifactsTask>("signReleaseArtifacts") {
+            group = "distribution"
+            description = "Signs release artifacts in -Pbisq.release.dir with detached armored GPG signatures."
+
+            this.releaseDirPath.set(releaseDirPath)
+            this.gpgUser.set(gpgUser)
+            this.expectedFingerprint.set(expectedFingerprint)
+            this.gpgExecutable.set(gpgExecutable)
+            artifactExtensions.set(listOf("dmg", "deb", "exe", "rpm", "sha256"))
+        }
+    }
+
+    private fun resolveGpgExecutable(): String {
+        return listOf(
+                "/opt/homebrew/bin/gpg",
+                "/usr/local/bin/gpg",
+                "/usr/bin/gpg"
+        ).firstOrNull { java.io.File(it).canExecute() } ?: "gpg"
     }
 }


### PR DESCRIPTION
Add release artifact GPG signing task

Add a packaging Gradle task that signs Bisq 2 release artifacts in an explicit release directory with detached armored SHA-256 GPG signatures.

The task requires an explicit GPG user, skips existing .asc files, signs only the expected release artifact extensions, and fails clearly when the release directory cannot be listed or contains no signable artifacts.

After each signature is created, verify it with gpg --status-fd 1 --verify and require a VALIDSIG line matching the expected full 40-character fingerprint. This prevents an operator typo or ambiguous GPG user from passing just because the selected local key can sign and verify the artifact.

Default the expected fingerprint to the current E222AA02 signing key while allowing release operators to override it with -PgpgFingerprint, -PbisqGpgFingerprint, or BISQ_GPG_FINGERPRINT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated GPG signing and verification into the release workflow to ensure the authenticity and integrity of released artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->