### PR TITLE
Harden webcam IPC failure handling

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/InputHandler.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/InputHandler.java
@@ -64,7 +64,7 @@ public class InputHandler {
         } catch (EOFException e) {
             throw new IllegalArgumentException("Incomplete webcam IPC frame", e);
         } catch (IOException e) {
-            model.getLocalException().set(e);
+            throw new IllegalArgumentException("Could not read webcam IPC frame", e);
         }
     }
 

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/webcam/InputHandlerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/webcam/InputHandlerTest.java
@@ -151,6 +151,16 @@ public class InputHandlerTest {
         InputHandler inputHandler = new InputHandler(model);
 
         assertThrows(IllegalArgumentException.class, () -> inputHandler.onSocket(timingOutSocket()));
+        assertNull(model.getLocalException().get());
+    }
+
+    @Test
+    void rejectsSocketReadFailureWithoutSettingLocalException() {
+        WebcamAppModel model = createModel();
+        InputHandler inputHandler = new InputHandler(model);
+
+        assertThrows(IllegalArgumentException.class, () -> inputHandler.onSocket(failingSocket()));
+        assertNull(model.getLocalException().get());
     }
 
     private WebcamAppModel createModel() {
@@ -192,6 +202,20 @@ public class InputHandlerTest {
                     @Override
                     public int read() throws IOException {
                         throw new SocketTimeoutException("timeout");
+                    }
+                };
+            }
+        };
+    }
+
+    private static Socket failingSocket() {
+        return new Socket() {
+            @Override
+            public InputStream getInputStream() {
+                return new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        throw new IOException("connection reset");
                     }
                 };
             }

--- a/apps/desktop/webcam-app/src/main/java/bisq/webcam/service/network/QrCodeSender.java
+++ b/apps/desktop/webcam-app/src/main/java/bisq/webcam/service/network/QrCodeSender.java
@@ -36,7 +36,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Slf4j
 public class QrCodeSender {
@@ -73,12 +72,21 @@ public class QrCodeSender {
     }
 
     public CompletableFuture<Void> send(WebcamControlSignals controlSignal, String payload) {
-        return doSend(controlSignal, Optional.of(checkNotNull(payload, "payload must not be null")));
+        if (payload == null) {
+            return CompletableFuture.failedFuture(new NullPointerException("payload must not be null"));
+        }
+        return doSend(controlSignal, Optional.of(payload));
     }
 
     private CompletableFuture<Void> doSend(WebcamControlSignals controlSignal, Optional<String> payload) {
-        WebcamIpcWireMessage wireMessage = WebcamIpcWireMessage.create(sessionSecret, controlSignal, payload);
         int payloadByteLength = payload.map(value -> value.getBytes(StandardCharsets.UTF_8).length).orElse(0);
+        WebcamIpcWireMessage wireMessage;
+        try {
+            wireMessage = WebcamIpcWireMessage.create(sessionSecret, controlSignal, payload);
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+
         log.info("send {} message with payloadByteLength={}", controlSignal, payloadByteLength);
         return CompletableFuture.runAsync(() -> {
                     try (Socket socket = new Socket()) {

--- a/apps/desktop/webcam-app/src/test/java/bisq/webcam/service/network/QrCodeSenderTest.java
+++ b/apps/desktop/webcam-app/src/test/java/bisq/webcam/service/network/QrCodeSenderTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.webcam.service.network;
+
+import bisq.common.webcam.WebcamControlSignals;
+import bisq.common.webcam.WebcamIpcWireMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class QrCodeSenderTest {
+    @Test
+    void sendReturnsFailedFutureWhenPayloadIsTooLarge() {
+        QrCodeSender qrCodeSender = new QrCodeSender(0, "secret");
+        String payload = "a".repeat(WebcamIpcWireMessage.MAX_PAYLOAD_LENGTH + 1);
+
+        try {
+            CompletableFuture<Void> future = assertDoesNotThrow(() ->
+                    qrCodeSender.send(WebcamControlSignals.QR_CODE_PREFIX, payload));
+
+            CompletionException exception = assertThrows(CompletionException.class, future::join);
+            assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+        } finally {
+            qrCodeSender.shutdown();
+        }
+    }
+
+    @Test
+    void sendReturnsFailedFutureWhenPayloadIsNull() {
+        QrCodeSender qrCodeSender = new QrCodeSender(0, "secret");
+
+        try {
+            CompletableFuture<Void> future = assertDoesNotThrow(() ->
+                    qrCodeSender.send(WebcamControlSignals.QR_CODE_PREFIX, null));
+
+            CompletionException exception = assertThrows(CompletionException.class, future::join);
+            assertInstanceOf(NullPointerException.class, exception.getCause());
+        } finally {
+            qrCodeSender.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Reject unreadable inbound webcam IPC frames as malformed messages instead of reporting them through the local exception observable. This keeps unauthenticated socket failures on the rejected-message path.

Return failed futures from QrCodeSender when payload validation or wire-message creation fails, so callers that attach CompletableFuture handlers observe those failures consistently.

Add regression coverage for inbound read failures and outbound oversized/null payload validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for webcam frame reading operations
  * Enhanced input validation for webcam data transmission
  * Better exception propagation in asynchronous operations

* **Tests**
  * Added comprehensive tests for error handling scenarios
  * Improved test coverage for webcam functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->