### PR TITLE
Harden Transifex CI supply chain for v2.1.11

### DIFF
--- a/.github/scripts/install-transifex-cli.bash
+++ b/.github/scripts/install-transifex-cli.bash
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI installer for GitHub's Ubuntu runners; extend the OS table before reusing it elsewhere.
+readonly TRANSIFEX_CLI_VERSION="v1.6.17"
+readonly TRANSIFEX_CLI_VERSION_NUMBER="${TRANSIFEX_CLI_VERSION#v}"
+readonly TX_LINUX_AMD64_SHA256="002dec5b9e71248a7e6a0808118e9da940205828d5a33ce88e04bb57a967164d"
+readonly TX_LINUX_ARM64_SHA256="c380ed9aece5d34316aa0fe2e5afa0633553656f98909f88cb72609e2fa13153"
+
+case "$(uname -s)" in
+    Linux)
+        os="linux"
+        ;;
+    *)
+        echo "::error::Unsupported operating system for Transifex CLI installation: $(uname -s)"
+        exit 1
+        ;;
+esac
+
+case "$(uname -m)" in
+    x86_64 | amd64)
+        arch="amd64"
+        checksum="$TX_LINUX_AMD64_SHA256"
+        ;;
+    aarch64 | arm64)
+        arch="arm64"
+        checksum="$TX_LINUX_ARM64_SHA256"
+        ;;
+    *)
+        echo "::error::Unsupported architecture for Transifex CLI installation: $(uname -m)"
+        exit 1
+        ;;
+esac
+
+asset="tx-${os}-${arch}.tar.gz"
+download_url="https://github.com/transifex/cli/releases/download/${TRANSIFEX_CLI_VERSION}/${asset}"
+install_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/tx-cli"
+archive="${install_dir}/${asset}"
+extract_dir="${install_dir}/extract"
+
+mkdir -p "$install_dir"
+rm -rf "$extract_dir"
+mkdir -p "$extract_dir"
+
+echo "::group::Install Transifex CLI ${TRANSIFEX_CLI_VERSION}"
+curl --fail --location --show-error --silent "$download_url" --output "$archive"
+printf '%s  %s\n' "$checksum" "$archive" | sha256sum -c -
+tar -xzf "$archive" -C "$extract_dir"
+rm -f "$archive"
+install -m 0755 "${extract_dir}/tx" "${install_dir}/tx"
+rm -rf "$extract_dir"
+
+actual_version="$("${install_dir}/tx" --version)"
+expected_version="TX Client, version=${TRANSIFEX_CLI_VERSION_NUMBER}"
+echo "Installed Transifex CLI: $actual_version"
+if [[ "$actual_version" != "$expected_version" ]]; then
+    echo "::error::Unexpected Transifex CLI version: $actual_version"
+    exit 1
+fi
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+    # GITHUB_PATH affects later workflow steps; this script uses the absolute tx path above.
+    echo "$install_dir" >> "$GITHUB_PATH"
+fi
+echo "::endgroup::"

--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -76,16 +76,6 @@ jobs:
             echo "commit_in_main=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: "Check if TX_TOKEN secret exists"
-        if: steps.check_commit.outputs.commit_in_main == 'true'
-        env:
-          transifex_secret: ${{ secrets.TX_TOKEN }}
-        run: |
-          if [ -z "$transifex_secret" ]; then
-            echo "The secret \"TX_TOKEN\" has not been set; please go to \"settings > secrets and variables\" to create it"
-            exit 1
-          fi
-
       - name: Check if batch script is available
         if: steps.check_commit.outputs.commit_in_main == 'true'
         id: check_batch_script
@@ -235,12 +225,36 @@ jobs:
             echo 't_matrix={"include":[]}' >> "$GITHUB_OUTPUT"
           fi
 
+      - name: "Check if TX_TOKEN secret exists"
+        if: steps.calculate-pushes.outputs.s_args != '' || steps.calculate-pushes.outputs.has_translation_changes == 'true'
+        env:
+          has_transifex_secret: ${{ secrets.TX_TOKEN != '' }}
+        run: |
+          if [ "$has_transifex_secret" != "true" ]; then
+            echo "The secret \"TX_TOKEN\" has not been set; please go to \"settings > secrets and variables\" to create it"
+            exit 1
+          fi
+
+      - name: Install Transifex CLI
+        if: steps.calculate-pushes.outputs.s_args != ''
+        shell: bash
+        run: bash .github/scripts/install-transifex-cli.bash
+
       - name: Push source files to Transifex
         if: steps.calculate-pushes.outputs.s_args != ''
-        uses: transifex/cli-action@584fd205cbe598773b5a81ce711fa44842678189 # v2
-        with:
-          token: ${{ secrets.TX_TOKEN }}
-          args: ${{ steps.calculate-pushes.outputs.s_args }}
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+          TX_ARGS: ${{ steps.calculate-pushes.outputs.s_args }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # s_args is built from static flags and Transifex resource IDs; keep it out of shell syntax.
+          if [[ "$TX_ARGS" == *$'\n'* || "$TX_ARGS" == *$'\r'* ]]; then
+            echo "::error::Unexpected multiline Transifex arguments"
+            exit 1
+          fi
+          read -r -a tx_args <<< "$TX_ARGS"
+          tx "${tx_args[@]}"
 
   push_translations:
     name: Push translations (${{ matrix.name }})
@@ -261,63 +275,73 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
-      # Install Transifex CLI for direct tx commands in retry/verification steps
       - name: Install Transifex CLI
-        run: |
-          curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
-          # Add to PATH for subsequent steps (takes effect in next step, not current)
-          echo "$PWD" >> $GITHUB_PATH
-          # Verify installation using full path
-          echo "::group::Transifex CLI Installation"
-          echo "Installed Transifex CLI version:"
-          ./tx --version
-          if [ -f ./tx ]; then echo "CLI installed at: $(pwd)/tx"; else echo "CLI not found in current directory"; fi
-          echo "::endgroup::"
-        env:
-          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        shell: bash
+        run: bash .github/scripts/install-transifex-cli.bash
 
       # Validate matrix resources field
       - name: Validate batch configuration
+        env:
+          BATCH_ID: ${{ matrix.id }}
+          BATCH_LOCALES: ${{ matrix.locales }}
+          BATCH_RESOURCES: ${{ matrix.resources }}
+        shell: bash
         run: |
-          if [ -z "${{ matrix.resources }}" ]; then
-            echo "::error::No resources specified for batch ${{ matrix.id }} (locales: ${{ matrix.locales }})"
+          set -euo pipefail
+
+          if [ -z "$BATCH_RESOURCES" ]; then
+            echo "::error::No resources specified for batch $BATCH_ID (locales: $BATCH_LOCALES)"
             echo "::error::This indicates a bug in the batch generation script"
             exit 1
           fi
-          echo "::notice::Batch ${{ matrix.id }} validated: ${{ matrix.locales }} → ${{ matrix.resources }}"
+          echo "::notice::Batch $BATCH_ID validated: $BATCH_LOCALES → $BATCH_RESOURCES"
 
       # PHASE 1: Stagger batch starts to prevent API overload
       - name: Stagger batch start
+        env:
+          BATCH_ID: ${{ matrix.id }}
+        shell: bash
         run: |
+          set -euo pipefail
+
+          if [[ ! "$BATCH_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid batch ID: $BATCH_ID"
+            exit 1
+          fi
+
           # Add delay based on batch ID to prevent simultaneous starts
-          DELAY=$(((${{ matrix.id }} - 1) * 10))
-          echo "::notice::Delaying batch ${{ matrix.id }} by ${DELAY}s for rate limiting"
+          DELAY=$(((10#$BATCH_ID - 1) * 10))
+          echo "::notice::Delaying batch $BATCH_ID by ${DELAY}s for rate limiting"
           sleep $DELAY
 
       # PHASE 1: Retry logic with exponential backoff
       - name: Push ${{ matrix.name }} translations with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         id: push_with_retry
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        with:
-          timeout_minutes: 30  # Increased from 10 to 30 due to CLI performance issues (transifex/cli#212)
-          max_attempts: 3
-          retry_wait_seconds: 60  # Increased from 15 to allow API recovery time
-          # exponential_backoff: true  # Removed - not supported by retry action v3
-          retry_on: error
-          command: |
-            set -euo pipefail
+          BATCH_NAME: ${{ matrix.name }}
+          BATCH_LOCALES: ${{ matrix.locales }}
+          BATCH_RESOURCES: ${{ matrix.resources }}
+        shell: bash
+        run: |
+          set -euo pipefail
 
-            echo "::group::Uploading translations for batch: ${{ matrix.locales }}"
+          max_attempts=3
+          retry_wait_seconds=60
+          attempt=1
+
+          while true; do
+            echo "::notice::Upload attempt ${attempt}/${max_attempts} for batch $BATCH_NAME"
+            attempt_result=0
+            echo "::group::Uploading translations for batch: $BATCH_LOCALES"
 
             # Split batch locales and upload with inter-locale delay
-            IFS=',' read -ra LOCALES <<< "${{ matrix.locales }}"
+            IFS=',' read -ra LOCALES <<< "$BATCH_LOCALES"
             UPLOADED_COUNT=0
 
             for locale in "${LOCALES[@]}"; do
               echo "::group::Uploading locale: $locale"
-              echo "Batch: ${{ matrix.name }} | Locale: $locale | Resource: ${{ matrix.resources }}"
+              echo "Batch: $BATCH_NAME | Locale: $locale | Resource: $BATCH_RESOURCES"
               echo "Start time: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
 
               # Rate limiting: 5s delay between locales within batch
@@ -329,15 +353,15 @@ jobs:
               # DEBUG: Show diagnostics before tx push
               echo "::group::DEBUG Diagnostics"
               echo "TX CLI version:"
-              ./tx --version || tx --version
+              tx --version
 
               # Extract first resource from comma-separated list for diagnostic check
               # Example: "bisq-2.walletproperties,bisq-2.accountproperties" -> "bisq-2.walletproperties"
-              FIRST_RESOURCE=$(echo "${{ matrix.resources }}" | cut -d',' -f1)
+              FIRST_RESOURCE=$(echo "$BATCH_RESOURCES" | cut -d',' -f1)
               # Derive base name: "bisq-2.walletproperties" -> "wallet"
               RESOURCE_BASE=$(echo "$FIRST_RESOURCE" | sed 's/^bisq-2\.//' | sed 's/properties$//')
 
-              echo "Resources from matrix: ${{ matrix.resources }}"
+              echo "Resources from matrix: $BATCH_RESOURCES"
               echo "Using first resource for diagnostics: ${FIRST_RESOURCE}"
               echo "Derived resource base: ${RESOURCE_BASE}"
 
@@ -361,13 +385,15 @@ jobs:
               # Real-time output instead of buffering (to see where it hangs)
               START_TIME=$(date +%s)
               EXIT_CODE=0
-              echo "Executing: tx push -t -l \"$locale\" -r \"${{ matrix.resources }}\""
+              echo "Executing: tx push -t -l \"$locale\" -r \"$BATCH_RESOURCES\""
               echo "::notice::Watching TX CLI output in real-time (buffering disabled for debugging)"
 
               # Run tx push with real-time output and capture to temp file
               TX_LOG="/tmp/tx_${locale}_$$.log"
-              ./tx push -t -l "$locale" -r "${{ matrix.resources }}" 2>&1 | tee "$TX_LOG"
+              set +e
+              timeout 30m tx push -t -l "$locale" -r "$BATCH_RESOURCES" 2>&1 | tee "$TX_LOG"
               EXIT_CODE=${PIPESTATUS[0]}
+              set -e
               OUTPUT=$(cat "$TX_LOG" 2>/dev/null || echo "No output captured")
               rm -f "$TX_LOG"  # Clean up temp file
 
@@ -384,19 +410,21 @@ jobs:
                 echo "$OUTPUT"
 
                 # Distinguish permanent vs transient errors
-                if echo "$OUTPUT" | grep -qi "unauthorized\|forbidden\|not found\|invalid"; then
+                if [ "$EXIT_CODE" -eq 124 ]; then
+                  echo "::warning::Timed out after 30 minutes - will retry"
+                  attempt_result=2
+                elif echo "$OUTPUT" | grep -qi "unauthorized\|forbidden\|not found\|invalid"; then
                   echo "::error::Permanent error detected - no retry"
-                  echo "::endgroup::"
-                  exit 1  # Don't retry permanent errors
+                  attempt_result=1
                 elif echo "$OUTPUT" | grep -qi "timeout\|rate limit\|too many requests\|connection\|network"; then
                   echo "::warning::Transient error detected - will retry"
-                  echo "::endgroup::"
-                  exit 2  # Retry transient errors
+                  attempt_result=2
                 else
                   echo "::warning::Unknown error type - will retry once"
-                  echo "::endgroup::"
-                  exit 2
+                  attempt_result=2
                 fi
+                echo "::endgroup::"
+                break
               fi
 
               if ! echo "$OUTPUT" | grep -q " - Uploading file"; then
@@ -405,7 +433,8 @@ jobs:
                 echo "Full output:"
                 echo "$OUTPUT"
                 echo "::endgroup::"
-                exit 1
+                attempt_result=1
+                break
               fi
 
               # Success - show abbreviated output
@@ -416,8 +445,28 @@ jobs:
               UPLOADED_COUNT=$((UPLOADED_COUNT + 1))
             done
 
+            if [ "$attempt_result" -eq 0 ]; then
+              echo "::notice::Batch $BATCH_NAME complete: ${UPLOADED_COUNT} locales uploaded"
+            fi
             echo "::endgroup::"
-            echo "::notice::Batch ${{ matrix.name }} complete: ${UPLOADED_COUNT} locales uploaded"
+
+            if [ "$attempt_result" -eq 0 ]; then
+              exit 0
+            fi
+
+            if [ "$attempt_result" -ne 2 ]; then
+              exit "$attempt_result"
+            fi
+
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::Upload failed after ${max_attempts} attempts"
+              exit 1
+            fi
+
+            echo "::warning::Transient upload error; retrying in ${retry_wait_seconds}s"
+            sleep "$retry_wait_seconds"
+            attempt=$((attempt + 1))
+          done
 
       # Upload confirmation step
       # Note: tx push with exit code 0 already confirms Transifex accepted the files.
@@ -425,20 +474,30 @@ jobs:
       - name: Confirm upload succeeded
         id: verify
         if: steps.push_with_retry.outcome == 'success'
+        env:
+          BATCH_LOCALES: ${{ matrix.locales }}
+        shell: bash
         run: |
-          echo "✅ Upload confirmed successful for batch: ${{ matrix.locales }}"
+          echo "✅ Upload confirmed successful for batch: $BATCH_LOCALES"
           echo "::notice::Transifex accepted the translation files (tx push exit code 0)"
 
       # Report metrics for monitoring
       - name: Report upload metrics
         if: always()
+        env:
+          BATCH_ID: ${{ matrix.id }}
+          BATCH_NAME: ${{ matrix.name }}
+          BATCH_LOCALES: ${{ matrix.locales }}
+          PUSH_OUTCOME: ${{ steps.push_with_retry.outcome }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome || 'skipped' }}
+        shell: bash
         run: |
-          echo "## 🌍 Batch ${{ matrix.name }} Upload Report" >> $GITHUB_STEP_SUMMARY
+          echo "## 🌍 Batch $BATCH_NAME Upload Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Batch ID**: ${{ matrix.id }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Locales**: ${{ matrix.locales }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status**: ${{ steps.push_with_retry.outcome }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Verification**: ${{ steps.verify.outcome || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Batch ID**: $BATCH_ID" >> $GITHUB_STEP_SUMMARY
+          echo "- **Locales**: $BATCH_LOCALES" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: $PUSH_OUTCOME" >> $GITHUB_STEP_SUMMARY
+          echo "- **Verification**: $VERIFY_OUTCOME" >> $GITHUB_STEP_SUMMARY
 
   # Summary job to aggregate results
   summary:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Supported Versions
+
+Bisq is security-sensitive software: vulnerabilities may affect user funds,
+privacy, trade settlement, or network integrity. Security fixes are prioritized
+for the current release line and active hotfix branches.
+
+| Version / Branch | Supported |
+| --- | --- |
+| Latest published Bisq 2 release | :white_check_mark: |
+| `main` development branch | :white_check_mark: |
+| Previous release branches after a newer release is published | :x: |
+| Unsupported forks, modified clients, or unofficial binaries | :x: |
+
+Users should run the latest official Bisq release from
+https://bisq.network/downloads and verify release signatures. Do not downgrade
+Bisq unless maintainers explicitly instruct you to do so.
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues,
+pull requests, Discussions, Matrix rooms, forums, or social media.
+
+Report suspected vulnerabilities privately through GitHub's **Report a
+vulnerability** flow on this repository's Security page. If that option is not
+available, open a minimal public issue asking maintainers to enable a private
+security reporting channel, but do not include exploit details.
+
+Include as much detail as possible:
+
+- affected version, branch, commit, or release tag;
+- affected component, such as trade protocol, wallet, P2P networking, DAO,
+  seednodes, price feeds, updater, or build/release infrastructure;
+- clear impact assessment, especially whether user funds, privacy, signatures,
+  settlement, or network availability are affected;
+- reproduction steps, logs, screenshots, transaction IDs, or packet/message
+  traces where relevant;
+- proof-of-concept code only when needed to demonstrate impact;
+- whether the issue is already exploited or time-sensitive.
+
+Bisq is an open-source project maintained by contributors. Response times may
+vary, but reports involving active exploitation, possible loss of funds, privacy
+exposure, or trade-protocol compromise are treated as urgent critical bugs and
+will be triaged as quickly as possible.
+
+For lower-severity issues, maintainers will respond when contributor capacity is
+available.
+
+If the report is accepted, maintainers may coordinate a fix in a private fork or
+security advisory, prepare release and network-mitigation steps, and publish an
+advisory after users have had a reasonable opportunity to update. If the report
+is declined, maintainers will explain the reason when possible.
+
+Please give maintainers reasonable time to investigate and release mitigations
+before public disclosure. For severe or actively exploited issues, coordinate
+timing with maintainers so public details do not increase harm to users.
+
+Bisq does not currently guarantee a bug bounty. Security work that qualifies as
+a critical bug fix may be eligible for Bisq DAO compensation according to the
+project's contributor and critical-bug processes.
+
+## CI Supply-Chain Pinning
+
+Security-sensitive GitHub Actions workflows should pin third-party actions to
+full commit SHAs instead of mutable tags. Keep a trailing version comment, such
+as `# v1.2.3`, next to the SHA for readability. When bumping an action, verify
+that the new upstream tag resolves to the committed SHA and update both the SHA
+and the version comment together.


### PR DESCRIPTION
## Summary

Backports the Transifex CI supply-chain hardening from PR #4776 to the `v2.1.11` release branch:

- replaces the floating `curl | bash` install from `transifex/cli/master` with a checked-in installer that downloads Transifex CLI `v1.6.17` from a versioned release URL
- verifies the downloaded Transifex CLI archive with committed SHA-256 checksums before installing it
- verifies the installed CLI version before any Transifex upload runs
- removes `transifex/cli-action` and `nick-fields/retry` from token-bearing workflow paths so `TX_TOKEN` is only exposed to direct `tx push` steps
- keeps the release branch's existing pinned `actions/checkout` SHA, `ubuntu-24.04` runners, and `persist-credentials: false` checkout settings
- adds `SECURITY.md` because the release branch did not yet contain the CI action SHA-pinning policy document

## Validation

- `bash -n .github/scripts/install-transifex-cli.bash`
- parsed `.github/workflows/sync_transifex.yml` as YAML
- `git diff --check HEAD~1 HEAD`
- checked that `sync_transifex.yml` no longer contains mutable Transifex installer execution, `transifex/cli-action`, `nick-fields/retry`, or tag-pinned `uses:` entries

## Notes

The exact Transifex CLI version check remains intentionally fail-closed. If upstream changes the CLI version output format, CI should stop until the pinned installer expectations are reviewed.
