### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Keep Gradle wrapper checksums stable across GitHub-hosted runners.
+gradlew text eol=lf
+gradlew.bat text eol=crlf
+gradle/wrapper/gradle-wrapper.properties text eol=lf
+gradle/wrapper/gradle-wrapper.sha256 text eol=lf
+gradle/wrapper/gradle-wrapper.jar binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build Bisq on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ ubuntu-24.04, macos-15, windows-2025 ]
 
     uses: ./.github/workflows/build_bisq_module.yml
     with:
@@ -26,7 +26,7 @@ jobs:
     name: Build apps module on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ ubuntu-24.04, macos-15, windows-2025 ]
 
     uses: ./.github/workflows/build_bisq_module.yml
     with:
@@ -38,7 +38,7 @@ jobs:
     name: Build network module on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ ubuntu-24.04, macos-15, windows-2025 ]
 
     uses: ./.github/workflows/build_bisq_module.yml
     with:
@@ -50,7 +50,7 @@ jobs:
     name: Build tor module on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        os: [ ubuntu-24.04, macos-15, windows-2025 ]
 
     uses: ./.github/workflows/build_bisq_module.yml
     with:

--- a/.github/workflows/build_bisq_module.yml
+++ b/.github/workflows/build_bisq_module.yml
@@ -13,24 +13,38 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ inputs.name }} on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify Gradle wrapper checksums
+        shell: bash
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c gradle/wrapper/gradle-wrapper.sha256
+          else
+            shasum -a 256 -c gradle/wrapper/gradle-wrapper.sha256
+          fi
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21'
+          java-version: '21.0.6'
           distribution: 'zulu'
+          check-latest: false
 
       - name: Gradle Build Action
-        uses: gradle/gradle-build-action@v3.5.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           arguments: build -x test
           build-root-directory: ${{ inputs.build-root-dir }}

--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -10,16 +10,20 @@ on:
     workflows: [ Build Bisq 2 ]
     types: [ completed ]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify Transifex configuration
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Verify that .tx/config is in sync with the i18n folder
         run: |
@@ -50,16 +54,17 @@ jobs:
     name: Calculate pushes and push source files
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     needs: verify
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       t_matrix: ${{ steps.calculate-pushes.outputs.t_matrix || '{"include":[]}' }}
       has_translation_changes: ${{ steps.calculate-pushes.outputs.has_translation_changes }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check if the commit is in the main branch
         id: check_commit
@@ -232,7 +237,7 @@ jobs:
 
       - name: Push source files to Transifex
         if: steps.calculate-pushes.outputs.s_args != ''
-        uses: transifex/cli-action@v2
+        uses: transifex/cli-action@584fd205cbe598773b5a81ce711fa44842678189 # v2
         with:
           token: ${{ secrets.TX_TOKEN }}
           args: ${{ steps.calculate-pushes.outputs.s_args }}
@@ -241,7 +246,7 @@ jobs:
     name: Push translations (${{ matrix.name }})
     if: needs.calculate_and_push_sources.outputs.t_matrix != '{"include":[]}'
     needs: calculate_and_push_sources
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # PHASE 1: Dynamic batching with controlled parallelism
     # Batches are generated dynamically based on changed locales only
     # Uses scripts/generate_transifex_batches.py for optimal batch configuration
@@ -251,9 +256,10 @@ jobs:
       fail-fast: false  # Don't cancel all jobs if one fails
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       # Install Transifex CLI for direct tx commands in retry/verification steps
       - name: Install Transifex CLI
@@ -290,7 +296,7 @@ jobs:
 
       # PHASE 1: Retry logic with exponential backoff
       - name: Push ${{ matrix.name }} translations with retry
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         id: push_with_retry
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -439,7 +445,7 @@ jobs:
     name: Upload Summary Report
     needs: [calculate_and_push_sources, push_translations]
     if: always() && needs.calculate_and_push_sources.outputs.has_translation_changes == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate summary
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.gradle.api.tasks.Delete
+import org.gradle.api.GradleException
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.util.Locale.getDefault
 
 plugins {
@@ -83,6 +85,119 @@ tasks.register<Delete>("cleanAll") {
     group = "build"
     description = "Cleans the entire project."
     delete(allBuildDirectories())
+}
+
+tasks.register("verifyGithubActionsSecurity") {
+    group = "verification"
+    description = "Verifies GitHub Actions workflows use pinned actions and non-floating build environments."
+
+    val workflowFiles = fileTree(".github/workflows") {
+        include("*.yml")
+        include("*.yaml")
+    }
+
+    inputs.files(workflowFiles)
+    outputs.upToDateWhen { false }
+
+    doLast {
+        val violations = mutableListOf<String>()
+        val usesRegex = Regex("""^\s*-?\s*uses:\s*([^#\s]+)(?:\s+#\s*(.+))?\s*$""")
+        val floatingRunnerRegex = Regex("""\b(ubuntu|macos|windows)-latest\b""", RegexOption.IGNORE_CASE)
+        val javaVersionRegex = Regex("""^\s*java-version:\s*([^#]+?)(?:\s+#.*)?$""")
+        val javaMatrixRegex = Regex("""^\s*java:\s*\[([^]]+)]\s*(?:#.*)?$""")
+        val exactJavaVersionRegex = Regex("""\d+\.\d+\.\d+""")
+        val checkLatestTrueRegex = Regex("""^\s*check-latest:\s*['"]?true['"]?\s*$""", RegexOption.IGNORE_CASE)
+        val checkLatestFalseRegex = Regex("""^\s*check-latest:\s*['"]?false['"]?\s*$""", RegexOption.IGNORE_CASE)
+        val persistCredentialsFalseRegex = Regex("""^\s*persist-credentials:\s*['"]?false['"]?\s*$""", RegexOption.IGNORE_CASE)
+        val nextStepRegex = Regex("""^\s*-\s+(name|uses):\s+.*""")
+
+        fun cleanYamlScalar(value: String): String {
+            return value.trim().trim('\'', '"')
+        }
+
+        fun stepLinesAfter(lines: List<String>, startIndex: Int): List<String> {
+            return lines.drop(startIndex + 1).takeWhile { !nextStepRegex.matches(it) }
+        }
+
+        workflowFiles.files.sortedBy { it.path }.forEach { workflowFile ->
+            val workflowPath = rootProject.relativePath(workflowFile)
+            val lines = workflowFile.readLines(StandardCharsets.UTF_8)
+
+            lines.forEachIndexed { index, line ->
+                val lineNumber = index + 1
+                val usesMatch = usesRegex.find(line)
+                if (usesMatch != null) {
+                    val actionRef = usesMatch.groupValues[1]
+                    val versionComment = usesMatch.groupValues[2].trim()
+
+                    if (!actionRef.startsWith("./")) {
+                        val ref = actionRef.substringAfterLast('@', missingDelimiterValue = "")
+                        if (!ref.matches(Regex("""[0-9a-fA-F]{40}"""))) {
+                            violations += "$workflowPath:$lineNumber uses '$actionRef' without a full 40-character commit SHA"
+                        }
+                        if (versionComment.isEmpty()) {
+                            violations += "$workflowPath:$lineNumber uses '$actionRef' without an inline version comment"
+                        }
+                    }
+
+                    if (actionRef.startsWith("actions/checkout@")) {
+                        val checkoutStepLines = stepLinesAfter(lines, index)
+                        if (checkoutStepLines.none { persistCredentialsFalseRegex.matches(it) }) {
+                            violations += "$workflowPath:$lineNumber uses actions/checkout without persist-credentials: false"
+                        }
+                    }
+
+                    if (actionRef.startsWith("actions/setup-java@")) {
+                        val setupJavaStepLines = stepLinesAfter(lines, index)
+                        if (setupJavaStepLines.none { checkLatestFalseRegex.matches(it) }) {
+                            violations += "$workflowPath:$lineNumber uses actions/setup-java without check-latest: false"
+                        }
+                    }
+                }
+
+                if (floatingRunnerRegex.containsMatchIn(line)) {
+                    violations += "$workflowPath:$lineNumber uses a floating GitHub runner label: ${line.trim()}"
+                }
+
+                val javaVersionMatch = javaVersionRegex.find(line)
+                if (javaVersionMatch != null) {
+                    val javaVersion = cleanYamlScalar(javaVersionMatch.groupValues[1])
+                    if (!javaVersion.startsWith("\${{") && !exactJavaVersionRegex.matches(javaVersion)) {
+                        violations += "$workflowPath:$lineNumber uses a floating Java version: ${line.trim()}"
+                    }
+                }
+
+                val javaMatrixMatch = javaMatrixRegex.find(line)
+                if (javaMatrixMatch != null) {
+                    javaMatrixMatch.groupValues[1]
+                        .split(',')
+                        .map { cleanYamlScalar(it) }
+                        .filter { it.isNotEmpty() && !it.startsWith("\${{") }
+                        .filterNot { exactJavaVersionRegex.matches(it) }
+                        .forEach {
+                            violations += "$workflowPath:$lineNumber uses a floating Java matrix version: $it"
+                        }
+                }
+
+                if (checkLatestTrueRegex.matches(line)) {
+                    violations += "$workflowPath:$lineNumber sets check-latest: true"
+                }
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "GitHub Actions security verification failed:\n" +
+                    violations.joinToString(separator = "\n") { "  - $it" }
+            )
+        }
+
+        logger.lifecycle("Verified ${workflowFiles.files.size} GitHub Actions workflow files.")
+    }
+}
+
+tasks.named("check") {
+    dependsOn("verifyGithubActionsSecurity")
 }
 
 tasks.register("publishAll") {

--- a/gradle/wrapper/gradle-wrapper.sha256
+++ b/gradle/wrapper/gradle-wrapper.sha256
@@ -1,0 +1,6 @@
+# Approved Gradle wrapper file checksums.
+# Update this file only after reviewing Gradle wrapper changes.
+8deee7d70dd19cf8180712bd9a4fc2f957ad4ce81f64ce825aec066275fdf761  gradlew
+fbc50a5a441b0917ea1bfba260c0717a8416fd54505338f074ccd3f03241ec09  gradlew.bat
+91a239400bb638f36a1795d8fdf7939d532cdc7d794d1119b7261aac158b1e60  gradle/wrapper/gradle-wrapper.jar
+ef02d8fe6df48d7e49abb80fea9caa3eb0fc562ee361380a480dabbba0ef07c5  gradle/wrapper/gradle-wrapper.properties


### PR DESCRIPTION
Port the generic GitHub Actions hardening from the Bisq 1 reference commits to Bisq 2 without the reproducible-release-builder-specific assertions.

Pin every external workflow action to an immutable 40-character commit SHA while keeping the audited tag as an inline version comment. Replace floating runner labels with ubuntu-24.04, macos-15, and windows-2025, and pin CI Java setup to Zulu 21.0.6 with check-latest disabled.

Set minimal workflow permissions, disable persisted checkout credentials on every actions/checkout step, and verify the Gradle wrapper file checksums before running Gradle. Add targeted .gitattributes entries so the wrapper checksum file remains stable across GitHub-hosted Linux, macOS, and Windows runners.

Add a generic verifyGithubActionsSecurity Gradle task and wire it into check so future workflow edits fail on unpinned actions, floating runner labels, floating Java versions, check-latest: true, setup-java without check-latest: false, or checkout steps without persist-credentials: false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build infrastructure security with pinned action versions and integrity verification for build artifacts.
  * Upgraded continuous integration environments to use fixed runner versions for improved reliability and consistency.
  * Added automated security validation for GitHub Actions workflow configurations.
  * Standardized version control settings for consistent cross-platform line ending handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->