### PR TITLE
Sort mediation cases by last message

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationCaseListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationCaseListItem.java
@@ -44,6 +44,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,6 +53,9 @@ import java.util.Optional;
 @ToString
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class BisqEasyMediationCaseListItem implements ActivatableTableItem, DateTableItem {
+    public static final Comparator<BisqEasyMediationCaseListItem> BY_LAST_MESSAGE_DATE =
+            Comparator.comparingLong(BisqEasyMediationCaseListItem::getLastMessageDate);
+
     @EqualsAndHashCode.Include
     private final BisqEasyMediationCase bisqEasyMediationCase;
     @EqualsAndHashCode.Include
@@ -66,7 +70,11 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
     private final boolean isMakerRequester;
     private final Badge makersBadge = new Badge();
     private final Badge takersBadge = new Badge();
+    private long lastMessageDate;
+    private final StringProperty lastMessageDateString = new SimpleStringProperty("");
+    private final StringProperty lastMessageTimeString = new SimpleStringProperty("");
     private Pin changedChatNotificationPin;
+    private Pin chatMessagesPin;
     private Pin isClosedPin;
     private Long closeCaseDate = 0L;
     private final StringProperty closeCaseDateString = new SimpleStringProperty("");
@@ -120,6 +128,9 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
 
         chatNotificationService.getNotConsumedNotifications().forEach(this::handleNotification);
         changedChatNotificationPin = chatNotificationService.getChangedNotification().addObserver(this::handleNotification);
+
+        updateLastMessageDate();
+        chatMessagesPin = channel.getChatMessages().addObserver(() -> UIThread.run(this::updateLastMessageDate));
     }
 
     @Override
@@ -129,6 +140,10 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
             isClosedPin = null;
         }
         changedChatNotificationPin.unbind();
+        if (chatMessagesPin != null) {
+            chatMessagesPin.unbind();
+            chatMessagesPin = null;
+        }
     }
 
     public String getCloseCaseDateString() {
@@ -137,6 +152,22 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
 
     public StringProperty getCloseCaseDateStringProperty() {
         return closeCaseDateString;
+    }
+
+    public String getLastMessageDateString() {
+        return lastMessageDateString.get();
+    }
+
+    public StringProperty getLastMessageDateStringProperty() {
+        return lastMessageDateString;
+    }
+
+    public String getLastMessageTimeString() {
+        return lastMessageTimeString.get();
+    }
+
+    public StringProperty getLastMessageTimeStringProperty() {
+        return lastMessageTimeString;
     }
 
     public String getCloseCaseTimeString() {
@@ -167,6 +198,15 @@ public class BisqEasyMediationCaseListItem implements ActivatableTableItem, Date
                     String.valueOf(numNotificationsFromTaker) :
                     "");
         });
+    }
+
+    private void updateLastMessageDate() {
+        lastMessageDate = channel.getChatMessages().stream()
+                .mapToLong(message -> message.getDate())
+                .max()
+                .orElse(date);
+        lastMessageDateString.set(DateFormatter.formatDate(lastMessageDate));
+        lastMessageTimeString.set(DateFormatter.formatTime(lastMessageDate));
     }
 
     private long getNumNotifications(UserProfile userProfile) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationTableView.java
@@ -52,6 +52,7 @@ class BisqEasyMediationTableView extends VBox {
     private final SearchBox searchBox;
     private final BisqTableView<BisqEasyMediationCaseListItem> tableView;
     private BisqTableColumn<BisqEasyMediationCaseListItem> closeCaseDateColumn;
+    private BisqTableColumn<BisqEasyMediationCaseListItem> lastMessageColumn;
     private final Hyperlink exportHyperlink;
     private final Label numEntriesLabel;
     private final ListChangeListener<BisqEasyMediationCaseListItem> listChangeListener;
@@ -275,7 +276,17 @@ class BisqEasyMediationTableView extends VBox {
                 .valueSupplier(item -> item.getTaker().getUserName())// For csv export
                 .build());
 
-        tableView.getColumns().add(DateColumnUtil.getDateColumn(tableView.getSortOrder()));
+        lastMessageColumn = new BisqTableColumn.Builder<BisqEasyMediationCaseListItem>()
+                .title(Res.get("authorizedRole.mediator.table.lastMessage"))
+                .minWidth(130)
+                .comparator(BisqEasyMediationCaseListItem.BY_LAST_MESSAGE_DATE)
+                .sortType(TableColumn.SortType.DESCENDING)
+                .setCellFactory(getLastMessageCellFactory())
+                .valueSupplier(item -> item.getLastMessageDateString() + " " + item.getLastMessageTimeString())
+                .build();
+        tableView.getColumns().add(lastMessageColumn);
+
+        tableView.getColumns().add(DateColumnUtil.getDateColumn());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyMediationCaseListItem>()
                 .title(Res.get("bisqEasy.openTrades.table.tradeId"))
@@ -320,6 +331,40 @@ class BisqEasyMediationTableView extends VBox {
                 .valueSupplier(item -> item.getCloseCaseDateString() + " " + item.getCloseCaseTimeString())
                 .build();
         tableView.getColumns().add(closeCaseDateColumn);
+
+        UIThread.runOnNextRenderFrame(() -> tableView.getSortOrder().add(lastMessageColumn));
+    }
+
+    private Callback<TableColumn<BisqEasyMediationCaseListItem, BisqEasyMediationCaseListItem>,
+            TableCell<BisqEasyMediationCaseListItem, BisqEasyMediationCaseListItem>> getLastMessageCellFactory() {
+        return column -> new TableCell<>() {
+            private final Label date = new Label();
+            private final Label time = new Label();
+            private final VBox vBox = new VBox(3, date, time);
+
+            {
+                date.getStyleClass().add("table-view-date-column-date");
+                time.getStyleClass().add("table-view-date-column-time");
+                vBox.setAlignment(Pos.CENTER);
+                setAlignment(Pos.CENTER);
+            }
+
+            @Override
+            protected void updateItem(BisqEasyMediationCaseListItem item, boolean empty) {
+                super.updateItem(item, empty);
+
+                date.textProperty().unbind();
+                time.textProperty().unbind();
+
+                if (item != null && !empty) {
+                    date.textProperty().bind(item.getLastMessageDateStringProperty());
+                    time.textProperty().bind(item.getLastMessageTimeStringProperty());
+                    setGraphic(vBox);
+                } else {
+                    setGraphic(null);
+                }
+            }
+        };
     }
 
     private Callback<TableColumn<BisqEasyMediationCaseListItem, BisqEasyMediationCaseListItem>,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItem.java
@@ -50,6 +50,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,6 +59,9 @@ import java.util.Optional;
 @ToString
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTableItem {
+    public static final Comparator<MuSigMediationCaseListItem> BY_LAST_MESSAGE_DATE =
+            Comparator.comparingLong(MuSigMediationCaseListItem::getLastMessageDate);
+
     @EqualsAndHashCode.Include
     private final MuSigMediationCase muSigMediationCase;
     private final ObjectProperty<Optional<MuSigOpenTradeChannel>> channel = new SimpleObjectProperty<>(Optional.empty());
@@ -71,6 +75,9 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
     private final boolean isMakerRequester;
     private final Badge makersBadge = new Badge();
     private final Badge takersBadge = new Badge();
+    private long lastMessageDate;
+    private final StringProperty lastMessageDateString = new SimpleStringProperty("");
+    private final StringProperty lastMessageTimeString = new SimpleStringProperty("");
     private Long closeCaseDate = 0L;
     private final StringProperty closeCaseDateString = new SimpleStringProperty("");
     private final StringProperty closeCaseTimeString = new SimpleStringProperty("");
@@ -78,6 +85,7 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
     private Pin mediatorHasLeftChatPin;
     private Pin changedChatNotificationPin;
     private Pin muSigMediationResultPin;
+    private Pin chatMessagesPin;
 
     MuSigMediationCaseListItem(ServiceProvider serviceProvider,
                                MuSigMediationCase muSigMediationCase,
@@ -130,6 +138,10 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
 
         chatNotificationService.getNotConsumedNotifications().forEach(this::handleNotification);
         changedChatNotificationPin = chatNotificationService.getChangedNotification().addObserver(this::handleNotification);
+
+        updateLastMessageDate();
+        channel.get().ifPresent(openTradeChannel ->
+                chatMessagesPin = openTradeChannel.getChatMessages().addObserver(() -> UIThread.run(this::updateLastMessageDate)));
     }
 
     @Override
@@ -143,6 +155,10 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
             muSigMediationResultPin = null;
         }
         changedChatNotificationPin.unbind();
+        if (chatMessagesPin != null) {
+            chatMessagesPin.unbind();
+            chatMessagesPin = null;
+        }
     }
 
     public Optional<MuSigOpenTradeChannel> getChannel() {
@@ -160,7 +176,39 @@ public class MuSigMediationCaseListItem implements ActivatableTableItem, DateTab
             this.channel.set(Optional.empty());
             makersBadge.setText("");
             takersBadge.setText("");
+            if (chatMessagesPin != null) {
+                chatMessagesPin.unbind();
+                chatMessagesPin = null;
+            }
+            updateLastMessageDate();
         }
+    }
+
+    public String getLastMessageDateString() {
+        return lastMessageDateString.get();
+    }
+
+    public StringProperty getLastMessageDateStringProperty() {
+        return lastMessageDateString;
+    }
+
+    public String getLastMessageTimeString() {
+        return lastMessageTimeString.get();
+    }
+
+    public StringProperty getLastMessageTimeStringProperty() {
+        return lastMessageTimeString;
+    }
+
+    private void updateLastMessageDate() {
+        lastMessageDate = channel.get()
+                .map(openTradeChannel -> openTradeChannel.getChatMessages().stream()
+                        .mapToLong(message -> message.getDate())
+                        .max()
+                        .orElse(date))
+                .orElse(date);
+        lastMessageDateString.set(DateFormatter.formatDate(lastMessageDate));
+        lastMessageTimeString.set(DateFormatter.formatTime(lastMessageDate));
     }
 
     public String getCloseCaseDateString() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationTableView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationTableView.java
@@ -69,6 +69,7 @@ class MuSigMediationTableView extends VBox {
     private final SearchBox searchBox;
     private final BisqTableView<MuSigMediationCaseListItem> tableView;
     private BisqTableColumn<MuSigMediationCaseListItem> closeCaseDateColumn;
+    private BisqTableColumn<MuSigMediationCaseListItem> lastMessageColumn;
     private final Hyperlink exportHyperlink;
     private final Label numEntriesLabel;
     private final ListChangeListener<MuSigMediationCaseListItem> listChangeListener;
@@ -292,7 +293,17 @@ class MuSigMediationTableView extends VBox {
                 .valueSupplier(item -> item.getTaker().getUserName())// For csv export
                 .build());
 
-        tableView.getColumns().add(DateColumnUtil.getDateColumn(tableView.getSortOrder()));
+        lastMessageColumn = new BisqTableColumn.Builder<MuSigMediationCaseListItem>()
+                .title(Res.get("authorizedRole.mediator.table.lastMessage"))
+                .minWidth(130)
+                .comparator(MuSigMediationCaseListItem.BY_LAST_MESSAGE_DATE)
+                .sortType(TableColumn.SortType.DESCENDING)
+                .setCellFactory(getLastMessageCellFactory())
+                .valueSupplier(item -> item.getLastMessageDateString() + " " + item.getLastMessageTimeString())
+                .build();
+        tableView.getColumns().add(lastMessageColumn);
+
+        tableView.getColumns().add(DateColumnUtil.getDateColumn());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<MuSigMediationCaseListItem>()
                 .title(Res.get("bisqEasy.openTrades.table.tradeId"))
@@ -337,6 +348,40 @@ class MuSigMediationTableView extends VBox {
                 .valueSupplier(item -> item.getCloseCaseDateString() + " " + item.getCloseCaseTimeString())
                 .build();
         tableView.getColumns().add(closeCaseDateColumn);
+
+        UIThread.runOnNextRenderFrame(() -> tableView.getSortOrder().add(lastMessageColumn));
+    }
+
+    private Callback<TableColumn<MuSigMediationCaseListItem, MuSigMediationCaseListItem>,
+            TableCell<MuSigMediationCaseListItem, MuSigMediationCaseListItem>> getLastMessageCellFactory() {
+        return column -> new TableCell<>() {
+            private final Label date = new Label();
+            private final Label time = new Label();
+            private final VBox vBox = new VBox(3, date, time);
+
+            {
+                date.getStyleClass().add("table-view-date-column-date");
+                time.getStyleClass().add("table-view-date-column-time");
+                vBox.setAlignment(Pos.CENTER);
+                setAlignment(Pos.CENTER);
+            }
+
+            @Override
+            protected void updateItem(MuSigMediationCaseListItem item, boolean empty) {
+                super.updateItem(item, empty);
+
+                date.textProperty().unbind();
+                time.textProperty().unbind();
+
+                if (item != null && !empty) {
+                    date.textProperty().bind(item.getLastMessageDateStringProperty());
+                    time.textProperty().bind(item.getLastMessageTimeStringProperty());
+                    setGraphic(vBox);
+                } else {
+                    setGraphic(null);
+                }
+            }
+        };
     }
 
     private Callback<TableColumn<MuSigMediationCaseListItem, MuSigMediationCaseListItem>,

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationCaseListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediationCaseListItemTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.authorized_role.mediator.bisq_easy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BisqEasyMediationCaseListItemTest {
+
+    @Test
+    void mostRecentLastMessageFirstFloatsActiveCasesToTop() {
+        BisqEasyMediationCaseListItem oldest = itemWith(1_000L);
+        BisqEasyMediationCaseListItem newest = itemWith(3_000L);
+        BisqEasyMediationCaseListItem middle = itemWith(2_000L);
+
+        List<BisqEasyMediationCaseListItem> items =
+                new ArrayList<>(List.of(oldest, newest, middle));
+        items.sort(BisqEasyMediationCaseListItem.BY_LAST_MESSAGE_DATE.reversed());
+
+        assertEquals(List.of(newest, middle, oldest), items);
+    }
+
+    private static BisqEasyMediationCaseListItem itemWith(long lastMessageDate) {
+        BisqEasyMediationCaseListItem item = mock(BisqEasyMediationCaseListItem.class);
+        when(item.getLastMessageDate()).thenReturn(lastMessageDate);
+        return item;
+    }
+}

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/authorized_role/mediator/mu_sig/MuSigMediationCaseListItemTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.authorized_role.mediator.mu_sig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MuSigMediationCaseListItemTest {
+
+    @Test
+    void mostRecentLastMessageFirstFloatsActiveCasesToTop() {
+        MuSigMediationCaseListItem oldest = itemWith(1_000L);
+        MuSigMediationCaseListItem newest = itemWith(3_000L);
+        MuSigMediationCaseListItem middle = itemWith(2_000L);
+
+        List<MuSigMediationCaseListItem> items =
+                new ArrayList<>(List.of(oldest, newest, middle));
+        items.sort(MuSigMediationCaseListItem.BY_LAST_MESSAGE_DATE.reversed());
+
+        assertEquals(List.of(newest, middle, oldest), items);
+    }
+
+    private static MuSigMediationCaseListItem itemWith(long lastMessageDate) {
+        MuSigMediationCaseListItem item = mock(MuSigMediationCaseListItem.class);
+        when(item.getLastMessageDate()).thenReturn(lastMessageDate);
+        return item;
+    }
+}

--- a/i18n/src/main/resources/authorized_role.properties
+++ b/i18n/src/main/resources/authorized_role.properties
@@ -117,6 +117,7 @@ authorizedRole.mediator.message.mediationCaseReOpened=The mediator has re-opened
 authorizedRole.mediator.noOpenCases=You don't have any open mediation cases
 authorizedRole.mediator.noClosedCases=You don't have any closed mediation cases
 authorizedRole.mediator.table.headline=Mediation cases
+authorizedRole.mediator.table.lastMessage=Last message
 authorizedRole.mediator.reOpen=Re-open case
 authorizedRole.mediator.hasRequested={0}\nHas requested mediation: {1}
 authorizedRole.mediator.close.warning=Are you sure you want to close the mediation case?\n\n\


### PR DESCRIPTION
Fixes #3909

Mediators with many cases had no quick way to see which ones were recently
active — they had to scroll a narrow panel hunting for them. This adds a
sortable **"Last message"** column to both mediator case tables, ordered by
the timestamp of the most recent chat message so the most recently active
cases surface on top.

## Change
- New **"Last message"** column (date + time) in both the Bisq Easy and
  MuSig mediator case tables, in `BisqEasyMediationTableView` /
  `MuSigMediationTableView`.
- **Default-sorted descending** so the most recently active cases appear on
  top; clicking any other column header takes over the sort (standard
  behaviour).
- Backed by observable `lastMessageDate` string/time properties on the list
  items; the value updates live via an observer on the channel's chat
  messages, and the cell is bound to it (same pattern as the existing
  per-trader badges).
- The per-trader maker/taker unread badges are unchanged and still indicate
  *who* has unread messages.

## Scope
- Applies to **both Bisq Easy and MuSig** mediator tables, open and closed
  case lists.
- Unit tests for the ordering comparator (`BY_LAST_MESSAGE_DATE`) on both
  `BisqEasyMediationCaseListItem` and `MuSigMediationCaseListItem`.

## Note on approach
The issue and earlier discussion leaned toward an unread-message **count**
column. I went with **last-message timestamp** instead because:
- It surfaces active cases regardless of read state, so the mediator tab
  auto-opening (and marking-read) the top case doesn't reshuffle the order
  or hide anything — the original count-based approach fought that
  auto-consume behaviour.
- It extends cleanly to MuSig, which has separate buyer/seller chats; "last
  message across the channel" needs no special chat-pair handling, so MuSig
  could be included rather than deferred.

The per-trader unread badges still cover the "who needs a reply" signal.
@suddenwhipvapor — happy to switch back to a count-based sort if you'd
prefer the literal unread-count column over recency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Last message" column to mediation case tables, displaying the timestamp of the most recent chat message
  * Mediation cases can now be sorted by last message date to prioritize recent activity

* **Tests**
  * Added verification tests for last message sorting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->