### PR TITLE
Verify update signatures with each key source

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,11 +129,6 @@ fun sha256(file: File): String {
     return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
 }
 
-fun sha256Bytes(bytes: ByteArray): String {
-    val digest = MessageDigest.getInstance("SHA-256")
-    return digest.digest(bytes).joinToString("") { "%02x".format(it.toInt() and 0xff) }
-}
-
 fun htmlEscape(value: Any?): String {
     return value?.toString()
         ?.replace("&", "&amp;")
@@ -947,13 +942,18 @@ tasks.register("verifyReleaseReadiness") {
                 addResult(results, "FAIL", "signingkey.asc GitHub asset", "Missing signingkey.asc from GitHub release")
             } else {
                 try {
-                    val githubSigningKey = httpGetBytes(browserDownloadUrl)
-                    val localHash = sha256(signingKeyFile)
-                    val githubHash = sha256Bytes(githubSigningKey)
-                    if (localHash == githubHash) {
-                        addResult(results, "PASS", "signingkey.asc exact content", "GitHub release matches local SHA-256 $localHash")
+                    val githubSigningKeyId = String(httpGetBytes(browserDownloadUrl), StandardCharsets.UTF_8)
+                        .trim()
+                        .uppercase(Locale.ROOT)
+                    if (githubSigningKeyId == activeSigningKeyId && bisq2ReleaseKeyIds.contains(githubSigningKeyId)) {
+                        addResult(results, "PASS", "signingkey.asc marker", "GitHub release points to active key $githubSigningKeyId")
                     } else {
-                        addResult(results, "FAIL", "signingkey.asc exact content", "local=$localHash, GitHub release=$githubHash")
+                        addResult(
+                            results,
+                            "FAIL",
+                            "signingkey.asc marker",
+                            "local=${activeSigningKeyId.ifEmpty { "<invalid>" }}, GitHub release=${githubSigningKeyId.ifEmpty { "<blank>" }}"
+                        )
                     }
                 } catch (exception: Exception) {
                     addResult(results, "FAIL", "signingkey.asc GitHub asset", exception.message)
@@ -961,27 +961,88 @@ tasks.register("verifyReleaseReadiness") {
             }
         }
 
+        val gpgExecutable = resolveGpgExecutable(gpgExecutableProperty.orNull)
+        val publicKeySourceDir = layout.buildDirectory
+            .dir("tmp/verifyReleaseReadiness/public-keys")
+            .get()
+            .asFile
+        if (publicKeySourceDir.exists()) {
+            publicKeySourceDir.deleteRecursively()
+        }
+        publicKeySourceDir.mkdirs()
+
+        fun safeFileName(value: String): String {
+            return value.replace(Regex("[^A-Za-z0-9._-]"), "_")
+        }
+
+        fun writePublicKeySource(keyId: String, sourceName: String, bytes: ByteArray): File {
+            val outputFile = File(publicKeySourceDir, "${keyId}_${safeFileName(sourceName)}.asc")
+            outputFile.writeBytes(bytes)
+            return outputFile
+        }
+
+        fun readPublicKeySourceFingerprint(keyId: String, sourceName: String, keyFile: File): String? {
+            val gpgResult = runCommand(
+                listOf(
+                    gpgExecutable,
+                    "--show-keys",
+                    "--with-colons",
+                    "--fingerprint",
+                    keyFile.absolutePath,
+                )
+            )
+            if (gpgResult.exitValue != 0) {
+                addResult(
+                    results,
+                    "FAIL",
+                    "Public key $keyId $sourceName metadata",
+                    "$gpgExecutable --show-keys failed. Install GnuPG or set -PgpgExecutable=/path/to/gpg. ${gpgResult.stderr.trim()}"
+                )
+                return null
+            }
+
+            val keyInfo = parseGpgKeyInfo(gpgResult.stdout)
+            if (keyInfo == null || keyInfo.fingerprint.isEmpty()) {
+                addResult(results, "FAIL", "Public key $keyId $sourceName metadata", "Could not parse fingerprint from gpg --show-keys output")
+                return null
+            }
+            val normalizedFingerprint = normalizeGpgFingerprintOrNull(keyInfo.fingerprint)
+            if (normalizedFingerprint == null) {
+                addResult(results, "FAIL", "Public key $keyId $sourceName metadata", "Could not parse full fingerprint ${keyInfo.fingerprint}")
+                return null
+            }
+            if (!normalizedFingerprint.endsWith(keyId.uppercase(Locale.ROOT))) {
+                addResult(results, "FAIL", "Public key $keyId $sourceName identity", "Fingerprint is $normalizedFingerprint")
+                return null
+            }
+            return normalizedFingerprint
+        }
+
         val resourceKeyFiles = mutableMapOf<String, File>()
+        val publicKeySourceFilesByKeyId = mutableMapOf<String, MutableMap<String, File>>()
         val expectedSignerFingerprintsByKeyId = mutableMapOf<String, String>()
         bisq2ReleaseKeyIds.forEach { keyId ->
             val resourceFile = file("evolution/src/main/resources/keys/$keyId.asc")
             val packageFile = file("apps/desktop/desktop-app-launcher/maintainer_public_keys/$keyId.asc")
             resourceKeyFiles[keyId] = resourceFile
 
-            val sourceBytesByName = mutableMapOf<String, ByteArray>()
             if (resourceFile.isFile) {
-                sourceBytesByName["app resources"] = resourceFile.readBytes()
+                publicKeySourceFilesByKeyId.getOrPut(keyId) { mutableMapOf() }["app resources"] = resourceFile
             } else {
                 addResult(results, "FAIL", "Public key $keyId app resource", "Missing ${rootProject.relativePath(resourceFile)}")
             }
             if (packageFile.isFile) {
-                sourceBytesByName["release package"] = packageFile.readBytes()
+                publicKeySourceFilesByKeyId.getOrPut(keyId) { mutableMapOf() }["release package"] = packageFile
             } else {
                 addResult(results, "FAIL", "Public key $keyId package resource", "Missing ${rootProject.relativePath(packageFile)}")
             }
 
             try {
-                sourceBytesByName["bisq.network/pubkey"] = httpGetBytes("https://bisq.network/pubkey/$keyId.asc")
+                publicKeySourceFilesByKeyId.getOrPut(keyId) { mutableMapOf() }["bisq.network/pubkey"] = writePublicKeySource(
+                    keyId,
+                    "bisq.network/pubkey",
+                    httpGetBytes("https://bisq.network/pubkey/$keyId.asc")
+                )
             } catch (exception: Exception) {
                 addResult(results, "FAIL", "Public key $keyId webpage", exception.message)
             }
@@ -990,7 +1051,11 @@ tasks.register("verifyReleaseReadiness") {
             val browserDownloadUrl = githubAsset?.get("browser_download_url")?.toString().orEmpty()
             if (browserDownloadUrl.isNotEmpty()) {
                 try {
-                    sourceBytesByName["GitHub release"] = httpGetBytes(browserDownloadUrl)
+                    publicKeySourceFilesByKeyId.getOrPut(keyId) { mutableMapOf() }["GitHub release"] = writePublicKeySource(
+                        keyId,
+                        "GitHub release",
+                        httpGetBytes(browserDownloadUrl)
+                    )
                 } catch (exception: Exception) {
                     addResult(results, "FAIL", "Public key $keyId GitHub asset", exception.message)
                 }
@@ -999,23 +1064,39 @@ tasks.register("verifyReleaseReadiness") {
             }
 
             val expectedKeySourceCount = if (releaseAssetsLoaded) 4 else 3
-            if (sourceBytesByName.size == expectedKeySourceCount) {
-                val hashes = sourceBytesByName.mapValues { (_, bytes) -> sha256Bytes(bytes) }
-                val uniqueHashes = hashes.values.toSet()
-                if (uniqueHashes.size == 1) {
-                    addResult(results, "PASS", "Public key $keyId exact content", "All checked sources match SHA-256 ${uniqueHashes.first()}")
+            val sourceFilesByName = publicKeySourceFilesByKeyId[keyId].orEmpty()
+            if (sourceFilesByName.size == expectedKeySourceCount) {
+                val fingerprints = sourceFilesByName.mapValues { (sourceName, keyFile) ->
+                    readPublicKeySourceFingerprint(keyId, sourceName, keyFile)
+                }
+                if (fingerprints.values.all { it != null }) {
+                    val uniqueFingerprints = fingerprints.values.filterNotNull().toSet()
+                    if (uniqueFingerprints.size == 1) {
+                        addResult(
+                            results,
+                            "PASS",
+                            "Public key $keyId identity",
+                            "All checked sources have fingerprint ${uniqueFingerprints.first()}; key metadata may differ"
+                        )
+                    } else {
+                        addResult(
+                            results,
+                            "FAIL",
+                            "Public key $keyId identity",
+                            fingerprints.entries.joinToString(", ") { (name, fingerprint) -> "$name=${fingerprint ?: "<invalid>"}" }
+                        )
+                    }
                 } else {
                     addResult(
                         results,
                         "FAIL",
-                        "Public key $keyId exact content",
-                        hashes.entries.joinToString(", ") { (name, hash) -> "$name=$hash" }
+                        "Public key $keyId identity",
+                        fingerprints.entries.joinToString(", ") { (name, fingerprint) -> "$name=${fingerprint ?: "<invalid>"}" }
                     )
                 }
             }
         }
 
-        val gpgExecutable = resolveGpgExecutable(gpgExecutableProperty.orNull)
         bisq2ReleaseKeyIds.forEach { keyId ->
             val keyFile = resourceKeyFiles[keyId]
             if (keyFile?.isFile != true) {
@@ -1083,9 +1164,19 @@ tasks.register("verifyReleaseReadiness") {
         }
 
         if (releaseAssetsLoaded) {
-            val expectedSignerFingerprints = expectedSignerFingerprintsByKeyId.values.sorted()
-            if (expectedSignerFingerprints.isEmpty()) {
-                addResult(results, "FAIL", "Release artifact signatures", "No expected maintainer fingerprints were available")
+            val activeSignerFingerprint = expectedSignerFingerprintsByKeyId[activeSigningKeyId]
+            val activeSigningKeySources = if (activeSigningKeyId.isEmpty()) {
+                emptyMap()
+            } else {
+                publicKeySourceFilesByKeyId[activeSigningKeyId].orEmpty()
+            }
+
+            if (activeSigningKeyId.isEmpty()) {
+                addResult(results, "FAIL", "Release artifact signatures", "No active signing key id was available")
+            } else if (activeSignerFingerprint == null) {
+                addResult(results, "FAIL", "Release artifact signatures", "No expected fingerprint was available for active signing key $activeSigningKeyId")
+            } else if (activeSigningKeySources.isEmpty()) {
+                addResult(results, "FAIL", "Release artifact signatures", "No public key sources were available for active signing key $activeSigningKeyId")
             } else {
                 val signatureVerificationDir = layout.buildDirectory
                     .dir("tmp/verifyReleaseReadiness/signatures")
@@ -1095,84 +1186,96 @@ tasks.register("verifyReleaseReadiness") {
                     signatureVerificationDir.deleteRecursively()
                 }
                 val downloadsDir = File(signatureVerificationDir, "downloads")
-                val gpgHomeDir = File(signatureVerificationDir, "gnupg")
                 downloadsDir.mkdirs()
-                gpgHomeDir.mkdirs()
-                gpgHomeDir.setReadable(false, false)
-                gpgHomeDir.setWritable(false, false)
-                gpgHomeDir.setExecutable(false, false)
-                gpgHomeDir.setReadable(true, true)
-                gpgHomeDir.setWritable(true, true)
-                gpgHomeDir.setExecutable(true, true)
 
-                val keyFilesToImport = bisq2ReleaseKeyIds.mapNotNull { keyId ->
-                    resourceKeyFiles[keyId]?.takeIf(File::isFile)
+                fun prepareGpgHomeDir(gpgHomeDir: File) {
+                    gpgHomeDir.mkdirs()
+                    gpgHomeDir.setReadable(false, false)
+                    gpgHomeDir.setWritable(false, false)
+                    gpgHomeDir.setExecutable(false, false)
+                    gpgHomeDir.setReadable(true, true)
+                    gpgHomeDir.setWritable(true, true)
+                    gpgHomeDir.setExecutable(true, true)
                 }
-                if (keyFilesToImport.isEmpty()) {
-                    addResult(results, "FAIL", "Release signature keyring", "No local maintainer public keys were available to import")
-                } else {
+
+                val downloadedArtifacts = mutableMapOf<String, Pair<File, File>>()
+                expectedBisq2SignableReleaseAssets(releaseVersion).forEach { artifactName ->
+                    val signatureName = "$artifactName.asc"
+                    val artifactUrl = releaseAssetsByName[artifactName]?.get("browser_download_url")?.toString().orEmpty()
+                    val signatureUrl = releaseAssetsByName[signatureName]?.get("browser_download_url")?.toString().orEmpty()
+                    if (artifactUrl.isEmpty() || signatureUrl.isEmpty()) {
+                        addResult(
+                            results,
+                            "FAIL",
+                            "GPG signature $signatureName",
+                            "Missing browser_download_url for ${listOfNotNull(
+                                artifactName.takeIf { artifactUrl.isEmpty() },
+                                signatureName.takeIf { signatureUrl.isEmpty() }
+                            ).joinToString(", ")}"
+                        )
+                        return@forEach
+                    }
+
+                    try {
+                        val artifactFile = File(downloadsDir, artifactName)
+                        val signatureFile = File(downloadsDir, signatureName)
+                        httpDownloadToFile(artifactUrl, artifactFile)
+                        httpDownloadToFile(signatureUrl, signatureFile)
+                        downloadedArtifacts[artifactName] = Pair(artifactFile, signatureFile)
+                    } catch (exception: Exception) {
+                        addResult(results, "FAIL", "GPG signature $signatureName", exception.message)
+                    }
+                }
+
+                activeSigningKeySources.forEach { (sourceName, keyFile) ->
+                    val gpgHomeDir = File(signatureVerificationDir, "gnupg-${safeFileName(sourceName)}")
+                    prepareGpgHomeDir(gpgHomeDir)
+
                     val importResult = runCommand(
                         listOf(
                             gpgExecutable,
                             "--homedir", gpgHomeDir.absolutePath,
                             "--batch",
                             "--import",
-                        ) + keyFilesToImport.map { it.absolutePath }
+                            keyFile.absolutePath,
+                        )
                     )
                     if (importResult.exitValue != 0) {
-                        addResult(results, "FAIL", "Release signature keyring", importResult.failureDetails())
+                        addResult(results, "FAIL", "Release signature keyring $sourceName", importResult.failureDetails())
                     } else {
-                        expectedBisq2SignableReleaseAssets(releaseVersion).forEach { artifactName ->
+                        downloadedArtifacts.forEach { (artifactName, files) ->
                             val signatureName = "$artifactName.asc"
-                            val artifactUrl = releaseAssetsByName[artifactName]?.get("browser_download_url")?.toString().orEmpty()
-                            val signatureUrl = releaseAssetsByName[signatureName]?.get("browser_download_url")?.toString().orEmpty()
-                            if (artifactUrl.isEmpty() || signatureUrl.isEmpty()) {
-                                addResult(
-                                    results,
-                                    "FAIL",
-                                    "GPG signature $signatureName",
-                                    "Missing browser_download_url for ${listOfNotNull(
-                                        artifactName.takeIf { artifactUrl.isEmpty() },
-                                        signatureName.takeIf { signatureUrl.isEmpty() }
-                                    ).joinToString(", ")}"
-                                )
-                                return@forEach
-                            }
-
                             try {
-                                val artifactFile = File(downloadsDir, artifactName)
-                                val signatureFile = File(downloadsDir, signatureName)
-                                httpDownloadToFile(artifactUrl, artifactFile)
-                                httpDownloadToFile(signatureUrl, signatureFile)
+                                val (artifactFile, signatureFile) = files
 
                                 val verifyResult = runCommand(
                                     gpgAssertSignerVerifyCommand(
                                         gpgExecutable,
-                                        expectedSignerFingerprints,
+                                        listOf(activeSignerFingerprint),
                                         signatureFile,
                                         artifactFile,
                                         listOf("--homedir", gpgHomeDir.absolutePath)
                                     )
                                 )
                                 if (verifyResult.exitValue != 0) {
-                                    addResult(results, "FAIL", "GPG signature $signatureName", verifyResult.failureDetails())
+                                    addResult(results, "FAIL", "GPG signature $signatureName with $sourceName key", verifyResult.failureDetails())
                                     return@forEach
                                 }
 
-                                val signerError = validateGpgVerifiedExpectedSigner(verifyResult, expectedSignerFingerprints)
+                                val signerError = validateGpgVerifiedExpectedSigner(verifyResult, listOf(activeSignerFingerprint))
                                 if (signerError == null) {
                                     val validSigFingerprints = parseGpgValidSigFingerprints(verifyResult.stdout)
                                     addResult(
                                         results,
                                         "PASS",
-                                        "GPG signature $signatureName",
-                                        "Valid signature from expected signer ${validSigFingerprints.intersect(expectedSignerFingerprints.toSet()).joinToString()}"
+                                        "GPG signature $signatureName with $sourceName key",
+                                        "Valid signature from active signer ${validSigFingerprints.intersect(setOf(activeSignerFingerprint)).joinToString()}"
                                     )
                                 } else {
-                                    addResult(results, "FAIL", "GPG signature $signatureName", signerError)
+                                    addResult(results, "FAIL", "GPG signature $signatureName with $sourceName key", signerError)
                                 }
                             } catch (exception: Exception) {
-                                addResult(results, "FAIL", "GPG signature $signatureName", exception.message)
+                                addResult(results, "FAIL", "GPG signature $signatureName with $sourceName key", exception.message)
                             }
                         }
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -586,6 +586,19 @@ tasks.register("verifyReleaseReadiness") {
                 .replace("\n", "<br>")
         }
 
+        fun ensureDirectory(directory: File, label: String) {
+            if (!directory.mkdirs() && !directory.isDirectory) {
+                throw GradleException("Failed to create $label: $directory")
+            }
+        }
+
+        fun resetTemporaryDirectory(directory: File, label: String) {
+            if (directory.exists() && !directory.deleteRecursively()) {
+                throw GradleException("Failed to delete $label before reuse: $directory")
+            }
+            ensureDirectory(directory, label)
+        }
+
         fun httpRequest(requestUrl: String,
                         requestMethod: String,
                         headers: Map<String, String>,
@@ -966,10 +979,7 @@ tasks.register("verifyReleaseReadiness") {
             .dir("tmp/verifyReleaseReadiness/public-keys")
             .get()
             .asFile
-        if (publicKeySourceDir.exists()) {
-            publicKeySourceDir.deleteRecursively()
-        }
-        publicKeySourceDir.mkdirs()
+        resetTemporaryDirectory(publicKeySourceDir, "release readiness public key source directory")
 
         fun safeFileName(value: String): String {
             return value.replace(Regex("[^A-Za-z0-9._-]"), "_")
@@ -1182,14 +1192,12 @@ tasks.register("verifyReleaseReadiness") {
                     .dir("tmp/verifyReleaseReadiness/signatures")
                     .get()
                     .asFile
-                if (signatureVerificationDir.exists()) {
-                    signatureVerificationDir.deleteRecursively()
-                }
+                resetTemporaryDirectory(signatureVerificationDir, "release signature verification directory")
                 val downloadsDir = File(signatureVerificationDir, "downloads")
-                downloadsDir.mkdirs()
+                ensureDirectory(downloadsDir, "release signature download directory")
 
                 fun prepareGpgHomeDir(gpgHomeDir: File) {
-                    gpgHomeDir.mkdirs()
+                    resetTemporaryDirectory(gpgHomeDir, "release signature GPG home directory")
                     gpgHomeDir.setReadable(false, false)
                     gpgHomeDir.setWritable(false, false)
                     gpgHomeDir.setExecutable(false, false)

--- a/evolution/src/main/java/bisq/evolution/updater/DownloadedFilesVerification.java
+++ b/evolution/src/main/java/bisq/evolution/updater/DownloadedFilesVerification.java
@@ -28,7 +28,6 @@ import java.util.List;
 import static bisq.evolution.updater.UpdaterUtils.ASC_EXTENSION;
 import static bisq.evolution.updater.UpdaterUtils.FROM_BISQ_WEBPAGE_PREFIX;
 import static bisq.evolution.updater.UpdaterUtils.FROM_RESOURCES_PREFIX;
-import static bisq.evolution.updater.UpdaterUtils.getSigningKey;
 import static bisq.evolution.updater.UpdaterUtils.getSigningKeyId;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -40,42 +39,48 @@ public class DownloadedFilesVerification {
                               boolean ignoreSigningKeyInResourcesCheck) throws IOException {
         String signingKeyId = getSigningKeyId(dirPath);
         checkArgument(keyIds.contains(signingKeyId), "signingKeyId not matching any of the provided keys");
-        String signingKey = getSigningKey(dirPath, signingKeyId);
         Path sigFilePath = dirPath.resolve(dataFileName + ASC_EXTENSION); // E.g. Bisq-2.1.3.dmg.asc
         Path dataFilePath = dirPath.resolve(dataFileName); // E.g. Bisq2.dmg
 
-        // We require that the signing key is provided on the Bisq webpage
-        checkSignatureWithKeyFromWebpage(dirPath, signingKeyId, signingKey, sigFilePath, dataFilePath);
+        // Do not compare public key files byte-for-byte. Renewed keys can differ in metadata while keeping
+        // the same signing key material. Require each key source to independently verify the artifact instead.
+        checkSignatureWithKeyFromWebpage(dirPath, signingKeyId, sigFilePath, dataFilePath);
 
         if (!ignoreSigningKeyInResourcesCheck) {
-            checkSignatureWithKeyInResources(dirPath, signingKeyId, signingKey, sigFilePath, dataFilePath);
+            checkSignatureWithKeyInResources(dirPath, signingKeyId, sigFilePath, dataFilePath);
         }
 
         String signingKeyFileName = signingKeyId + ASC_EXTENSION;
         Path signingKeyFilePath = dirPath.resolve(signingKeyId + ASC_EXTENSION); // E.g. E222AA02.asc
-        checkArgument(PgPUtils.isSignatureValid(signingKeyFilePath, sigFilePath, dataFilePath), "Signature verification failed: signingKeyFileName=" + signingKeyFileName);
+        checkSignature(signingKeyFileName, signingKeyFilePath, sigFilePath, dataFilePath);
         log.info("signature verification succeeded");
     }
 
     private static void checkSignatureWithKeyFromWebpage(Path dirPath,
                                                          String signingKeyId,
-                                                         String signingKey,
                                                          Path sigFilePath,
                                                          Path dataFilePath) {
 
         String signingKeyFileName = FROM_BISQ_WEBPAGE_PREFIX + signingKeyId + ASC_EXTENSION;
         Path signingKeyFilePath = dirPath.resolve(signingKeyFileName); // E.g. from_bisq_webpage_E222AA02.asc
-        checkArgument(PgPUtils.isSignatureValid(signingKeyFilePath, sigFilePath, dataFilePath), "Signature verification failed: signingKeyFileName=" + signingKeyFileName);
+        checkSignature(signingKeyFileName, signingKeyFilePath, sigFilePath, dataFilePath);
     }
 
     private static void checkSignatureWithKeyInResources(Path dirPath,
                                                          String signingKeyId,
-                                                         String signingKey,
                                                          Path sigFilePath,
                                                          Path dataFilePath) throws IOException {
         String signingKeyFileName = FROM_RESOURCES_PREFIX + signingKeyId + ASC_EXTENSION;
         Path signingKeyFilePath = dirPath.resolve(signingKeyFileName); // E.g. from_resources_E222AA02.asc
         FileMutatorUtils.resourceToFile("keys/" + signingKeyId + ASC_EXTENSION, signingKeyFilePath); // We copy key from resources to download directory
-        checkArgument(PgPUtils.isSignatureValid(signingKeyFilePath, sigFilePath, dataFilePath), "Signature verification failed: signingKeyFileName=" + signingKeyFileName);
+        checkSignature(signingKeyFileName, signingKeyFilePath, sigFilePath, dataFilePath);
+    }
+
+    private static void checkSignature(String signingKeyFileName,
+                                       Path signingKeyFilePath,
+                                       Path sigFilePath,
+                                       Path dataFilePath) {
+        checkArgument(PgPUtils.isSignatureValid(signingKeyFilePath, sigFilePath, dataFilePath),
+                "Signature verification failed: signingKeyFileName=" + signingKeyFileName);
     }
 }

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
@@ -40,10 +40,6 @@ public class UpdaterUtils {
         return FileReaderUtils.readUTF8String(dirPath.resolve(SIGNING_KEY_FILE));
     }
 
-    public static String getSigningKey(Path dirPath, String signingKeyId) throws IOException {
-        return FileReaderUtils.readUTF8String(dirPath.resolve(signingKeyId + ASC_EXTENSION));
-    }
-
     public static String getDownloadFileName(String version, boolean isLauncherUpdate) {
         return isLauncherUpdate ? getInstallerFileName(version) : getJarFileName(version);
     }

--- a/evolution/src/test/java/bisq/evolution/updater/DownloadedFilesVerificationTest.java
+++ b/evolution/src/test/java/bisq/evolution/updater/DownloadedFilesVerificationTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.evolution.updater;
+
+import bisq.common.file.FileMutatorUtils;
+import bisq.common.file.FileReaderUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+import static bisq.evolution.updater.UpdaterUtils.ASC_EXTENSION;
+import static bisq.evolution.updater.UpdaterUtils.FROM_BISQ_WEBPAGE_PREFIX;
+import static bisq.evolution.updater.UpdaterUtils.SIGNING_KEY_FILE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DownloadedFilesVerificationTest {
+    private static final String KEY_ID = "387C8307";
+    private static final String OTHER_KEY_ID = "E222AA02";
+    private static final String DATA_FILE_NAME = "desktop_app-1.9.10-all.jar";
+    private static final String TEST_RELEASE_RESOURCE_DIR = "1.9.10/";
+
+    @Test
+    void verifyAcceptsEquivalentKeysWithDifferentArmorMetadata(@TempDir Path tempDirPath) throws IOException {
+        writeValidDownloadFiles(tempDirPath);
+
+        String resourceKey = readResourceAsString("keys/" + KEY_ID + ASC_EXTENSION);
+        String releaseKey = withArmorComment(readResourceAsString(TEST_RELEASE_RESOURCE_DIR + KEY_ID + ASC_EXTENSION),
+                "release key armor metadata differs");
+        String webpageKey = withArmorComment(readResourceAsString(TEST_RELEASE_RESOURCE_DIR + KEY_ID + ASC_EXTENSION),
+                "webpage key armor metadata differs");
+        FileMutatorUtils.writeToPath(releaseKey, tempDirPath.resolve(KEY_ID + ASC_EXTENSION));
+        FileMutatorUtils.writeToPath(webpageKey, tempDirPath.resolve(FROM_BISQ_WEBPAGE_PREFIX + KEY_ID + ASC_EXTENSION));
+
+        assertNotEquals(resourceKey, releaseKey);
+        assertNotEquals(resourceKey, webpageKey);
+
+        assertDoesNotThrow(() -> DownloadedFilesVerification.verify(tempDirPath, DATA_FILE_NAME, List.of(KEY_ID), false));
+    }
+
+    @Test
+    void verifyFailsWhenAnyKeySourceCannotVerifyArtifact(@TempDir Path tempDirPath) throws IOException {
+        writeValidDownloadFiles(tempDirPath);
+        copyResource(TEST_RELEASE_RESOURCE_DIR + KEY_ID + ASC_EXTENSION, tempDirPath.resolve(KEY_ID + ASC_EXTENSION));
+        copyResource("keys/" + OTHER_KEY_ID + ASC_EXTENSION,
+                tempDirPath.resolve(FROM_BISQ_WEBPAGE_PREFIX + KEY_ID + ASC_EXTENSION));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> DownloadedFilesVerification.verify(tempDirPath, DATA_FILE_NAME, List.of(KEY_ID), false));
+
+        assertTrue(exception.getMessage().contains(FROM_BISQ_WEBPAGE_PREFIX + KEY_ID + ASC_EXTENSION));
+    }
+
+    private static void writeValidDownloadFiles(Path tempDirPath) throws IOException {
+        FileMutatorUtils.writeToPath(KEY_ID, tempDirPath.resolve(SIGNING_KEY_FILE));
+        copyResource(TEST_RELEASE_RESOURCE_DIR + DATA_FILE_NAME, tempDirPath.resolve(DATA_FILE_NAME));
+        copyResource(TEST_RELEASE_RESOURCE_DIR + DATA_FILE_NAME + ASC_EXTENSION, tempDirPath.resolve(DATA_FILE_NAME + ASC_EXTENSION));
+    }
+
+    private static void copyResource(String resourceName, Path destinationPath) throws IOException {
+        try (InputStream inputStream = FileReaderUtils.getResourceAsStream(resourceName)) {
+            Files.copy(inputStream, destinationPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private static String readResourceAsString(String resourceName) throws IOException {
+        try (InputStream inputStream = FileReaderUtils.getResourceAsStream(resourceName)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static String withArmorComment(String publicKey, String comment) {
+        return publicKey.replaceFirst("-----BEGIN PGP PUBLIC KEY BLOCK-----\\R",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\nComment: " + comment + "\n");
+    }
+}

--- a/security/src/main/java/bisq/security/PgPUtils.java
+++ b/security/src/main/java/bisq/security/PgPUtils.java
@@ -37,9 +37,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.SignatureException;
 import java.util.Iterator;
+import java.util.Locale;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class PgPUtils {
@@ -49,7 +49,12 @@ public class PgPUtils {
             PGPPublicKeyRing pgpPublicKeyRing = readPgpPublicKeyRing(pubKeyFilePath);
             PGPSignature pgpSignature = readPgpSignature(sigFilePath);
             long keyIdFromSignature = pgpSignature.getKeyID();
-            PGPPublicKey publicKey = checkNotNull(pgpPublicKeyRing.getPublicKey(keyIdFromSignature), "No public key found for key ID from signature");
+            PGPPublicKey publicKey = pgpPublicKeyRing.getPublicKey(keyIdFromSignature);
+            if (publicKey == null) {
+                log.error("Signature verification failed. No public key found for signature key ID {}. \npubKeyFilePath={} \nsigFilePath={} \ndataFilePath={}.",
+                        Long.toHexString(keyIdFromSignature).toUpperCase(Locale.ROOT), pubKeyFilePath, sigFilePath, dataFilePath);
+                return false;
+            }
             return isSignatureValid(pgpSignature, publicKey, dataFilePath);
         } catch (PGPException | IOException | SignatureException e) {
             log.error("Signature verification failed. \npubKeyFilePath={} \nsigFilePath={} \ndataFilePath={}.",


### PR DESCRIPTION
Change the in-app update verifier so it no longer depends on byte-for-byte public key equality. The downloaded artifact signature must now verify independently with the release-provided key, the bisq.network webpage key, and the bundled app resource key, while allowing public key armor or metadata to differ.

Update release-readiness checks to compare release key identity by fingerprint and to verify every signable release artifact with each active signing-key source instead of hashing key files for exact content. The signingkey.asc marker is normalized to the active key id.

Add regression coverage for metadata-different key files that still verify the same artifact, plus failure coverage when any key source cannot verify. PgPUtils now returns a clean false when a signature key id is absent from the provided keyring.

Tests: ./gradlew :evolution:test; ./gradlew :security:test; git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened release artifact verification with more rigorous source consistency validation.
  * Enhanced error diagnostics when signature verification issues occur.

* **Tests**
  * Added tests to ensure signature verification handles key metadata variations correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->