### PR TITLE
bugfix/opted_in_android_relayed_notifications_too_many_per_open_trade

### DIFF
--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationService.java
@@ -1,0 +1,388 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bisq_easy;
+
+import bisq.common.application.Service;
+import bisq.common.observable.Pin;
+import bisq.common.observable.collection.CollectionObserver;
+import bisq.i18n.Res;
+import bisq.notifications.NotificationService;
+import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.bisq_easy.BisqEasyTradeService;
+import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Emits mobile-push notifications for the trade-state transitions that the user actually
+ * needs to act on, mirroring the Android nodeApp's {@code OpenTradesNotificationService}
+ * which has proven sound at scale.
+ * <p>
+ * Why this exists: the {@link bisq.chat.notifications.ChatNotificationService} push path
+ * was suppressing {@code PROTOCOL_LOG_MESSAGE} chat events for mobile (issue
+ * {@code bisq-network/bisq-mobile#1450} — they fired 6–10+ times per active trade and
+ * spammed users). That filter killed the noise AND the few signal events. This service
+ * re-introduces the useful signal events on the mobile relay path, observing
+ * {@link BisqEasyTrade#tradeStateObservable()} directly with a tight whitelist of states.
+ * <p>
+ * Dispatch is mobile-only (via {@link NotificationService#dispatchMobileOnlyNotification})
+ * because the desktop already surfaces these events through the in-app trade chat's
+ * protocol log and the trade detail header — we don't want desktop users to see a
+ * duplicate OS-level toast.
+ * <p>
+ * Per-trade {@code notifiedPaymentInfo} dedup mirrors the nodeApp guard documented in
+ * {@code OpenTradesNotificationService}: the offer-response state AND the payment-data
+ * observer can each fire for the same logical "payment account info exchanged" event,
+ * so we collapse them to one push per trade.
+ * <p>
+ * Whitelist of states (in order):
+ * <ul>
+ *   <li>{@code BUYER_SENT_FIAT_SENT_CONFIRMATION} — buyer-side push: "you sent fiat";
+ *       seller-side push: "peer sent fiat".</li>
+ *   <li>{@code SELLER_RECEIVED_FIAT_SENT_CONFIRMATION} — seller-side: "you received
+ *       the fiat-sent confirmation"; buyer-side: "you sent fiat".</li>
+ *   <li>{@code BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION} /
+ *       {@code SELLER_CONFIRMED_FIAT_RECEIPT} — buyer-side: "peer confirmed receipt";
+ *       seller-side: "you confirmed receipt".</li>
+ *   <li>{@code SELLER_SENT_BTC_SENT_CONFIRMATION} — seller-side: "you sent BTC";
+ *       buyer-side: "peer sent BTC".</li>
+ *   <li>{@code BUYER_RECEIVED_BTC_SENT_CONFIRMATION} — buyer-side: "you received BTC
+ *       confirmation"; seller-side: "you sent BTC".</li>
+ *   <li>{@code TAKER_SENT_TAKE_OFFER_REQUEST} — maker-side only: "your offer was
+ *       taken" (the taker initiated, no push needed there).</li>
+ *   <li>{@code MAKER_SENT_TAKE_OFFER_RESPONSE__*} (2 variants) — "offer taken"
+ *       observed from the response side.</li>
+ *   <li>{@code TAKER_RECEIVED_TAKE_OFFER_RESPONSE__*} (3 variants) — payment-info
+ *       exchanged; gated by per-trade dedup so the user gets ONE "payment info
+ *       sent/received" push regardless of which observer fires first.</li>
+ *   <li>Terminal states ({@code BTC_CONFIRMED}, {@code REJECTED}, {@code PEER_REJECTED},
+ *       {@code CANCELLED}, {@code PEER_CANCELLED}, {@code FAILED}, {@code FAILED_AT_PEER}).
+ * </ul>
+ * <p>
+ * All other states are intentionally silent — they're intermediate protocol bookkeeping
+ * the user doesn't need a push for. Same set as Android nodeApp.
+ */
+@Slf4j
+public class BisqEasyMobileTradeNotificationService implements Service {
+    private final BisqEasyTradeService bisqEasyTradeService;
+    private final UserProfileService userProfileService;
+    private final NotificationService notificationService;
+
+    /** Per-trade state-observer Pins so we can unbind on trade removal / shutdown. */
+    private final Map<String, Pin> tradeStatePins = new ConcurrentHashMap<>();
+
+    /**
+     * Trade IDs whose state observer has fired at least once. {@code Observable#addObserver}
+     * fires synchronously with the current value when subscribed — we treat that first
+     * emission as "we just started watching" rather than a real transition, so existing
+     * trades don't re-notify on service startup. Subsequent emissions are real transitions.
+     */
+    private final Set<String> tradesWithInitializedState = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Trades for which we've already emitted a "payment account info exchanged" push.
+     * Mirrors {@code OpenTradesNotificationService.notifiedPaymentInfo} on Android
+     * nodeApp.
+     */
+    private final Set<String> notifiedPaymentInfo = ConcurrentHashMap.newKeySet();
+
+    @Nullable
+    private Pin tradesPin;
+
+    public BisqEasyMobileTradeNotificationService(BisqEasyTradeService bisqEasyTradeService,
+                                                  UserProfileService userProfileService,
+                                                  NotificationService notificationService) {
+        this.bisqEasyTradeService = bisqEasyTradeService;
+        this.userProfileService = userProfileService;
+        this.notificationService = notificationService;
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // Service lifecycle
+    /* --------------------------------------------------------------------- */
+
+    @Override
+    public CompletableFuture<Boolean> initialize() {
+        log.info("initialize");
+        tradesPin = bisqEasyTradeService.getTrades().addObserver(new CollectionObserver<BisqEasyTrade>() {
+            @Override
+            public void onAdded(BisqEasyTrade trade) {
+                subscribeToTrade(trade);
+            }
+
+            @Override
+            public void onRemoved(Object element) {
+                if (element instanceof BisqEasyTrade trade) {
+                    unsubscribeFromTrade(trade);
+                }
+            }
+
+            @Override
+            public void onCleared() {
+                clearAllState();
+            }
+        });
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> shutdown() {
+        log.info("shutdown");
+        if (tradesPin != null) {
+            tradesPin.unbind();
+            tradesPin = null;
+        }
+        clearAllState();
+        return CompletableFuture.completedFuture(true);
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // Per-trade subscription
+    /* --------------------------------------------------------------------- */
+
+    private void subscribeToTrade(BisqEasyTrade trade) {
+        String tradeId = trade.getId();
+        Pin previous = tradeStatePins.remove(tradeId);
+        if (previous != null) {
+            previous.unbind();
+        }
+        Pin pin = trade.tradeStateObservable().addObserver(state -> onStateEmitted(trade, state));
+        tradeStatePins.put(tradeId, pin);
+    }
+
+    private void unsubscribeFromTrade(BisqEasyTrade trade) {
+        Pin pin = tradeStatePins.remove(trade.getId());
+        if (pin != null) {
+            pin.unbind();
+        }
+        tradesWithInitializedState.remove(trade.getId());
+        notifiedPaymentInfo.remove(trade.getId());
+    }
+
+    private void clearAllState() {
+        tradeStatePins.values().forEach(Pin::unbind);
+        tradeStatePins.clear();
+        tradesWithInitializedState.clear();
+        notifiedPaymentInfo.clear();
+    }
+
+    private void onStateEmitted(BisqEasyTrade trade, BisqEasyTradeState state) {
+        if (state == null) {
+            return;
+        }
+        String tradeId = trade.getId();
+        boolean isFirstEmission = tradesWithInitializedState.add(tradeId);
+        if (isFirstEmission) {
+            log.debug("Skipping initial state observation for trade {} (state={})", tradeId, state);
+            return;
+        }
+        try {
+            handleStateChange(trade, state);
+        } catch (Exception e) {
+            log.error("Failed to handle mobile-push trade state change for trade {} state {}", tradeId, state, e);
+        }
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // Whitelist + dispatch
+    /* --------------------------------------------------------------------- */
+
+    private void handleStateChange(BisqEasyTrade trade, BisqEasyTradeState state) {
+        switch (state) {
+            case BUYER_SENT_FIAT_SENT_CONFIRMATION -> {
+                if (trade.isBuyer()) {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youSentFiat.title",
+                            "bisqEasy.mobileNotifications.youSentFiat.message");
+                } else {
+                    dispatch(trade, "bisqEasy.mobileNotifications.peerSentFiat.title",
+                            "bisqEasy.mobileNotifications.peerSentFiat.message");
+                }
+            }
+
+            case SELLER_RECEIVED_FIAT_SENT_CONFIRMATION -> {
+                if (trade.isSeller()) {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youReceivedFiatConfirmation.title",
+                            "bisqEasy.mobileNotifications.youReceivedFiatConfirmation.message");
+                } else {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youSentFiat.title",
+                            "bisqEasy.mobileNotifications.youSentFiat.message");
+                }
+            }
+
+            case BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION,
+                 SELLER_CONFIRMED_FIAT_RECEIPT -> {
+                if (trade.isBuyer()) {
+                    dispatch(trade, "bisqEasy.mobileNotifications.peerReceivedFiat.title",
+                            "bisqEasy.mobileNotifications.peerReceivedFiat.message");
+                } else {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youReceivedFiat.title",
+                            "bisqEasy.mobileNotifications.youReceivedFiat.message");
+                }
+            }
+
+            case SELLER_SENT_BTC_SENT_CONFIRMATION -> {
+                if (trade.isSeller()) {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youSentBtc.title",
+                            "bisqEasy.mobileNotifications.youSentBtc.message");
+                } else {
+                    dispatch(trade, "bisqEasy.mobileNotifications.peerSentBtc.title",
+                            "bisqEasy.mobileNotifications.peerSentBtc.message");
+                }
+            }
+
+            case BUYER_RECEIVED_BTC_SENT_CONFIRMATION -> {
+                if (trade.isBuyer()) {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youReceivedBtc.title",
+                            "bisqEasy.mobileNotifications.youReceivedBtc.message");
+                } else {
+                    dispatch(trade, "bisqEasy.mobileNotifications.youSentBtc.title",
+                            "bisqEasy.mobileNotifications.youSentBtc.message");
+                }
+            }
+
+            case TAKER_SENT_TAKE_OFFER_REQUEST -> {
+                // Notify the maker only — the taker initiated and already knows.
+                if (trade.isMaker()) {
+                    dispatch(trade, "bisqEasy.mobileNotifications.offerTaken.title",
+                            "bisqEasy.mobileNotifications.offerTaken.message");
+                }
+            }
+
+            case MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA ->
+                    dispatch(trade, "bisqEasy.mobileNotifications.offerTaken.title",
+                            "bisqEasy.mobileNotifications.offerTaken.message");
+
+            case TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS_,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_ -> {
+                // Payment-info exchange — the offer-response state AND the payment-data
+                // change observer can both fire here, so dedup to one push per trade.
+                if (notifiedPaymentInfo.add(trade.getId())) {
+                    if (trade.isSeller()) {
+                        dispatch(trade, "bisqEasy.mobileNotifications.paymentInfoSent.title",
+                                "bisqEasy.mobileNotifications.paymentInfoSent.message");
+                    } else {
+                        dispatch(trade, "bisqEasy.mobileNotifications.paymentInfoReceived.title",
+                                "bisqEasy.mobileNotifications.paymentInfoReceived.message");
+                    }
+                }
+            }
+
+            default -> {
+                if (state.isFinalState()) {
+                    String terminalKey = terminalI18nKey(state);
+                    if (terminalKey != null) {
+                        dispatchTerminal(trade, terminalKey);
+                    }
+                }
+                // Other non-whitelist, non-terminal states are intentionally silent.
+            }
+        }
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // Helpers
+    /* --------------------------------------------------------------------- */
+
+    private void dispatch(BisqEasyTrade trade, String titleKey, String messageKey) {
+        String shortTradeId = shortTradeId(trade);
+        String peerName = peerNameFor(trade);
+        String title = Res.get(titleKey, shortTradeId);
+        String message = Res.get(messageKey, peerName);
+        String notificationId = notificationIdFor(trade);
+        notificationService.dispatchMobileOnlyNotification(new MobileTradeNotification(notificationId, title, message));
+    }
+
+    private void dispatchTerminal(BisqEasyTrade trade, String terminalI18nKey) {
+        String shortTradeId = shortTradeId(trade);
+        String peerName = peerNameFor(trade);
+        String terminalLabel = Res.get(terminalI18nKey);
+        String title = Res.get("bisqEasy.mobileNotifications.tradeCompleted.title", shortTradeId);
+        String message = Res.get("bisqEasy.mobileNotifications.tradeCompleted.message", peerName, terminalLabel);
+        notificationService.dispatchMobileOnlyNotification(
+                new MobileTradeNotification(notificationIdFor(trade), title, message));
+    }
+
+    @Nullable
+    static String terminalI18nKey(BisqEasyTradeState state) {
+        return switch (state) {
+            case BTC_CONFIRMED -> "bisqEasy.mobileNotifications.terminal.completed";
+            case REJECTED -> "bisqEasy.mobileNotifications.terminal.rejected";
+            case PEER_REJECTED -> "bisqEasy.mobileNotifications.terminal.peerRejected";
+            case CANCELLED -> "bisqEasy.mobileNotifications.terminal.cancelled";
+            case PEER_CANCELLED -> "bisqEasy.mobileNotifications.terminal.peerCancelled";
+            case FAILED -> "bisqEasy.mobileNotifications.terminal.failed";
+            case FAILED_AT_PEER -> "bisqEasy.mobileNotifications.terminal.failedAtPeer";
+            default -> null;
+        };
+    }
+
+    /**
+     * Whitelist check — exposed package-private so callers and tests can reason about
+     * whether a given state will produce a push without depending on the full handler.
+     */
+    static boolean isWhitelistedState(BisqEasyTradeState state) {
+        return switch (state) {
+            case BUYER_SENT_FIAT_SENT_CONFIRMATION,
+                 SELLER_RECEIVED_FIAT_SENT_CONFIRMATION,
+                 BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION,
+                 SELLER_CONFIRMED_FIAT_RECEIPT,
+                 SELLER_SENT_BTC_SENT_CONFIRMATION,
+                 BUYER_RECEIVED_BTC_SENT_CONFIRMATION,
+                 TAKER_SENT_TAKE_OFFER_REQUEST,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA,
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS_,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_ -> true;
+            default -> state.isFinalState();
+        };
+    }
+
+    private static String shortTradeId(BisqEasyTrade trade) {
+        String id = trade.getId();
+        return id.substring(0, Math.min(8, id.length()));
+    }
+
+    private String peerNameFor(BisqEasyTrade trade) {
+        return userProfileService.findUserProfile(trade.getPeer().getNetworkId().getId())
+                .map(UserProfile::getUserName)
+                .orElse("?");
+    }
+
+    /**
+     * Stable per-trade notification id so that subsequent state changes for the same trade
+     * REPLACE the previous push on the device rather than stack up another row in the
+     * notification tray (this matches Android nodeApp's {@code NotificationIds.getTradeStateUpdatedId(...)}).
+     */
+    private static String notificationIdFor(BisqEasyTrade trade) {
+        return "bisq-easy-mobile-trade-" + shortTradeId(trade);
+    }
+}

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
@@ -82,6 +82,7 @@ public class BisqEasyService implements Service {
     private final Set<String> bannedAccountDataSet = new HashSet<>();
     private final BisqEasySellersReputationBasedTradeAmountService bisqEasySellersReputationBasedTradeAmountService;
     private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
+    private final BisqEasyMobileTradeNotificationService bisqEasyMobileTradeNotificationService;
 
     private Pin difficultyAdjustmentFactorPin, ignoreDiffAdjustmentFromSecManagerPin,
             mostRecentDiffAdjustmentValueOrDefaultPin, selectedMarketPin, authorizedAlertDataSetPin;
@@ -129,6 +130,15 @@ public class BisqEasyService implements Service {
                 userService.getReputationService(),
                 marketPriceService);
         bisqEasyOfferbookMessageService = new BisqEasyOfferbookMessageService(chatService, userService, bisqEasySellersReputationBasedTradeAmountService);
+
+        // Mobile push notifications for Bisq Easy trade-state transitions, mirroring the
+        // proven Android nodeApp OpenTradesNotificationService whitelist. Dispatch is
+        // mobile-only (desktop already shows these via the trade chat protocol log).
+        // See bisq-network/bisq-mobile#1450.
+        bisqEasyMobileTradeNotificationService = new BisqEasyMobileTradeNotificationService(
+                tradeService.getBisqEasyTradeService(),
+                userService.getUserProfileService(),
+                notificationService);
     }
 
 
@@ -178,7 +188,8 @@ public class BisqEasyService implements Service {
         });
         return bisqEasySellersReputationBasedTradeAmountService.initialize()
                 .thenCompose(result -> bisqEasyOfferbookMessageService.initialize())
-                .thenCompose(result -> bisqEasyNotificationsService.initialize());
+                .thenCompose(result -> bisqEasyNotificationsService.initialize())
+                .thenCompose(result -> bisqEasyMobileTradeNotificationService.initialize());
     }
 
     public CompletableFuture<Boolean> shutdown() {
@@ -193,6 +204,7 @@ public class BisqEasyService implements Service {
         return getStorePendingMessagesInMailboxFuture().exceptionally(e -> false) // continue even if flush fails
                 .thenCompose(v -> CompletableFutureUtils.allOf( // shut down in parallel
                         bisqEasyNotificationsService.shutdown().exceptionally(e -> false),
+                        bisqEasyMobileTradeNotificationService.shutdown().exceptionally(e -> false),
                         bisqEasyOfferbookMessageService.shutdown().exceptionally(e -> false),
                         bisqEasySellersReputationBasedTradeAmountService.shutdown().exceptionally(e -> false)))
                 .thenApply(list -> list.stream().allMatch(Boolean::booleanValue));

--- a/bisq-easy/src/main/java/bisq/bisq_easy/MobileTradeNotification.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/MobileTradeNotification.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bisq_easy;
+
+import bisq.notifications.Notification;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Lightweight {@link Notification} carrying a per-trade mobile push payload built by
+ * {@link BisqEasyMobileTradeNotificationService}. Not persisted — only used as a
+ * transient envelope between the trade-state observer and the mobile relay path.
+ */
+@Getter
+@ToString
+@EqualsAndHashCode
+public final class MobileTradeNotification implements Notification {
+    private final String id;
+    private final String title;
+    private final String message;
+
+    public MobileTradeNotification(String id, String title, String message) {
+        this.id = id;
+        this.title = title;
+        this.message = message;
+    }
+
+    @Override
+    public Category getCategory() {
+        return Category.TRADE_UPDATE;
+    }
+}

--- a/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationServiceWhitelistTest.java
+++ b/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationServiceWhitelistTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bisq_easy;
+
+import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the trade-state whitelist + terminal-state mapping used by
+ * {@link BisqEasyMobileTradeNotificationService}. Mirror of the Android nodeApp's
+ * {@code OpenTradesNotificationService} state handler — the source of truth for
+ * which trade transitions surface as mobile pushes.
+ * <p>
+ * See bisq-network/bisq-mobile#1450.
+ */
+public class BisqEasyMobileTradeNotificationServiceWhitelistTest {
+
+    /**
+     * Exactly mirrors {@code OpenTradesNotificationService.handleTradeStateNotification}
+     * on Android nodeApp. Any change here must be matched there and vice-versa.
+     */
+    private static final Set<BisqEasyTradeState> EXPECTED_NON_TERMINAL_WHITELIST = EnumSet.of(
+            BisqEasyTradeState.BUYER_SENT_FIAT_SENT_CONFIRMATION,
+            BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION,
+            BisqEasyTradeState.BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION,
+            BisqEasyTradeState.SELLER_CONFIRMED_FIAT_RECEIPT,
+            BisqEasyTradeState.SELLER_SENT_BTC_SENT_CONFIRMATION,
+            BisqEasyTradeState.BUYER_RECEIVED_BTC_SENT_CONFIRMATION,
+            BisqEasyTradeState.TAKER_SENT_TAKE_OFFER_REQUEST,
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA,
+            BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+            BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS_,
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_
+    );
+
+    @Test
+    void whitelistCoversExactlyTheExpectedNonTerminalStates() {
+        for (BisqEasyTradeState state : BisqEasyTradeState.values()) {
+            boolean actual = BisqEasyMobileTradeNotificationService.isWhitelistedState(state);
+            boolean expected = EXPECTED_NON_TERMINAL_WHITELIST.contains(state) || state.isFinalState();
+            assertEquals(expected, actual,
+                    () -> "Mobile-push eligibility mismatch for state " + state +
+                            " — update the EXPECTED_NON_TERMINAL_WHITELIST in this test if the change is intentional, " +
+                            "and mirror it in OpenTradesNotificationService on Android nodeApp.");
+        }
+    }
+
+    @Test
+    void allTerminalStatesAreImplicitlyWhitelisted() {
+        for (BisqEasyTradeState state : BisqEasyTradeState.values()) {
+            if (state.isFinalState()) {
+                assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(state),
+                        "Every terminal state should produce a push (via the terminal-fallback branch) — missed: " + state);
+            }
+        }
+    }
+
+    @Test
+    void intermediateProtocolStatesAreSuppressed() {
+        // INIT and intermediate "did_not_*" states are the kind that emit PROTOCOL_LOG_MESSAGE
+        // noise on the chat path. They MUST NOT also fire a push here.
+        assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(BisqEasyTradeState.INIT),
+                "INIT is the protocol entry state, not a user-actionable event");
+    }
+
+    @Test
+    void terminalI18nKeyResolvesForEachTerminalState() {
+        // Each terminal state must have a resolvable label or the tradeCompleted message
+        // will render with a null/missing translation argument.
+        assertEquals("bisqEasy.mobileNotifications.terminal.completed",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.BTC_CONFIRMED));
+        assertEquals("bisqEasy.mobileNotifications.terminal.rejected",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.REJECTED));
+        assertEquals("bisqEasy.mobileNotifications.terminal.peerRejected",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.PEER_REJECTED));
+        assertEquals("bisqEasy.mobileNotifications.terminal.cancelled",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.CANCELLED));
+        assertEquals("bisqEasy.mobileNotifications.terminal.peerCancelled",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.PEER_CANCELLED));
+        assertEquals("bisqEasy.mobileNotifications.terminal.failed",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.FAILED));
+        assertEquals("bisqEasy.mobileNotifications.terminal.failedAtPeer",
+                BisqEasyMobileTradeNotificationService.terminalI18nKey(BisqEasyTradeState.FAILED_AT_PEER));
+    }
+
+    @Test
+    void terminalI18nKeyHasMappingForEveryTerminalState() {
+        for (BisqEasyTradeState state : BisqEasyTradeState.values()) {
+            String key = BisqEasyMobileTradeNotificationService.terminalI18nKey(state);
+            if (state.isFinalState()) {
+                assertNotNull(key,
+                        "Terminal state " + state + " must map to an i18n key in terminalI18nKey()");
+            } else {
+                assertNull(key,
+                        "Non-terminal state " + state + " must NOT map to a terminalI18nKey");
+            }
+        }
+    }
+}

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
@@ -41,6 +41,11 @@ public class ChatNotification implements Notification, PersistableProto {
         return channelId + "." + messageId;
     }
 
+    @Override
+    public Category getCategory() {
+        return Category.CHAT_MESSAGE;
+    }
+
     private final String id;
     private final String title;
     private final String message;

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -499,7 +499,7 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
 
         if (shouldSendNotification) {
             addNotification(chatNotification);
-            maybeDispatchNotification(chatNotification);
+            maybeDispatchNotification(chatNotification, chatMessage);
         } else {
             consumeNotification(chatNotification);
         }
@@ -541,12 +541,14 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
                 senderUserProfile);
     }
 
-    private void maybeDispatchNotification(ChatNotification chatNotification) {
+    private void maybeDispatchNotification(ChatNotification chatNotification, ChatMessage chatMessage) {
         boolean afterStartUp = isReceivedAfterStartUp(chatNotification);
         boolean domainMatches = testChatChannelDomainPredicate(chatNotification);
         if (!isApplicationFocussed && afterStartUp && domainMatches) {
-            log.debug("Dispatching notification for channel '{}': {}", chatNotification.getChatChannelDomain(), chatNotification.getTitle());
-            notificationService.dispatchNotification(chatNotification);
+            boolean mobileEligible = isMobileEligible(chatMessage);
+            log.debug("Dispatching notification for channel '{}': {} (mobileEligible={})",
+                    chatNotification.getChatChannelDomain(), chatNotification.getTitle(), mobileEligible);
+            notificationService.dispatchNotification(chatNotification, mobileEligible);
         } else {
             log.debug("Skipping notification dispatch for '{}' (focused={}, afterStartUp={}, domainPredicate={})",
                     chatNotification.getTitle(),
@@ -554,6 +556,38 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
                     afterStartUp,
                     domainMatches);
         }
+    }
+
+    private boolean isMobileEligible(ChatMessage chatMessage) {
+        return chatMessage == null || isMobileEligible(chatMessage.getChatMessageType());
+    }
+
+    /**
+     * Decides whether a chat message of the given type should reach the mobile relay
+     * (FCM / APNs) or be delivered only to the desktop (system) channel.
+     * <p>
+     * Mirrors {@code OpenTradesNotificationService} on Android nodeApp which has
+     * proven sound at scale: only {@code TEXT} (real peer chat) and
+     * {@code TAKE_BISQ_EASY_OFFER} (your offer was taken) are surfaced as pushes.
+     * <p>
+     * {@code PROTOCOL_LOG_MESSAGE} in particular is suppressed: the Bisq Easy trade
+     * protocol emits one per state transition (take-offer, account-info, btc-address,
+     * fiat-sent, fiat-receipt, btc-sent, completed, …) which produces 6–10+ push
+     * notifications per active trade — the noise pattern reported in
+     * {@code bisq-network/bisq-mobile#1450}.
+     * <p>
+     * Important trade-state transitions that the user does need pushed (e.g. "peer
+     * confirmed fiat receipt") will be re-introduced via a dedicated service that
+     * observes {@code BisqEasyTrade.tradeState} directly — see follow-up to #1450.
+     * <p>
+     * Package-private static so it can be unit-tested without instantiating the full
+     * {@link ChatNotificationService} (which has many constructor dependencies).
+     */
+    static boolean isMobileEligible(bisq.chat.ChatMessageType type) {
+        return switch (type) {
+            case TEXT, TAKE_BISQ_EASY_OFFER -> true;
+            case PROTOCOL_LOG_MESSAGE, LEAVE, CHAT_RULES_WARNING, EXPIRED_MESSAGES_INDICATOR -> false;
+        };
     }
 
     private boolean isReceivedAfterStartUp(ChatNotification chatNotification) {

--- a/chat/src/test/java/bisq/chat/notifications/ChatNotificationServiceMobileEligibilityTest.java
+++ b/chat/src/test/java/bisq/chat/notifications/ChatNotificationServiceMobileEligibilityTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.chat.notifications;
+
+import bisq.chat.ChatMessageType;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the mobile-eligibility whitelist used by {@code ChatNotificationService} when
+ * deciding whether to push a chat notification to the mobile relay (FCM / APNs).
+ * <p>
+ * Mirror of the proven Android nodeApp {@code OpenTradesNotificationService} behavior:
+ * only {@code TEXT} and {@code TAKE_BISQ_EASY_OFFER} are surfaced as pushes; the
+ * trade protocol log noise and other in-app indicators are desktop-only.
+ * <p>
+ * See bisq-network/bisq-mobile#1450.
+ */
+public class ChatNotificationServiceMobileEligibilityTest {
+
+    private static final Set<ChatMessageType> EXPECTED_MOBILE_ELIGIBLE = EnumSet.of(
+            ChatMessageType.TEXT,
+            ChatMessageType.TAKE_BISQ_EASY_OFFER
+    );
+
+    @Test
+    void textMessagesAreMobileEligible() {
+        assertTrue(ChatNotificationService.isMobileEligible(ChatMessageType.TEXT),
+                "Peer text chat messages must reach mobile push");
+    }
+
+    @Test
+    void offerTakenMessagesAreMobileEligible() {
+        assertTrue(ChatNotificationService.isMobileEligible(ChatMessageType.TAKE_BISQ_EASY_OFFER),
+                "Offer-taken notifications must reach mobile push");
+    }
+
+    @Test
+    void protocolLogMessagesAreSuppressedFromMobile() {
+        assertFalse(ChatNotificationService.isMobileEligible(ChatMessageType.PROTOCOL_LOG_MESSAGE),
+                "PROTOCOL_LOG_MESSAGE is the high-volume per-state-transition noise that motivated #1450 — must not reach mobile push");
+    }
+
+    @Test
+    void inAppIndicatorsAreSuppressedFromMobile() {
+        assertFalse(ChatNotificationService.isMobileEligible(ChatMessageType.LEAVE),
+                "LEAVE events are in-app channel housekeeping, not user-facing pushes");
+        assertFalse(ChatNotificationService.isMobileEligible(ChatMessageType.CHAT_RULES_WARNING),
+                "CHAT_RULES_WARNING is a desktop in-app banner, not a push event");
+        assertFalse(ChatNotificationService.isMobileEligible(ChatMessageType.EXPIRED_MESSAGES_INDICATOR),
+                "EXPIRED_MESSAGES_INDICATOR is a desktop in-app marker, not a push event");
+    }
+
+    /**
+     * Pins the FULL whitelist so that adding a new {@link ChatMessageType} forces a
+     * deliberate decision: should it be a mobile push or not? Without this test,
+     * a new enum value silently defaults to the {@code switch} compile error (good)
+     * but a careless author could pick the wrong branch. This test fails loudly if
+     * the whitelist changes and reminds the reviewer to update issue #1450 follow-ups.
+     */
+    @Test
+    void mobileEligibleWhitelistIsExactlyTextAndOfferTaken() {
+        for (ChatMessageType type : ChatMessageType.values()) {
+            boolean actual = ChatNotificationService.isMobileEligible(type);
+            boolean expected = EXPECTED_MOBILE_ELIGIBLE.contains(type);
+            if (actual != expected) {
+                throw new AssertionError(
+                        "Mobile-eligibility whitelist changed for " + type +
+                                " (expected=" + expected + ", actual=" + actual + "). " +
+                                "If this is intentional, update EXPECTED_MOBILE_ELIGIBLE in this test " +
+                                "and note the change in the #1450 follow-up.");
+            }
+        }
+    }
+}

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -1030,3 +1030,42 @@ bisqEasy.mediation.request.feedback.msg=A request to the registered mediators ha
   Please have patience until a mediator is online to join the trade chat and help to resolve any problems.
 bisqEasy.mediation.request.feedback.noMediatorAvailable=There is no mediator available. Please use the support chat instead.
 bisqEasy.mediation.requester.tradeLogMessage={0} requested mediation
+
+# ---------------------------------------------------------------------------------------------
+# Mobile push notifications (Bisq Easy trade state transitions)
+# See bisq-network/bisq-mobile#1450 — surfaced via BisqEasyMobileTradeNotificationService,
+# dispatched only to the mobile relay (FCM / APNs), not to desktop (desktop already
+# shows these via the in-app trade chat protocol log).
+# {0} = short trade id, {1} = peer username (or terminal-state label for tradeCompleted.message).
+# ---------------------------------------------------------------------------------------------
+bisqEasy.mobileNotifications.offerTaken.title=Your offer was taken ({0})
+bisqEasy.mobileNotifications.offerTaken.message=Trade taken by {0}.
+bisqEasy.mobileNotifications.paymentInfoSent.title=Payment info sent ({0})
+bisqEasy.mobileNotifications.paymentInfoSent.message=Payment account info sent to {0}.
+bisqEasy.mobileNotifications.paymentInfoReceived.title=Payment info received ({0})
+bisqEasy.mobileNotifications.paymentInfoReceived.message=Payment account info received from {0}.
+bisqEasy.mobileNotifications.youSentFiat.title=You confirmed fiat sent ({0})
+bisqEasy.mobileNotifications.youSentFiat.message=Waiting on {0} to confirm receipt.
+bisqEasy.mobileNotifications.peerSentFiat.title=Peer confirmed fiat sent ({0})
+bisqEasy.mobileNotifications.peerSentFiat.message={0} confirmed sending fiat. Check your account and confirm receipt.
+bisqEasy.mobileNotifications.youReceivedFiatConfirmation.title=Fiat-sent confirmation received ({0})
+bisqEasy.mobileNotifications.youReceivedFiatConfirmation.message={0} confirmed sending fiat. Verify in your account and confirm receipt.
+bisqEasy.mobileNotifications.peerReceivedFiat.title=Peer confirmed fiat receipt ({0})
+bisqEasy.mobileNotifications.peerReceivedFiat.message={0} confirmed receiving the fiat. Waiting on Bitcoin.
+bisqEasy.mobileNotifications.youReceivedFiat.title=You confirmed fiat receipt ({0})
+bisqEasy.mobileNotifications.youReceivedFiat.message=Send Bitcoin to {0} to complete the trade.
+bisqEasy.mobileNotifications.youSentBtc.title=You sent Bitcoin ({0})
+bisqEasy.mobileNotifications.youSentBtc.message=Waiting on {0} to confirm receipt.
+bisqEasy.mobileNotifications.peerSentBtc.title=Peer sent Bitcoin ({0})
+bisqEasy.mobileNotifications.peerSentBtc.message={0} sent the Bitcoin. Waiting for confirmation.
+bisqEasy.mobileNotifications.youReceivedBtc.title=Bitcoin received ({0})
+bisqEasy.mobileNotifications.youReceivedBtc.message=You confirmed receipt of Bitcoin from {0}.
+bisqEasy.mobileNotifications.tradeCompleted.title=Trade {0}
+bisqEasy.mobileNotifications.tradeCompleted.message=Trade with {0} is {1}.
+bisqEasy.mobileNotifications.terminal.completed=completed
+bisqEasy.mobileNotifications.terminal.rejected=rejected
+bisqEasy.mobileNotifications.terminal.peerRejected=rejected by peer
+bisqEasy.mobileNotifications.terminal.cancelled=cancelled
+bisqEasy.mobileNotifications.terminal.peerCancelled=cancelled by peer
+bisqEasy.mobileNotifications.terminal.failed=failed
+bisqEasy.mobileNotifications.terminal.failedAtPeer=failed at peer

--- a/notifications/src/main/java/bisq/notifications/Notification.java
+++ b/notifications/src/main/java/bisq/notifications/Notification.java
@@ -1,9 +1,68 @@
 package bisq.notifications;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public interface Notification {
     String getId();
 
     String getTitle();
 
     String getMessage();
+
+    /** Category surfaced to the mobile relay so the client can route / label the
+     * notification without parsing the title. Default {@link Category#GENERAL}
+     * keeps existing implementations (no category awareness) on the generic
+     * banner rather than mis-tagging. */
+    default Category getCategory() {
+        return Category.GENERAL;
+    }
+
+    /**
+     * Stable category surfaced to the mobile relay. Must stay in lock-step with
+     * {@code BisqFirebaseMessagingService.NotificationCategory} on Android and
+     * the iOS NSE category mapping — the {@link #getId() id} is the on-wire
+     * value those clients compare against.
+     */
+    enum Category {
+        GENERAL("general"),
+        TRADE_UPDATE("trade_update"),
+        CHAT_MESSAGE("chat_message"),
+        OFFER_UPDATE("offer_update");
+
+        private final String id;
+
+        Category(String id) {
+            this.id = id;
+        }
+
+        /**
+         * Marked {@code @JsonValue} so Jackson serializes this enum as the
+         * stable lowercase id (e.g. {@code "chat_message"}) the mobile clients
+         * already expect — not the Java constant name {@code CHAT_MESSAGE}.
+         */
+        @JsonValue
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * Forward-compatible deserialization: unknown ids from a newer bisq2
+         * (e.g. a future {@code "dispute_alert"}) deserialize to
+         * {@link #GENERAL} instead of throwing, so older bisq2 instances and
+         * tests don't break when wire payloads from newer producers arrive.
+         */
+        @JsonCreator
+        public static Category fromId(String id) {
+            if (id == null) {
+                return GENERAL;
+            }
+            for (Category category : values()) {
+                if (category.id.equals(id)) {
+                    return category;
+                }
+            }
+            return GENERAL;
+        }
+    }
 }

--- a/notifications/src/main/java/bisq/notifications/NotificationService.java
+++ b/notifications/src/main/java/bisq/notifications/NotificationService.java
@@ -57,7 +57,48 @@ public class NotificationService implements Service {
     }
 
     public void dispatchNotification(Notification notification) {
+        dispatchNotification(notification, true);
+    }
+
+    /**
+     * Dispatches a notification to the system path (desktop OS-native) and conditionally
+     * to the mobile relay path (FCM / APNs) based on {@code mobileEligible}.
+     * <p>
+     * The mobile path delivers push notifications to registered devices via the bisq-relay,
+     * which has no in-app grouping or dismissal affordances per event. Callers therefore
+     * filter low-value, high-volume events (e.g. Bisq Easy trade protocol log messages) so
+     * the mobile inbox is reserved for things the user actually needs to act on. Desktop
+     * remains noisy-by-default because the chat view groups and lets users dismiss in-app.
+     * <p>
+     * See {@code bisq-network/bisq-mobile#1450}.
+     *
+     * @param notification    the notification to dispatch
+     * @param mobileEligible  if {@code false}, the mobile relay dispatch is suppressed;
+     *                        the system (desktop) dispatch still happens
+     */
+    public void dispatchNotification(Notification notification, boolean mobileEligible) {
         systemNotificationService.dispatchNotification(notification);
+        if (mobileEligible) {
+            mobileNotificationService.dispatchNotification(notification);
+        } else {
+            log.debug("Mobile relay suppressed for notification '{}' (not mobile-eligible)", notification.getTitle());
+        }
+    }
+
+    /**
+     * Dispatches a notification ONLY to the mobile relay path. Skips the desktop
+     * system notification.
+     * <p>
+     * Used when the desktop already surfaces the same event through another channel
+     * (e.g. Bisq Easy trade state transitions are visible to desktop users via the
+     * in-app trade chat's protocol log messages, and the trade detail header — we
+     * don't want a duplicate OS-level toast on desktop too). The mobile inbox has
+     * no such in-app surface, so a dedicated push is needed there.
+     * <p>
+     * See {@code bisq-network/bisq-mobile#1450}.
+     */
+    public void dispatchMobileOnlyNotification(Notification notification) {
+        log.debug("Dispatching mobile-only notification '{}'", notification.getTitle());
         mobileNotificationService.dispatchNotification(notification);
     }
 }

--- a/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationPayload.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationPayload.java
@@ -17,6 +17,7 @@
 
 package bisq.notifications.mobile;
 
+import bisq.notifications.Notification;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
@@ -28,15 +29,30 @@ public class MobileNotificationPayload {
     private final String id;
     private final String title;
     private final String message;
+    /**
+     * Stable category mirroring the mobile client's {@code NotificationCategory#id}.
+     * Lets the client route/label notifications without relying on the title-keyword
+     * heuristic, which mislabels e.g. trade-private chats (whose title contains
+     * "Open Trades") as trade updates. See bisq-network/bisq-mobile#1450.
+     * <p>
+     * Serialized via {@link Notification.Category}'s {@code @JsonValue} as the
+     * lowercase id (e.g. {@code "chat_message"}) — the on-wire format the mobile
+     * client compares against. Null-on-wire and unknown ids both deserialize to
+     * {@link Notification.Category#GENERAL} (forward-compat for older clients
+     * that don't emit the field, and newer producers that introduce new ids).
+     */
+    private final Notification.Category category;
 
     @JsonCreator
     public MobileNotificationPayload(
             @JsonProperty("id") String id,
             @JsonProperty("title") String title,
-            @JsonProperty("message") String message
+            @JsonProperty("message") String message,
+            @JsonProperty("category") Notification.Category category
     ) {
         this.id = id;
         this.title = title;
         this.message = message;
+        this.category = category == null ? Notification.Category.GENERAL : category;
     }
 }

--- a/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationService.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationService.java
@@ -68,7 +68,8 @@ public class MobileNotificationService implements Service {
                     String platform = isAndroid ? "Android" : "iOS";
                     MobileNotificationPayload payload = new MobileNotificationPayload(notification.getId(),
                             notification.getTitle(),
-                            notification.getMessage());
+                            notification.getMessage(),
+                            notification.getCategory());
                     try {
                         String json = JsonMapperProvider.get().writeValueAsString(payload);
 

--- a/notifications/src/test/java/bisq/notifications/mobile/MobileNotificationPayloadCategoryTest.java
+++ b/notifications/src/test/java/bisq/notifications/mobile/MobileNotificationPayloadCategoryTest.java
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.notifications.mobile;
+
+import bisq.common.json.JsonMapperProvider;
+import bisq.notifications.Notification;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the wire contract between bisq2's {@link MobileNotificationPayload} and the mobile
+ * client's {@code BisqFirebaseMessagingService.NotificationPayload} (Android) / iOS NSE
+ * decoder. Specifically guards against:
+ * <p>
+ *   - Drift in the {@code category} id strings (mobile uses {@code "chat_message"},
+ *     {@code "trade_update"}, {@code "offer_update"}, {@code "general"}).
+ *   - Loss of forward-compatibility when newer bisq2 instances emit category ids the
+ *     local enum doesn't know about — those must deserialize to
+ *     {@link Notification.Category#GENERAL} rather than throwing.
+ *   - A future refactor making {@code category} required on the wire, breaking older
+ *     trusted nodes that don't yet override {@code Notification#getCategory()}.
+ * <p>
+ * Mirror for bisq-network/bisq-mobile#1450.
+ */
+class MobileNotificationPayloadCategoryTest {
+
+    private final ObjectMapper mapper = JsonMapperProvider.get();
+
+    @Test
+    void chatCategoryRoundTripsThroughJson() throws Exception {
+        MobileNotificationPayload original = new MobileNotificationPayload(
+                "channel.msg-123",
+                "Alice (Bisq Easy → Open Trades → Bob)",
+                "hey, account info incoming",
+                Notification.Category.CHAT_MESSAGE);
+
+        String json = mapper.writeValueAsString(original);
+        assertTrue(json.contains("\"category\":\"chat_message\""),
+                "category must be serialized as the lowercase id (via @JsonValue) for the mobile client: " + json);
+
+        MobileNotificationPayload decoded = mapper.readValue(json, MobileNotificationPayload.class);
+        assertEquals(original, decoded);
+        assertEquals(Notification.Category.CHAT_MESSAGE, decoded.getCategory());
+    }
+
+    @Test
+    void tradeUpdateCategoryRoundTripsThroughJson() throws Exception {
+        MobileNotificationPayload original = new MobileNotificationPayload(
+                "trade-id.abcd",
+                "Trade abcd1234",
+                "Peer confirmed fiat receipt",
+                Notification.Category.TRADE_UPDATE);
+
+        String json = mapper.writeValueAsString(original);
+        assertTrue(json.contains("\"category\":\"trade_update\""), json);
+
+        MobileNotificationPayload decoded = mapper.readValue(json, MobileNotificationPayload.class);
+        assertEquals(Notification.Category.TRADE_UPDATE, decoded.getCategory());
+    }
+
+    @Test
+    void absentCategoryInJsonDefaultsToGeneralForOlderNodes() throws Exception {
+        // Simulates a payload built by an older bisq2 (pre-#1450) where Notification
+        // implementations didn't override getCategory(). The deserializer must accept
+        // the absent field and default to GENERAL rather than throwing.
+        String legacyJson = "{\"id\":\"x\",\"title\":\"t\",\"message\":\"m\"}";
+
+        MobileNotificationPayload decoded = mapper.readValue(legacyJson, MobileNotificationPayload.class);
+
+        assertEquals(Notification.Category.GENERAL, decoded.getCategory());
+    }
+
+    @Test
+    void unknownCategoryIdFromNewerNodeDeserializesAsGeneralRatherThanThrowing() throws Exception {
+        // Forward-compat: a newer bisq2 may introduce e.g. "dispute_alert" before
+        // older instances / mobile clients learn the id. {@link Notification.Category#fromId}
+        // returns GENERAL rather than throwing, so older receivers keep working
+        // (they'll just show the generic banner instead of the new category).
+        String futureJson = "{\"id\":\"x\",\"title\":\"t\",\"message\":\"m\",\"category\":\"dispute_alert\"}";
+
+        MobileNotificationPayload decoded = mapper.readValue(futureJson, MobileNotificationPayload.class);
+
+        assertEquals(Notification.Category.GENERAL, decoded.getCategory());
+    }
+
+    @Test
+    void categoryIsAlwaysPresentOnTheWire() throws Exception {
+        // Constructor normalises null → GENERAL, so the payload field is never null
+        // at serialization time. The mobile client can therefore assume the JSON
+        // always carries a `category` key — no `null` and no missing key.
+        MobileNotificationPayload general = new MobileNotificationPayload("i", "t", "m", null);
+
+        String json = mapper.writeValueAsString(general);
+        assertTrue(json.contains("\"category\":\"general\""),
+                "constructor normalises null → GENERAL; that explicit category must be on the wire: " + json);
+        assertFalse(json.contains("\"category\":null"),
+                "must never emit a null category to the wire: " + json);
+    }
+
+    @Test
+    void categoryEnumIdsMatchMobileWireContract() {
+        // The mobile client (BisqFirebaseMessagingService.NotificationCategory.CHAT_MESSAGE)
+        // uses the literal id "chat_message" and compares against the on-wire value
+        // produced by `Category#getId` (via @JsonValue). If these literals ever drift,
+        // every chat push on every device version drops back to GENERAL silently — pin
+        // the wire format here, not the enum constant names.
+        assertEquals("chat_message", Notification.Category.CHAT_MESSAGE.getId());
+        assertEquals("trade_update", Notification.Category.TRADE_UPDATE.getId());
+        assertEquals("offer_update", Notification.Category.OFFER_UPDATE.getId());
+        assertEquals("general", Notification.Category.GENERAL.getId());
+    }
+}


### PR DESCRIPTION
 - contribs to https://github.com/bisq-network/bisq-mobile/issues/1450
 - mimick node implementation to avoid dups and non-trade-significant updates on relayed notifications + tests
 - include category in trade notification + tests
 - add headers docs
 - add i18n for notification content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile push for Bisq Easy trade-state updates (offer taken, payment info, payments, terminal outcomes) with deduplication and deterministic per-trade notification IDs.
  * Notification categories added (general, trade_update, chat_message, offer_update) and included in mobile payloads.
  * Mobile-only dispatch path introduced.

* **Behavior Changes**
  * Chat messages now evaluate mobile eligibility; only user-facing types trigger mobile pushes.

* **Tests**
  * Added tests for trade whitelist/terminal keys, chat mobile eligibility, and mobile payload category wire contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->