### PR TITLE
Add isolated CVE scan tool

### DIFF
--- a/tools/cve-scan/README.md
+++ b/tools/cve-scan/README.md
@@ -1,0 +1,78 @@
+# CVE Scan
+
+Standalone OWASP Dependency-Check build for Bisq 2. It scans every library
+declared in `gradle/libs.versions.toml`, including transitive dependencies.
+
+This build is isolated from the main Bisq build. It does not modify the main
+build classpath, runtime dependencies, `gradle/verification-metadata.xml`, or
+dependency versions.
+
+## Usage
+
+Run from the repository root:
+
+```bash
+./gradlew -p tools/cve-scan cveCheck
+```
+
+The `cveCheck` task is throttled: it skips when the last successful scan is
+less than 24 hours old and `gradle/libs.versions.toml` has not changed.
+
+Force a new scan:
+
+```bash
+./gradlew -p tools/cve-scan cveCheck --rerun-tasks
+```
+
+The underlying Dependency-Check task is also available:
+
+```bash
+./gradlew -p tools/cve-scan dependencyCheckAggregate
+```
+
+## Reports
+
+Reports are written to:
+
+- `tools/cve-scan/build/reports/dependency-check-report.html`
+- `tools/cve-scan/build/reports/dependency-check-report.json`
+
+## NVD API Key
+
+An NVD API key is recommended to avoid slow unauthenticated API throttling.
+Pass it with either an environment variable or a Gradle property:
+
+```bash
+export NVD_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+./gradlew -p tools/cve-scan cveCheck
+
+./gradlew -p tools/cve-scan cveCheck -PnvdApiKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+Request an API key from `https://nvd.nist.gov/developers/request-an-api-key`.
+Dependency-Check caches NVD data in the Gradle user home between runs.
+
+## Failure Threshold
+
+By default, the build fails on any reported CVE:
+
+```kotlin
+failBuildOnCVSS = 0.0f
+```
+
+Override the threshold with `-PcveFailCvss=<score>`:
+
+```bash
+./gradlew -p tools/cve-scan cveCheck -PcveFailCvss=7
+```
+
+## Scope
+
+The scanner imports the Bisq 2 version catalog and declares every `[libraries]`
+entry in an isolated `implementation` configuration. Dependency-Check is scoped
+to the resulting `runtimeClasspath` and does not scan its own buildscript or
+plugin classpath. Plugin aliases and internal project dependencies are not
+scanned directly; third-party libraries declared in the catalog are scanned.
+
+The standalone build disables analyzers that are not relevant to Bisq 2's Java
+dependency scan, including .NET/NuGet, Node/RetireJS, and anonymous OSS Index.

--- a/tools/cve-scan/build.gradle.kts
+++ b/tools/cve-scan/build.gradle.kts
@@ -1,0 +1,80 @@
+import java.time.Instant
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.owasp.dependencycheck.gradle.tasks.Aggregate
+
+plugins {
+    java
+    id("org.owasp.dependencycheck") version "12.1.0"
+}
+
+val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val cveFailCvss = providers.gradleProperty("cveFailCvss")
+    .map { it.toFloat() }
+    .orElse(0.0f)
+val nvdApiKey = System.getenv("NVD_API_KEY")?.takeIf { it.isNotBlank() }
+    ?: providers.gradleProperty("nvdApiKey").orNull?.takeIf { it.isNotBlank() }
+val versionsFile = layout.projectDirectory.file("../../gradle/libs.versions.toml")
+val cveMarker = layout.buildDirectory.file("cve-check.ok")
+val cveTtlMs = 24L * 60L * 60L * 1000L
+
+dependencies {
+    catalog.libraryAliases.forEach { alias ->
+        add("implementation", catalog.findLibrary(alias).get())
+    }
+}
+
+dependencyCheck {
+    scanBuildEnv = false
+    scanConfigurations = listOf("runtimeClasspath")
+    analyzedTypes = listOf("jar")
+    failBuildOnCVSS = cveFailCvss.get()
+    formats = listOf("HTML", "JSON")
+
+    nvd {
+        nvdApiKey?.let {
+            apiKey = it
+        }
+        validForHours = 24
+    }
+
+    analyzers {
+        assemblyEnabled = false
+        nuspecEnabled = false
+        nugetconfEnabled = false
+        nodeEnabled = false
+        nodeAuditEnabled = false
+        retirejs {
+            enabled = false
+        }
+        ossIndex {
+            enabled = false
+        }
+    }
+}
+
+tasks.named<Aggregate>("dependencyCheckAggregate") {
+    onlyIf {
+        val marker = cveMarker.get().asFile
+        if (!marker.isFile) {
+            return@onlyIf true
+        }
+        val catalogFile = versionsFile.asFile
+        if (catalogFile.isFile && catalogFile.lastModified() > marker.lastModified()) {
+            return@onlyIf true
+        }
+        System.currentTimeMillis() - marker.lastModified() > cveTtlMs
+    }
+
+    doLast {
+        cveMarker.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText("ok ${Instant.now()}\n")
+        }
+    }
+}
+
+tasks.register("cveCheck") {
+    group = "verification"
+    description = "Runs the OWASP Dependency-Check CVE scan for Bisq 2 catalog libraries."
+    dependsOn("dependencyCheckAggregate")
+}

--- a/tools/cve-scan/settings.gradle.kts
+++ b/tools/cve-scan/settings.gradle.kts
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven("https://jitpack.io")
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "bisq-cve-scan"


### PR DESCRIPTION
Create a standalone tools/cve-scan Gradle build based on the Bisq 1 OWASP Dependency-Check scanner pattern.

Import the Bisq 2 version catalog inside the tool build and declare every catalog library on the scanner's isolated runtimeClasspath, leaving the main build classpath, runtime dependencies, verification metadata, and dependency versions untouched.

Configure HTML and JSON Dependency-Check reports, NVD API key support via NVD_API_KEY or -PnvdApiKey, a configurable CVSS failure threshold defaulting to fail on any CVE, and disabled analyzers for irrelevant .NET, NuGet, Node, RetireJS, and anonymous OSS Index checks.

Document usage, report paths, NVD key options, threshold override, scan throttling, and the scanner scope in tools/cve-scan/README.md.