### PR TITLE
Fix take failing when offer max is fractional

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/amount/TakeOfferAmountController.java
@@ -128,7 +128,7 @@ public class TakeOfferAmountController implements Controller {
     }
 
     void onSetReputationBasedAmount() {
-        amountSelectionController.setMaxOrFixedQuoteSideAmount(amountSelectionController.getRightMarkerQuoteSideValue().round(0));
+        amountSelectionController.setMaxOrFixedQuoteSideAmount(amountSelectionController.getRightMarkerQuoteSideValue());
     }
 
     void onKeyPressedWhileShowingOverlay(KeyEvent keyEvent) {
@@ -175,8 +175,9 @@ public class TakeOfferAmountController implements Controller {
         }
         long sellersReputationScore = model.getSellersReputationScore();
         Monetary reputationBasedQuoteSideAmount = model.getSellersReputationBasedQuoteSideAmount().round(0);
-        Monetary offersQuoteSideMaxOrFixedAmount = OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, bisqEasyOffer).orElseThrow().round(0);
-        Monetary minRangeValue = OptionalQuoteSideMinAmount.get().round(0);
+        // Don't round the offer's exact min/max bounds, else a fractional bound is rejected by the validator.
+        Monetary offersQuoteSideMaxOrFixedAmount = OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, bisqEasyOffer).orElseThrow();
+        Monetary minRangeValue = OptionalQuoteSideMinAmount.get();
         Monetary maxAmount = reputationBasedQuoteSideAmount.isLessThan(offersQuoteSideMaxOrFixedAmount)
                 ? reputationBasedQuoteSideAmount
                 : offersQuoteSideMaxOrFixedAmount;
@@ -225,7 +226,7 @@ public class TakeOfferAmountController implements Controller {
     }
 
     private void applyReputationBasedQuoteSideAmount() {
-        amountSelectionController.setMaxOrFixedQuoteSideAmount(amountSelectionController.getRightMarkerQuoteSideValue().round(0));
+        amountSelectionController.setMaxOrFixedQuoteSideAmount(amountSelectionController.getRightMarkerQuoteSideValue());
     }
 
     private void maxOrFixedQuoteSideAmountChanged(Monetary value) {


### PR DESCRIPTION
## Problem

Taking a Bisq Easy **range** offer at the maximum could fail with
`IllegalArgumentException: Quote side amount must not be above the offer maximum amount`
(e.g. `quoteSideAmount=2000000; maxAmount=1999599`).

## Root cause

`TakeOfferAmountController` rounded the offer's quote max with `.round(0)`. When an offer's max is fractional (e.g. 199.96), rounding to whole units bumps it **up** (to 200.00) — above the offer's actual maximum. The UI then offers that rounded-up value as takeable, but `BisqEasyOfferAmountValidator` (which uses the un-rounded offer spec) rejects it. Rounding a ceiling up is the bug.

## Fix

Stop rounding the offer-max ceiling and the two "set to max" sites, so the taker takes at exactly the offer's real max. It's a no-op for offers with a whole-unit max. For a fractional-max offer the max now shows the exact value (e.g. 199.96) instead of rounding up to 200 — which is the correct behaviour, since a taker can't exceed the maker's offer.

## Testing

Verified end-to-end on two local desktop clients (A/B).

**1. Maker creates a Bisq Easy range offer with a fractional quote max** — the create-offer wizard accepts and keeps the cents (50.00 – 199.96 USD):

![Create a range offer with a fractional max](https://github.com/user-attachments/assets/3f8a5d96-d62f-4c4b-85ee-d26cf7d09b46)

**2. Taker takes the offer at the maximum** — the max is the offer's exact value (199.96 USD), not rounded up to 200:

![Take at max — capped at the exact offer max](https://github.com/user-attachments/assets/2f7736b5-5a72-4d68-91f9-3aa07d997d0c)

**Before vs after the fix**, taking at that maximum:

- **Before:** crash — `IllegalArgumentException: Quote side amount must not be above the offer maximum amount. quoteSideAmount=2000000; maxAmount=1999599` (the take side rounded the fractional max up, above the offer's real max).
- **After:** the take succeeds — offer accepted, `BisqEasyTakeOfferResponse` received, trade established, no exception.

Fixes #4791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in quote currency amount calculations during offer acceptance by preserving fractional amounts instead of rounding them. This ensures more accurate amount handling in the Take Offer flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->