### PR TITLE
Enable neutral view in mediation cases

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediatorController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediatorController.java
@@ -145,7 +145,6 @@ public class BisqEasyMediatorController implements Controller {
 
         searchPredicatePin = EasyBind.subscribe(model.getSearchPredicate(), searchPredicate -> updatePredicate());
         closedCasesPredicatePin = EasyBind.subscribe(model.getClosedCasesPredicate(), closedCasesPredicate -> updatePredicate());
-        maybeSelectFirst();
         updateEmptyState();
 
         model.getListItems().addListener(itemListener);
@@ -154,6 +153,7 @@ public class BisqEasyMediatorController implements Controller {
     @Override
     public void onDeactivate() {
         doCloseChatWindow();
+        selectionService.selectChannel(null);
 
         model.getListItems().removeListener(itemListener);
         model.getListItems().onDeactivate();
@@ -212,7 +212,6 @@ public class BisqEasyMediatorController implements Controller {
                 model.getSelectedItem().set(null);
                 bisqEasyMediationCaseHeader.setMediationCaseListItem(null);
                 bisqEasyMediationCaseHeader.setShowClosedCases(model.getShowClosedCases().get());
-                maybeSelectFirst();
                 updateEmptyState();
             } else if (chatChannel instanceof BisqEasyOpenTradeChannel tradeChannel) {
                 model.getListItems().stream()
@@ -232,12 +231,12 @@ public class BisqEasyMediatorController implements Controller {
         // Need a predicate change to trigger a list update
         applyFilteredListPredicate(!model.getShowClosedCases().get());
         applyFilteredListPredicate(model.getShowClosedCases().get());
-        maybeSelectFirst();
+        deselectIfFilteredOut();
     }
 
     private void updatePredicate() {
         model.getListItems().setPredicate(item -> model.getSearchPredicate().get().test(item) && model.getClosedCasesPredicate().get().test(item));
-        maybeSelectFirst();
+        deselectIfFilteredOut();
         updateEmptyState();
     }
 
@@ -262,12 +261,11 @@ public class BisqEasyMediatorController implements Controller {
         }
     }
 
-    private void maybeSelectFirst() {
-        UIThread.runOnNextRenderFrame(() -> {
-            if (!model.getListItems().getFilteredList().isEmpty()) {
-                selectionService.selectChannel(model.getListItems().getSortedList().get(0).getChannel());
-            }
-        });
+    private void deselectIfFilteredOut() {
+        BisqEasyMediationCaseListItem selectedItem = model.getSelectedItem().get();
+        if (selectedItem != null && model.getListItems().getFilteredList().stream().noneMatch(selectedItem::equals)) {
+            selectionService.selectChannel(null);
+        }
     }
 
     private BisqEasyOpenTradeChannel findOrCreateChannel(BisqEasyMediationRequest bisqEasyMediationRequest,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediatorView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediatorView.java
@@ -24,6 +24,7 @@ import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.i18n.Res;
+import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
@@ -31,6 +32,8 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -46,7 +49,8 @@ public class BisqEasyMediatorView extends View<ScrollPane, BisqEasyMediatorModel
     private final VBox centerVBox, chatVBox;
     private final Button toggleChatWindowButton;
     private final BisqEasyMediationTableView bisqEasyMediationTableView;
-    private Subscription noOpenCasesPin, chatWindowPin;
+    private final EventHandler<KeyEvent> escapeKeyHandler = this::onKeyPressed;
+    private Subscription selectedItemPin, chatWindowPin;
     private Stage detachedChatWindow;
 
     public BisqEasyMediatorView(BisqEasyMediatorModel model,
@@ -89,20 +93,33 @@ public class BisqEasyMediatorView extends View<ScrollPane, BisqEasyMediatorModel
     @Override
     protected void onViewAttached() {
         bisqEasyMediationTableView.initialize();
-        noOpenCasesPin = EasyBind.subscribe(model.getNoOpenCases(), noOpenCases -> {
-            chatVBox.setVisible(!noOpenCases);
-            chatVBox.setManaged(!noOpenCases);
+        selectedItemPin = EasyBind.subscribe(model.getSelectedItem(), selectedItem -> {
+            boolean caseSelected = selectedItem != null;
+            chatVBox.setVisible(caseSelected);
+            chatVBox.setManaged(caseSelected);
         });
         chatWindowPin = EasyBind.subscribe(model.getChatWindow(), this::chatWindowChanged);
         toggleChatWindowButton.setOnAction(e -> controller.onToggleChatWindow());
+        root.addEventHandler(KeyEvent.KEY_PRESSED, escapeKeyHandler);
     }
 
     @Override
     protected void onViewDetached() {
         bisqEasyMediationTableView.dispose();
-        noOpenCasesPin.unsubscribe();
+        selectedItemPin.unsubscribe();
         chatWindowPin.unsubscribe();
         toggleChatWindowButton.setOnAction(null);
+        root.removeEventHandler(KeyEvent.KEY_PRESSED, escapeKeyHandler);
+    }
+
+    private void onKeyPressed(KeyEvent keyEvent) {
+        if (keyEvent.getCode() == KeyCode.ESCAPE) {
+            deFocusSelectedCase();
+        }
+    }
+
+    private void deFocusSelectedCase() {
+        controller.onSelectItem(null);
     }
 
     private void chatWindowChanged(Stage chatWindow) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediatorView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/mediator/bisq_easy/BisqEasyMediatorView.java
@@ -21,6 +21,7 @@ import bisq.desktop.CssConfig;
 import bisq.desktop.common.Layout;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ImageUtil;
+import bisq.desktop.common.utils.KeyHandlerUtil;
 import bisq.desktop.common.view.View;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.i18n.Res;
@@ -31,8 +32,8 @@ import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
@@ -113,9 +114,14 @@ public class BisqEasyMediatorView extends View<ScrollPane, BisqEasyMediatorModel
     }
 
     private void onKeyPressed(KeyEvent keyEvent) {
-        if (keyEvent.getCode() == KeyCode.ESCAPE) {
-            deFocusSelectedCase();
+        if (isTextInputFocused()) {
+            return;
         }
+        KeyHandlerUtil.handleEscapeKeyEvent(keyEvent, this::deFocusSelectedCase);
+    }
+
+    private boolean isTextInputFocused() {
+        return root.getScene() != null && root.getScene().getFocusOwner() instanceof TextInputControl;
     }
 
     private void deFocusSelectedCase() {


### PR DESCRIPTION
Fixes #3910

The Mediator tab auto-opened the first case on load, and a focused case consumes its chat notifications — so opening the tab (or keeping a case focused) dismissed new-message badges before the mediator could notice them.

## Change (Bisq Easy mediation)
- **Neutral on entry:** the tab no longer auto-selects a case (`maybeSelectFirst` removed from `onActivate`); it opens with no case focused.
- **De-focus on leaving the tab:** `onDeactivate` clears the selection (`selectionService.selectChannel(null)`), mirroring `BisqEasyOpenTradesController`. Incoming messages to the previously-open case then show as unread badges instead of being consumed.
- **Esc** de-focuses the open case (scoped so it doesn't interfere with the chat input, which consumes Esc itself).
- **Selection clears stick** (removed the re-select on the null branch of `selectedChannelChanged`).
- On search / show-closed-cases toggle, the selection is cleared only if the open case is filtered out, rather than left on a hidden case.
- Selecting a case by clicking still works as before; the chat panel shows only while a case is selected.

Scope: **Bisq Easy mediation only** — MuSig mediation is left untouched (handled separately).

## Notes
- This is selection/UI behaviour, so it's verified manually (open the tab → no case auto-opens, badges stay; click a case → opens; leave tab / Esc → de-focuses; toggle closed cases → no stale chat). UI selection logic isn't unit-tested in this codebase.
- Complements #3909 / #4801 (the "New messages" column): with neutral view, opening the tab no longer auto-reads the top case, so that column reflects unread cases as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale chat-channel selections when filtering mediation cases (search/closed) or when the mediator view is closed
  * Ensured chat visibility stays synchronized with applied filters to avoid inconsistent UI state
  * Added keyboard support (ESC) to quickly deselect and close the active mediation case and improve interaction responsiveness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->