### PR TITLE
Add Montenegro to SEPA country list

### DIFF
--- a/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRailUtil.java
+++ b/account/src/main/java/bisq/account/payment_method/fiat/FiatPaymentRailUtil.java
@@ -67,7 +67,7 @@ public class FiatPaymentRailUtil {
 
     public static List<String> getSepaEuroCountries() {
         return List.of("AT", "BE", "BG", "CY", "DE", "EE", "FI", "FR", "GR", "HR", "IE",
-                "IT", "LV", "LT", "LU", "MC", "MT", "NL", "PT", "SK", "SI", "ES", "AD", "SM", "VA");
+                "IT", "LV", "LT", "LU", "MC", "ME", "MT", "NL", "PT", "SK", "SI", "ES", "AD", "SM", "VA");
     }
 
     public static List<String> getSepaNonEuroCountries() {

--- a/account/src/test/java/bisq/account/payment_method/FiatPaymentRailUtilTest.java
+++ b/account/src/test/java/bisq/account/payment_method/FiatPaymentRailUtilTest.java
@@ -1,0 +1,33 @@
+package bisq.account.payment_method;
+
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentRailUtil;
+import bisq.common.locale.Country;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FiatPaymentRailUtilTest {
+
+    @Test
+    void sepaCountriesContainMontenegro() {
+        assertThat(FiatPaymentRailUtil.getAllSepaCountryCodes()).contains("ME");
+    }
+
+    @Test
+    void montenegroResolvesToCountryInSepaList() {
+        assertThat(FiatPaymentRailUtil.getAllSepaCountries())
+                .extracting(Country::getCode)
+                .contains("ME");
+    }
+
+    @Test
+    void montenegroIsSupportedBySepaAndSepaInstantRails() {
+        assertThat(FiatPaymentRail.SEPA.getSupportedCountries())
+                .extracting(Country::getCode)
+                .contains("ME");
+        assertThat(FiatPaymentRail.SEPA_INSTANT.getSupportedCountries())
+                .extracting(Country::getCode)
+                .contains("ME");
+    }
+}


### PR DESCRIPTION
Fixes #4728

Montenegro became an operational SEPA member in November 2024 but was missing from Bisq's SEPA country list, so Montenegrin users could not create SEPA or SEPA Instant accounts.

## Change
- Add `"ME"` to `FiatPaymentRailUtil.getSepaEuroCountries()`. Montenegro uses the euro, so it sits alongside the other non-EU euro users already listed (MC/AD/SM/VA). The entry propagates via `getAllSepaCountries()` to the `SEPA`, `SEPA_INSTANT` and `MoneyBeam` rails, IBAN validation, and the account-creation UI — no other production changes needed.
- Per the maintainer's confirmation on the issue, Montenegro is added to **both** SEPA and SEPA Instant (it's in the SCT Inst geographical scope and instant is rolling out soon), keeping the shared data structure as-is.

## Tests
Added `FiatPaymentRailUtilTest` covering:
- `getAllSepaCountryCodes()` contains `"ME"`
- `"ME"` resolves to a `Country` in `getAllSepaCountries()`
- both `FiatPaymentRail.SEPA` and `FiatPaymentRail.SEPA_INSTANT` report Montenegro as supported

`./gradlew :account:build` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Montenegro is now supported as a SEPA payment country.

* **Tests**
  * Added test verification for Montenegro's inclusion in SEPA and SEPA Instant payment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->