### PR TITLE
Pin build toolchain versions

### DIFF
--- a/.github/workflows/build_bisq_module.yml
+++ b/.github/workflows/build_bisq_module.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '21.0.6'
+          java-version: '21.0.11'
           distribution: 'zulu'
           check-latest: false
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -3,12 +3,6 @@ plugins {
     id("bisq.protobuf")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 dependencies {
     implementation("bisq:persistence")
     implementation("bisq:java-se")

--- a/apps/api-app/build.gradle.kts
+++ b/apps/api-app/build.gradle.kts
@@ -3,12 +3,6 @@ plugins {
     application
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 application {
     mainClass.set("bisq.api_app.ApiApp")
 }

--- a/apps/desktop/desktop/build.gradle.kts
+++ b/apps/desktop/desktop/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }

--- a/apps/node-monitor-web-app/build.gradle.kts
+++ b/apps/node-monitor-web-app/build.gradle.kts
@@ -3,12 +3,6 @@ plugins {
     application
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 application {
     mainClass.set("bisq.node_monitor_app.NodeMonitorApp")
 }

--- a/bisq-easy/build.gradle.kts
+++ b/bisq-easy/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     id("bisq.java-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 dependencies {
     implementation(project(":persistence"))
     implementation(project(":i18n"))

--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -9,9 +9,14 @@ repositories {
     }
 }
 
+val pinnedJavaLanguageVersion = providers.gradleProperty("releaseBuild.javaVersion")
+    .map { it.substringBefore('.').toInt() }
+    .orElse(21)
+
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(pinnedJavaLanguageVersion.map { JavaLanguageVersion.of(it) })
+        vendor.set(JvmVendorSpec.AZUL)
     }
 }
 

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -73,7 +73,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
 
             dependsOn(generateHashesTask)
 
-            jdkDirectory.set(getJPackageJdkDirectory(extension))
+            jdkDirectory.set(getJPackageJdkDirectory(project, extension))
 
             distDirFile.set(installDistTask.map { it.destinationDir })
             mainJarFile.set(jarTask.flatMap { it.archiveFile })
@@ -95,7 +95,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             packageResourcesDir.set(packageResourcesDirFile)
 
             runtimeImageDirectory.set(
-                getJPackageJdkDirectory(extension)
+                getJPackageJdkDirectory(project, extension)
             )
 
             outputDirectory.set(project.layout.buildDirectory.dir("packaging/jpackage/packages"))
@@ -116,27 +116,30 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         }
     }
 
-    private fun getJPackageJdkDirectory(extension: PackagingPluginExtension): Provider<Directory> {
+    private fun getJPackageJdkDirectory(project: Project, extension: PackagingPluginExtension): Provider<Directory> {
         val launcherProvider = javaToolchainService.launcherFor {
-            languageVersion.set(getJavaLanguageVersion(extension))
+            languageVersion.set(getJavaLanguageVersion(project, extension))
             vendor.set(JvmVendorSpec.AZUL)
             implementation.set(JvmImplementation.VENDOR_SPECIFIC)
         }
         return launcherProvider.map { it.metadata.installationPath }
     }
 
-    private fun getJavaLanguageVersion(extension: PackagingPluginExtension): Provider<JavaLanguageVersion> {
-        val javaVersion = extension.name.map { appName ->
+    private fun getJavaLanguageVersion(project: Project, extension: PackagingPluginExtension): Provider<JavaLanguageVersion> {
+        val pinnedJavaVersion = project.providers.gradleProperty("releaseBuild.javaVersion")
+            .map { it.substringBefore('.').toInt() }
+            .orElse(21)
+        val javaVersion = extension.name.flatMap { appName ->
             if (appName == "Bisq") {
                 // Bisq1
                 if (getOS() == OS.MAC_OS) {
-                    15
+                    project.provider { 15 }
                 } else {
-                    17
+                    project.provider { 17 }
                 }
             } else {
                 // Bisq2
-                21
+                pinnedJavaVersion
             }
         }
         return javaVersion.map { JavaLanguageVersion.of(it) }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -73,7 +73,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
 
             dependsOn(generateHashesTask)
 
-            jdkDirectory.set(getJPackageJdkDirectory(project, extension))
+            jdkDirectory.set(getJPackageJdkDirectory(project))
 
             distDirFile.set(installDistTask.map { it.destinationDir })
             mainJarFile.set(jarTask.flatMap { it.archiveFile })
@@ -95,7 +95,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             packageResourcesDir.set(packageResourcesDirFile)
 
             runtimeImageDirectory.set(
-                getJPackageJdkDirectory(project, extension)
+                getJPackageJdkDirectory(project)
             )
 
             outputDirectory.set(project.layout.buildDirectory.dir("packaging/jpackage/packages"))
@@ -116,32 +116,19 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
         }
     }
 
-    private fun getJPackageJdkDirectory(project: Project, extension: PackagingPluginExtension): Provider<Directory> {
+    private fun getJPackageJdkDirectory(project: Project): Provider<Directory> {
         val launcherProvider = javaToolchainService.launcherFor {
-            languageVersion.set(getJavaLanguageVersion(project, extension))
+            languageVersion.set(getJavaLanguageVersion(project))
             vendor.set(JvmVendorSpec.AZUL)
             implementation.set(JvmImplementation.VENDOR_SPECIFIC)
         }
         return launcherProvider.map { it.metadata.installationPath }
     }
 
-    private fun getJavaLanguageVersion(project: Project, extension: PackagingPluginExtension): Provider<JavaLanguageVersion> {
-        val pinnedJavaVersion = project.providers.gradleProperty("releaseBuild.javaVersion")
+    private fun getJavaLanguageVersion(project: Project): Provider<JavaLanguageVersion> {
+        return project.providers.gradleProperty("releaseBuild.javaVersion")
             .map { it.substringBefore('.').toInt() }
             .orElse(21)
-        val javaVersion = extension.name.flatMap { appName ->
-            if (appName == "Bisq") {
-                // Bisq1
-                if (getOS() == OS.MAC_OS) {
-                    project.provider { 15 }
-                } else {
-                    project.provider { 17 }
-                }
-            } else {
-                // Bisq2
-                pinnedJavaVersion
-            }
-        }
-        return javaVersion.map { JavaLanguageVersion.of(it) }
+            .map { JavaLanguageVersion.of(it) }
     }
 }

--- a/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
+++ b/build-logic/toolchain-resolver/src/main/kotlin/bisq/gradle/toolchain_resolver/BisqToolchainResolver.kt
@@ -7,6 +7,8 @@ import org.gradle.platform.OperatingSystem
 import java.net.URI
 import java.util.*
 
+private const val OS_ARCH_PROPERTY = "os.arch"
+
 @Suppress("UnstableApiUsage")
 abstract class BisqToolchainResolver : JavaToolchainResolver {
     override fun resolve(toolchainRequest: JavaToolchainRequest): Optional<JavaToolchainDownload> {
@@ -35,9 +37,7 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
             }
 
     private fun getToolchainUrlForMacOs(javaVersion: Int): String? {
-        val osArch = System.getProperty("os.arch").lowercase(Locale.US)
-        // Note, they use x64 not x86 (or x86_64)
-        val macOsArchName = if (osArch.contains("aarch64")) "aarch64" else "x64"
+        val macOsArchName = getMacOsArchitectureClassifier()
         return when (javaVersion) {
             11 -> "https://cdn.azul.com/zulu/bin/zulu11.66.15_1-ca-jdk11.0.20-macosx_" + macOsArchName + ".tar.gz"
             15 -> "https://cdn.azul.com/zulu/bin/zulu15.46.17-ca-jdk15.0.10-macosx_" + macOsArchName + ".tar.gz"
@@ -54,4 +54,30 @@ abstract class BisqToolchainResolver : JavaToolchainResolver {
                 21 -> "https://cdn.azul.com/zulu/bin/zulu21.50.19-ca-jdk21.0.11-win_x64.zip"
                 else -> null
             }
+
+    private fun getMacOsArchitectureClassifier(): String {
+        val osArch = getOsArch()
+        if (osArch.isBlank()) {
+            throw IllegalStateException("Cannot choose macOS JDK toolchain because os.arch is missing or blank (value='$osArch').")
+        }
+
+        val architecture = osArch.trim().lowercase(Locale.US)
+        if (architecture == "aarch64" || architecture == "arm64") {
+            return "aarch64"
+        }
+        if (architecture == "x86_64" || architecture == "amd64" || architecture == "x64" ||
+            architecture == "x86" || architecture == "i386" || architecture == "i686") {
+            return "x64"
+        }
+
+        throw IllegalStateException("Cannot choose macOS JDK toolchain for unsupported os.arch value: '$osArch'.")
+    }
+
+    private fun getOsArch(): String {
+        return try {
+            System.getProperty(OS_ARCH_PROPERTY, "")
+        } catch (e: SecurityException) {
+            throw IllegalStateException("Cannot choose macOS JDK toolchain because os.arch cannot be read.", e)
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.GradleException
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Delete
 
 import java.io.File
@@ -29,9 +30,20 @@ val compositeBuilds = listOf(
 apply(from = "gradle/dependency-verification.gradle.kts")
 
 val gradleWrapperChecksums = layout.projectDirectory.file("gradle/wrapper/gradle-wrapper.sha256")
+val expectedReleaseJavaVersion = providers.gradleProperty("releaseBuild.javaVersion")
+val expectedReleaseJavaVendor = providers.gradleProperty("releaseBuild.javaVendor")
+val expectedReleaseGradleVersion = providers.gradleProperty("releaseBuild.gradleVersion")
 
 fun getGradleCommand(): String {
     return if (System.getProperty("os.name").lowercase(getDefault()).contains("win")) "gradlew.bat" else "./gradlew"
+}
+
+fun requiredGradleProperty(propertyName: String, property: Provider<String>): String {
+    val value = property.orNull?.trim()
+    if (value.isNullOrEmpty()) {
+        throw GradleException("Missing $propertyName in gradle.properties")
+    }
+    return value
 }
 
 fun sha256(file: File): String {
@@ -130,6 +142,52 @@ tasks.register<Delete>("cleanAll") {
     delete(allBuildDirectories())
 }
 
+tasks.register("verifyBuildEnvironment") {
+    group = "verification"
+    description = "Verifies the local Gradle and Java runtime match the pinned build environment."
+
+    inputs.property("expectedReleaseJavaVersion", expectedReleaseJavaVersion.orElse(""))
+    inputs.property("expectedReleaseJavaVendor", expectedReleaseJavaVendor.orElse(""))
+    inputs.property("expectedReleaseGradleVersion", expectedReleaseGradleVersion.orElse(""))
+    outputs.upToDateWhen { false }
+
+    doLast {
+        val expectedJavaVersion = requiredGradleProperty("releaseBuild.javaVersion", expectedReleaseJavaVersion)
+        val expectedJavaVendor = requiredGradleProperty("releaseBuild.javaVendor", expectedReleaseJavaVendor)
+        val expectedGradleVersion = requiredGradleProperty("releaseBuild.gradleVersion", expectedReleaseGradleVersion)
+        val actualJavaVersion = System.getProperty("java.version")
+        val actualJavaVendor = System.getProperty("java.vendor")
+        val violations = mutableListOf<String>()
+
+        if (actualJavaVersion != expectedJavaVersion) {
+            violations += "Java version expected $expectedJavaVersion but was $actualJavaVersion"
+        }
+        if (actualJavaVendor != expectedJavaVendor) {
+            violations += "Java vendor expected $expectedJavaVendor but was $actualJavaVendor"
+        }
+        if (gradle.gradleVersion != expectedGradleVersion) {
+            violations += "Gradle version expected $expectedGradleVersion but was ${gradle.gradleVersion}"
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Build environment verification failed:\n" +
+                        violations.joinToString("\n") { "  - $it" }
+            )
+        }
+
+        logger.lifecycle(
+            "Verified build environment: Gradle ${gradle.gradleVersion}, Java $actualJavaVersion ($actualJavaVendor)."
+        )
+    }
+}
+
+tasks.register("verifyReleaseEnvironment") {
+    group = "verification"
+    description = "Verifies the local Gradle and Java runtime match the pinned release build environment."
+    dependsOn("verifyBuildEnvironment")
+}
+
 tasks.register("verifyGradleWrapperSecurity") {
     group = "verification"
     description = "Verifies Gradle wrapper checksums and pinned distribution metadata."
@@ -142,6 +200,7 @@ tasks.register("verifyGradleWrapperSecurity") {
     )
 
     inputs.file(gradleWrapperChecksums)
+    inputs.property("expectedReleaseGradleVersion", expectedReleaseGradleVersion.orElse(""))
     inputs.files(requiredPaths.map { file(it) })
     outputs.upToDateWhen { false }
 
@@ -211,6 +270,7 @@ tasks.register("verifyGradleWrapperSecurity") {
         val wrapperProperties = loadGradleWrapperProperties()
         val distributionUrl = wrapperProperties.getProperty("distributionUrl")
         val distributionSha256Sum = wrapperProperties.getProperty("distributionSha256Sum")
+        val expectedGradleVersion = expectedReleaseGradleVersion.orNull?.trim()
         val distributionUrlRegex =
             Regex("""^https://services[.]gradle[.]org/distributions/gradle-[A-Za-z0-9][A-Za-z0-9_.+-]*-(bin|all)[.]zip$""")
         val sha256Regex = Regex("""^[0-9a-f]{64}$""")
@@ -221,6 +281,15 @@ tasks.register("verifyGradleWrapperSecurity") {
         }
         if (distributionSha256Sum == null || !sha256Regex.matches(distributionSha256Sum)) {
             violations += "Gradle wrapper distributionSha256Sum must be a pinned lowercase SHA-256 value"
+        }
+        if (expectedGradleVersion.isNullOrEmpty()) {
+            violations += "Missing releaseBuild.gradleVersion in gradle.properties"
+        } else {
+            val pinnedDistributionUrlRegex =
+                Regex("""^https://services[.]gradle[.]org/distributions/gradle-${Regex.escape(expectedGradleVersion)}-(bin|all)[.]zip$""")
+            if (distributionUrl != null && !pinnedDistributionUrlRegex.matches(distributionUrl)) {
+                violations += "Gradle wrapper distributionUrl must use releaseBuild.gradleVersion $expectedGradleVersion"
+            }
         }
 
         if (violations.isNotEmpty()) {
@@ -244,9 +313,11 @@ tasks.register("verifyGithubActionsSecurity") {
     }
 
     inputs.files(workflowFiles)
+    inputs.property("expectedReleaseJavaVersion", expectedReleaseJavaVersion.orElse(""))
     outputs.upToDateWhen { false }
 
     doLast {
+        val expectedJavaVersion = expectedReleaseJavaVersion.orNull?.trim()
         val violations = mutableListOf<String>()
         val usesRegex = Regex("""^\s*-?\s*uses:\s*([^#\s]+)(?:\s+#\s*(.+))?\s*$""")
         val floatingRunnerRegex = Regex("""\b(ubuntu|macos|windows)-latest\b""", RegexOption.IGNORE_CASE)
@@ -257,6 +328,10 @@ tasks.register("verifyGithubActionsSecurity") {
         val checkLatestFalseRegex = Regex("""^\s*check-latest:\s*['"]?false['"]?\s*$""", RegexOption.IGNORE_CASE)
         val persistCredentialsFalseRegex = Regex("""^\s*persist-credentials:\s*['"]?false['"]?\s*$""", RegexOption.IGNORE_CASE)
         val stepStartRegex = Regex("""^(\s*)-\s+[A-Za-z_][A-Za-z0-9_-]*\s*:.*$""")
+
+        if (expectedJavaVersion.isNullOrEmpty()) {
+            violations += "Missing releaseBuild.javaVersion in gradle.properties"
+        }
 
         fun cleanYamlScalar(value: String): String {
             return value.trim().trim('\'', '"')
@@ -323,6 +398,10 @@ tasks.register("verifyGithubActionsSecurity") {
                     val javaVersion = cleanYamlScalar(javaVersionMatch.groupValues[1])
                     if (!javaVersion.startsWith("\${{") && !exactJavaVersionRegex.matches(javaVersion)) {
                         violations += "$workflowPath:$lineNumber uses a floating Java version: ${line.trim()}"
+                    } else if (!javaVersion.startsWith("\${{") &&
+                        !expectedJavaVersion.isNullOrEmpty() &&
+                        javaVersion != expectedJavaVersion) {
+                        violations += "$workflowPath:$lineNumber uses Java version $javaVersion but releaseBuild.javaVersion is $expectedJavaVersion"
                     }
                 }
 
@@ -332,9 +411,12 @@ tasks.register("verifyGithubActionsSecurity") {
                         .split(',')
                         .map { cleanYamlScalar(it) }
                         .filter { it.isNotEmpty() && !it.startsWith("\${{") }
-                        .filterNot { exactJavaVersionRegex.matches(it) }
                         .forEach {
-                            violations += "$workflowPath:$lineNumber uses a floating Java matrix version: $it"
+                            if (!exactJavaVersionRegex.matches(it)) {
+                                violations += "$workflowPath:$lineNumber uses a floating Java matrix version: $it"
+                            } else if (!expectedJavaVersion.isNullOrEmpty() && it != expectedJavaVersion) {
+                                violations += "$workflowPath:$lineNumber uses Java matrix version $it but releaseBuild.javaVersion is $expectedJavaVersion"
+                            }
                         }
                 }
 
@@ -356,6 +438,7 @@ tasks.register("verifyGithubActionsSecurity") {
 }
 
 tasks.named("check") {
+    dependsOn("verifyBuildEnvironment")
     dependsOn("verifyGradleWrapperSecurity")
     dependsOn("verifyGithubActionsSecurity")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,6 @@ org.gradle.jvmargs=-Xmx5120M
 version=2.1.11
 tor.version=15.0.13
 org.gradle.java.installations.auto-detect=false
+releaseBuild.javaVersion=21.0.11
+releaseBuild.javaVendor=Azul Systems, Inc.
+releaseBuild.gradleVersion=8.9

--- a/mu-sig/build.gradle.kts
+++ b/mu-sig/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     id("bisq.java-library")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 dependencies {
     implementation(project(":persistence"))
     implementation(project(":i18n"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java runtime version to 21.0.11 for builds and GitHub Actions
  * Centralized build environment configuration for consistent Java and Gradle versions across all modules
  * Enhanced build environment verification to ensure pinned Java and Gradle versions match expectations
  * Strengthened security validation for Gradle wrapper and GitHub Actions workflows with version-pinned checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->