### PR TITLE
Update Logback conversion rule syntax

### DIFF
--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <property name="LOG_ROOT" value="logs" />
-    <conversionRule conversionWord="mask" converterClass="bisq.common.logging.LogMaskConverter"/>
+    <conversionRule conversionWord="mask" class="bisq.common.logging.LogMaskConverter"/>
 
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
Logback 1.5 deprecates the converterClass attribute on conversionRule in favor of class. The old attribute caused Logback to emit its internal status output during desktop app startup, including a deprecation warning before normal application logging began.

Switch the mask converter registration to the supported class attribute so startup logging stays quiet while preserving the existing LogMaskConverter behavior.