### PR TITLE
Canonicalize BTC address before on-chain match

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/StateMainChain3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/StateMainChain3b.java
@@ -24,6 +24,7 @@ import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.common.monetary.Coin;
 import bisq.common.util.ExceptionUtil;
 import bisq.common.util.StringUtils;
+import bisq.common.validation.BitcoinAddressValidation;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Browser;
 import bisq.desktop.common.threading.UIScheduler;
@@ -245,8 +246,9 @@ public abstract class StateMainChain3b<C extends StateMainChain3b.Controller<?, 
         }
 
         private List<Long> findTxOutputValuesForAddress(Tx tx, String address) {
+            String canonicalAddress = BitcoinAddressValidation.canonicalize(address);
             return tx.getOutputs().stream()
-                    .filter(output -> address.equals(output.getAddress()))
+                    .filter(output -> canonicalAddress.equals(output.getAddress()))
                     .map(Output::getValue)
                     .toList();
         }

--- a/common/src/main/java/bisq/common/validation/BitcoinAddressValidation.java
+++ b/common/src/main/java/bisq/common/validation/BitcoinAddressValidation.java
@@ -17,6 +17,9 @@
 
 package bisq.common.validation;
 
+import bisq.common.encoding.BitcoinURIScheme;
+
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -40,5 +43,13 @@ public class BitcoinAddressValidation {
     public static boolean isValid(String address) {
         return BASE58_PATTERN.matcher(address).matches() ||
                 BECH32_PATTERN.matcher(address).matches();
+    }
+
+    public static String canonicalize(String address) {
+        String extracted = BitcoinURIScheme.extractBitcoinAddress(address);
+        // bech32 is case-insensitive and stored lowercase on-chain; base58 is case-sensitive
+        return BECH32_PATTERN.matcher(extracted).matches()
+                ? extracted.toLowerCase(Locale.ROOT)
+                : extracted;
     }
 }

--- a/common/src/test/java/bisq/common/validation/BitcoinAddressValidationTest.java
+++ b/common/src/test/java/bisq/common/validation/BitcoinAddressValidationTest.java
@@ -20,4 +20,23 @@ public class BitcoinAddressValidationTest {
         assertFalse(BitcoinAddressValidation.isValid("4A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")); // Invalid address
         assertFalse(BitcoinAddressValidation.isValid("")); // Empty string
     }
+
+    @Test
+    public void testCanonicalize() {
+        // bitcoin: prefix stripped (#4782) and bech32 lowercased (#4712) to match the explorer output
+        assertEquals("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+                BitcoinAddressValidation.canonicalize("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"));
+        assertEquals("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+                BitcoinAddressValidation.canonicalize("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4"));
+        assertEquals("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+                BitcoinAddressValidation.canonicalize("bitcoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"));
+        assertEquals("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+                BitcoinAddressValidation.canonicalize("BITCOIN:BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4"));
+
+        // base58 is case-sensitive: never altered (prefix/params still stripped)
+        assertEquals("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+                BitcoinAddressValidation.canonicalize("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"));
+        assertEquals("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+                BitcoinAddressValidation.canonicalize("bitcoin:3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy?amount=1"));
+    }
 }


### PR DESCRIPTION
Fixes #4782, #4712.

The buyer's BTC address is matched against the explorer's transaction output with an exact, case-sensitive `equals` in `StateMainChain3b`. Explorers return lowercase bech32, so an address entered with a `bitcoin:` prefix or as uppercase bech32 never matches — the payment shows as not found on chain.

Fix: canonicalize the address right before the comparison — new `BitcoinAddressValidation.canonicalize` strips the `bitcoin:` prefix (via the existing `BitcoinURIScheme`) and lowercases bech32 only; base58 is case-sensitive and left untouched.

This is a **match-time fix only** — it corrects detection regardless of how the address was entered, including trades already on the wire. Input-time normalization (storing it canonical in `BuyerState1a`) is intentionally out of scope, a possible follow-up.

Tests: `BitcoinAddressValidationTest.testCanonicalize` covers the prefix, uppercase bech32, both combined, and the base58 case-preservation guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced consistency of Bitcoin address validation when comparing transaction outputs to stored payment addresses, improving trade verification accuracy
- Improved handling of different Bitcoin address formats (Bech32 and base58) with proper canonicalization and Bitcoin URI extraction support

## Tests
- Added test coverage for Bitcoin address canonicalization across various address format types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->