### PR TITLE
Fix navigate-to-private-chat landing in the public channel

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/Navigation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/Navigation.java
@@ -61,23 +61,26 @@ public class Navigation {
 
     public static void navigateTo(NavigationTarget navigationTarget) {
         history.add(navigationTarget);
-        navigationControllers.forEach((key, value) -> {
-            if (navigationTarget.getPath().contains(key)) {
-                value.forEach(l -> l.processNavigationTarget(navigationTarget, Optional.empty()));
-            }
-        });
+        dispatch(navigationTarget, Optional.empty());
         currentNavigationTarget.set(navigationTarget);
     }
 
-    // If data is passed we don't add it to the history as we would need to store the data as well, and it could be 
-    // stale anyway at a later moment.  
+    // If data is passed we don't add it to the history as we would need to store the data as well, and it could be
+    // stale anyway at a later moment.
     public static void navigateTo(NavigationTarget navigationTarget, Object data) {
-        navigationControllers.forEach((key, value) -> {
-            if (navigationTarget.getPath().contains(key)) {
-                value.forEach(l -> l.processNavigationTarget(navigationTarget, Optional.of(data)));
-            }
-        });
+        dispatch(navigationTarget, Optional.of(data));
         currentNavigationTarget.set(navigationTarget);
+    }
+
+    // Dispatches the target to each registered host along its navigation path, from the root down to
+    // the target. Iterating the path in order (rather than the unordered controllers map) processes
+    // parents before children, so a host that lazily creates a child host on its path registers that
+    // child before the dispatch reaches it. See #4114.
+    private static void dispatch(NavigationTarget navigationTarget, Optional<Object> data) {
+        navigationTarget.getPath().forEach(host ->
+                Optional.ofNullable(navigationControllers.get(host))
+                        .ifPresent(controllers -> controllers.forEach(controller ->
+                                controller.processNavigationTarget(navigationTarget, data))));
     }
 
     static void persistNavigationTarget(NavigationTarget navigationTarget) {
@@ -92,11 +95,7 @@ public class Navigation {
         }
         NavigationTarget navigationTarget = history.pollLast();
         alt.add(navigationTarget);
-        navigationControllers.forEach((key, value) -> {
-            if (navigationTarget.getPath().contains(key)) {
-                value.forEach(l -> l.processNavigationTarget(navigationTarget, Optional.empty()));
-            }
-        });
+        dispatch(navigationTarget, Optional.empty());
     }
 
     public static void forth() {
@@ -105,10 +104,6 @@ public class Navigation {
         }
         NavigationTarget navigationTarget = alt.pollLast();
         history.add(navigationTarget);
-        navigationControllers.forEach((key, value) -> {
-            if (navigationTarget.getPath().contains(key)) {
-                value.forEach(l -> l.processNavigationTarget(navigationTarget, Optional.empty()));
-            }
-        });
+        dispatch(navigationTarget, Optional.empty());
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/NavigationController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/NavigationController.java
@@ -19,6 +19,7 @@ package bisq.desktop.common.view;
 
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.desktop.common.threading.UIThread;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
@@ -32,6 +33,19 @@ public abstract class NavigationController implements Controller {
 
     public NavigationController(NavigationTarget host) {
         this.host = host;
+    }
+
+    // Returns the segment of `target`'s path that sits directly under `host`,
+    // or empty if `host` is not a proper ancestor of `target`.
+    @VisibleForTesting
+    static Optional<NavigationTarget> resolveChildTarget(NavigationTarget target, NavigationTarget host) {
+        Optional<NavigationTarget> parent = target.getParent();
+        NavigationTarget child = target;
+        while (parent.isPresent() && parent.get() != host) {
+            child = parent.get();
+            parent = child.getParent();
+        }
+        return parent.isPresent() ? Optional.of(child) : Optional.empty();
     }
 
     void processNavigationTarget(NavigationTarget navigationTarget, Optional<Object> data) {
@@ -97,27 +111,27 @@ public abstract class NavigationController implements Controller {
     public void onActivateInternal() {
         Navigation.addNavigationController(host, this);
 
-        // Apply child target for our host from the persisted NavigationTarget
+        // Pick our child target: keep a retained one, else resolve it from the persisted target, else
+        // fall back to the default child.
         NavigationModel model = getModel();
         if (model.getNavigationTarget() == null) {
-            Navigation.getPersistedNavigationTarget().ifPresent(persisted -> {
-                Optional<NavigationTarget> hostCandidate = persisted.getParent();
-                NavigationTarget childCandidate = persisted;
-                while (hostCandidate.isPresent() && hostCandidate.get() != host) {
-                    childCandidate = hostCandidate.get();
-                    hostCandidate = childCandidate.getParent();
-                }
-                NavigationTarget finalChildCandidate = childCandidate;
-                hostCandidate.ifPresent(e -> model.setNavigationTarget(finalChildCandidate));
-            });
-        }
-        // If we did not have a persisted target we apply the default
-        if (model.getNavigationTarget() == null) {
-            model.setNavigationTarget(model.getDefaultNavigationTarget());
+            NavigationTarget childTarget = Navigation.getPersistedNavigationTarget()
+                    .flatMap(persisted -> resolveChildTarget(persisted, host))
+                    .orElseGet(model::getDefaultNavigationTarget);
+            model.setNavigationTarget(childTarget);
         }
 
         if (model.getNavigationTarget() != NavigationTarget.NONE) {
-            UIThread.runOnNextRenderFrame(() -> processNavigationTarget(model.getNavigationTarget(), Optional.empty()));
+            NavigationTarget childTarget = model.getNavigationTarget();
+            // A navigateTo dispatch processes hosts in navigation-path order, so a dispatch targeting a
+            // deeper target (e.g. CHAT_PRIVATE) resolves it on this host directly. Only fall back to our
+            // own child here if that dispatch did not already resolve a target, so we don't override a
+            // deep target with our default/persisted child. See #4114.
+            UIThread.runOnNextRenderFrame(() -> {
+                if (getModel().getResolvedTarget().isEmpty()) {
+                    processNavigationTarget(childTarget, Optional.empty());
+                }
+            });
         }
 
         onActivate();

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/common/view/NavigationControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/common/view/NavigationControllerTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.common.view;
+
+import bisq.desktop.navigation.NavigationTarget;
+import javafx.scene.Parent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the navigation dispatch and child-target resolution behind #4114, where navigating to the
+ * private chat (CHAT_PRIVATE) landed in the public channel. Root cause: dispatch iterated the
+ * unordered controllers map, so the lazily-created CHAT host could register after the dispatch had
+ * already passed it and never received the target. Dispatch now follows the navigation path
+ * (parents before children) so a host created by its parent mid-dispatch is reached afterwards.
+ */
+class NavigationControllerTest {
+
+    // --- dispatch ordering: a host registered by its parent mid-dispatch must still be reached ---
+
+    @Test
+    void dispatchReachesHostRegisteredLazilyByItsParentDuringDispatch() {
+        List<NavigationTarget> processOrder = new ArrayList<>();
+        RecordingController content = new RecordingController(NavigationTarget.CONTENT, processOrder);
+        RecordingController chat = new RecordingController(NavigationTarget.CHAT, processOrder);
+        // CONTENT lazily creates and registers the CHAT host while being processed, mirroring
+        // ContentController creating the Chat controller on demand (#4114).
+        content.onProcess = () -> Navigation.addNavigationController(NavigationTarget.CHAT, chat);
+
+        Navigation.addNavigationController(NavigationTarget.CONTENT, content);
+        try {
+            Navigation.navigateTo(NavigationTarget.CHAT_PRIVATE);
+
+            // CHAT registered only after CONTENT ran, yet path-order dispatch still delivered the
+            // target to it, and parents were processed before children.
+            assertEquals(List.of(NavigationTarget.CHAT_PRIVATE), chat.received);
+            assertEquals(List.of(NavigationTarget.CONTENT, NavigationTarget.CHAT), processOrder);
+        } finally {
+            Navigation.removeNavigationController(NavigationTarget.CONTENT, content);
+            Navigation.removeNavigationController(NavigationTarget.CHAT, chat);
+        }
+    }
+
+    // --- resolveChildTarget: which segment of a target's path sits directly under a host ---
+
+    @Test
+    void resolveChildTarget_directLeafUnderHost() {
+        assertEquals(Optional.of(NavigationTarget.CHAT_PRIVATE),
+                NavigationController.resolveChildTarget(NavigationTarget.CHAT_PRIVATE, NavigationTarget.CHAT));
+    }
+
+    @Test
+    void resolveChildTarget_intermediateSegmentUnderHost() {
+        // Under CONTENT, the segment of CHAT_PRIVATE's path is CHAT.
+        assertEquals(Optional.of(NavigationTarget.CHAT),
+                NavigationController.resolveChildTarget(NavigationTarget.CHAT_PRIVATE, NavigationTarget.CONTENT));
+    }
+
+    @Test
+    void resolveChildTarget_publicLeafUnderHost() {
+        assertEquals(Optional.of(NavigationTarget.CHAT_DISCUSSION),
+                NavigationController.resolveChildTarget(NavigationTarget.CHAT_DISCUSSION, NavigationTarget.CHAT));
+    }
+
+    @Test
+    void resolveChildTarget_hostNotOnPath_empty() {
+        assertEquals(Optional.empty(),
+                NavigationController.resolveChildTarget(NavigationTarget.CHAT_PRIVATE, NavigationTarget.DASHBOARD));
+    }
+
+    @Test
+    void resolveChildTarget_targetEqualsHost_empty() {
+        assertEquals(Optional.empty(),
+                NavigationController.resolveChildTarget(NavigationTarget.CHAT, NavigationTarget.CHAT));
+    }
+
+    /**
+     * Records the targets it receives and the order in which hosts are processed, and optionally runs
+     * a hook to simulate a parent lazily registering a child host mid-dispatch. processNavigationTarget
+     * is overridden to bypass the real model/view wiring, keeping the test free of JavaFX.
+     */
+    private static class RecordingController extends NavigationController {
+        private final List<NavigationTarget> received = new ArrayList<>();
+        private final List<NavigationTarget> processOrder;
+        private Runnable onProcess;
+
+        private RecordingController(NavigationTarget host, List<NavigationTarget> processOrder) {
+            super(host);
+            this.processOrder = processOrder;
+        }
+
+        @Override
+        void processNavigationTarget(NavigationTarget navigationTarget, Optional<Object> data) {
+            received.add(navigationTarget);
+            processOrder.add(host);
+            if (onProcess != null) {
+                onProcess.run();
+            }
+        }
+
+        @Override
+        protected Optional<? extends Controller> createController(NavigationTarget navigationTarget) {
+            return Optional.empty();
+        }
+
+        @Override
+        protected NavigationModel getModel() {
+            return null;
+        }
+
+        @Override
+        public View<? extends Parent, ? extends Model, ? extends Controller> getView() {
+            return null;
+        }
+
+        @Override
+        public void onActivate() {
+        }
+
+        @Override
+        public void onDeactivate() {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4114.

## Problem

Navigating to a private chat from outside the Chat screen would sometimes land the user in the public Discussion channel instead. The dispatch in `Navigation` iterated `navigationControllers` (a `ConcurrentHashMap` keyed on the `NavigationTarget` enum), whose order is unrelated to the navigation hierarchy. The Chat tab host is created lazily by its parent *during* the `navigateTo(CHAT_PRIVATE)` dispatch and registers itself only then; if the dispatch had already passed the Chat host's slot, the host never received `CHAT_PRIVATE` and fell back to its default tab (`CHAT_DISCUSSION`, public). It's intermittent because enum `hashCode` is identity-based and varies per JVM launch, so iteration order — and whether the loop revisits the just-registered host — changes per run.

## Fix

Dispatch the target along its navigation path instead of over the unordered map (thanks @KimStrand for the suggestion):

- `Navigation.dispatch` now iterates `navigationTarget.getPath()` (root → leaf), so parents are processed before children. When a parent lazily creates and registers a child host on the path, the dispatch reaches that child afterwards and delivers the target to it — independent of map iteration order. `navigateTo` / `navigateTo(data)` / `back` / `forth` all route through this helper.
- `NavigationController.onActivateInternal` resolves the host's child target from the persisted target (or its default) and skips its deferred fallback when an in-flight dispatch has already resolved a target, so a deep target like `CHAT_PRIVATE` isn't overwritten by the host's default child.

`TabController` is unchanged.

## Testing

- `NavigationControllerTest` adds `dispatchReachesHostRegisteredLazilyByItsParentDuringDispatch`, which simulates a parent registering a child host mid-dispatch and asserts the child still receives the deep target with parents processed before children — reproducing the original ordering problem. It fails on the old map-iteration dispatch and passes on the path-order fix. The existing `resolveChildTarget` path-segment tests are kept.
- Verified end-to-end against the cold-host reproduction from #4114 (Chat screen not opened this session), with navigation tracing, for both a first-time Chat host and a reused/cached one: the path-order dispatch delivers `CHAT_PRIVATE` to the Chat host deterministically and opens the private chat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized navigation dispatch logic to unify routing and avoid duplicated iteration during forward/back navigation.
  * Improved target resolution so initial and restored views resolve more reliably within nested navigation.

* **Tests**
  * Added regression and unit tests covering navigation dispatch reachability and child-target resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->