### PR TITLE
Bundle custom Java runtime image

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JLinkTask.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/JLinkTask.kt
@@ -2,12 +2,14 @@ package bisq.gradle.packaging
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 abstract class JLinkTask : DefaultTask() {
@@ -15,58 +17,83 @@ abstract class JLinkTask : DefaultTask() {
     @get:InputDirectory
     abstract val jdkDirectory: DirectoryProperty
 
-    @get:Optional
-    @get:InputDirectory
-    abstract val javaModulesDirectory: DirectoryProperty
+    @get:Input
+    abstract val modules: SetProperty<String>
 
-    @get:InputFile
-    abstract val jDepsOutputFile: RegularFileProperty
+    @get:Input
+    abstract val options: ListProperty<String>
+
+    @get:Input
+    abstract val excludedNativeCommands: SetProperty<String>
+
+    @get:Input
+    abstract val requireJavaLauncher: Property<Boolean>
 
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
     fun run() {
-        // jlink expects non-existent output directory
+        val moduleNames = modules.get()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .toSortedSet()
+        check(moduleNames.isNotEmpty()) { "At least one module must be configured for jlink." }
+
         val outputDirectoryFile = outputDirectory.asFile.get()
+        // jlink expects a non-existent output directory.
         outputDirectoryFile.deleteRecursively()
 
         val jLinkPath = jdkDirectory.asFile.get().toPath().resolve("bin").resolve("jlink")
-        val processBuilder = ProcessBuilder(
+        val command = mutableListOf(
                 jLinkPath.toAbsolutePath().toString(),
-
-                "--add-modules", parseUsedJavaModulesFromJDepsOutput(),
-
-                "--strip-native-commands",
-                "--no-header-files",
-                "--no-man-pages",
-                "--strip-debug",
-
-                "--output", outputDirectoryFile.absolutePath
+                "--add-modules", moduleNames.joinToString(","),
         )
+        command.addAll(options.get())
+        command.addAll(listOf("--output", outputDirectoryFile.absolutePath))
 
-        if (javaModulesDirectory.isPresent) {
-            val commands = processBuilder.command()
-            commands.add("--module-path")
-            commands.add(javaModulesDirectory.asFile.get().absolutePath)
-        }
-
+        val processBuilder = ProcessBuilder(command)
         processBuilder.inheritIO()
 
         val process = processBuilder.start()
-        process.waitFor(2, TimeUnit.MINUTES)
+        val finished = process.waitFor(2, TimeUnit.MINUTES)
+        if (!finished) {
+            process.destroyForcibly()
+            throw IllegalStateException("jlink did not finish within 2 minutes.")
+        }
 
         val isSuccess = process.exitValue() == 0
         if (!isSuccess) {
             throw IllegalStateException("jlink couldn't create custom runtime.")
         }
+
+        deleteExcludedNativeCommands(outputDirectoryFile)
+
+        if (requireJavaLauncher.get()) {
+            val javaExecutableName = if (getOS() == OS.WINDOWS) "java.exe" else "java"
+            val javaExecutable = outputDirectoryFile.toPath().resolve("bin").resolve(javaExecutableName).toFile()
+            check(javaExecutable.isFile) {
+                "The generated runtime image does not contain bin/$javaExecutableName. " +
+                        "Do not use --strip-native-commands while Bisq starts child JVM processes."
+            }
+        }
     }
 
-    private fun parseUsedJavaModulesFromJDepsOutput(): String {
-        var readLines = jDepsOutputFile.asFile.get().readLines()
-        if (!javaModulesDirectory.isPresent) {
-            readLines = readLines.filter { it.startsWith("java.") }
+    private fun deleteExcludedNativeCommands(outputDirectoryFile: File) {
+        val excludedCommands = excludedNativeCommands.get()
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .toSet()
+        if (excludedCommands.isEmpty()) {
+            return
         }
-        return readLines.joinToString(",")
+
+        val binDirectory = outputDirectoryFile.toPath().resolve("bin").toFile()
+        excludedCommands
+                .map { binDirectory.resolve(it) }
+                .filter { it.isFile }
+                .forEach {
+                    check(it.delete()) { "Could not remove excluded runtime command: ${it.absolutePath}" }
+                }
     }
 }

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPlugin.kt
@@ -23,10 +23,64 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
 
     companion object {
         const val OUTPUT_DIR_PATH = "packaging/jpackage/packages"
+        private val DEFAULT_RUNTIME_IMAGE_MODULES = setOf(
+                "java.base",
+                "java.compiler",
+                "java.desktop",
+                "java.instrument",
+                "java.logging",
+                "java.management",
+                "java.naming",
+                "java.net.http",
+                "java.security.jgss",
+                "java.sql",
+                "java.xml",
+                "jdk.attach",
+                "jdk.charsets",
+                "jdk.crypto.ec",
+                "jdk.httpserver",
+                "jdk.jdi",
+                "jdk.jfr",
+                "jdk.localedata",
+                "jdk.management",
+                "jdk.net",
+                "jdk.unsupported",
+        )
+        private val DEFAULT_RUNTIME_IMAGE_JLINK_OPTIONS = listOf(
+                "--no-header-files",
+                "--no-man-pages",
+                "--strip-debug",
+                "--compress", "zip-6",
+        )
+        private val DEFAULT_RUNTIME_IMAGE_EXCLUDED_NATIVE_COMMANDS = setOf(
+                "jdb",
+                "jdb.exe",
+                "jfr",
+                "jfr.exe",
+                "jwebserver",
+                "jwebserver.exe",
+        )
     }
 
     override fun apply(project: Project) {
         val extension = project.extensions.create<PackagingPluginExtension>("packaging")
+        extension.runtimeImageModules.convention(DEFAULT_RUNTIME_IMAGE_MODULES)
+        extension.runtimeImageJlinkOptions.convention(DEFAULT_RUNTIME_IMAGE_JLINK_OPTIONS)
+        extension.runtimeImageExcludedNativeCommands.convention(DEFAULT_RUNTIME_IMAGE_EXCLUDED_NATIVE_COMMANDS)
+        extension.requireJavaLauncher.convention(true)
+
+        val jPackageJdkDirectory = getJPackageJdkDirectory(project)
+        val runtimeImageTask = project.tasks.register<JLinkTask>("createJPackageRuntimeImage") {
+            group = "distribution"
+            description = "Create the Java runtime image bundled into jpackage installers."
+
+            jdkDirectory.set(jPackageJdkDirectory)
+            modules.set(extension.runtimeImageModules)
+            options.set(extension.runtimeImageJlinkOptions)
+            excludedNativeCommands.set(extension.runtimeImageExcludedNativeCommands)
+            requireJavaLauncher.set(extension.requireJavaLauncher)
+            outputDirectory.set(project.layout.buildDirectory.dir("packaging/jlink/runtime-image"))
+        }
 
         val installDistTask: TaskProvider<Sync> = project.tasks.named("installDist", Sync::class.java)
 
@@ -73,7 +127,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
 
             dependsOn(generateHashesTask)
 
-            jdkDirectory.set(getJPackageJdkDirectory(project))
+            jdkDirectory.set(jPackageJdkDirectory)
 
             distDirFile.set(installDistTask.map { it.destinationDir })
             mainJarFile.set(jarTask.flatMap { it.archiveFile })
@@ -95,7 +149,7 @@ class PackagingPlugin @Inject constructor(private val javaToolchainService: Java
             packageResourcesDir.set(packageResourcesDirFile)
 
             runtimeImageDirectory.set(
-                getJPackageJdkDirectory(project)
+                extension.runtimeImageDirectory.orElse(runtimeImageTask.flatMap { it.outputDirectory })
             )
 
             outputDirectory.set(project.layout.buildDirectory.dir("packaging/jpackage/packages"))

--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPluginExtension.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/PackagingPluginExtension.kt
@@ -1,8 +1,16 @@
 package bisq.gradle.packaging
 
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 abstract class PackagingPluginExtension {
     abstract val name: Property<String>
     abstract val version: Property<String>
+    abstract val runtimeImageDirectory: DirectoryProperty
+    abstract val runtimeImageModules: SetProperty<String>
+    abstract val runtimeImageJlinkOptions: ListProperty<String>
+    abstract val runtimeImageExcludedNativeCommands: SetProperty<String>
+    abstract val requireJavaLauncher: Property<Boolean>
 }

--- a/docs/dev/java-runtime-packaging.md
+++ b/docs/dev/java-runtime-packaging.md
@@ -1,16 +1,17 @@
 # Java runtime packaging analysis
 
-Assessed on 2026-05-21 against the current Bisq 2 Gradle workspace.
+Assessed and implemented on 2026-05-21 against the current Bisq 2 Gradle workspace.
 
 ## Executive summary
 
-Bisq can move away from shipping the full JDK with the desktop installer. The current installer path does not require
-compiler or packaging tools at runtime; it uses `jpackage` during the build and then launches the desktop application on
-the classpath with the application jars and OpenJFX jars in the app `lib` directory.
+Bisq can move away from shipping the full JDK with the desktop installer. The installer path needs a JDK at build time
+for `jpackage` and `jlink`, but the installed app does not need compiler, debugger, source, header, or packaging tools.
+It launches on the classpath with the application jars and OpenJFX jars in the app `lib` directory.
 
-The lowest-risk change is to keep the current classpath launch and replace the bundled JDK image with a pinned Java 21
-JRE/runtime image for the target OS and architecture. This should be a packaging change, not an application code change.
-It still needs cross-platform installer testing, but it does not require JPMS migration.
+Implemented direction: keep the current classpath launch, keep the Azul JDK toolchain for build-time `jpackage`, and
+feed `jpackage --runtime-image` from a separate runtime-image provider. By default, packaging now generates a conservative
+Java 21 `jlink` runtime image with `bin/java` retained. The packaging extension can also point at an external vendor
+JRE/runtime image if release engineering prefers that.
 
 The larger benefit comes from a `jlink` runtime image. A local prototype for the desktop app plus the spawned BI2P and
 webcam Java processes produced a 67 MB runtime image, compared with a 342 MB Zulu JDK 21.0.11 image on this macOS
@@ -18,26 +19,36 @@ machine. This is feasible while the application remains on the classpath, but it
 and smoke tests because `jdeps` cannot see every reflective, service-provider, crypto, locale, and native-integration
 path.
 
-Recommendation: split the packaging JDK from the bundled runtime image first, then choose between a pinned vendor JRE
-for the quickest low-risk win and a generated `jlink` runtime for the best size/security result. Do not make a full JPMS
-migration a prerequisite for this work.
+Recommendation: use the generated `jlink` image as the default packaging target, keep the external JRE override as an
+escape hatch, and require full platform smoke tests before release. Do not make a full JPMS migration a prerequisite for
+this work.
 
-## Current packaging state
+## Implemented packaging state
 
 - `apps/desktop/desktop-app-launcher` applies `bisq.gradle.packaging.PackagingPlugin`.
 - `PackagingPlugin` obtains an Azul Java 21 toolchain through `JavaToolchainService`.
-- The `generateInstallers` task sets both `jdkDirectory` and `runtimeImageDirectory` to the same toolchain directory.
+- The `generateInstallers` task still uses the Azul toolchain as its build-time `jdkDirectory`.
+- A new `createJPackageRuntimeImage` task generates the default bundled runtime image with `jlink`.
+- `generateInstallers.runtimeImageDirectory` now uses `packaging.runtimeImageDirectory` when explicitly configured, or
+  the generated `createJPackageRuntimeImage` output otherwise.
 - `JPackageTask` calls `<jdkDirectory>/bin/jpackage`.
 - `PackageFactory` always passes `--runtime-image <runtimeImageDirectory>` to `jpackage`.
-- `build-logic/toolchain-resolver` pins Zulu JDK download URLs, not JRE URLs.
-- The launcher comment says "JRE", but the build currently provides the full JDK image.
+- `build-logic/toolchain-resolver` still pins Zulu JDK download URLs. The generated runtime image is derived from that
+  pinned JDK.
+- The generated runtime intentionally keeps `bin/java` because the desktop app starts child JVM processes.
 
-The current implementation therefore conflates two separate concerns:
+The implementation now separates two concerns:
 
 1. The build-time JDK needed to run `jpackage`, `jdeps`, and `jlink`.
 2. The runtime image copied into the installer and used on end-user machines.
 
-These should be separate Gradle inputs.
+Relevant extension properties:
+
+- `packaging.runtimeImageDirectory`: optional external runtime image, for example a pinned vendor JRE.
+- `packaging.runtimeImageModules`: module roots used by the generated `jlink` image.
+- `packaging.runtimeImageJlinkOptions`: options passed to `jlink`.
+- `packaging.runtimeImageExcludedNativeCommands`: native commands removed after `jlink` while keeping the runtime usable.
+- `packaging.requireJavaLauncher`: verifies `bin/java` or `bin/java.exe` exists in the generated image.
 
 ## Local measurements
 
@@ -55,11 +66,63 @@ release decision.
 | Prototype `jlink` image for desktop main runtime | 65 MB |
 | Prototype `jlink` image for desktop plus BI2P/webcam child processes | 67 MB |
 | Prototype `jlink ALL-MODULE-PATH` image | 92 MB |
+| Implemented generated `jlink` image | 67 MB |
+| Implemented generated `jlink` image `bin` directory | 144 KB |
 
 The `installDist` measurement is not the final compressed installer size. It also does not necessarily include every
 resource wired only by `generateInstallers`, such as generated BI2P/webcam payload resources. The runtime savings are
 still additive: replacing a 342 MB runtime with a smaller runtime directly reduces the app image contents before
 installer compression.
+
+## JRE vs custom `jlink` runtime
+
+### Vendor JRE/runtime image
+
+Benefits:
+
+- Lowest behavioral risk because it is closest to a normal Java runtime.
+- Less chance of missing modules discovered only by rarely used features.
+- Easier support story: the runtime comes from a vendor artifact with normal release notes and checksums.
+- Still removes most JDK-only material, such as `javac`, `javadoc`, `jlink`, `jpackage`, `jmods`, headers, and source.
+
+Risks and costs:
+
+- Size reduction is limited by what the vendor includes.
+- Runtime contents are less tailored to Bisq.
+- Release engineering must pin and verify additional JRE artifacts for every OS/architecture.
+- Some Java vendors no longer publish traditional standalone JREs for every platform/version, so availability may vary.
+
+### Custom `jlink` runtime
+
+Benefits:
+
+- Smallest runtime image because only selected JDK modules are present.
+- Generated from the same pinned JDK already used by the release build, so there is no separate vendor runtime download.
+- Better control over executable surface and runtime contents.
+- The module list becomes explicit packaging documentation.
+
+Risks and costs:
+
+- Higher behavioral risk: static analysis can miss reflection, service providers, charsets, locale data, crypto, and
+  platform integration needs.
+- Every new feature or dependency may require revisiting the module list.
+- More release testing is required, especially for BI2P, webcam, networking/TLS, notifications, resource loading, and
+  non-English locales.
+- A too-aggressive image can fail late on a user's machine rather than at compile time.
+
+### Security impact of a stripped runtime
+
+A stripped runtime has real but bounded security benefits.
+
+It reduces local attack surface by removing tools and modules that the app does not need. For example, not shipping
+`javac`, `jshell`, `jpackage`, `jlink`, `jmods`, source archives, and headers gives an attacker who already has local
+code execution fewer convenient tools inside the app bundle. A selected-module `jlink` image also removes entire JDK
+modules that cannot be loaded because they are not present.
+
+It does not turn the runtime into a sandbox and it does not by itself mitigate vulnerabilities in the modules that remain
+available, the JVM, JavaFX, third-party jars, native libraries, Tor, I2P, or the operating system. It is defense in depth,
+not a primary security boundary. The most important security requirements remain fast runtime updates, dependency
+updates, code signing/notarization, checksum verification, and feature-level hardening.
 
 ## Feasibility: vendor JRE/runtime image
 
@@ -69,12 +132,11 @@ The desktop app is not using `javac`, `javadoc`, `jlink`, `jpackage`, `jdeps`, `
 The build needs a JDK, but the installed app should only need a Java 21 runtime with `bin/java`, standard runtime modules,
 the certificate store, and platform native libraries.
 
-Expected engineering work:
+Engineering work if choosing an external JRE instead of the generated `jlink` default:
 
-- Add a separate runtime image input to the packaging extension or plugin.
+- Configure `packaging.runtimeImageDirectory` to point at the unpacked, pinned runtime image.
 - Keep the current Azul JDK toolchain as the build-time `jpackage` tool provider.
-- Add a pinned per-OS/per-architecture runtime image source, or generate a runtime image from the pinned JDK.
-- Point `JPackageTask.runtimeImageDirectory` at that runtime image instead of the build JDK.
+- Add a pinned per-OS/per-architecture runtime image source.
 - Add release verification that records the runtime vendor, version, architecture, checksum, and `java -version` output.
 - Run full installer smoke tests on macOS, Windows, and Linux.
 
@@ -86,8 +148,8 @@ Expected benefit:
 - Keeps behavior close to the current full-JDK packaging because the runtime still contains the normal Java runtime
   modules.
 
-Estimated effort: 3 to 7 engineering days, plus release-platform QA. The build change is small; the main work is pinning
-runtime artifacts and proving the generated installers behave the same on all supported platforms.
+Estimated additional effort: 2 to 5 engineering days, plus release-platform QA. The plugin now supports an external
+runtime-image input; the remaining work is artifact pinning and platform verification.
 
 ## Feasibility: `jlink` runtime image
 
@@ -97,8 +159,7 @@ A custom `jlink` runtime can be used even if Bisq continues to launch on the cla
 to become JPMS modules first. `jdeps` can provide a starting module set, then the build can create a runtime image from
 the pinned JDK and pass it to `jpackage` with `--runtime-image`.
 
-The existing `JDepsTask` and `JLinkTask` classes are useful scaffolding, but they are not currently registered in the
-active packaging path and are too narrow for the desktop app as-is. They need to account for:
+The active packaging path now registers `createJPackageRuntimeImage`. The selected module set accounts for:
 
 - The desktop launcher app.
 - The main desktop app jars.
@@ -138,7 +199,7 @@ The prototype runtime also included conservative runtime modules such as `jdk.cr
 `jdk.charsets` because TLS, locale-sensitive UI/resources, and non-UTF charsets are common areas where static analysis
 under-reports real runtime needs.
 
-Useful `jlink` options:
+Default `jlink` options:
 
 ```text
 --no-header-files
@@ -147,11 +208,22 @@ Useful `jlink` options:
 --compress zip-6
 ```
 
+Default commands removed after `jlink`:
+
+```text
+jdb
+jfr
+jwebserver
+```
+
+The generated macOS image currently retains only `java` and `keytool` in `bin`. `java` is required by webcam and BI2P
+child-process launchers. `keytool` is kept conservatively because it is a normal runtime support tool and very small.
+
 On this machine, `--compress zip-6` reduced the selected runtime from 123 MB to 67 MB. `zip-9` did not materially change
 the measured size.
 
-Estimated effort: 1 to 2 engineering weeks for a production-quality selected-module runtime, assuming no major
-cross-platform regressions. Add more time if CI/release automation must build and test all runtime images.
+Estimated remaining effort: 3 to 7 engineering days for release hardening and cross-platform smoke testing, assuming no
+major runtime regressions. Add more time if CI/release automation must build and archive runtime-image reports.
 
 ## Important blockers and risks
 
@@ -166,6 +238,7 @@ Both derive the executable from `System.getProperty("java.home")` and expect `bi
 
 Therefore, do not use `jlink --strip-native-commands` unless those launch paths are refactored or another Java launcher
 is provided. A stripped image without native commands has no `bin/java` and will break webcam and embedded BI2P startup.
+The implemented task removes selected unneeded commands after `jlink` instead.
 
 ### JavaFX module metadata is not clean
 
@@ -211,17 +284,18 @@ Runtime work should not be expected to solve all installer-size issues by itself
 
 1. Split build JDK and bundled runtime image in `PackagingPlugin`.
 
-   Keep the JDK toolchain for `jpackage`; add a separate runtime image provider for `--runtime-image`.
+   Done. The JDK toolchain is still used for `jpackage`; the bundled runtime comes from an external override or the
+   generated `jlink` task.
 
 2. Implement a low-risk runtime-image option first.
 
-   Either use a pinned vendor JRE or generate a broad `jlink` image. A broad `jlink ALL-MODULE-PATH` image measured 92 MB
-   locally, but it still includes JDK tool launchers. A vendor JRE likely gives better tool removal with low module risk.
+   Done as a conservative selected-module `jlink` image with `bin/java` retained. An external vendor JRE can still be
+   supplied through `packaging.runtimeImageDirectory`.
 
 3. Add a selected-module `jlink` path behind an explicit Gradle property.
 
-   Use it for CI experiments before making it the release default. Include the desktop launcher, desktop app, BI2P, and
-   webcam jars in module analysis.
+   Done as the default path. Before release, add CI/runtime reports and smoke tests for the desktop launcher, desktop app,
+   BI2P, and webcam jars.
 
 4. Keep `bin/java` in the runtime image.
 
@@ -243,7 +317,7 @@ Runtime work should not be expected to solve all installer-size issues by itself
 | Option | Feasibility | Effort | Runtime size benefit | Behavior risk | Notes |
 | --- | --- | ---: | ---: | --- | --- |
 | Keep full JDK | Already done | none | none | low | Largest image and ships build tools. |
-| Vendor JRE/runtime image | high | low-medium | medium | low-medium | Best first step if pinned artifacts are available for all platforms. |
+| Vendor JRE/runtime image | high | low-medium | medium | low-medium | Supported fallback if pinned artifacts are available for all platforms. |
 | Broad `jlink` image | high | medium | high | low-medium | Can be generated from the pinned JDK; may still include unwanted tool launchers if all modules are kept. |
-| Selected-module `jlink` image | medium-high | medium | highest | medium | Best long-term packaging target; requires stronger analysis and smoke tests. |
+| Selected-module `jlink` image | medium-high | medium | highest | medium | Implemented default; requires stronger analysis and smoke tests before release. |
 | Full JPMS + `jlink` | medium | high | high | high | Not required for runtime-size work; see `docs/dev/jpms-feasibility.md`. |


### PR DESCRIPTION
This is just a feasibility test. I tried on aarch64 macOS and the app looks ok but I did not test all use case like webcam. The dmg file is just 45 MB smaller and the app size is nearly double as large. This might be mistakes in the implementation. We can look into it later it it would be feasible. The other option to use vendor provided JRE is not tested yet, but rough numbers are:

Package | Download Size | Installed/Extracted Size
-- | -- | --
JRE 21 | ~30–55 MB | ~140–200 MB
JDK 21 | ~180–230 MB | ~350–500 MB

Don't know how much the impact would be on the dmg and app files.



Split the build-time JDK from the runtime image passed to jpackage. The packaging plugin now creates a conservative jlink runtime image by default, while still allowing an externally supplied runtime image such as a pinned vendor JRE.

Configure the generated runtime for the desktop launcher, desktop app, and spawned BI2P/webcam Java processes. Keep bin/java available for child JVM launchers, remove unused native commands after jlink, and fail the task if the Java launcher is missing.

Document the JRE versus custom jlink tradeoffs, including the bounded security benefits of a stripped runtime and the remaining release-testing risks.

Verification performed: ./gradlew :build-logic:packaging:compileKotlin; ./gradlew :apps:desktop:desktop-app-launcher:createJPackageRuntimeImage --rerun-tasks; ./gradlew :apps:desktop:desktop-app-launcher:installDist; ./gradlew :apps:desktop:desktop-app-launcher:generateInstallers.