### PR TITLE
Route webcam helper stderr to rolling log

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLauncher.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLauncher.java
@@ -18,7 +18,6 @@
 package bisq.desktop.webcam;
 
 import bisq.common.file.FileMutatorUtils;
-import bisq.common.file.FileReaderUtils;
 import bisq.common.locale.LanguageRepository;
 import bisq.common.platform.OS;
 import bisq.common.threading.ExecutorFactory;
@@ -26,12 +25,12 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +41,7 @@ import static bisq.common.threading.ExecutorFactory.commonForkJoinPool;
 public class WebcamProcessLauncher {
     private final Path webcamDirPath;
     private final WebcamJarProvider webcamJarProvider;
-    private Optional<Process> runningProcess = Optional.empty();
+    private Optional<LauncherState> launcherState = Optional.empty();
 
     public WebcamProcessLauncher(Path appDataDirPath) {
         this.webcamDirPath = appDataDirPath.resolve("webcam");
@@ -50,12 +49,19 @@ public class WebcamProcessLauncher {
     }
 
     public CompletableFuture<Process> start(String sessionSecret) {
-        ExecutorService launchExecutor = ExecutorFactory.newSingleThreadExecutor("WebcamProcessLauncher");
+        LauncherState startingState = setStartingState();
+        ExecutorService launchExecutor;
+        try {
+            launchExecutor = ExecutorFactory.newSingleThreadExecutor("WebcamProcessLauncher");
+        } catch (RuntimeException e) {
+            getAndClearLauncherStateIfCurrent(startingState);
+            throw e;
+        }
+
         return CompletableFuture.supplyAsync(() -> {
             try {
+                ensureCurrentLauncherState(startingState);
                 Path jarFilePath = webcamJarProvider.prepareWebcamJar();
-
-                String logFileParam = "--logFile=" + URLEncoder.encode(webcamDirPath.toAbsolutePath().toString(), StandardCharsets.UTF_8) + FileReaderUtils.FILE_SEP + "webcam-app";
                 String languageTagParam = "--languageTag=" + LanguageRepository.getDefaultLanguageTag();
 
                 String pathToJavaExe = System.getProperty("java.home") + "/bin/java";
@@ -67,22 +73,52 @@ public class WebcamProcessLauncher {
                         FileMutatorUtils.resourceToFile("images/webcam/webcam-app-icon@2x.png", bisqIconPath);
                     }
                     String jvmArgs = "-Xdock:icon=" + iconPath;
-                    processBuilder = new ProcessBuilder(pathToJavaExe, jvmArgs, "-jar", jarFilePath.toAbsolutePath().toString(), logFileParam, languageTagParam);
+                    processBuilder = new ProcessBuilder(pathToJavaExe, jvmArgs, "-jar", jarFilePath.toAbsolutePath().toString(), languageTagParam);
                 } else {
-                    processBuilder = new ProcessBuilder(pathToJavaExe, "-jar", jarFilePath.toAbsolutePath().toString(), logFileParam, languageTagParam);
+                    processBuilder = new ProcessBuilder(pathToJavaExe, "-jar", jarFilePath.toAbsolutePath().toString(), languageTagParam);
                 }
-                processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+                // Stdout is reserved for framed webcam IPC. Stderr is reserved for child process logs.
+                processBuilder.redirectOutput(ProcessBuilder.Redirect.PIPE);
+                processBuilder.redirectError(ProcessBuilder.Redirect.PIPE);
+
+                ensureCurrentLauncherState(startingState);
                 log.info("Launching webcam app process");
                 Process process = processBuilder.start();
-                sendSessionSecret(process, sessionSecret);
-                setRunningProcess(process);
+                Optional<WebcamProcessLogReader> logReader = Optional.empty();
+                Optional<LauncherState> runningState = Optional.empty();
+                try {
+                    logReader = Optional.of(WebcamProcessLogReader.start(process.getErrorStream(), webcamDirPath.resolve("webcam-app")));
+                    runningState = setRunningState(startingState, process, logReader.get());
+                    if (runningState.isEmpty()) {
+                        throw new CancellationException("Webcam app process launch was cancelled");
+                    }
+                    sendSessionSecret(process, sessionSecret);
+                    ensureCurrentLauncherState(runningState.get());
+                } catch (Exception e) {
+                    clearFailedStartupState(process, logReader, runningState);
+                    throw e;
+                }
                 log.info("Webcam app process successfully launched");
                 return process;
+            } catch (CancellationException e) {
+                log.info("Webcam app process launch cancelled");
+                throw e;
             } catch (Exception e) {
+                getAndClearLauncherStateIfCurrent(startingState);
                 log.error("Launching process failed", e);
                 throw new RuntimeException(e);
             }
         }, launchExecutor).whenComplete((process, throwable) -> launchExecutor.shutdown());
+    }
+
+    private void destroyFailedStartupProcess(Process process) {
+        process.destroyForcibly();
+        try {
+            process.waitFor(2, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.warn("Thread got interrupted while waiting after failed startup shutdown", e);
+            Thread.currentThread().interrupt();
+        }
     }
 
     private void sendSessionSecret(Process process, String sessionSecret) {
@@ -92,46 +128,104 @@ public class WebcamProcessLauncher {
             writer.newLine();
             writer.flush();
         } catch (Exception e) {
-            process.destroyForcibly();
             throw new RuntimeException("Sending webcam IPC session secret failed", e);
         }
     }
 
     public CompletableFuture<Boolean> shutdown() {
-        Optional<Process> processToShutdown = getAndClearRunningProcess();
-        return CompletableFuture.supplyAsync(() -> processToShutdown.map(process -> {
+        Optional<LauncherState> launcherState = getAndClearLauncherState();
+        return CompletableFuture.supplyAsync(() -> launcherState.map(state -> state.process().map(process -> {
             log.info("Shutting down webcam app process");
-            process.destroy();
-            boolean terminatedGracefully = false;
             try {
-                terminatedGracefully = process.waitFor(2, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                log.warn("Thread got interrupted at shutdown", e);
-                Thread.currentThread().interrupt(); // Restore interrupted state
-            }
-
-            if (process.isAlive()) {
-                log.warn("Stopping webcam app process gracefully did not terminate it. We destroy it forcibly.");
-                process.destroyForcibly();
+                process.destroy();
+                boolean terminatedGracefully = false;
                 try {
-                    process.waitFor(2, TimeUnit.SECONDS);
+                    terminatedGracefully = process.waitFor(2, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
-                    log.warn("Thread got interrupted while waiting after forced shutdown", e);
-                    Thread.currentThread().interrupt();
+                    log.warn("Thread got interrupted at shutdown", e);
+                    Thread.currentThread().interrupt(); // Restore interrupted state
                 }
-                terminatedGracefully = false;
+
+                if (process.isAlive()) {
+                    log.warn("Stopping webcam app process gracefully did not terminate it. We destroy it forcibly.");
+                    process.destroyForcibly();
+                    try {
+                        process.waitFor(2, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        log.warn("Thread got interrupted while waiting after forced shutdown", e);
+                        Thread.currentThread().interrupt();
+                    }
+                    terminatedGracefully = false;
+                }
+                return terminatedGracefully;
+            } finally {
+                state.logReader().ifPresent(WebcamProcessLogReader::shutdown);
             }
-            return terminatedGracefully;
-        }).orElse(true), commonForkJoinPool());
+        }).orElse(true)).orElse(true), commonForkJoinPool());
     }
 
-    private synchronized void setRunningProcess(Process process) {
-        runningProcess = Optional.of(process);
+    private synchronized LauncherState setStartingState() {
+        if (launcherState.isPresent()) {
+            throw new IllegalStateException("Webcam app process launch already active");
+        }
+        LauncherState state = LauncherState.starting();
+        launcherState = Optional.of(state);
+        return state;
     }
 
-    private synchronized Optional<Process> getAndClearRunningProcess() {
-        Optional<Process> process = runningProcess;
-        runningProcess = Optional.empty();
-        return process;
+    private synchronized Optional<LauncherState> setRunningState(LauncherState startingState, Process process, WebcamProcessLogReader logReader) {
+        if (launcherState.filter(state -> state == startingState).isEmpty()) {
+            return Optional.empty();
+        }
+        LauncherState state = startingState.running(process, logReader);
+        launcherState = Optional.of(state);
+        return Optional.of(state);
+    }
+
+    private synchronized boolean isCurrentLauncherState(LauncherState expectedState) {
+        return launcherState.filter(state -> state == expectedState).isPresent();
+    }
+
+    private void ensureCurrentLauncherState(LauncherState expectedState) {
+        if (!isCurrentLauncherState(expectedState)) {
+            throw new CancellationException("Webcam app process launch was cancelled");
+        }
+    }
+
+    private void clearFailedStartupState(Process process, Optional<WebcamProcessLogReader> logReader, Optional<LauncherState> runningState) {
+        if (runningState.isPresent()) {
+            getAndClearLauncherStateIfCurrent(runningState.get()).ifPresent(state -> {
+                destroyFailedStartupProcess(process);
+                state.logReader().ifPresent(WebcamProcessLogReader::shutdown);
+            });
+        } else {
+            destroyFailedStartupProcess(process);
+            logReader.ifPresent(WebcamProcessLogReader::shutdown);
+        }
+    }
+
+    private synchronized Optional<LauncherState> getAndClearLauncherState() {
+        Optional<LauncherState> currentState = launcherState;
+        launcherState = Optional.empty();
+        return currentState;
+    }
+
+    private synchronized Optional<LauncherState> getAndClearLauncherStateIfCurrent(LauncherState expectedState) {
+        Optional<LauncherState> currentState = launcherState;
+        if (currentState.filter(state -> state == expectedState).isEmpty()) {
+            return Optional.empty();
+        }
+        launcherState = Optional.empty();
+        return currentState;
+    }
+
+    private record LauncherState(Optional<Process> process, Optional<WebcamProcessLogReader> logReader) {
+        static LauncherState starting() {
+            return new LauncherState(Optional.empty(), Optional.empty());
+        }
+
+        LauncherState running(Process process, WebcamProcessLogReader logReader) {
+            return new LauncherState(Optional.of(process), Optional.of(logReader));
+        }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLogReader.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/webcam/WebcamProcessLogReader.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.webcam;
+
+import bisq.common.logging.LogSetup;
+import bisq.common.threading.ExecutorFactory;
+import bisq.common.util.StringUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+
+@Slf4j
+class WebcamProcessLogReader {
+    private static final String WEBCAM_PROCESS_LOGGER_NAME = "bisq.desktop.webcam.WebcamProcess";
+
+    private final InputStream inputStream;
+    private final ExecutorService executorService;
+    private final Logger webcamProcessLogger;
+
+    private volatile boolean isStopped;
+
+    private WebcamProcessLogReader(InputStream inputStream, Path logFilePath) throws IOException {
+        this.inputStream = inputStream;
+        this.executorService = ExecutorFactory.newSingleThreadExecutor("WebcamProcessLogReader");
+        Files.createDirectories(logFilePath.getParent());
+        webcamProcessLogger = LogSetup.setupRawRollingLogger(WEBCAM_PROCESS_LOGGER_NAME, logFilePath.toAbsolutePath().toString());
+    }
+
+    static WebcamProcessLogReader start(InputStream inputStream, Path logFilePath) throws IOException {
+        WebcamProcessLogReader reader = new WebcamProcessLogReader(inputStream, logFilePath);
+        reader.start();
+        return reader;
+    }
+
+    void shutdown() {
+        isStopped = true;
+        try {
+            inputStream.close();
+        } catch (IOException ignore) {
+        }
+        executorService.shutdownNow();
+    }
+
+    private void start() {
+        executorService.submit(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+                String line;
+                while (!isStopped && (line = reader.readLine()) != null) {
+                    webcamProcessLogger.info(StringUtils.maskHomeDirectory(line));
+                }
+            } catch (IOException e) {
+                if (!isStopped) {
+                    log.warn("Reading webcam app stderr failed", e);
+                }
+            } finally {
+                executorService.shutdown();
+            }
+        });
+    }
+}

--- a/apps/desktop/webcam-app/README.md
+++ b/apps/desktop/webcam-app/README.md
@@ -15,6 +15,6 @@ To include the resources in the desktop application it requires to run the gradl
 webcam project (subproject of desktop).
 This task creates a shadow jar, makes a zip and copies the zip to the build directory in the `desktop:desktop` project.
 The target directory is `apps/desktop/desktop/build/generated/src/main/resources/webcam-app`.
-It also copies teh `version.txt` file from the `desktop:webcam` projects root directory to the same resource directory.
+It also copies the `version.txt` file from the `desktop:webcam` projects root directory to the same resource directory.
 
 `

--- a/apps/desktop/webcam-app/src/main/java/bisq/webcam/WebcamApp.java
+++ b/apps/desktop/webcam-app/src/main/java/bisq/webcam/WebcamApp.java
@@ -18,10 +18,8 @@
 package bisq.webcam;
 
 
-import bisq.common.file.FileReaderUtils;
 import bisq.common.logging.LogSetup;
 import bisq.common.platform.OS;
-import bisq.common.platform.PlatformUtils;
 import bisq.common.webcam.WebcamControlSignals;
 import bisq.common.webcam.WebcamIpcWireMessage;
 import bisq.i18n.Res;
@@ -84,12 +82,7 @@ public class WebcamApp extends Application {
     public void init() {
         Parameters parameters = getParameters();
         try {
-            String logFile = PlatformUtils.getUserDataDirPath().resolve("Bisq-webcam-app").toAbsolutePath() + FileReaderUtils.FILE_SEP + "webcam-app";
-            String logFileParam = parameters.getNamed().get("logFile");
-            if (logFileParam != null) {
-                logFile = URLDecoder.decode(logFileParam, StandardCharsets.UTF_8);
-            }
-            LogSetup.setupWithoutConsoleAppender(logFile);
+            LogSetup.setupStderrAppenderOnly();
             log.info("Webcam app logging initialized");
 
             String languageTag = "en";

--- a/common/src/main/java/bisq/common/logging/LogSetup.java
+++ b/common/src/main/java/bisq/common/logging/LogSetup.java
@@ -22,6 +22,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class LogSetup {
     private static final String CONSOLE_APPENDER_NAME = "CONSOLE_APPENDER";
+    private static final String STDERR_APPENDER_NAME = "STDERR_APPENDER";
     private static Logger logbackLogger;
     public static final Level DEFAULT_LOG_LEVEL = Level.INFO;
 
@@ -42,17 +44,77 @@ public class LogSetup {
         setup(fileName, 20, "10MB", DEFAULT_LOG_LEVEL);
     }
 
-    public static void setupWithoutConsoleAppender(String fileName) {
-        setup(fileName);
-        detachConsoleAppender();
+    public static void setupStderrAppenderOnly() {
+        if (!(LoggerFactory.getILoggerFactory() instanceof LoggerContext)) {
+            LoggerFactory.getLogger(LogSetup.class).warn("Cannot configure stderr-only logging because logger factory is {}",
+                    LoggerFactory.getILoggerFactory().getClass().getName());
+            return;
+        }
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Logger rootLogger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        rootLogger.detachAppender(CONSOLE_APPENDER_NAME);
+        rootLogger.detachAppender(STDERR_APPENDER_NAME);
+
+        ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<>();
+        appender.setContext(loggerContext);
+        appender.setName(STDERR_APPENDER_NAME);
+        appender.setTarget("System.err");
+
+        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+        encoder.setContext(loggerContext);
+        encoder.setPattern("%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{15}: %mask(%msg) %xEx%n");
+        encoder.setCharset(Charsets.UTF_8);
+        encoder.start();
+        appender.setEncoder(encoder);
+        appender.start();
+
+        rootLogger.addAppender(appender);
+        rootLogger.setLevel(DEFAULT_LOG_LEVEL);
+        logbackLogger = rootLogger;
     }
 
-    private static void detachConsoleAppender() {
-        if (LoggerFactory.getILoggerFactory() instanceof LoggerContext) {
-            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-            Logger rootLogger = loggerContext.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-            rootLogger.detachAppender(CONSOLE_APPENDER_NAME);
+    public static org.slf4j.Logger setupRawRollingLogger(String loggerName, String fileName) {
+        if (!(LoggerFactory.getILoggerFactory() instanceof LoggerContext)) {
+            return LoggerFactory.getLogger(loggerName);
         }
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Logger logger = loggerContext.getLogger(loggerName);
+        logger.detachAndStopAllAppenders();
+
+        RollingFileAppender<ILoggingEvent> appender = new RestrictedRollingFileAppender();
+        appender.setContext(loggerContext);
+        appender.setName(loggerName + "_APPENDER");
+        appender.setFile(fileName + ".log");
+
+        FixedWindowRollingPolicy rollingPolicy = new FixedWindowRollingPolicy();
+        rollingPolicy.setContext(loggerContext);
+        rollingPolicy.setParent(appender);
+        rollingPolicy.setFileNamePattern(fileName + "_%i.log");
+        rollingPolicy.setMinIndex(1);
+        rollingPolicy.setMaxIndex(20);
+        rollingPolicy.start();
+
+        SizeBasedTriggeringPolicy<ILoggingEvent> triggeringPolicy = new SizeBasedTriggeringPolicy<>();
+        triggeringPolicy.setMaxFileSize(FileSize.valueOf("10MB"));
+        triggeringPolicy.start();
+
+        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+        encoder.setContext(loggerContext);
+        encoder.setPattern("%msg%n");
+        encoder.setCharset(Charsets.UTF_8);
+        encoder.start();
+
+        appender.setEncoder(encoder);
+        appender.setRollingPolicy(rollingPolicy);
+        appender.setTriggeringPolicy(triggeringPolicy);
+        appender.start();
+
+        logger.addAppender(appender);
+        logger.setAdditive(false);
+        logger.setLevel(DEFAULT_LOG_LEVEL);
+        return logger;
     }
 
     public static void setup(String fileName, int rollingPolicyMaxIndex, String maxFileSize, Level logLevel) {


### PR DESCRIPTION
The webcam log may now include JVM/JavaFX stderr diagnostics that were previously discarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust webcam startup and shutdown with stronger failure handling to avoid hung processes.
  * Continuous capture of webcam process output with rolling logs; sensitive home-directory paths are masked and startup logs are directed to stderr.

* **Documentation**
  * Fixed a typo in the webcam app build instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->