### PR TITLE
Clear chat input when switching channels

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -269,9 +269,18 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
 
     protected void selectedChannelChanged(ChatChannel<? extends ChatMessage> chatChannel) {
         UIThread.run(() -> {
+            ChatChannel<? extends ChatMessage> previousChannel = model.getSelectedChannel().get();
+            if (previousChannel != null && !previousChannel.equals(chatChannel)) {
+                clearChatInput();
+            }
             model.getSelectedChannel().set(chatChannel);
             applyUserProfileOrChannelChange();
         });
+    }
+
+    private void clearChatInput() {
+        model.getTextInput().set("");
+        citationBlock.close();
     }
 
     private void doSendMessage(String text) {


### PR DESCRIPTION
Fixes #4808

When text was typed into the chat input but not sent, then the user switched to another channel, the draft stayed in the shared input. Because the send path resolves the target channel at send time, that draft — and any pending reply citation — could then be sent to the **wrong** channel.

## Change
`ChatMessageContainerController.selectedChannelChanged()` now clears the unsent draft (input text **and** any pending citation) when the selected channel actually changes (`!previousChannel.equals(chatChannel)`). The guard means re-selecting the same channel (e.g. on tab re-activation) does **not** wipe an in-progress draft.

The input is a single shared component (`ChatMessageContainerController`, no subclasses) used by every chat area — public, private, trade, mediation, arbitration — so this one change covers all of them. The older #2071 only cleared the input after a successful send, never on a channel switch.

## Testing
Verified manually with two local clients (one on `main`, one with the fix):
- Type a draft in channel A → switch to B: `main` keeps the text (sendable to B); fixed clears it.
- Re-select the **same** channel: draft preserved (guard works).
- Reply-quote a message in A → switch to B: citation also cleared.

No unit test added: this is `UIThread`/service-bound controller logic and the desktop module has no controller test harness (UI logic is verified manually here). Happy to extract the clear-draft decision into a testable unit if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unsent chat messages and draft content are now automatically cleared when switching between channels, providing a clean input slate. Any open citation/quote blocks are closed on channel change. After switching, channel visibility and user/profile state are correctly reapplied so the displayed conversation context matches the newly selected channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->