### PR TITLE
Install JDK 21 in seed Debian installer

### DIFF
--- a/apps/seed-node-app/service-scripts/seed-debian-install.sh
+++ b/apps/seed-node-app/service-scripts/seed-debian-install.sh
@@ -9,8 +9,8 @@ echo "[*] Upgrading apt packages"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt update -q
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt upgrade -qq -y
 
-echo "[*] Installing OpenJDK 17"
-sudo -H -i -u "${ROOT_USER}" apt install -qq -y openjdk-17-jdk
+echo "[*] Installing OpenJDK 21"
+sudo -H -i -u "${ROOT_USER}" apt install -qq -y openjdk-21-jdk
 
 echo "[*] Installing Git"
 sudo -H -i -u "${ROOT_USER}" apt install -qq -y git


### PR DESCRIPTION
The seed installer builds apps:seed-node-app from source after provisioning the host. The repository now requires Java 21 and pins release builds to 21.0.11, but the installer still installed OpenJDK 17.

Update the package and status message to install OpenJDK 21 so fresh seed hosts use the supported Java line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenJDK dependency from version 17 to version 21 for the seed node application installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->