### PR TITLE
bugfix/any_network_active_chat_message_causing_relayed_notification_android_opted_in

### DIFF
--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationService.java
@@ -213,55 +213,54 @@ public class BisqEasyMobileTradeNotificationService implements Service {
     /* --------------------------------------------------------------------- */
 
     private void handleStateChange(BisqEasyTrade trade, BisqEasyTradeState state) {
+        // Self-action suppression rationale (bisq-network/bisq-mobile#1464 follow-up).
+        //
+        // Each "*_SENT_*" / "*_CONFIRMED_*" state below is reached via a LOCAL event
+        // handler in the user's own trade FSM (see e.g.
+        // BisqEasyBuyerAsTakerProtocol.java:102-104: BisqEasyConfirmFiatSentEvent → BUYER_SENT_FIAT_SENT_CONFIRMATION).
+        // Pushing the user about an action they just took on the device is pure noise —
+        // they already see the result in the UI. The nodeApp (decentralised) avoids this
+        // by unregistering observers while the app is foregrounded; the relay path has
+        // no foreground signal, so we suppress at the source instead.
+        //
+        // The counterparty's notification still fires on THEIR machine via the
+        // symmetric "*_RECEIVED_*" state (e.g. SELLER_RECEIVED_FIAT_SENT_CONFIRMATION
+        // for the buyer's "I sent fiat" action), so no information is lost — each side
+        // is informed about the OTHER side's action exactly once.
+        //
+        // Suppressed (own-action) states intentionally fall through to the default
+        // branch as no-ops:
+        //   - BUYER_SENT_FIAT_SENT_CONFIRMATION                 (buyer's local "I sent fiat" event)
+        //   - SELLER_CONFIRMED_FIAT_RECEIPT                     (seller's local "I received fiat" event)
+        //   - SELLER_SENT_BTC_SENT_CONFIRMATION                 (seller's local "I sent BTC" event)
+        //   - MAKER_SENT_TAKE_OFFER_RESPONSE__*                 (maker's local response event;
+        //                                                        peer-side already pushed via
+        //                                                        TAKER_SENT_TAKE_OFFER_REQUEST below)
         switch (state) {
-            case BUYER_SENT_FIAT_SENT_CONFIRMATION -> {
-                if (trade.isBuyer()) {
-                    dispatch(trade, "bisqEasy.mobileNotifications.youSentFiat.title",
-                            "bisqEasy.mobileNotifications.youSentFiat.message");
-                } else {
-                    dispatch(trade, "bisqEasy.mobileNotifications.peerSentFiat.title",
-                            "bisqEasy.mobileNotifications.peerSentFiat.message");
-                }
-            }
-
             case SELLER_RECEIVED_FIAT_SENT_CONFIRMATION -> {
                 if (trade.isSeller()) {
                     dispatch(trade, "bisqEasy.mobileNotifications.youReceivedFiatConfirmation.title",
                             "bisqEasy.mobileNotifications.youReceivedFiatConfirmation.message");
-                } else {
-                    dispatch(trade, "bisqEasy.mobileNotifications.youSentFiat.title",
-                            "bisqEasy.mobileNotifications.youSentFiat.message");
                 }
             }
 
-            case BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION,
-                 SELLER_CONFIRMED_FIAT_RECEIPT -> {
+            case BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION -> {
+                // Peer (seller) confirmed fiat receipt — buyer learns about it here.
+                // SELLER_CONFIRMED_FIAT_RECEIPT (the seller's own-action twin of this
+                // state) is intentionally absent — see suppressed list above.
                 if (trade.isBuyer()) {
                     dispatch(trade, "bisqEasy.mobileNotifications.peerReceivedFiat.title",
                             "bisqEasy.mobileNotifications.peerReceivedFiat.message");
-                } else {
-                    dispatch(trade, "bisqEasy.mobileNotifications.youReceivedFiat.title",
-                            "bisqEasy.mobileNotifications.youReceivedFiat.message");
-                }
-            }
-
-            case SELLER_SENT_BTC_SENT_CONFIRMATION -> {
-                if (trade.isSeller()) {
-                    dispatch(trade, "bisqEasy.mobileNotifications.youSentBtc.title",
-                            "bisqEasy.mobileNotifications.youSentBtc.message");
-                } else {
-                    dispatch(trade, "bisqEasy.mobileNotifications.peerSentBtc.title",
-                            "bisqEasy.mobileNotifications.peerSentBtc.message");
                 }
             }
 
             case BUYER_RECEIVED_BTC_SENT_CONFIRMATION -> {
+                // Peer (seller) sent BTC — buyer learns about it here.
+                // SELLER_SENT_BTC_SENT_CONFIRMATION (seller's own-action twin) is
+                // intentionally suppressed — see list above.
                 if (trade.isBuyer()) {
                     dispatch(trade, "bisqEasy.mobileNotifications.youReceivedBtc.title",
                             "bisqEasy.mobileNotifications.youReceivedBtc.message");
-                } else {
-                    dispatch(trade, "bisqEasy.mobileNotifications.youSentBtc.title",
-                            "bisqEasy.mobileNotifications.youSentBtc.message");
                 }
             }
 
@@ -273,16 +272,38 @@ public class BisqEasyMobileTradeNotificationService implements Service {
                 }
             }
 
-            case MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
-                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA ->
-                    dispatch(trade, "bisqEasy.mobileNotifications.offerTaken.title",
-                            "bisqEasy.mobileNotifications.offerTaken.message");
-
-            case TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+            // Payment-info exchange — push once per trade as soon as the user's
+            // FSM reflects that either (a) account data has been received or (b)
+            // account data has been sent. Because the Bisq Easy protocol allows
+            // BTC-address and account-data to be sent in either order, and the
+            // "received take-offer response" can interleave with both, the
+            // payment-info event has many possible state representations across
+            // the four trade roles (buyer/seller × maker/taker) and three timing
+            // branches (1.1 / 1.2 / 2). We whitelist all of them; the
+            // notifiedPaymentInfo dedup collapses them to a single push per trade
+            // regardless of which transition fires first.
+            //
+            // Originally only the three Branch-1.2 / Branch-2 intermediates were
+            // listed. The Branch-1.1 ("btc-address sent first, account-data
+            // arrives later") and final-converging ("both halves done") paths
+            // silently produced no push, which surfaced in
+            // bisq-network/bisq-mobile#1464 once the public-chat noise that had
+            // been masking the gap got correctly filtered out.
+            case
+                // --- BUYER AS TAKER ---
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 // --- SELLER AS MAKER ---
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                 // --- SELLER AS TAKER ---
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
                  TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS_,
-                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_ -> {
-                // Payment-info exchange — the offer-response state AND the payment-data
-                // change observer can both fire here, so dedup to one push per trade.
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                 // --- BUYER AS MAKER ---
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA -> {
                 if (notifiedPaymentInfo.add(trade.getId())) {
                     if (trade.isSeller()) {
                         dispatch(trade, "bisqEasy.mobileNotifications.paymentInfoSent.title",
@@ -349,19 +370,27 @@ public class BisqEasyMobileTradeNotificationService implements Service {
      * whether a given state will produce a push without depending on the full handler.
      */
     static boolean isWhitelistedState(BisqEasyTradeState state) {
+        // Own-action states (BUYER_SENT_FIAT_SENT_CONFIRMATION,
+        // SELLER_CONFIRMED_FIAT_RECEIPT, SELLER_SENT_BTC_SENT_CONFIRMATION,
+        // MAKER_SENT_TAKE_OFFER_RESPONSE__*) are deliberately absent — see the
+        // self-action suppression comment in handleStateChange.
         return switch (state) {
-            case BUYER_SENT_FIAT_SENT_CONFIRMATION,
-                 SELLER_RECEIVED_FIAT_SENT_CONFIRMATION,
+            case SELLER_RECEIVED_FIAT_SENT_CONFIRMATION,
                  BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION,
-                 SELLER_CONFIRMED_FIAT_RECEIPT,
-                 SELLER_SENT_BTC_SENT_CONFIRMATION,
                  BUYER_RECEIVED_BTC_SENT_CONFIRMATION,
                  TAKER_SENT_TAKE_OFFER_REQUEST,
-                 MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
-                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA,
+                 // Payment-info exchange (covers all 4 roles × Branch-1.x + final-converging).
+                 // See the matching case block in handleStateChange for rationale.
                  TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
                  TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS_,
-                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_ -> true;
+                 TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_,
+                 MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA -> true;
             default -> state.isFinalState();
         };
     }

--- a/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationServiceWhitelistTest.java
+++ b/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationServiceWhitelistTest.java
@@ -40,22 +40,40 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BisqEasyMobileTradeNotificationServiceWhitelistTest {
 
     /**
-     * Exactly mirrors {@code OpenTradesNotificationService.handleTradeStateNotification}
-     * on Android nodeApp. Any change here must be matched there and vice-versa.
+     * Mirrors the trade-state whitelist in
+     * {@link BisqEasyMobileTradeNotificationService#handleStateChange} (kept in sync
+     * with {@code OpenTradesNotificationService} on Android nodeApp).
+     * <p>
+     * Self-action states reached via a LOCAL event (BUYER_SENT_FIAT_SENT_CONFIRMATION,
+     * SELLER_CONFIRMED_FIAT_RECEIPT, SELLER_SENT_BTC_SENT_CONFIRMATION,
+     * MAKER_SENT_TAKE_OFFER_RESPONSE__*) are intentionally absent from the
+     * whitelist — pushing the user about an action they just took on the device
+     * is noise, and the counterparty already gets the push on their own machine
+     * via the symmetric "*_RECEIVED_*" state. See bisq-network/bisq-mobile#1464.
+     * <p>
+     * The payment-info-exchange block lists all 10 states across the 4 trade roles
+     * (buyer/seller × maker/taker) and 3 timing branches; the dedup keyed on
+     * {@code notifiedPaymentInfo} collapses them to a single push per trade.
      */
     private static final Set<BisqEasyTradeState> EXPECTED_NON_TERMINAL_WHITELIST = EnumSet.of(
-            BisqEasyTradeState.BUYER_SENT_FIAT_SENT_CONFIRMATION,
             BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION,
             BisqEasyTradeState.BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION,
-            BisqEasyTradeState.SELLER_CONFIRMED_FIAT_RECEIPT,
-            BisqEasyTradeState.SELLER_SENT_BTC_SENT_CONFIRMATION,
             BisqEasyTradeState.BUYER_RECEIVED_BTC_SENT_CONFIRMATION,
             BisqEasyTradeState.TAKER_SENT_TAKE_OFFER_REQUEST,
-            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
-            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA,
+            // Payment-info exchange — buyer-as-taker (Branch-1.2 + final converging)
             BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+            BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+            // Payment-info exchange — seller-as-maker (Branch-1.2 + final converging)
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+            // Payment-info exchange — seller-as-taker (Branch-1.1 + Branch-2 + final converging)
+            BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
             BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS_,
-            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_
+            BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+            // Payment-info exchange — buyer-as-maker (Branch-1.2 + Branch-2 + final converging)
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA,
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA_,
+            BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA
     );
 
     @Test
@@ -86,6 +104,106 @@ public class BisqEasyMobileTradeNotificationServiceWhitelistTest {
         // noise on the chat path. They MUST NOT also fire a push here.
         assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(BisqEasyTradeState.INIT),
                 "INIT is the protocol entry state, not a user-actionable event");
+    }
+
+    /**
+     * #1464 follow-up: states reached via a LOCAL event in the user's own FSM
+     * must NOT push — pushing the user about an action they just took on the
+     * device is noise. The counterparty still learns about each action on their
+     * own machine via the symmetric "*_RECEIVED_*" state, so this is purely
+     * about silencing self-notifications, not dropping signal.
+     * <p>
+     * Mirrors the foreground-gated behaviour of the nodeApp
+     * {@code OpenTradesNotificationService} — the relay path has no foreground
+     * signal, so we suppress at the source instead.
+     */
+    @Test
+    void selfActionStatesAreSuppressedFromMobile() {
+        assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.BUYER_SENT_FIAT_SENT_CONFIRMATION),
+                "BUYER_SENT_FIAT_SENT_CONFIRMATION is reached via the buyer's local BisqEasyConfirmFiatSentEvent — must not self-notify");
+        assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.SELLER_CONFIRMED_FIAT_RECEIPT),
+                "SELLER_CONFIRMED_FIAT_RECEIPT is the seller's local 'I received fiat' event — must not self-notify");
+        assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.SELLER_SENT_BTC_SENT_CONFIRMATION),
+                "SELLER_SENT_BTC_SENT_CONFIRMATION is the seller's local 'I sent BTC' event — must not self-notify");
+        assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_DID_NOT_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS),
+                "MAKER_SENT_TAKE_OFFER_RESPONSE__* is the maker's local response event — already pushed via TAKER_SENT_TAKE_OFFER_REQUEST");
+        assertFalse(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_DID_NOT_SENT_BTC_ADDRESS__BUYER_DID_NOT_RECEIVED_ACCOUNT_DATA),
+                "MAKER_SENT_TAKE_OFFER_RESPONSE__* is the maker's local response event — already pushed via TAKER_SENT_TAKE_OFFER_REQUEST");
+    }
+
+    /**
+     * Peer-action states (the "*_RECEIVED_*" twins of the self-suppressed states)
+     * remain whitelisted — those are the meaningful signals.
+     */
+    @Test
+    void peerActionStatesStillFireForCorrectRole() {
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION),
+                "Seller must still be notified when buyer sends fiat (peer action)");
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.BUYER_RECEIVED_SELLERS_FIAT_RECEIPT_CONFIRMATION),
+                "Buyer must still be notified when seller confirms receipt (peer action)");
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.BUYER_RECEIVED_BTC_SENT_CONFIRMATION),
+                "Buyer must still be notified when seller sends BTC (peer action)");
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.TAKER_SENT_TAKE_OFFER_REQUEST),
+                "Maker must still be notified when taker takes the offer (peer action; gated to maker in dispatch)");
+    }
+
+    /**
+     * Regression for bisq-network/bisq-mobile#1464 — buyer-as-taker sends BTC
+     * address first, then the seller sends account data while the app is
+     * backgrounded. Before the fix, the resulting state
+     * ({@code TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA},
+     * the "final converging" state of Branch 1.1) was NOT whitelisted, so the
+     * trade-state observer produced no mobile push and the buyer never learned
+     * payment info had arrived.
+     * <p>
+     * The same gap existed for the symmetric final-converging states of the
+     * other three roles (seller-as-maker, seller-as-taker, buyer-as-maker),
+     * plus the seller-as-maker / seller-as-taker / buyer-as-maker Branch-1.x
+     * intermediates that the original 3-state whitelist also missed.
+     */
+    @Test
+    void paymentInfoExchangeFiresForBuyerAsTakerWhoSentBtcAddressFirst() {
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                        BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA),
+                "buyer-as-taker who sent btc address first must still get a push when account data arrives (#1464)");
+    }
+
+    @Test
+    void paymentInfoExchangeFiresForAllFourFinalConvergingStates() {
+        // The "both halves done" state — reached when either party completes the
+        // exchange after the other side has already sent its half — must always
+        // trigger a push (deduped) regardless of role / ordering.
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA),
+                "buyer-as-taker final converging");
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS),
+                "seller-as-maker final converging");
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                BisqEasyTradeState.TAKER_RECEIVED_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS),
+                "seller-as-taker final converging");
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__BUYER_SENT_BTC_ADDRESS__BUYER_RECEIVED_ACCOUNT_DATA),
+                "buyer-as-maker final converging");
+    }
+
+    @Test
+    void sellerAsMakerSendingAccountDataFirstFiresPush() {
+        // Before #1464, seller-as-maker had NO state at all in the payment-info
+        // whitelist — neither Branch-1.2 nor final converging — so they never
+        // got a "payment info sent" push regardless of ordering. Pin both.
+        assertTrue(BisqEasyMobileTradeNotificationService.isWhitelistedState(
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS),
+                "seller-as-maker who sent account data before receiving btc address must still get a push (#1464)");
     }
 
     @Test

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -559,7 +559,16 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
     }
 
     private boolean isMobileEligible(ChatMessage chatMessage) {
-        return chatMessage == null || isMobileEligible(chatMessage.getChatMessageType());
+        if (chatMessage == null) {
+            // Fail-closed: an eligibility whitelist can't say "yes" without knowing
+            // what's being checked. In practice the caller (onMessageAdded → maybeDispatchNotification)
+            // always passes a non-null message, but if that contract is ever broken we'd rather
+            // skip the relay push than spam every registered device with a notification we
+            // can't classify.
+            return false;
+        }
+        return isMobileEligible(chatMessage.getChatMessageType())
+                && isMobileEligible(chatMessage.getChatChannelDomain());
     }
 
     /**
@@ -583,10 +592,56 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
      * Package-private static so it can be unit-tested without instantiating the full
      * {@link ChatNotificationService} (which has many constructor dependencies).
      */
-    static boolean isMobileEligible(bisq.chat.ChatMessageType type) {
+    static boolean isMobileEligible(ChatMessageType type) {
         return switch (type) {
             case TEXT, TAKE_BISQ_EASY_OFFER -> true;
             case PROTOCOL_LOG_MESSAGE, LEAVE, CHAT_RULES_WARNING, EXPIRED_MESSAGES_INDICATOR -> false;
+        };
+    }
+
+    /**
+     * Decides whether a chat message in the given channel domain should reach the
+     * mobile relay (FCM / APNs).
+     * <p>
+     * The mobile inbox is scoped to trade-relevant signals: a relayed-notifications
+     * opt-in means "tell me when something happens with my trades", not "stream the
+     * global Bisq community chat to my phone". The previous type-only filter
+     * (introduced in {@code bisq-network/bisq-mobile#1450}) suppressed protocol
+     * log noise but still pushed every TEXT message — including unrelated chatter
+     * in the global {@link ChatChannelDomain#DISCUSSION} / {@link
+     * ChatChannelDomain#SUPPORT} channels and any active
+     * {@link ChatChannelDomain#BISQ_EASY_OFFERBOOK} market — which surfaced as the
+     * "Bisq New Message" notifications continuing to arrive long after the user's
+     * trade had completed (reported in {@code bisq-network/bisq-mobile#1464}).
+     * <p>
+     * Only the user's private trade channels are eligible:
+     * <ul>
+     *   <li>{@link ChatChannelDomain#BISQ_EASY_OPEN_TRADES} — Bisq Easy trade chat
+     *       (1-on-1 with the peer, plus mediator when escalated).</li>
+     *   <li>{@link ChatChannelDomain#MU_SIG_OPEN_TRADES} — MuSig trade chat
+     *       (analogous to Bisq Easy). Currently not subscribed by
+     *       {@link #initialize()} but whitelisted here so the filter stays correct
+     *       if mobile relay is later wired up for MuSig.</li>
+     * </ul>
+     * <p>
+     * Public chat ({@link ChatChannelDomain#BISQ_EASY_OFFERBOOK},
+     * {@link ChatChannelDomain#DISCUSSION}, {@link ChatChannelDomain#SUPPORT}) is
+     * desktop-only — desktop users see those in the in-app chat view; mobile users
+     * who care about offerbook activity check the app.
+     * <p>
+     * Exhaustive switch by design: adding a new {@link ChatChannelDomain} value
+     * is a compile error here, forcing a deliberate push/no-push decision rather
+     * than silently inheriting the wrong default.
+     */
+    static boolean isMobileEligible(ChatChannelDomain domain) {
+        return switch (domain) {
+            case BISQ_EASY_OPEN_TRADES, MU_SIG_OPEN_TRADES -> true;
+            case BISQ_EASY_OFFERBOOK,
+                 DISCUSSION,
+                 SUPPORT,
+                 BISQ_EASY_PRIVATE_CHAT, // deprecated, falls back to DISCUSSION
+                 EVENTS                  // deprecated, falls back to DISCUSSION
+                    -> false;
         };
     }
 

--- a/chat/src/test/java/bisq/chat/notifications/ChatNotificationServiceMobileEligibilityTest.java
+++ b/chat/src/test/java/bisq/chat/notifications/ChatNotificationServiceMobileEligibilityTest.java
@@ -17,6 +17,7 @@
 
 package bisq.chat.notifications;
 
+import bisq.chat.ChatChannelDomain;
 import bisq.chat.ChatMessageType;
 import org.junit.jupiter.api.Test;
 
@@ -30,18 +31,35 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Pins the mobile-eligibility whitelist used by {@code ChatNotificationService} when
  * deciding whether to push a chat notification to the mobile relay (FCM / APNs).
  * <p>
- * Mirror of the proven Android nodeApp {@code OpenTradesNotificationService} behavior:
- * only {@code TEXT} and {@code TAKE_BISQ_EASY_OFFER} are surfaced as pushes; the
- * trade protocol log noise and other in-app indicators are desktop-only.
- * <p>
- * See bisq-network/bisq-mobile#1450.
+ * Two orthogonal axes are checked:
+ * <ol>
+ *   <li>{@link ChatMessageType} — only {@code TEXT} and {@code TAKE_BISQ_EASY_OFFER}
+ *       are pushable (the {@code PROTOCOL_LOG_MESSAGE} noise filter from
+ *       {@code bisq-network/bisq-mobile#1450}).</li>
+ *   <li>{@link ChatChannelDomain} — only the user's private trade channels
+ *       ({@code BISQ_EASY_OPEN_TRADES}, {@code MU_SIG_OPEN_TRADES}) push. Public
+ *       chat domains (offerbook, discussion, support) stay desktop-only, fixing
+ *       the "global community chat keeps notifying my phone after my trade
+ *       closed" bug reported in {@code bisq-network/bisq-mobile#1464}.</li>
+ * </ol>
+ * Both checks must pass for a message to reach the mobile relay.
  */
 public class ChatNotificationServiceMobileEligibilityTest {
 
-    private static final Set<ChatMessageType> EXPECTED_MOBILE_ELIGIBLE = EnumSet.of(
+    private static final Set<ChatMessageType> EXPECTED_MOBILE_ELIGIBLE_TYPES = EnumSet.of(
             ChatMessageType.TEXT,
             ChatMessageType.TAKE_BISQ_EASY_OFFER
     );
+
+    private static final Set<ChatChannelDomain> EXPECTED_MOBILE_ELIGIBLE_DOMAINS = EnumSet.of(
+            ChatChannelDomain.BISQ_EASY_OPEN_TRADES,
+            ChatChannelDomain.MU_SIG_OPEN_TRADES
+    );
+
+
+    /* --------------------------------------------------------------------- */
+    // ChatMessageType axis
+    /* --------------------------------------------------------------------- */
 
     @Test
     void textMessagesAreMobileEligible() {
@@ -72,23 +90,90 @@ public class ChatNotificationServiceMobileEligibilityTest {
     }
 
     /**
-     * Pins the FULL whitelist so that adding a new {@link ChatMessageType} forces a
-     * deliberate decision: should it be a mobile push or not? Without this test,
-     * a new enum value silently defaults to the {@code switch} compile error (good)
-     * but a careless author could pick the wrong branch. This test fails loudly if
-     * the whitelist changes and reminds the reviewer to update issue #1450 follow-ups.
+     * Pins the FULL message-type whitelist so adding a new {@link ChatMessageType}
+     * forces a deliberate decision: should it be a mobile push or not? Without
+     * this test, a new enum value would silently inherit whichever branch a
+     * careless author picked. Fails loudly so the reviewer remembers to revisit
+     * the #1450 / #1464 follow-ups.
      */
     @Test
-    void mobileEligibleWhitelistIsExactlyTextAndOfferTaken() {
+    void mobileEligibleTypeWhitelistIsExactlyTextAndOfferTaken() {
         for (ChatMessageType type : ChatMessageType.values()) {
             boolean actual = ChatNotificationService.isMobileEligible(type);
-            boolean expected = EXPECTED_MOBILE_ELIGIBLE.contains(type);
+            boolean expected = EXPECTED_MOBILE_ELIGIBLE_TYPES.contains(type);
             if (actual != expected) {
                 throw new AssertionError(
-                        "Mobile-eligibility whitelist changed for " + type +
+                        "Mobile-eligibility (type) whitelist changed for " + type +
                                 " (expected=" + expected + ", actual=" + actual + "). " +
-                                "If this is intentional, update EXPECTED_MOBILE_ELIGIBLE in this test " +
-                                "and note the change in the #1450 follow-up.");
+                                "If this is intentional, update EXPECTED_MOBILE_ELIGIBLE_TYPES in this test " +
+                                "and note the change in the #1450 / #1464 follow-up.");
+            }
+        }
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // ChatChannelDomain axis (#1464)
+    /* --------------------------------------------------------------------- */
+
+    @Test
+    void bisqEasyOpenTradeChannelsAreMobileEligible() {
+        assertTrue(ChatNotificationService.isMobileEligible(ChatChannelDomain.BISQ_EASY_OPEN_TRADES),
+                "Bisq Easy private trade chat is the user's main signal — must reach mobile push");
+    }
+
+    @Test
+    void muSigOpenTradeChannelsAreMobileEligible() {
+        assertTrue(ChatNotificationService.isMobileEligible(ChatChannelDomain.MU_SIG_OPEN_TRADES),
+                "MuSig private trade chat must reach mobile push — kept in the allowlist for when the mobile relay is wired up for MuSig");
+    }
+
+    @Test
+    void publicOfferbookChannelsAreSuppressedFromMobile() {
+        assertFalse(ChatNotificationService.isMobileEligible(ChatChannelDomain.BISQ_EASY_OFFERBOOK),
+                "Bisq Easy offerbook chat is global per-market chatter, not a user-facing trade signal — desktop only");
+    }
+
+    @Test
+    void globalDiscussionChannelsAreSuppressedFromMobile() {
+        assertFalse(ChatNotificationService.isMobileEligible(ChatChannelDomain.DISCUSSION),
+                "DISCUSSION is the global Bisq community chat — exactly the source of the post-trade #1464 noise; desktop only");
+    }
+
+    @Test
+    void supportChannelsAreSuppressedFromMobile() {
+        assertFalse(ChatNotificationService.isMobileEligible(ChatChannelDomain.SUPPORT),
+                "SUPPORT is the public Bisq support channel — not the user's trade context; desktop only");
+    }
+
+    @Test
+    void deprecatedDomainsAreSuppressedFromMobile() {
+        //noinspection deprecation
+        assertFalse(ChatNotificationService.isMobileEligible(ChatChannelDomain.BISQ_EASY_PRIVATE_CHAT),
+                "BISQ_EASY_PRIVATE_CHAT is deprecated (migrates to DISCUSSION) — never push");
+        //noinspection deprecation
+        assertFalse(ChatNotificationService.isMobileEligible(ChatChannelDomain.EVENTS),
+                "EVENTS is deprecated (migrates to DISCUSSION) — never push");
+    }
+
+    /**
+     * Same loud-failure pin as the type axis: a new {@link ChatChannelDomain}
+     * must be classified explicitly. The exhaustive switch in
+     * {@code ChatNotificationService} already gives a compile error, but this
+     * test catches the silent case where a developer adds the new case but
+     * forgets to update the mobile-push policy.
+     */
+    @Test
+    void mobileEligibleDomainWhitelistIsExactlyTradeChannels() {
+        for (ChatChannelDomain domain : ChatChannelDomain.values()) {
+            boolean actual = ChatNotificationService.isMobileEligible(domain);
+            boolean expected = EXPECTED_MOBILE_ELIGIBLE_DOMAINS.contains(domain);
+            if (actual != expected) {
+                throw new AssertionError(
+                        "Mobile-eligibility (domain) whitelist changed for " + domain +
+                                " (expected=" + expected + ", actual=" + actual + "). " +
+                                "If this is intentional, update EXPECTED_MOBILE_ELIGIBLE_DOMAINS in this test " +
+                                "and note the change in the #1464 follow-up.");
             }
         }
     }


### PR DESCRIPTION
 - fixes https://github.com/bisq-network/bisq-mobile/issues/1464
 - implemented fix by improving notification filtering + docs + tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mobile push eligibility now requires both message type and channel domain; unknown/null values are blocked and only specific trade-related channels are allowed while public/deprecated discussion domains are suppressed.
  * Trade push behavior: suppresses local/self-action notifications, preserves peer/received notifications, and refines payment-info exchange handling to avoid duplicate or misleading pushes.

* **Tests**
  * Added exhaustive tests asserting exact allowlists for message types and channel domains and pinned trade-state whitelist behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->