### PR TITLE
Inform user when chat peer is banned

### DIFF
--- a/chat/src/main/java/bisq/chat/priv/PrivateChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/priv/PrivateChatChannelService.java
@@ -36,9 +36,12 @@ import bisq.persistence.PersistableStore;
 import bisq.user.UserService;
 import bisq.user.identity.UserIdentity;
 import bisq.user.profile.UserProfile;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
@@ -100,6 +103,7 @@ public abstract class PrivateChatChannelService<
             return CompletableFuture.failedFuture(new RuntimeException());
         }
         if (isPeerBanned(receiver)) {
+            addPeerBannedSystemMessage(channel, myUserIdentity, receiver, date);
             return CompletableFuture.failedFuture(new RuntimeException("Peer is banned"));
         }
 
@@ -120,6 +124,40 @@ public abstract class PrivateChatChannelService<
 
     protected boolean isPeerBanned(UserProfile userProfile) {
         return bannedUserService.isUserProfileBanned(userProfile);
+    }
+
+    @VisibleForTesting
+    static final String PEER_BANNED_NOTICE_KEY = "chat.privateChannel.peerBanned";
+
+    private void addPeerBannedSystemMessage(C channel, UserIdentity myUserIdentity, UserProfile receiver, long date) {
+        if (alreadyNotifiedAboutBannedPeer(channel.getChatMessages(), receiver.getUserName())) {
+            return;
+        }
+        UserProfile nonBannedAuthor = myUserIdentity.getUserProfile();
+        M systemMessage = createAndGetNewPrivateChatMessage(StringUtils.createUid(),
+                channel,
+                nonBannedAuthor,
+                receiver,
+                Res.encode(PEER_BANNED_NOTICE_KEY, receiver.getUserName()),
+                Optional.empty(),
+                date,
+                false,
+                ChatMessageType.PROTOCOL_LOG_MESSAGE);
+        addMessage(systemMessage, channel);
+    }
+
+    @VisibleForTesting
+    static boolean alreadyNotifiedAboutBannedPeer(Collection<? extends ChatMessage> messages, String peerName) {
+        String peerNotice = Res.encode(PEER_BANNED_NOTICE_KEY, peerName);
+        return messages.stream()
+                .sorted(Comparator.comparingLong(ChatMessage::getDate).reversed())
+                .takeWhile(PrivateChatChannelService::isPeerBannedNotice)
+                .anyMatch(message -> message.getText().map(peerNotice::equals).orElse(false));
+    }
+
+    private static boolean isPeerBannedNotice(ChatMessage message) {
+        return message.getChatMessageType() == ChatMessageType.PROTOCOL_LOG_MESSAGE
+                && message.getText().map(text -> text.startsWith(PEER_BANNED_NOTICE_KEY)).orElse(false);
     }
 
     public void leaveChannel(String id) {

--- a/chat/src/test/java/bisq/chat/priv/PrivateChatChannelServiceTest.java
+++ b/chat/src/test/java/bisq/chat/priv/PrivateChatChannelServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.chat.priv;
+
+import bisq.chat.ChatChannelDomain;
+import bisq.chat.ChatMessage;
+import bisq.chat.ChatMessageType;
+import bisq.chat.Citation;
+import bisq.chat.reactions.ChatMessageReaction;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.i18n.Res;
+import bisq.network.p2p.services.data.storage.MetaData;
+import com.google.protobuf.Message;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the de-duplication guard for the "peer is banned" system notice (#4769): a peer already
+ * named in the trailing run of ban notices is not notified again.
+ */
+public class PrivateChatChannelServiceTest {
+    private static final String NOTICE_BOB = Res.encode(PrivateChatChannelService.PEER_BANNED_NOTICE_KEY, "Bob");
+    private static final String NOTICE_ALICE = Res.encode(PrivateChatChannelService.PEER_BANNED_NOTICE_KEY, "Alice");
+    private static final String LEAVE = Res.encode("chat.privateChannel.message.leave", "Bob");
+
+    @Test
+    void emptyChannelIsNotYetNotified() {
+        assertFalse(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(List.of(), "Bob"));
+    }
+
+    @Test
+    void noticeForThisPeerInTrailingRunMeansAlreadyNotified() {
+        assertTrue(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(
+                List.of(message(1, NOTICE_BOB, ChatMessageType.PROTOCOL_LOG_MESSAGE)), "Bob"));
+    }
+
+    @Test
+    void aNoticeForAnotherPeerDoesNotSuppressThisPeer() {
+        assertFalse(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(
+                List.of(message(1, NOTICE_ALICE, ChatMessageType.PROTOCOL_LOG_MESSAGE)), "Bob"));
+    }
+
+    @Test
+    void bothPeersNamedInTheRunAreEachAlreadyNotified() {
+        var messages = List.of(
+                message(1, NOTICE_BOB, ChatMessageType.PROTOCOL_LOG_MESSAGE),
+                message(2, NOTICE_ALICE, ChatMessageType.PROTOCOL_LOG_MESSAGE));
+        assertTrue(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(messages, "Bob"));
+        assertTrue(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(messages, "Alice"));
+    }
+
+    @Test
+    void aRealMessageAfterTheNoticeResetsTheRun() {
+        assertFalse(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(List.of(
+                message(1, NOTICE_BOB, ChatMessageType.PROTOCOL_LOG_MESSAGE),
+                message(2, "hi", ChatMessageType.TEXT)), "Bob"));
+    }
+
+    @Test
+    void aDifferentSystemMessageIsNotABanNotice() {
+        assertFalse(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(
+                List.of(message(1, LEAVE, ChatMessageType.PROTOCOL_LOG_MESSAGE)), "Bob"));
+    }
+
+    @Test
+    void aNormalTextMessageWithTheNoticeTextIsNotABanNotice() {
+        assertFalse(PrivateChatChannelService.alreadyNotifiedAboutBannedPeer(
+                List.of(message(1, NOTICE_BOB, ChatMessageType.TEXT)), "Bob"));
+    }
+
+    private static ChatMessage message(long date, String text, ChatMessageType type) {
+        return new TestChatMessage(date, text, type);
+    }
+
+    private static class TestChatMessage extends ChatMessage {
+        private TestChatMessage(long date, String text, ChatMessageType type) {
+            super("id", ChatChannelDomain.DISCUSSION, "channelId", "author",
+                    Optional.ofNullable(text), Optional.<Citation>empty(), date, false, type);
+        }
+
+        @Override
+        protected MetaData getMetaData() {
+            return null;
+        }
+
+        @Override
+        public <R extends ChatMessageReaction> ObservableSet<R> getChatMessageReactions() {
+            return null;
+        }
+
+        @Override
+        public boolean addChatMessageReaction(ChatMessageReaction reaction) {
+            return false;
+        }
+
+        @Override
+        public Message.Builder getBuilder(boolean serializeForHash) {
+            return null;
+        }
+    }
+}

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -5,6 +5,7 @@
 ####################################################################
 
 chat.privateChannel.message.leave={0} left that chat
+chat.privateChannel.peerBanned=Your message was not delivered to {0} because they have been banned.
 
 ####################################################################
 # Notifications


### PR DESCRIPTION
Fixes #4769.

When the peer in a private or trade chat is banned, their messages are silently dropped and the user gets no feedback — they just see their messages going nowhere. `PrivateChatChannelService.sendMessage` already blocks the send (it returns a failed future), it just doesn't surface anything.

This adds a local system message to the channel — *"Your message was not delivered to {0} because they have been banned."* — so the not-banned user knows what's happening. It's authored by the local user (otherwise `addMessage` would drop it as a banned sender), only added locally so the banned peer is never told. Both private and trade chats go through the same `sendMessage`, so one hook covers both, and it renders via the existing `PROTOCOL_LOG_MESSAGE` system-message box (same style as "X left that chat").

**Mediation fan-out** (raised by @KimStrand): in a mediated trade the send fans out to each trader and the mediator, and sends to non-banned participants still go out. The notice is therefore recipient-specific — it only claims that delivery *to the named banned receiver* failed, so it stays accurate when another participant did receive the message. De-duplication is per banned peer: each banned receiver is named once, repeated send attempts don't stack duplicate notices, and a regular message in between resets the suppression so a later failed send notifies again. (The alternative — aggregating the group-send results into one summary notice — would need failure-classification plumbing across both trade channel services; happy to do that as a follow-up if preferred.)

The de-duplication guard (`alreadyNotifiedAboutBannedPeer`) is unit-tested. The end-to-end behaviour was verified manually with a three-instance setup — two traders plus a mediator, ban check forced on: the sender sees one notice per banned receiver, the banned peer sees nothing, and resends don't stack.

<img width="1662" height="960" alt="Screenshot from 2026-06-11 16-36-17" src="https://github.com/user-attachments/assets/595a3725-44e6-4253-8032-53a91fb6f498" />
<img width="1412" height="960" alt="Screenshot from 2026-06-11 16-34-31" src="https://github.com/user-attachments/assets/3cba731b-f6d6-4e1c-ba72-dc6121e7d904" />
<img width="1412" height="960" alt="Screenshot from 2026-06-11 16-28-45" src="https://github.com/user-attachments/assets/a13d206d-125d-48f7-9d33-bef5a9bc4edb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notification when attempting to send a message to a banned peer, clearly indicating the peer has been banned and the message was not delivered.
  * Implemented deduplication to prevent duplicate notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
