### PR TITLE
Treat range amount with equal min/max as fixed

### DIFF
--- a/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
+++ b/offer/src/main/java/bisq/offer/amount/OfferAmountUtil.java
@@ -23,14 +23,13 @@ import bisq.common.monetary.Monetary;
 import bisq.common.util.MathUtils;
 import bisq.offer.Offer;
 import bisq.offer.amount.spec.AmountSpec;
+import bisq.offer.amount.spec.AmountSpecFactory;
 import bisq.offer.amount.spec.AmountSpecUtil;
 import bisq.offer.amount.spec.BaseSideAmountSpec;
 import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
-import bisq.offer.amount.spec.BaseSideRangeAmountSpec;
 import bisq.offer.amount.spec.FixedAmountSpec;
 import bisq.offer.amount.spec.QuoteSideAmountSpec;
 import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
-import bisq.offer.amount.spec.QuoteSideRangeAmountSpec;
 import bisq.offer.amount.spec.RangeAmountSpec;
 import bisq.offer.price.PriceUtil;
 import bisq.offer.price.spec.PriceSpec;
@@ -239,7 +238,7 @@ public class OfferAmountUtil {
                             .map(quote -> quote.toQuoteSideMonetary(maxAmount)))
                     .map(Monetary::getValue);
             if (minQuoteSideAmount.isPresent() && maxQuoteSideAmount.isPresent()) {
-                return Optional.of(new QuoteSideRangeAmountSpec(minQuoteSideAmount.get(), maxQuoteSideAmount.get()));
+                return Optional.of(AmountSpecFactory.createQuoteSideAmountSpec(minQuoteSideAmount.get(), maxQuoteSideAmount.get()));
             } else {
                 return Optional.empty();
             }
@@ -268,7 +267,7 @@ public class OfferAmountUtil {
                             .map(quote -> quote.toBaseSideMonetary(maxAmount)))
                     .map(Monetary::getValue);
             if (minBaseSideAmount.isPresent() && maxBaseSideAmount.isPresent()) {
-                return Optional.of(new BaseSideRangeAmountSpec(minBaseSideAmount.get(), maxBaseSideAmount.get()));
+                return Optional.of(AmountSpecFactory.createBaseSideAmountSpec(minBaseSideAmount.get(), maxBaseSideAmount.get()));
             } else {
                 return Optional.empty();
             }

--- a/offer/src/main/java/bisq/offer/amount/spec/AmountSpecFactory.java
+++ b/offer/src/main/java/bisq/offer/amount/spec/AmountSpecFactory.java
@@ -50,7 +50,7 @@ public class AmountSpecFactory {
         if (useRangeAmount) {
             long minAmount = minTradeAmount.getBaseSideAmount().getValue();
             long maxAmount = maxTradeAmount.getBaseSideAmount().getValue();
-            return new BaseSideRangeAmountSpec(minAmount, maxAmount);
+            return createBaseSideAmountSpec(minAmount, maxAmount);
         } else {
             long fixAmount = fixTradeAmount.getBaseSideAmount().getValue();
             return new BaseSideFixedAmountSpec(fixAmount);
@@ -64,10 +64,22 @@ public class AmountSpecFactory {
         if (useRangeAmount) {
             long minAmount = minTradeAmount.getQuoteSideAmount().getValue();
             long maxAmount = maxTradeAmount.getQuoteSideAmount().getValue();
-            return new QuoteSideRangeAmountSpec(minAmount, maxAmount);
+            return createQuoteSideAmountSpec(minAmount, maxAmount);
         } else {
             long fixAmount = fixTradeAmount.getQuoteSideAmount().getValue();
             return new QuoteSideFixedAmountSpec(fixAmount);
         }
+    }
+
+    public static BaseSideAmountSpec createBaseSideAmountSpec(long minAmount, long maxAmount) {
+        return minAmount == maxAmount
+                ? new BaseSideFixedAmountSpec(minAmount)
+                : new BaseSideRangeAmountSpec(minAmount, maxAmount);
+    }
+
+    public static QuoteSideAmountSpec createQuoteSideAmountSpec(long minAmount, long maxAmount) {
+        return minAmount == maxAmount
+                ? new QuoteSideFixedAmountSpec(minAmount)
+                : new QuoteSideRangeAmountSpec(minAmount, maxAmount);
     }
 }

--- a/offer/src/test/java/bisq/offer/amount/spec/AmountSpecFactoryTest.java
+++ b/offer/src/test/java/bisq/offer/amount/spec/AmountSpecFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.amount.spec;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class AmountSpecFactoryTest {
+
+    @Test
+    void quoteSideWithEqualMinAndMaxBecomesFixed() {
+        QuoteSideAmountSpec spec = AmountSpecFactory.createQuoteSideAmountSpec(100, 100);
+        QuoteSideFixedAmountSpec fixed = assertInstanceOf(QuoteSideFixedAmountSpec.class, spec);
+        assertEquals(100, fixed.getAmount());
+    }
+
+    @Test
+    void quoteSideWithDifferentMinAndMaxStaysRange() {
+        QuoteSideAmountSpec spec = AmountSpecFactory.createQuoteSideAmountSpec(100, 200);
+        QuoteSideRangeAmountSpec range = assertInstanceOf(QuoteSideRangeAmountSpec.class, spec);
+        assertEquals(100, range.getMinAmount());
+        assertEquals(200, range.getMaxAmount());
+    }
+
+    @Test
+    void baseSideWithEqualMinAndMaxBecomesFixed() {
+        BaseSideAmountSpec spec = AmountSpecFactory.createBaseSideAmountSpec(100, 100);
+        BaseSideFixedAmountSpec fixed = assertInstanceOf(BaseSideFixedAmountSpec.class, spec);
+        assertEquals(100, fixed.getAmount());
+    }
+
+    @Test
+    void baseSideWithDifferentMinAndMaxStaysRange() {
+        BaseSideAmountSpec spec = AmountSpecFactory.createBaseSideAmountSpec(100, 200);
+        BaseSideRangeAmountSpec range = assertInstanceOf(BaseSideRangeAmountSpec.class, spec);
+        assertEquals(100, range.getMinAmount());
+        assertEquals(200, range.getMaxAmount());
+    }
+}


### PR DESCRIPTION
Fixes #4531

A range offer whose min equals max showed the taker an amount selector that couldn't be moved (min and max identical). Such offers should be fixed-amount offers.

## Change
- `AmountSpecFactory`: new `createBaseSideAmountSpec(long, long)` / `createQuoteSideAmountSpec(long, long)` overloads return a **fixed** spec when `min == max`, else a range spec. The existing `create*AmountSpec` range branches delegate to them, so the MuSig draft-workflow path is covered.
- `OfferAmountUtil`: the two price-recompute paths (`updateQuoteSideAmountSpecWithPriceSpec` / `updateBaseSideAmountSpecWithPriceSpec`) now route through the same overloads, so a price change can't reintroduce a single-value range.

Per @HenrikJannsen's confirmation on the issue, the normalization is centralized in `AmountSpecFactory`.

## Out of scope (by design)
- **Create-offer UI controllers** (`TradeWizardAmountController`, `MuSigCreateOfferAmountController`) already collapse `min == max` to fixed — left unchanged.
- **`fromProto()`** and **API `DtoMappings`** — deserialization / external input, not offer *creation*; not normalized here (avoids touching persisted/network data).

## Tests
`AmountSpecFactoryTest`: equal min/max → fixed, different → range, for both base and quote side. `./gradlew :offer:build` passes.

## Aside (not addressed here)
`OfferAmountUtil.updateBaseSideAmountSpecWithPriceSpec` appears to compute both min and max from `findQuoteSideFixedAmount` (looks like a copy-paste; max may be intended to use a max variant). Left untouched as unrelated to this issue — flagging in case it's a real bug worth a separate ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored offer amount specification creation to use factory methods instead of direct instantiation, improving code consistency and maintainability across base-side and quote-side amount handling.

* **Tests**
  * Added comprehensive test coverage for the amount specification factory, verifying correct behavior for both fixed and range amount specifications with proper boundary testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bisq-network/bisq2/pull/4800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->