### PR TITLE
Fix node monitor web entry route

### DIFF
--- a/api/src/main/java/bisq/api/HttpServerBootstrapService.java
+++ b/api/src/main/java/bisq/api/HttpServerBootstrapService.java
@@ -31,8 +31,12 @@ import bisq.common.observable.Observable;
 import bisq.common.observable.ReadOnlyObservable;
 import jakarta.ws.rs.core.UriBuilder;
 import lombok.extern.slf4j.Slf4j;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpHandlerRegistration;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.grizzly.websockets.WebSocketAddOn;
@@ -237,6 +241,17 @@ public class HttpServerBootstrapService implements Service {
         httpServer.ifPresentOrElse(httpServer ->
                         httpServer.getServerConfiguration().addHttpHandler(new StaticFileHandler(context), path),
                 () -> log.error("addStaticFileHandler called before httpServer is set."));
+    }
+
+    public void addRedirectHandler(String path, String location) {
+        httpServer.ifPresentOrElse(httpServer ->
+                        httpServer.getServerConfiguration().addHttpHandler(new HttpHandler() {
+                            @Override
+                            public void service(Request request, Response response) throws IOException {
+                                response.sendRedirect(location);
+                            }
+                        }, HttpHandlerRegistration.fromString(path)),
+                () -> log.error("addRedirectHandler called before httpServer is set."));
     }
 
     public ReadOnlyObservable<State> getState() {

--- a/api/src/main/java/bisq/api/rest_api/util/StaticFileHandler.java
+++ b/api/src/main/java/bisq/api/rest_api/util/StaticFileHandler.java
@@ -32,16 +32,14 @@ import java.util.Arrays;
 
 /**
  * Server needs handler for serving files, will change in JDK 18
- * Currently this is only to serve the swagger-ui content to the client.
- * So any call to this handler must begin with api/v1. We keep v1 in case
- * we will have incompatible changes in the future.
- * This handler is limited to html,css,json and javascript files.
+ * Serves bundled static resources from the classpath.
+ * This handler is limited to html, css, json, javascript, png and svg files.
  */
 @Slf4j
 public class StaticFileHandler extends HttpHandler {
     private static final String NOT_FOUND = "404 (Not Found)\n";
 
-    public static final String[] VALID_SUFFIX = {".html", ".json", ".css", ".js"};
+    public static final String[] VALID_SUFFIX = {".html", ".json", ".css", ".js", ".png", ".svg"};
 
     public StaticFileHandler(@NonNull String rootContext) {
         this.rootContext = rootContext;
@@ -55,17 +53,33 @@ public class StaticFileHandler extends HttpHandler {
 
     public void service(Request request, Response response) throws IOException {
         String filename = request.getRequestURI();
+        String normalizedRootContext = rootContext.endsWith("/") ? rootContext : rootContext + "/";
+        String rootContextWithoutTrailingSlash = normalizedRootContext.substring(0, normalizedRootContext.length() - 1);
 
         log.debug("requesting: {}", filename);
-        if (filename == null || !filename.startsWith(rootContext) ||
-                Arrays.stream(VALID_SUFFIX).noneMatch(filename::endsWith)) {
+        if (filename == null) {
+            respond404(response);
+            return;
+        }
+        if (filename.equals(rootContextWithoutTrailingSlash)) {
+            response.sendRedirect(normalizedRootContext);
+            return;
+        }
+        if (!filename.startsWith(normalizedRootContext)) {
+            respond404(response);
+            return;
+        }
+        if (filename.endsWith("/")) {
+            filename = filename + "index.html";
+        }
+        if (Arrays.stream(VALID_SUFFIX).noneMatch(filename::endsWith)) {
             respond404(response);
             return;
         }
         // resource loading without leading slash
         String resourceName = filename.replace("..", "");
-        if (filename.charAt(0) == '/') {
-            resourceName = filename.substring(1);
+        if (resourceName.charAt(0) == '/') {
+            resourceName = resourceName.substring(1);
         }
 
         // we are using getResourceAsStream to ultimately prevent load from parent directories
@@ -81,6 +95,7 @@ public class StaticFileHandler extends HttpHandler {
             if (resourceName.endsWith(".json")) mime = "application/json";
             if (resourceName.endsWith(".css")) mime = "text/css";
             if (resourceName.endsWith(".png")) mime = "image/png";
+            if (resourceName.endsWith(".svg")) mime = "image/svg+xml";
 
             response.setHeader("Content-Type", mime);
             response.setStatus(200);

--- a/api/src/test/java/bisq/api/rest_api/util/StaticFileHandlerTest.java
+++ b/api/src/test/java/bisq/api/rest_api/util/StaticFileHandlerTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.util;
+
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StaticFileHandlerTest {
+    @Test
+    void redirectsRootContextWithoutTrailingSlash() throws Exception {
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        when(request.getRequestURI()).thenReturn("/doc/v1");
+
+        new StaticFileHandler("/doc/v1/").service(request, response);
+
+        verify(response).sendRedirect("/doc/v1/");
+    }
+
+    @Test
+    void resolvesRootContextWithTrailingSlashToIndexHtml() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        when(request.getRequestURI()).thenReturn("/doc/v1/");
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        new StaticFileHandler("/doc/v1/").service(request, response);
+
+        verify(response).setHeader("Content-Type", "text/html");
+        verify(response).setStatus(200);
+        assertThat(outputStream.toString(StandardCharsets.UTF_8)).contains("<title>Swagger UI</title>");
+    }
+}

--- a/apps/node-monitor-web-app/src/main/java/bisq/node_monitor_app/NodeMonitorApp.java
+++ b/apps/node-monitor-web-app/src/main/java/bisq/node_monitor_app/NodeMonitorApp.java
@@ -38,7 +38,10 @@ public class NodeMonitorApp extends Executable<NodeMonitorApplicationService> {
     @Override
     protected void onApplicationServiceInitialized(Boolean result, Throwable throwable) {
         applicationService.getHttpServerBootstrapService()
-                .ifPresent(svc -> svc.addStaticFileHandler("/node-monitor", "/node-monitor/"));
+                .ifPresent(svc -> {
+                    svc.addRedirectHandler("", "/node-monitor/");
+                    svc.addStaticFileHandler("/node-monitor", "/node-monitor/");
+                });
     }
 
     @Override


### PR DESCRIPTION
Register an exact root redirect to the node monitor UI and let the classpath static handler resolve directory requests to index.html. This makes http://127.0.0.1:<port>/ and /node-monitor/ usable while preserving /api/v1 REST routing. Also keep static asset serving scoped to allowed suffixes and cover the redirect/index behavior with tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving image files (.png) and vector graphics (.svg) via HTTP
  * Improved URL path handling with automatic trailing slash normalization
  * Added automatic mapping of directory requests to index.html
  * Enhanced HTTP request redirection capabilities

* **Tests**
  * Added tests for static file serving behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->