### PR TITLE
chore/bring_missing_push_notifications_code_from_2.1.10

### DIFF
--- a/api/src/main/java/bisq/api/rest_api/endpoints/devices/DevicesRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/devices/DevicesRestApi.java
@@ -21,6 +21,9 @@ import bisq.api.rest_api.endpoints.RestApiBase;
 import bisq.common.util.StringUtils;
 import bisq.notifications.mobile.registration.DeviceRegistrationService;
 import bisq.notifications.mobile.registration.MobileDevicePlatform;
+
+import java.util.Base64;
+import java.util.Optional;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -84,6 +87,7 @@ public class DevicesRestApi extends RestApiBase {
         String publicKeyBase64 = request.getPublicKeyBase64();
         String deviceDescriptor = request.getDeviceDescriptor();
         MobileDevicePlatform platform = request.getPlatform();
+        Optional<String> symmetricKeyBase64 = Optional.ofNullable(request.getSymmetricKeyBase64());
 
         log.debug(
                 "Register device request: deviceId={}, descriptor={}, tokenLength={}, platform={}",
@@ -110,13 +114,32 @@ public class DevicesRestApi extends RestApiBase {
             }
         }
 
+        // Validate symmetricKeyBase64 if provided
+        if (symmetricKeyBase64.isPresent() && !symmetricKeyBase64.get().isEmpty()) {
+            try {
+                byte[] decoded = Base64.getDecoder().decode(symmetricKeyBase64.get());
+                if (decoded.length != 32) {
+                    return buildResponse(
+                            Response.Status.BAD_REQUEST,
+                            "symmetricKeyBase64 must decode to 32 bytes (AES-256)"
+                    );
+                }
+            } catch (IllegalArgumentException e) {
+                return buildResponse(
+                        Response.Status.BAD_REQUEST,
+                        "symmetricKeyBase64 must be valid Base64 and decode to 32 bytes (AES-256)"
+                );
+            }
+        }
+
         try {
             deviceRegistrationService.register(
                     deviceId,
                     deviceToken,
                     publicKeyBase64,
                     deviceDescriptor,
-                    platform
+                    platform,
+                    symmetricKeyBase64
             );
 
             log.info("Device registered: deviceId={}, platform={}", deviceId, platform);

--- a/api/src/main/java/bisq/api/rest_api/endpoints/devices/RegisterDeviceRequest.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/devices/RegisterDeviceRequest.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+
+import javax.annotation.Nullable;
 /**
  * Request payload for registering a mobile device for push notifications.
  *
@@ -69,18 +71,30 @@ public class RegisterDeviceRequest {
     )
     private final MobileDevicePlatform platform;
 
+    @Schema(
+            description = "Optional Base64-encoded AES-256 symmetric key for push notification encryption. " +
+                    "When present, notifications are encrypted with AES-GCM instead of ECIES. " +
+                    "Required for iOS Notification Service Extension decryption.",
+            required = false,
+            example = "dGhpcyBpcyBhIHRlc3Qga2V5IGZvciBkZW1vbnN0cmF0aW9u"
+    )
+    @Nullable
+    private final String symmetricKeyBase64;
+
     @JsonCreator
     public RegisterDeviceRequest(
             @JsonProperty("deviceId") String deviceId,
             @JsonProperty("deviceToken") String deviceToken,
             @JsonProperty("publicKeyBase64") String publicKeyBase64,
             @JsonProperty("deviceDescriptor") String deviceDescriptor,
-            @JsonProperty("platform") MobileDevicePlatform platform
+            @JsonProperty("platform") MobileDevicePlatform platform,
+            @Nullable @JsonProperty("symmetricKeyBase64") String symmetricKeyBase64
     ) {
         this.deviceId = deviceId;
         this.deviceToken = deviceToken;
         this.publicKeyBase64 = publicKeyBase64;
         this.deviceDescriptor = deviceDescriptor;
         this.platform = platform;
+        this.symmetricKeyBase64 = symmetricKeyBase64;
     }
 }

--- a/bonded-roles/src/main/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClient.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClient.java
@@ -17,20 +17,25 @@
 
 package bisq.bonded_roles.mobile_notification_relay;
 
+import bisq.common.data.Pair;
+import bisq.common.json.JsonMapperProvider;
 import bisq.common.threading.ExecutorFactory;
 import bisq.network.NetworkService;
+import bisq.network.http.BaseHttpClient;
 import bisq.network.http.HttpRequestService;
 import bisq.network.http.HttpRequestServiceConfig;
 import bisq.network.http.HttpRequestUrlProvider;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 
 @Slf4j
 public class MobileNotificationRelayClient extends HttpRequestService<MobileNotificationRelayClient.RequestData, String> {
-    private static final String SUCCESS = "success";
 
     private static ExecutorService getExecutorService() {
         return ExecutorFactory.newCachedThreadPool(MobileNotificationRelayClient.class.getSimpleName(),
@@ -52,32 +57,84 @@ public class MobileNotificationRelayClient extends HttpRequestService<MobileNoti
 
     @Override
     protected String getParam(HttpRequestUrlProvider provider, RequestData requestData) {
-        return provider.getApiPath() + "?" +
+        String params = provider.getApiPath() + "?" +
                 "isAndroid=" + requestData.isAndroid() +
-                "&token=" + requestData.getDeviceTokenHex() +
-                "&msg=" + requestData.getEncryptedMessageHex();
+                "&token=" + requestData.getDeviceToken() +
+                "&msg=" + requestData.getEncryptedMessage();
+        if (requestData.isMutableContent()) {
+            params += "&mutableContent=true";
+        }
+        return params;
     }
 
+    /**
+     * Sends a push notification via the relay's v1 POST endpoint.
+     * Uses POST /v1/apns/device/{token} or /v1/fcm/device/{token} with a JSON body
+     * containing the Base64-encoded encrypted payload. This avoids the hex encoding
+     * round-trip of the legacy GET /relay endpoint which corrupts binary ciphertext.
+     */
     public CompletableFuture<Boolean> sendToRelayServer(boolean isAndroid,
-                                                        String deviceTokenHex,
-                                                        String encryptedMessageHex) {
-        RequestData requestData = new RequestData(isAndroid,
-                deviceTokenHex,
-                encryptedMessageHex);
-        return request(requestData)
-                .thenApply(SUCCESS::equals);
+                                                        String deviceToken,
+                                                        String encryptedBase64,
+                                                        boolean mutableContent) {
+        if (noProviderAvailable) {
+            return CompletableFuture.failedFuture(new RuntimeException("No relay provider available"));
+        }
+
+        HttpRequestUrlProvider provider = selectedProvider.get();
+        if (provider == null) {
+            return CompletableFuture.failedFuture(new RuntimeException("No relay provider selected"));
+        }
+
+        String platformPath = isAndroid ? "/v1/fcm/device/" : "/v1/apns/device/";
+        String baseUrl = provider.getBaseUrl().replaceAll("/+$", "");
+        String fullUrl = baseUrl + platformPath + deviceToken;
+        String jsonBody = buildJsonBody(encryptedBase64, true, mutableContent);
+
+        return CompletableFuture.supplyAsync(() -> {
+            BaseHttpClient client = networkService.getHttpClient(
+                    fullUrl, userAgent, provider.getTransportType());
+            try {
+                log.info("Sending push notification via POST to {}", provider.getBaseUrl() + platformPath + "...");
+                String response = client.post(jsonBody,
+                        Optional.of(new Pair<>("Content-Type", "application/json")));
+                log.info("Relay v1 response: {}", response);
+                return true;
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            } finally {
+                try {
+                    client.shutdown();
+                } catch (Exception e) {
+                    log.warn("Failed to shut down HTTP client", e);
+                }
+            }
+        }, executorService);
+    }
+
+    static String buildJsonBody(String encryptedBase64, boolean isUrgent, boolean isMutableContent) {
+        try {
+            return JsonMapperProvider.get().writeValueAsString(Map.of(
+                    "encrypted", encryptedBase64,
+                    "isUrgent", isUrgent,
+                    "isMutableContent", isMutableContent));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize push notification body", e);
+        }
     }
 
     @Getter
     public static class RequestData {
         private final boolean isAndroid;
-        private final String deviceTokenHex;
-        private final String encryptedMessageHex;
+        private final String deviceToken;
+        private final String encryptedMessage;
+        private final boolean mutableContent;
 
-        public RequestData(boolean isAndroid, String deviceTokenHex, String encryptedMessageHex) {
+        public RequestData(boolean isAndroid, String deviceToken, String encryptedMessage, boolean mutableContent) {
             this.isAndroid = isAndroid;
-            this.deviceTokenHex = deviceTokenHex;
-            this.encryptedMessageHex = encryptedMessageHex;
+            this.deviceToken = deviceToken;
+            this.encryptedMessage = encryptedMessage;
+            this.mutableContent = mutableContent;
         }
     }
 

--- a/bonded-roles/src/test/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClientTest.java
+++ b/bonded-roles/src/test/java/bisq/bonded_roles/mobile_notification_relay/MobileNotificationRelayClientTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bonded_roles.mobile_notification_relay;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MobileNotificationRelayClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void buildJsonBody_withAllFields() throws Exception {
+        String json = MobileNotificationRelayClient.buildJsonBody("dGVzdA==", true, true);
+
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.get("encrypted").asText()).isEqualTo("dGVzdA==");
+        assertThat(node.get("isUrgent").asBoolean()).isTrue();
+        assertThat(node.get("isMutableContent").asBoolean()).isTrue();
+    }
+
+    @Test
+    void buildJsonBody_withMutableContentFalse() throws Exception {
+        String json = MobileNotificationRelayClient.buildJsonBody("abc123==", true, false);
+
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.get("encrypted").asText()).isEqualTo("abc123==");
+        assertThat(node.get("isUrgent").asBoolean()).isTrue();
+        assertThat(node.get("isMutableContent").asBoolean()).isFalse();
+    }
+
+    @Test
+    void buildJsonBody_producesValidJson_withUrgentFalse() throws Exception {
+        String json = MobileNotificationRelayClient.buildJsonBody("payload==", false, true);
+
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.size()).isEqualTo(3);
+        assertThat(node.get("isUrgent").asBoolean()).isFalse();
+        assertThat(node.get("isMutableContent").asBoolean()).isTrue();
+    }
+
+    @Test
+    void buildJsonBody_preservesBase64Padding() throws Exception {
+        // Base64 with padding characters must survive JSON serialization
+        String base64 = "SGVsbG8gV29ybGQ=";
+        String json = MobileNotificationRelayClient.buildJsonBody(base64, true, true);
+
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.get("encrypted").asText()).isEqualTo(base64);
+    }
+}

--- a/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationService.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationService.java
@@ -20,8 +20,6 @@ package bisq.notifications.mobile;
 
 import bisq.bonded_roles.mobile_notification_relay.MobileNotificationRelayClient;
 import bisq.common.application.Service;
-import bisq.common.encoding.Base64;
-import bisq.common.encoding.Hex;
 import bisq.common.json.JsonMapperProvider;
 import bisq.notifications.Notification;
 import bisq.notifications.mobile.registration.DeviceRegistrationService;
@@ -66,26 +64,39 @@ public class MobileNotificationService implements Service {
         log.info("Dispatching push notification '{}' to {} registered device(s)", notification.getTitle(), profiles.size());
         profiles.forEach(mobileDeviceProfile -> {
                     boolean isAndroid = mobileDeviceProfile.getPlatform() == MobileDevicePlatform.ANDROID;
-                    String deviceTokenHex = mobileDeviceProfile.getDeviceToken();
+                    String deviceToken = mobileDeviceProfile.getDeviceToken();
                     String platform = isAndroid ? "Android" : "iOS";
                     MobileNotificationPayload payload = new MobileNotificationPayload(notification.getId(),
                             notification.getTitle(),
                             notification.getMessage());
                     try {
                         String json = JsonMapperProvider.get().writeValueAsString(payload);
-                        String encryptedBase64 = MobileNotificationEncryption.encrypt(mobileDeviceProfile.getPublicKeyBase64(), json);
-                        // The bisq-relay server expects hex-encoded encrypted messages.
-                        // MobileNotificationEncryption.encrypt() returns Base64, so we
-                        // convert here to match the relay's expected format.
-                        String encryptedMessageHex = Hex.encode(Base64.decode(encryptedBase64));
+
+                        // Use AES-GCM when a symmetric key is available (iOS NSE),
+                        // otherwise fall back to ECIES (legacy / Android)
+                        String encryptedBase64;
+                        boolean mutableContent = false;
+                        if (mobileDeviceProfile.hasSymmetricKey()) {
+                            encryptedBase64 = MobileNotificationEncryption.encryptWithSymmetricKey(
+                                    mobileDeviceProfile.getSymmetricKeyBase64().orElseThrow(), json);
+                            mutableContent = true;
+                        } else {
+                            encryptedBase64 = MobileNotificationEncryption.encrypt(
+                                    mobileDeviceProfile.getPublicKeyBase64(), json);
+                        }
+
+                        // Send Base64-encoded encrypted payload directly to the relay's v1 POST endpoint.
+                        // The v1 endpoint accepts JSON with the encrypted field as Base64, avoiding the
+                        // hex-encoding round-trip of the legacy GET /relay endpoint which corrupts binary data.
                         mobileNotificationRelayClient.sendToRelayServer(isAndroid,
-                                        deviceTokenHex,
-                                        encryptedMessageHex)
+                                        deviceToken,
+                                        encryptedBase64,
+                                        mutableContent)
                                 .whenComplete((success, throwable) -> {
                                     if (throwable != null) {
                                         log.warn("Failed to send push notification to {} device", platform, throwable);
                                     } else if (Boolean.TRUE.equals(success)) {
-                                        log.info("Push notification sent to {} device (token: {}...)", platform, deviceTokenHex.substring(0, Math.min(8, deviceTokenHex.length())));
+                                        log.info("Push notification sent to {} device (token: {}...)", platform, deviceToken.substring(0, Math.min(8, deviceToken.length())));
                                     } else {
                                         log.warn("Push notification relay returned failure for {} device", platform);
                                     }

--- a/notifications/src/main/java/bisq/notifications/mobile/registration/DeviceRegistrationService.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/registration/DeviceRegistrationService.java
@@ -26,6 +26,7 @@ import bisq.persistence.RateLimitedPersistenceClient;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -46,7 +47,8 @@ public class DeviceRegistrationService extends RateLimitedPersistenceClient<Devi
                          String deviceToken,
                          String publicKeyBase64,
                          String deviceDescriptor,
-                         MobileDevicePlatform platform) {
+                         MobileDevicePlatform platform,
+                         Optional<String> symmetricKeyBase64) {
         checkArgument(StringUtils.isNotEmpty(deviceId), "deviceId must not be null or empty");
         checkArgument(StringUtils.isNotEmpty(deviceToken), "deviceToken must not be null or empty");
         checkArgument(StringUtils.isNotEmpty(publicKeyBase64), "publicKeyBase64 must not be null or empty");
@@ -54,17 +56,18 @@ public class DeviceRegistrationService extends RateLimitedPersistenceClient<Devi
         checkNotNull(platform, "platform must not be null");
 
         // Log at DEBUG level to avoid exposing sensitive device identifiers
-        log.debug("Registering device - deviceId: {}, deviceDescriptor: {}, platform: {}",
-                deviceId, deviceDescriptor, platform);
+        log.debug("Registering device - deviceId: {}, deviceDescriptor: {}, platform: {}, hasSymmetricKey: {}",
+                deviceId, deviceDescriptor, platform, symmetricKeyBase64.isPresent());
         // Log minimal info at INFO level for monitoring
-        log.info("Device registration: platform={}, deviceIdLength={}, descriptorLength={}",
-                platform, deviceId.length(), deviceDescriptor.length());
+        log.info("Device registration: platform={}, deviceIdLength={}, descriptorLength={}, hasSymmetricKey={}",
+                platform, deviceId.length(), deviceDescriptor.length(), symmetricKeyBase64.isPresent());
 
         MobileDeviceProfile mobileDeviceProfile = new MobileDeviceProfile(deviceId,
                 deviceToken,
                 publicKeyBase64,
                 deviceDescriptor,
-                platform);
+                platform,
+                symmetricKeyBase64);
         MobileDeviceProfile previous = persistableStore.getDeviceByDeviceId().put(deviceId, mobileDeviceProfile);
         if (previous == null || !previous.equals(mobileDeviceProfile)) {
             persist();

--- a/notifications/src/main/java/bisq/notifications/mobile/registration/MobileDeviceProfile.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/registration/MobileDeviceProfile.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Optional;
+
 @Getter
 @ToString
 @EqualsAndHashCode
@@ -31,18 +33,25 @@ public final class MobileDeviceProfile implements PersistableProto {
     private final String publicKeyBase64;
     private final String deviceDescriptor;
     private final MobileDevicePlatform platform;
+    private final Optional<String> symmetricKeyBase64;
 
     public MobileDeviceProfile(String deviceId,
                                String deviceToken,
                                String publicKeyBase64,
                                String deviceDescriptor,
-                               MobileDevicePlatform platform
+                               MobileDevicePlatform platform,
+                               Optional<String> symmetricKeyBase64
     ) {
         this.deviceId = deviceId;
         this.deviceToken = deviceToken;
         this.publicKeyBase64 = publicKeyBase64;
         this.deviceDescriptor = deviceDescriptor;
         this.platform = platform;
+        this.symmetricKeyBase64 = symmetricKeyBase64;
+    }
+
+    public boolean hasSymmetricKey() {
+        return symmetricKeyBase64.isPresent() && !symmetricKeyBase64.get().isEmpty();
     }
 
     @Override
@@ -52,20 +61,26 @@ public final class MobileDeviceProfile implements PersistableProto {
 
     @Override
     public bisq.notifications.protobuf.MobileDeviceProfile.Builder getBuilder(boolean serializeForHash) {
-        return bisq.notifications.protobuf.MobileDeviceProfile.newBuilder()
+        var builder = bisq.notifications.protobuf.MobileDeviceProfile.newBuilder()
                 .setDeviceId(deviceId)
                 .setDeviceToken(deviceToken)
                 .setPublicKeyBase64(publicKeyBase64)
                 .setDeviceDescriptor(deviceDescriptor)
                 .setPlatform(platform.toProtoEnum());
+        symmetricKeyBase64.ifPresent(builder::setSymmetricKeyBase64);
+        return builder;
     }
 
     public static MobileDeviceProfile fromProto(bisq.notifications.protobuf.MobileDeviceProfile proto) {
+        Optional<String> symmetricKey = proto.hasSymmetricKeyBase64()
+                ? Optional.of(proto.getSymmetricKeyBase64())
+                : Optional.empty();
         return new MobileDeviceProfile(proto.getDeviceId(),
                 proto.getDeviceToken(),
                 proto.getPublicKeyBase64(),
                 proto.getDeviceDescriptor(),
-                MobileDevicePlatform.fromProto(proto.getPlatform()));
+                MobileDevicePlatform.fromProto(proto.getPlatform()),
+                symmetricKey);
     }
 }
 

--- a/notifications/src/main/proto/notifications.proto
+++ b/notifications/src/main/proto/notifications.proto
@@ -32,6 +32,7 @@ message MobileDeviceProfile {
   string publicKeyBase64 = 3;
   string deviceDescriptor = 4;
   MobileDevicePlatform platform = 5;
+  optional string symmetricKeyBase64 = 6;
 }
 
 message DeviceRegistrationStore {

--- a/security/src/main/java/bisq/security/mobile_notifications/MobileNotificationEncryption.java
+++ b/security/src/main/java/bisq/security/mobile_notifications/MobileNotificationEncryption.java
@@ -19,11 +19,14 @@ package bisq.security.mobile_notifications;
 
 
 import bisq.common.encoding.Base64;
+import bisq.common.util.ByteArrayUtils;
+import bisq.security.AesGcm;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.IESParameterSpec;
 
 import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -32,9 +35,11 @@ import java.security.spec.X509EncodedKeySpec;
 
 @Slf4j
 public class MobileNotificationEncryption {
+    private static final int GCM_NONCE_LENGTH = 12;
 
     /**
      * Encrypt the message using the device's public key (ECIES for EC keys).
+     * Used as fallback when no symmetric key is available.
      *
      * @param publicKeyBase64 The Base64 encoded public key
      * @param message         The message to encrypt
@@ -67,7 +72,41 @@ public class MobileNotificationEncryption {
 
             return Base64.encode(encryptedBytes);
         } catch (Exception e) {
-            log.error("Encryption failed", e);
+            log.error("ECIES encryption failed", e);
+            throw new GeneralSecurityException(e);
+        }
+    }
+
+    /**
+     * Encrypt the message using a shared AES-256 symmetric key (AES-GCM).
+     * Used for iOS devices that provide a symmetric key during registration,
+     * enabling decryption in the Notification Service Extension via Apple CryptoKit.
+     *
+     * <p>Output format: nonce (12 bytes) || ciphertext || authentication tag (16 bytes)
+     * This matches the format expected by the iOS NSE (CryptoKit AES.GCM).
+     *
+     * @param symmetricKeyBase64 The Base64 encoded AES-256 key (32 bytes)
+     * @param message            The message to encrypt
+     * @return Base64 encoded encrypted message (nonce + ciphertext + tag)
+     */
+    public static String encryptWithSymmetricKey(String symmetricKeyBase64, String message) throws GeneralSecurityException {
+        try {
+            byte[] keyBytes = Base64.decode(symmetricKeyBase64);
+            if (keyBytes.length != 32) {
+                throw new GeneralSecurityException("Symmetric key must be 256 bits (32 bytes), got " + keyBytes.length);
+            }
+
+            SecretKeySpec secretKey = new SecretKeySpec(keyBytes, "AES");
+            byte[] nonce = ByteArrayUtils.getRandomBytes(GCM_NONCE_LENGTH);
+
+            // Reuse the project's AesGcm utility for the cipher operation.
+            // Java's GCM mode appends the authentication tag to the ciphertext.
+            byte[] ciphertextWithTag = AesGcm.encrypt(secretKey, nonce, message.getBytes(StandardCharsets.UTF_8));
+
+            // Output: nonce || ciphertext || tag — matches CryptoKit AES.GCM on iOS
+            return Base64.encode(ByteArrayUtils.concat(nonce, ciphertextWithTag));
+        } catch (Exception e) {
+            log.error("AES-GCM encryption failed", e);
             throw new GeneralSecurityException(e);
         }
     }


### PR DESCRIPTION
Regression on relayed pushed notifications (mobile) in this branch -> this is a clean cherry-pick of **4182eb449d** (PR
  #4689 to main) with zero conflicts.

dev logs:
 - add mutable content support for relay notifications
 - symetric key iOS compatible encryption optional support (backward compatible) for relayed push notifications
 - use @Nullable whenever appropriate and add validations as suggested by CRAI
 - fix encoding issues in recent changes, always use base64 now and migrated to new bisq-relay API abandoning the deprecated one
 - apply CRAI & reviewer suggestions
 - Reuse the project AesGcm utility to avoid duplicated code, with output adaptation for iOS CryptoKit