### PR TITLE
Warn instead of crash when an alert blocks trading

### DIFF
--- a/api/src/main/java/bisq/api/rest_api/PairingApiResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/PairingApiResourceConfig.java
@@ -3,6 +3,7 @@ package bisq.api.rest_api;
 import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.api.rest_api.error.CustomExceptionMapper;
 import bisq.api.rest_api.error.RestApiException;
+import bisq.api.rest_api.error.TradingNotAllowedExceptionMapper;
 import bisq.common.json.JsonMapperProvider;
 import jakarta.ws.rs.ApplicationPath;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
@@ -17,6 +18,7 @@ public class PairingApiResourceConfig extends ResourceConfig {
                 JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS);
         register(CustomExceptionMapper.class)
                 .register(RestApiException.Mapper.class)
+                .register(TradingNotAllowedExceptionMapper.class)
                 .register(provider);
 
         register(AccessApi.class);

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
@@ -48,6 +48,7 @@ import bisq.trade.TradeService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.user.UserService;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
@@ -122,6 +123,7 @@ public class TradeRestApi extends RestApiBase {
                     @ApiResponse(responseCode = "201", description = "",
                             content = @Content(schema = @Schema(example = ""))),
                     @ApiResponse(responseCode = "400", description = "Invalid input"),
+                    @ApiResponse(responseCode = "409", description = "Conflict - Trading is currently disallowed by a security manager alert"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
@@ -206,6 +208,9 @@ public class TradeRestApi extends RestApiBase {
             asyncResponse.resume(buildErrorResponse("Thread was interrupted."));
         } catch (IllegalArgumentException e) {
             asyncResponse.resume(buildResponse(Response.Status.BAD_REQUEST, "Invalid input: " + e.getMessage()));
+        } catch (TradingNotAllowedException e) {
+            // Resume with the exception so the registered TradingNotAllowedExceptionMapper maps it to 409.
+            asyncResponse.resume(e);
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
@@ -222,6 +227,7 @@ public class TradeRestApi extends RestApiBase {
                     @ApiResponse(responseCode = "204", description = "Trade event processed successfully"),
                     @ApiResponse(responseCode = "404", description = "Trade or trade channel not found"),
                     @ApiResponse(responseCode = "400", description = "Invalid trade event data"),
+                    @ApiResponse(responseCode = "409", description = "Conflict - Trading is currently disallowed by a security manager alert"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
@@ -265,6 +271,9 @@ public class TradeRestApi extends RestApiBase {
                 case BTC_CONFIRMED -> handleBtcConfirmed(channel, trade, paymentRail, userName);
             }
             asyncResponse.resume(buildNoContentResponse());
+        } catch (TradingNotAllowedException e) {
+            // Resume with the exception so the registered TradingNotAllowedExceptionMapper maps it to 409.
+            asyncResponse.resume(e);
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
@@ -273,17 +282,17 @@ public class TradeRestApi extends RestApiBase {
     private void handleRejectTrade(BisqEasyOpenTradeChannel channel,
                                    BisqEasyTrade trade,
                                    String userName) throws Exception {
+        bisqEasyTradeService.rejectTrade(trade);
         String encoded = Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).get();
-        bisqEasyTradeService.rejectTrade(trade);
     }
 
     private void handleCancelTrade(BisqEasyOpenTradeChannel channel,
                                    BisqEasyTrade trade,
                                    String userName) throws Exception {
+        bisqEasyTradeService.cancelTrade(trade);
         String encoded = Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel).get();
-        bisqEasyTradeService.cancelTrade(trade);
     }
 
     private void handleCloseTrade(BisqEasyOpenTradeChannel channel, BisqEasyTrade trade) throws Exception {
@@ -296,9 +305,9 @@ public class TradeRestApi extends RestApiBase {
                                                  TradeEventDto tradeEvent,
                                                  String userName) throws Exception {
         String paymentAccountData = checkNotNull(tradeEvent.data(), "paymentAccountData must not be null");
+        bisqEasyTradeService.sellerSendsPaymentAccount(trade, paymentAccountData);
         String encoded = Res.encode("bisqEasy.tradeState.info.seller.phase1.tradeLogMessage", userName, paymentAccountData);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
-        bisqEasyTradeService.sellerSendsPaymentAccount(trade, paymentAccountData);
     }
 
     private void handleBuyerSendBitcoinPaymentData(BisqEasyOpenTradeChannel channel,
@@ -309,29 +318,29 @@ public class TradeRestApi extends RestApiBase {
         String btcRailName = paymentRail.name();
         String key = "bisqEasy.tradeState.info.buyer.phase1a.tradeLogMessage." + btcRailName;
         String bitcoinPaymentData = checkNotNull(tradeEvent.data(), "bitcoinPaymentData must not be null");
+        bisqEasyTradeService.buyerSendBitcoinPaymentData(trade, bitcoinPaymentData);
         String encoded = Res.encode(key, userName, bitcoinPaymentData);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
-        bisqEasyTradeService.buyerSendBitcoinPaymentData(trade, bitcoinPaymentData);
     }
 
     private void handleSellerConfirmFiatReceipt(BisqEasyOpenTradeChannel channel,
                                                 BisqEasyTrade trade,
                                                 String userName) throws Exception {
+        bisqEasyTradeService.sellerConfirmFiatReceipt(trade);
         long quoteSideAmount = trade.getContract().getQuoteSideAmount();
         String quoteCurrencyCode = trade.getOffer().getMarket().getQuoteCurrencyCode();
         String formattedQuoteAmount = AmountFormatter.formatQuoteAmountWithCode(Fiat.from(quoteSideAmount, quoteCurrencyCode));
         String encoded = Res.encode("bisqEasy.tradeState.info.seller.phase2b.tradeLogMessage", userName, formattedQuoteAmount);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
-        bisqEasyTradeService.sellerConfirmFiatReceipt(trade);
     }
 
     private void handleBuyerConfirmFiatSent(BisqEasyOpenTradeChannel channel,
                                             BisqEasyTrade trade,
                                             String userName) throws Exception {
+        bisqEasyTradeService.buyerConfirmFiatSent(trade);
         String quoteCurrencyCode = trade.getOffer().getMarket().getQuoteCurrencyCode();
         String encoded = Res.encode("bisqEasy.tradeState.info.buyer.phase2a.tradeLogMessage", userName, quoteCurrencyCode);
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
-        bisqEasyTradeService.buyerConfirmFiatSent(trade);
     }
 
     private void handleSellerConfirmBtcSent(BisqEasyOpenTradeChannel channel,
@@ -344,6 +353,7 @@ public class TradeRestApi extends RestApiBase {
         if (isMainChain) {
             checkArgument(paymentProof.isPresent(), "Transaction ID is required for Bitcoin settlement");
         }
+        bisqEasyTradeService.sellerConfirmBtcSent(trade, paymentProof);
         String encoded;
         if (paymentProof.isEmpty()) {
             encoded = Res.encode("bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.noProofProvided", userName);
@@ -353,18 +363,17 @@ public class TradeRestApi extends RestApiBase {
             encoded = Res.encode("bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage", userName, proofType, paymentProof.get());
         }
         bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
-        bisqEasyTradeService.sellerConfirmBtcSent(trade, paymentProof);
     }
 
     private void handleBtcConfirmed(BisqEasyOpenTradeChannel channel,
                                     BisqEasyTrade trade,
                                     BitcoinPaymentRail paymentRail,
                                     String userName) throws Exception {
+        bisqEasyTradeService.btcConfirmed(trade);
         if (paymentRail.equals(BitcoinPaymentRail.LN) && trade.isBuyer()) {
             String encoded = Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", userName);
             bisqEasyOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
         }
-        bisqEasyTradeService.btcConfirmed(trade);
     }
 
     @POST

--- a/api/src/main/java/bisq/api/rest_api/error/TradingNotAllowedExceptionMapper.java
+++ b/api/src/main/java/bisq/api/rest_api/error/TradingNotAllowedExceptionMapper.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.api.rest_api.error;
+
+import bisq.trade.exceptions.TradingNotAllowedException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Maps {@link TradingNotAllowedException} to 409 Conflict. The trade action is rejected because a
+ * security manager alert currently disallows trading (trading on halt or a min. version required),
+ * which is an expected, client-actionable condition rather than a server error (the generic mapper
+ * would otherwise turn it into a 500).
+ */
+@Slf4j
+@Provider
+public class TradingNotAllowedExceptionMapper implements ExceptionMapper<TradingNotAllowedException> {
+    @Override
+    public Response toResponse(TradingNotAllowedException exception) {
+        log.info("Trade action rejected as trading is currently not allowed: {}", exception.getMessage());
+        return Response.status(Response.Status.CONFLICT)
+                .entity(new ErrorMessage(exception.getMessage()))
+                .build();
+    }
+}

--- a/api/src/test/java/bisq/api/rest_api/endpoints/trades/TradeRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/trades/TradeRestApiTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.trades;
+
+import bisq.account.payment_method.BitcoinPaymentMethod;
+import bisq.account.payment_method.BitcoinPaymentMethodSpec;
+import bisq.account.payment_method.BitcoinPaymentRail;
+import bisq.api.rest_api.error.TradingNotAllowedExceptionMapper;
+import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.ChatChannelDomain;
+import bisq.chat.ChatChannelSelectionService;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
+import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
+import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelService;
+import bisq.chat.priv.LeavePrivateChatManager;
+import bisq.support.SupportService;
+import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
+import bisq.trade.TradeService;
+import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.bisq_easy.BisqEasyTradeService;
+import bisq.trade.exceptions.TradingNotAllowedException;
+import bisq.user.UserService;
+import bisq.user.banned.BannedUserService;
+import bisq.user.identity.UserIdentityService;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TradeRestApiTest {
+
+    @Test
+    void processTradeEventPropagatesTradingNotAllowedExceptionAndSkipsTradeLogMessage() {
+        BisqEasyOpenTradeChannelService openTradeChannelService = mock(BisqEasyOpenTradeChannelService.class);
+        BisqEasyTradeService bisqEasyTradeService = mock(BisqEasyTradeService.class);
+        TradeRestApi restApi = newTradeRestApi(openTradeChannelService, bisqEasyTradeService);
+
+        String tradeId = "trade-1";
+        BisqEasyOpenTradeChannel channel = mock(BisqEasyOpenTradeChannel.class, RETURNS_DEEP_STUBS);
+        BisqEasyTrade trade = mock(BisqEasyTrade.class);
+        BisqEasyContract contract = mock(BisqEasyContract.class);
+        BitcoinPaymentMethodSpec paymentMethodSpec = mock(BitcoinPaymentMethodSpec.class);
+        BitcoinPaymentMethod paymentMethod = mock(BitcoinPaymentMethod.class);
+        when(openTradeChannelService.findChannelByTradeId(tradeId)).thenReturn(Optional.of(channel));
+        when(bisqEasyTradeService.findTrade(tradeId)).thenReturn(Optional.of(trade));
+        when(trade.getContract()).thenReturn(contract);
+        when(contract.getBaseSidePaymentMethodSpec()).thenReturn(paymentMethodSpec);
+        when(paymentMethodSpec.getPaymentMethod()).thenReturn(paymentMethod);
+        when(paymentMethod.getPaymentRail()).thenReturn(BitcoinPaymentRail.MAIN_CHAIN);
+
+        // The guarded trade action throws because a security manager alert disallows trading.
+        doThrow(new TradingNotAllowedException("For trading you need version 2.1.11 or higher"))
+                .when(bisqEasyTradeService).buyerConfirmFiatSent(trade);
+
+        AsyncResponse asyncResponse = mock(AsyncResponse.class);
+        TradeEventDto event = new TradeEventDto(TradeEventTypeDto.BUYER_CONFIRM_FIAT_SENT, null);
+
+        restApi.processTradeEvent(tradeId, event, asyncResponse);
+
+        // The exception is propagated to the async response (not swallowed into a 500), so the
+        // registered TradingNotAllowedExceptionMapper maps it to 409.
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(asyncResponse).resume(captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(TradingNotAllowedException.class);
+
+        Response mapped = new TradingNotAllowedExceptionMapper()
+                .toResponse((TradingNotAllowedException) captor.getValue());
+        assertThat(mapped.getStatus()).isEqualTo(Response.Status.CONFLICT.getStatusCode());
+
+        // No trade-log message is sent because the action failed before any chat message is emitted.
+        verify(openTradeChannelService, never()).sendTradeLogMessage(any(), any());
+    }
+
+    private TradeRestApi newTradeRestApi(BisqEasyOpenTradeChannelService openTradeChannelService,
+                                         BisqEasyTradeService bisqEasyTradeService) {
+        ChatService chatService = mock(ChatService.class);
+        when(chatService.getBisqEasyOfferbookChannelService()).thenReturn(mock(BisqEasyOfferbookChannelService.class));
+        when(chatService.getChatChannelSelectionService(ChatChannelDomain.BISQ_EASY_OFFERBOOK))
+                .thenReturn(mock(ChatChannelSelectionService.class));
+        when(chatService.getBisqEasyOpenTradeChannelService()).thenReturn(openTradeChannelService);
+        when(chatService.getLeavePrivateChatManager()).thenReturn(mock(LeavePrivateChatManager.class));
+
+        UserService userService = mock(UserService.class);
+        when(userService.getUserIdentityService()).thenReturn(mock(UserIdentityService.class));
+        when(userService.getBannedUserService()).thenReturn(mock(BannedUserService.class));
+
+        SupportService supportService = mock(SupportService.class);
+        when(supportService.getBisqEasyMediationRequestService()).thenReturn(mock(BisqEasyMediationRequestService.class));
+
+        TradeService tradeService = mock(TradeService.class);
+        when(tradeService.getBisqEasyTradeService()).thenReturn(bisqEasyTradeService);
+
+        return new TradeRestApi(chatService,
+                mock(MarketPriceService.class),
+                userService,
+                supportService,
+                tradeService);
+    }
+}

--- a/api/src/test/java/bisq/api/rest_api/error/TradingNotAllowedExceptionMapperTest.java
+++ b/api/src/test/java/bisq/api/rest_api/error/TradingNotAllowedExceptionMapperTest.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.api.rest_api.error;
+
+import bisq.trade.exceptions.TradingNotAllowedException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class TradingNotAllowedExceptionMapperTest {
+
+    @Test
+    void mapsToConflictWithMessage() {
+        TradingNotAllowedExceptionMapper mapper = new TradingNotAllowedExceptionMapper();
+
+        Response response = mapper.toResponse(new TradingNotAllowedException("Trading is on halt"));
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        ErrorMessage entity = assertInstanceOf(ErrorMessage.class, response.getEntity());
+        assertEquals("Trading is on halt", entity.error());
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/TradeExceptionHandler.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/TradeExceptionHandler.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.common.utils;
+
+import bisq.desktop.components.overlay.Popup;
+import bisq.trade.exceptions.TradingNotAllowedException;
+
+public final class TradeExceptionHandler {
+    private TradeExceptionHandler() {
+    }
+
+    public static boolean run(Runnable tradeAction) {
+        try {
+            tradeAction.run();
+            return true;
+        } catch (TradingNotAllowedException e) {
+            new Popup().warning(e.getMessage()).show();
+            return false;
+        }
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -32,6 +32,7 @@ import bisq.desktop.common.observable.FxBindings;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState1a;
@@ -277,13 +278,15 @@ public class TradeStateController implements Controller {
         switch (model.getTradeCloseType()) {
             case REJECT:
                 encoded = Res.encode("bisqEasy.openTrades.tradeLogMessage.rejected", userName);
-                channelService.sendTradeLogMessage(encoded, channel);
-                bisqEasyTradeService.rejectTrade(trade);
+                if (TradeExceptionHandler.run(() -> bisqEasyTradeService.rejectTrade(trade))) {
+                    channelService.sendTradeLogMessage(encoded, channel);
+                }
                 break;
             case CANCEL:
                 encoded = Res.encode("bisqEasy.openTrades.tradeLogMessage.cancelled", userName);
-                channelService.sendTradeLogMessage(encoded, channel);
-                bisqEasyTradeService.cancelTrade(trade);
+                if (TradeExceptionHandler.run(() -> bisqEasyTradeService.cancelTrade(trade))) {
+                    channelService.sendTradeLogMessage(encoded, channel);
+                }
                 break;
             case COMPLETED:
             default:

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState1a.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState1a.java
@@ -27,6 +27,7 @@ import bisq.desktop.common.ManagedDuration;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ImageUtil;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.BisqIconButton;
@@ -172,8 +173,9 @@ public class BuyerState1a extends BaseState {
             String btcRailName = getPaymentRail().name();
             String key = "bisqEasy.tradeState.info.buyer.phase1a.tradeLogMessage." + btcRailName;
             String bitcoinPaymentData = model.getBitcoinPaymentData().get();
-            sendTradeLogMessage(Res.encode(key, model.getChannel().getMyUserIdentity().getUserName(), bitcoinPaymentData));
-            bisqEasyTradeService.buyerSendBitcoinPaymentData(model.getTrade(), bitcoinPaymentData);
+            if (TradeExceptionHandler.run(() -> bisqEasyTradeService.buyerSendBitcoinPaymentData(model.getTrade(), bitcoinPaymentData))) {
+                sendTradeLogMessage(Res.encode(key, model.getChannel().getMyUserIdentity().getUserName(), bitcoinPaymentData));
+            }
         }
 
         void onOpenWalletGuide() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState2a.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerState2a.java
@@ -22,6 +22,7 @@ import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Icons;
 import bisq.desktop.common.utils.ClipboardUtil;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.WrappingText;
@@ -98,7 +99,7 @@ public class BuyerState2a extends BaseState {
                 moderationRequestService.reportUserProfile(peer, message);
 
                 // We reject the trade to avoid the banned user can continue
-                bisqEasyTradeService.cancelTrade(trade);
+                TradeExceptionHandler.run(() -> bisqEasyTradeService.cancelTrade(trade));
 
                 new Popup().warning(Res.get("bisqEasy.tradeState.info.buyer.phase2a.accountDataBanned.popup.warning")).show();
             } else {
@@ -113,9 +114,10 @@ public class BuyerState2a extends BaseState {
         }
 
         private void onConfirmFiatSent() {
-            sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.buyer.phase2a.tradeLogMessage",
-                    model.getChannel().getMyUserIdentity().getUserName(), model.getQuoteCode()));
-            bisqEasyTradeService.buyerConfirmFiatSent(model.getTrade());
+            if (TradeExceptionHandler.run(() -> bisqEasyTradeService.buyerConfirmFiatSent(model.getTrade()))) {
+                sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.buyer.phase2a.tradeLogMessage",
+                        model.getChannel().getMyUserIdentity().getUserName(), model.getQuoteCode()));
+            }
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerStateLightning3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/BuyerStateLightning3b.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states;
 
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.desktop.components.controls.validator.LightningPreImageValidator;
@@ -80,8 +81,9 @@ public class BuyerStateLightning3b extends BaseState {
         }
 
         private void onButtonClicked() {
-            sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", model.getChannel().getMyUserIdentity().getUserName()));
-            bisqEasyTradeService.btcConfirmed(model.getTrade());
+            if (TradeExceptionHandler.run(() -> bisqEasyTradeService.btcConfirmed(model.getTrade()))) {
+                sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.buyer.phase3b.tradeLogMessage.ln", model.getChannel().getMyUserIdentity().getUserName()));
+            }
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState1.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState1.java
@@ -26,6 +26,7 @@ import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.AutoCompleteComboBox;
 import bisq.desktop.components.controls.MaterialTextArea;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.overlay.Popup;
 import bisq.i18n.Res;
 import bisq.trade.bisq_easy.BisqEasyTrade;
@@ -127,9 +128,10 @@ public class SellerState1 extends BaseState {
                 new Popup().warning(Res.get("validation.tooLong", UserProfile.MAX_LENGTH_STATEMENT)).show();
                 return;
             }
-            sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase1.tradeLogMessage",
-                    model.getChannel().getMyUserIdentity().getUserName(), model.getPaymentAccountData().get()));
-            bisqEasyTradeService.sellerSendsPaymentAccount(model.getTrade(), paymentAccountData);
+            if (TradeExceptionHandler.run(() -> bisqEasyTradeService.sellerSendsPaymentAccount(model.getTrade(), paymentAccountData))) {
+                sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase1.tradeLogMessage",
+                        model.getChannel().getMyUserIdentity().getUserName(), model.getPaymentAccountData().get()));
+            }
         }
 
         private void onSelectAccount(UserDefinedFiatAccount account) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState2b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState2b.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states;
 
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.i18n.Res;
 import bisq.trade.bisq_easy.BisqEasyTrade;
@@ -66,9 +67,10 @@ public class SellerState2b extends BaseState {
         }
 
         private void onConfirmFiatReceipt() {
-            sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase2b.tradeLogMessage",
-                    model.getChannel().getMyUserIdentity().getUserName(), model.getFormattedQuoteAmount()));
-            bisqEasyTradeService.sellerConfirmFiatReceipt(model.getTrade());
+            if (TradeExceptionHandler.run(() -> bisqEasyTradeService.sellerConfirmFiatReceipt(model.getTrade()))) {
+                sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase2b.tradeLogMessage",
+                        model.getChannel().getMyUserIdentity().getUserName(), model.getFormattedQuoteAmount()));
+            }
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState3a.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerState3a.java
@@ -30,6 +30,7 @@ import bisq.desktop.common.qr.QrCodeDisplay;
 import bisq.desktop.common.threading.UIScheduler;
 import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.utils.KeyHandlerUtil;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.BitcoinAmountDisplay;
 import bisq.desktop.components.controls.MaterialBitcoinAmountDisplay;
@@ -189,13 +190,14 @@ public class SellerState3a extends BaseState {
         }
 
         private void confirmedBtcSent(Optional<String> paymentProof, String userName, String proofType) {
-            if (paymentProof.isEmpty()) {
-                sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.noProofProvided", userName));
-            } else {
-                sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage",
-                        userName, proofType, paymentProof.get()));
+            if (TradeExceptionHandler.run(() -> bisqEasyTradeService.sellerConfirmBtcSent(model.getTrade(), paymentProof))) {
+                if (paymentProof.isEmpty()) {
+                    sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage.noProofProvided", userName));
+                } else {
+                    sendTradeLogMessage(Res.encode("bisqEasy.tradeState.info.seller.phase3a.tradeLogMessage",
+                            userName, proofType, paymentProof.get()));
+                }
             }
-            bisqEasyTradeService.sellerConfirmBtcSent(model.getTrade(), paymentProof);
         }
 
         void onShowQrCodeDisplay() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/SellerStateLightning3b.java
@@ -28,6 +28,7 @@ import bisq.common.observable.collection.CollectionObserver;
 import bisq.common.util.StringUtils;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.threading.UIThread;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.desktop.main.content.bisq_easy.components.trade.WaitingAnimation;
 import bisq.desktop.main.content.bisq_easy.components.trade.WaitingState;
@@ -146,7 +147,7 @@ public class SellerStateLightning3b extends BaseState {
         private void onButtonClicked() {
             // todo should we send a system message? if so we should change the text
             //sendTradeLogMessage(Res.get("bisqEasy.tradeState.info.phase3b.tradeLogMessage", model.getChannel().getMyUserIdentity().getUserName()));
-            bisqEasyTradeService.btcConfirmed(model.getTrade());
+            TradeExceptionHandler.run(() -> bisqEasyTradeService.btcConfirmed(model.getTrade()));
         }
 
         private String getEncodedWithNickName(BisqEasyOpenTradeChannel bisqEasyOpenTradeChannel) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/StateMainChain3b.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/StateMainChain3b.java
@@ -33,6 +33,7 @@ import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.desktop.components.controls.validator.BitcoinTransactionValidator;
 import bisq.desktop.components.controls.validator.ExplorerResultValidator;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.components.trade.WaitingAnimation;
 import bisq.desktop.main.content.bisq_easy.components.trade.WaitingState;
@@ -168,7 +169,7 @@ public abstract class StateMainChain3b<C extends StateMainChain3b.Controller<?, 
         private void doCompleteTrade() {
             // todo should we send a system message? if so we should change the text
             //sendTradeLogMessage(Res.get("bisqEasy.tradeState.info.phase3b.tradeLogMessage", model.getChannel().getMyUserIdentity().getUserName()));
-            bisqEasyTradeService.btcConfirmed(model.getTrade());
+            TradeExceptionHandler.run(() -> bisqEasyTradeService.btcConfirmed(model.getTrade()));
         }
 
         private void requestTx() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
@@ -58,6 +58,7 @@ import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
 import bisq.user.identity.UserIdentityService;
@@ -193,15 +194,21 @@ public class TakeOfferReviewController implements Controller {
         FiatPaymentMethodSpec fiatPaymentMethodSpec = model.getFiatPaymentMethodSpec();
         PriceSpec priceSpec = bisqEasyOffer.getPriceSpec();
         long marketPrice = model.getMarketPrice();
-        BisqEasyProtocol bisqEasyProtocol = bisqEasyTradeService.takerCreatesProtocol(takerIdentity.getIdentity(),
-                bisqEasyOffer,
-                takersBaseSideAmount,
-                takersQuoteSideAmount,
-                bitcoinPaymentMethodSpec,
-                fiatPaymentMethodSpec,
-                mediator,
-                priceSpec,
-                marketPrice);
+        BisqEasyProtocol bisqEasyProtocol;
+        try {
+            bisqEasyProtocol = bisqEasyTradeService.takerCreatesProtocol(takerIdentity.getIdentity(),
+                    bisqEasyOffer,
+                    takersBaseSideAmount,
+                    takersQuoteSideAmount,
+                    bitcoinPaymentMethodSpec,
+                    fiatPaymentMethodSpec,
+                    mediator,
+                    priceSpec,
+                    marketPrice);
+        } catch (TradingNotAllowedException e) {
+            new Popup().warning(e.getMessage()).show();
+            return;
+        }
         BisqEasyTrade trade = bisqEasyProtocol.getModel();
         log.info("Selected mediator for trade {}: {}", trade.getShortId(), mediator.map(UserProfile::getUserName).orElse("N/A"));
         model.setBisqEasyTrade(trade);
@@ -247,7 +254,21 @@ public class TakeOfferReviewController implements Controller {
                 }
         );
 
-        bisqEasyTradeService.takeOffer(trade);
+        try {
+            bisqEasyTradeService.takeOffer(trade);
+        } catch (TradingNotAllowedException e) {
+            // The error observers were already bound above; unbind them so a retry doesn't stack them.
+            if (errorMessagePin != null) {
+                errorMessagePin.unbind();
+                errorMessagePin = null;
+            }
+            if (peersErrorMessagePin != null) {
+                peersErrorMessagePin.unbind();
+                peersErrorMessagePin = null;
+            }
+            new Popup().warning(e.getMessage()).show();
+            return;
+        }
         model.getTakeOfferStatus().set(TakeOfferReviewModel.TakeOfferStatus.SENT);
 
         BisqEasyContract contract = trade.getContract();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -70,6 +70,7 @@ import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
 import bisq.user.identity.UserIdentityService;
@@ -468,15 +469,21 @@ public class TradeWizardReviewController implements Controller {
         FiatPaymentMethodSpec fiatPaymentMethodSpec = new FiatPaymentMethodSpec(model.getTakersSelectedFiatPaymentMethod());
         PriceSpec sellersPriceSpec = model.getPriceSpec();
         long marketPrice = model.getMarketPrice();
-        BisqEasyProtocol bisqEasyProtocol = bisqEasyTradeService.takerCreatesProtocol(takerIdentity.getIdentity(),
-                bisqEasyOffer,
-                takersBaseSideAmount,
-                takersQuoteSideAmount,
-                bitcoinPaymentMethodSpec,
-                fiatPaymentMethodSpec,
-                mediator,
-                sellersPriceSpec,
-                marketPrice);
+        BisqEasyProtocol bisqEasyProtocol;
+        try {
+            bisqEasyProtocol = bisqEasyTradeService.takerCreatesProtocol(takerIdentity.getIdentity(),
+                    bisqEasyOffer,
+                    takersBaseSideAmount,
+                    takersQuoteSideAmount,
+                    bitcoinPaymentMethodSpec,
+                    fiatPaymentMethodSpec,
+                    mediator,
+                    sellersPriceSpec,
+                    marketPrice);
+        } catch (TradingNotAllowedException e) {
+            new Popup().warning(e.getMessage()).show();
+            return;
+        }
         BisqEasyTrade trade = bisqEasyProtocol.getModel();
         log.info("Selected mediator for trade {}: {}", trade.getShortId(), mediator.map(UserProfile::getUserName).orElse("N/A"));
         model.setBisqEasyTrade(trade);
@@ -522,7 +529,21 @@ public class TradeWizardReviewController implements Controller {
                 }
         );
 
-        bisqEasyTradeService.takeOffer(trade);
+        try {
+            bisqEasyTradeService.takeOffer(trade);
+        } catch (TradingNotAllowedException e) {
+            // The error observers were already bound above; unbind them so a retry doesn't stack them.
+            if (errorMessagePin != null) {
+                errorMessagePin.unbind();
+                errorMessagePin = null;
+            }
+            if (peersErrorMessagePin != null) {
+                peersErrorMessagePin.unbind();
+                peersErrorMessagePin = null;
+            }
+            new Popup().warning(e.getMessage()).show();
+            return;
+        }
         model.getTakeOfferStatus().set(TradeWizardReviewModel.TakeOfferStatus.SENT);
 
         BisqEasyContract contract = trade.getContract();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/take_offer/review/MuSigTakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/take_offer/review/MuSigTakeOfferReviewController.java
@@ -52,6 +52,7 @@ import bisq.presentation.formatters.PercentageFormatter;
 import bisq.presentation.formatters.PriceFormatter;
 import bisq.support.arbitration.mu_sig.NoMuSigArbitratorAvailableException;
 import bisq.support.mediation.mu_sig.NoMuSigMediatorAvailableException;
+import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.trade.mu_sig.MuSigTrade;
 import bisq.trade.mu_sig.protocol.MuSigProtocol;
 import bisq.user.banned.BannedUserService;
@@ -241,6 +242,11 @@ public class MuSigTakeOfferReviewController implements Controller {
             model.getTakeOfferStatus().set(MuSigTakeOfferReviewModel.TakeOfferStatus.SENT);
             // todo simulate a small delay until we have a solution for the above issue
             UIScheduler.run(() -> model.getTakeOfferStatus().set(MuSigTakeOfferReviewModel.TakeOfferStatus.SUCCESS)).after(200);
+        } catch (TradingNotAllowedException e) {
+            UIThread.run(() -> {
+                new Popup().warning(e.getMessage()).show();
+                onCancelHandler.run();
+            });
         } catch (UserProfileBannedException e) {
             UIThread.run(() -> {
                 if (muSigOffer.getMakersUserProfileId().equals(e.getUserProfileId())) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState1bWaitForDepositTxConfirmation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState1bWaitForDepositTxConfirmation.java
@@ -25,6 +25,7 @@ import bisq.common.util.ExceptionUtil;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Browser;
 import bisq.desktop.common.threading.UIScheduler;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.WrappingText;
@@ -149,7 +150,7 @@ public class MuSigState1bWaitForDepositTxConfirmation extends MuSigBaseState {
         }
 
         void onSkipWaitForConfirmation() {
-            muSigTradeService.skipWaitForConfirmation(model.getTrade());
+            TradeExceptionHandler.run(() -> muSigTradeService.skipWaitForConfirmation(model.getTrade()));
         }
 
         private void requestTx() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState2BuyerSendPayment.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState2BuyerSendPayment.java
@@ -26,6 +26,7 @@ import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
 import bisq.desktop.common.Icons;
 import bisq.desktop.common.utils.ClipboardUtil;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.MaterialTextField;
 import bisq.desktop.components.controls.WrappingText;
@@ -147,9 +148,10 @@ public class MuSigState2BuyerSendPayment extends MuSigBaseState {
         }
 
         private void onConfirmFiatSent() {
-            sendTradeLogMessage(Res.encode("muSig.trade.state.phase2a.tradeLogMessage.buyer",
-                    model.getChannel().getMyUserIdentity().getUserName(), model.getQuoteCode()));
-            muSigTradeService.paymentInitiated(model.getTrade());
+            if (TradeExceptionHandler.run(() -> muSigTradeService.paymentInitiated(model.getTrade()))) {
+                sendTradeLogMessage(Res.encode("muSig.trade.state.phase2a.tradeLogMessage.buyer",
+                        model.getChannel().getMyUserIdentity().getUserName(), model.getQuoteCode()));
+            }
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState3aSellerConfirmPaymentReceipt.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/trade/pending/trade_state/states/MuSigState3aSellerConfirmPaymentReceipt.java
@@ -23,6 +23,7 @@ import bisq.account.accounts.crypto.CryptoAssetAccountPayload;
 import bisq.account.payment_method.PaymentMethod;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.controls.MaterialTextArea;
 import bisq.desktop.components.controls.WrappingText;
 import bisq.i18n.Res;
@@ -97,9 +98,10 @@ public class MuSigState3aSellerConfirmPaymentReceipt extends MuSigBaseState {
         }
 
         private void onPaymentReceiptConfirmed() {
-            sendTradeLogMessage(Res.encode("muSig.trade.state.phase3a.logMessage",
-                    model.getChannel().getMyUserIdentity().getUserName(), model.getFormattedNonBtcAmount()));
-            muSigTradeService.paymentReceiptConfirmed(model.getTrade());
+            if (TradeExceptionHandler.run(() -> muSigTradeService.paymentReceiptConfirmed(model.getTrade()))) {
+                sendTradeLogMessage(Res.encode("muSig.trade.state.phase3a.logMessage",
+                        model.getChannel().getMyUserIdentity().getUserName(), model.getFormattedNonBtcAmount()));
+            }
         }
     }
 

--- a/i18n/src/main/resources/default.properties
+++ b/i18n/src/main/resources/default.properties
@@ -66,6 +66,9 @@ data.add=Add
 data.remove=Remove
 data.redacted=Data has been removed for privacy and security reasons
 
+trade.error.tradingHalted=Trading is currently halted. The Bisq security manager has published an emergency alert that suspends trading for security reasons.
+trade.error.minVersionRequired=Trading requires Bisq version {0} or later. The Bisq security manager has published an emergency alert that sets a minimum required version for trading.
+
 offer.create=Create offer
 offer.takeOffer.buy.button=Buy bitcoin
 offer.takeOffer.sell.button=Sell bitcoin

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
@@ -65,6 +65,7 @@ import bisq.trade.bisq_easy.protocol.events.BisqEasyTakeOfferEvent;
 import bisq.trade.bisq_easy.protocol.events.BisqEasyTradeEvent;
 import bisq.trade.bisq_easy.protocol.messages.BisqEasyTakeOfferRequest;
 import bisq.trade.bisq_easy.protocol.messages.BisqEasyTradeMessage;
+import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.user.banned.BannedUserService;
 import bisq.user.contact_list.ContactListService;
 import bisq.user.contact_list.ContactReason;
@@ -214,8 +215,13 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     @Override
     public void onMessage(EnvelopePayloadMessage envelopePayloadMessage) {
         if (envelopePayloadMessage instanceof BisqEasyTradeMessage bisqEasyTradeMessage) {
-            verifyTradingNotOnHalt();
-            verifyMinVersionForTrading();
+            try {
+                verifyTradingNotOnHalt();
+                verifyMinVersionForTrading();
+            } catch (TradingNotAllowedException e) {
+                log.warn("Ignoring inbound trade message as trading is currently not allowed: {}", e.getMessage());
+                return;
+            }
 
             if (bannedUserService.isUserProfileBanned(bisqEasyTradeMessage.getSender())) {
                 log.warn("Message ignored as sender is banned");
@@ -460,15 +466,15 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     }
 
     private void verifyTradingNotOnHalt() {
-        checkArgument(!haltTrading, "Trading is on halt for security reasons. " +
-                "The Bisq security manager has published an emergency alert with haltTrading set to true");
+        if (haltTrading) {
+            throw new TradingNotAllowedException(Res.get("trade.error.tradingHalted"));
+        }
     }
 
     private void verifyMinVersionForTrading() {
-        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent()) {
-            checkArgument(ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get())),
-                    "For trading you need to have version " + minRequiredVersionForTrading.get() + " installed. " +
-                            "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent() &&
+                !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get()))) {
+            throw new TradingNotAllowedException(Res.get("trade.error.minVersionRequired", minRequiredVersionForTrading.get()));
         }
     }
 

--- a/trade/src/main/java/bisq/trade/exceptions/TradingNotAllowedException.java
+++ b/trade/src/main/java/bisq/trade/exceptions/TradingNotAllowedException.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.exceptions;
+
+/**
+ * Thrown when a trade action is blocked by a security manager alert (trading on halt or a min.
+ * version required for trading). This is an expected, user-actionable condition, not a bug, so the
+ * UI presents the message as a warning rather than a bug report.
+ */
+public class TradingNotAllowedException extends RuntimeException {
+    public TradingNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -40,6 +40,7 @@ import bisq.common.platform.Version;
 import bisq.common.threading.ExecutorFactory;
 import bisq.common.timer.Scheduler;
 import bisq.contract.mu_sig.MuSigContract;
+import bisq.i18n.Res;
 import bisq.identity.Identity;
 import bisq.identity.IdentityService;
 import bisq.network.NetworkService;
@@ -60,6 +61,7 @@ import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.trade.ServiceProvider;
+import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService;
 import bisq.trade.mu_sig.events.MuSigTradeEvent;
 import bisq.trade.mu_sig.events.blockchain.DepositTxConfirmedEvent;
@@ -345,8 +347,13 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     @Override
     public void onMessage(EnvelopePayloadMessage envelopePayloadMessage) {
         if (envelopePayloadMessage instanceof MuSigTradeMessage muSigTradeMessage) {
-            verifyTradingNotOnHalt();
-            verifyMinVersionForTrading();
+            try {
+                verifyTradingNotOnHalt();
+                verifyMinVersionForTrading();
+            } catch (TradingNotAllowedException e) {
+                log.warn("Ignoring inbound trade message as trading is currently not allowed: {}", e.getMessage());
+                return;
+            }
 
             if (bannedUserService.isUserProfileBanned(muSigTradeMessage.getSender())) {
                 log.warn("Message ignored as sender is banned");
@@ -693,15 +700,15 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     }
 
     private void verifyTradingNotOnHalt() {
-        checkArgument(!haltTrading, "Trading is on halt for security reasons. " +
-                "The Bisq security manager has published an emergency alert with haltTrading set to true");
+        if (haltTrading) {
+            throw new TradingNotAllowedException(Res.get("trade.error.tradingHalted"));
+        }
     }
 
     private void verifyMinVersionForTrading() {
-        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent()) {
-            checkArgument(ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get())),
-                    "For trading you need to have version " + minRequiredVersionForTrading.get() + " installed. " +
-                            "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent() &&
+                !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get()))) {
+            throw new TradingNotAllowedException(Res.get("trade.error.minVersionRequired", minRequiredVersionForTrading.get()));
         }
     }
 


### PR DESCRIPTION
## Problem

When a security manager emergency alert is active — trading **on halt**, or a **minimum version required for trading** — performing a trade action crashes with the **"Report a bug to Bisq developers"** dialog.

From the reporter's log (#4818), clicking "Confirm fiat sent" while below the required version:

```
java.lang.IllegalArgumentException: For trading you need to have version 2.1.11 installed.
The Bisq security manager has published an emergency alert with a min. version required for trading.
  at BisqEasyTradeService.verifyMinVersionForTrading(BisqEasyTradeService.java:467)
  at BisqEasyTradeService.handleBisqEasyTradeEvent(BisqEasyTradeService.java:350)
  at BisqEasyTradeService.buyerConfirmFiatSent(BisqEasyTradeService.java:321)
  at BuyerState2a$Controller.onConfirmFiatSent(BuyerState2a.java:118)
```

## Root cause

`verifyTradingNotOnHalt()` and `verifyMinVersionForTrading()` enforce the alert with `checkArgument`, which throws an `IllegalArgumentException`. Triggered by a trade action on the JavaFX thread, the exception is uncaught, and the global handler renders any uncaught throwable as a bug report. But this is an **expected, user-actionable** condition (update the app / wait for the alert to clear), not a bug.

## Fix

The guards now throw a dedicated `TradingNotAllowedException` (in both `BisqEasyTradeService` and `MuSigTradeService`), and it's handled **at each boundary** rather than the global uncaught handler — because the guards are reached from more than just the desktop UI:

- **Desktop UI** → caught at the trade-action call sites via a small shared `TradeExceptionHandler` and shown as a **warning** popup; the `DesktopController.onUncaughtException` special-case is removed. The trade-log message is now emitted **only after** the guarded call is accepted (previously a blocked action could still leave a "confirmed/sent" entry in the trade chat).
- **Network inbound** (`onMessage`) → logs and **drops** the inbound trade message instead of throwing.
- **REST API** → mapped to **409 Conflict** (`TradingNotAllowedExceptionMapper`), instead of the generic mapper's 500.
- The guard messages are now **i18n** keys (`default.properties`).

The guards run at the top of the trade-event entry points, before any FSM mutation, so no trade state is affected.

> Reworked from an earlier version that handled the exception centrally in `DesktopController.onUncaughtException`, per review feedback that this was desktop-only and treated an expected rejection as an uncaught error.

## Testing

`TradingNotAllowedException` was forced to fire on demand (a runtime toggle in `verifyTradingNotOnHalt`) across two local CLEAR-net traders (Alice/Bob) + seeds, walking a full BisqEasy trade and tripping the halt right before each guarded action. Every action showed a **Warning** popup (not the bug dialog), with **0 `Uncaught exception`** in either client's log throughout (i.e. handled at the boundary). The log-ordering fix was confirmed: no trade-log message is written when the action is blocked.

**Layer 1 — Desktop UI (warning popup at the trade-action boundary):**
<img width="1399" height="958" alt="Screenshot from 2026-06-17 12-19-41" src="https://github.com/user-attachments/assets/4866dd02-c764-42bb-812e-ddc9324abda5" />


| # | Action | Side | Result |
|---|--------|------|--------|
| 1 | Take offer (offerbook) | taker | Warning ✅ |
| 2 | Seller sends payment account | seller | Warning ✅ |
| 3 | Buyer sends BTC payment data | buyer | Warning ✅ |
| 4 | **Buyer confirms fiat sent (reported #4818 action)** | buyer | Warning ✅ |
| 5 | Seller confirms fiat receipt | seller | Warning ✅ |
| 6 | Seller confirms BTC sent | seller | Warning ✅ |
| 7 | Buyer confirms BTC received | buyer | Warning ✅ |
| 8 | Cancel / Reject trade (shared handler) | either | Warning ✅ |

**Layer 2 — Network inbound (`onMessage` logs & drops):** with only the receiver halted, the sender took its offer; the receiver dropped the inbound trade message at the network boundary instead of throwing:

```
WARN [Network.notify] b.t.b.BisqEasyTradeService: Ignoring inbound trade message as trading is
currently not allowed: Trading is currently halted. The Bisq security manager has published an
emergency alert that suspends trading for security reasons.
```

**Layer 3 — REST API (409 Conflict):** unit-tested via `TradingNotAllowedExceptionMapperTest` — the mapper returns 409 with the message body.

**Recovery after upgrade (min-version case):** since the guards run before any FSM mutation, a blocked action leaves no residue and the trade resumes once the version requirement is met. Verified end-to-end on the same Alice/Bob setup:

1. **Establish** — normal build, version check passing. Drive a BisqEasy trade to the buyer's "Confirm fiat sent" step (state `…BUYER_RECEIVED_ACCOUNT_DATA`).
2. **Block** — rebuild with min version forced to `99.0.0`, restart the buyer on the same data dir. The trade reloads at the same step. Clicking the button shows the Warning popup, the button stays, and the log shows no state transition and no message sent.
3. **Restart while blocked** — restart the buyer again. The trade reloads at the same step, unchanged — the blocked click left no stuck/corrupted state.
4. **Recover** — rebuild with the requirement removed (the upgrade), restart the buyer on the same data dir. Clicking the same button proceeds normally:

```
Handle BisqEasyConfirmFiatSentEvent at BisqEasyConfirmFiatSentEventHandler
Transition completed to new state BUYER_SENT_FIAT_SENT_CONFIRMATION
Sent message to Addresses: 127.0.0.1:…
```

Fixes #4818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trading actions are now blocked during emergency halt and when the app is below the minimum required version, with clear warning messages.

* **Improvements**
  * REST API returns **409 Conflict** with a user-facing error when trading is restricted.
  * Trade UI now shows warnings instead of failing silently, suppresses repeated notifications on retries, and records trade log messages only after successful actions.

* **Tests**
  * Added tests to verify the REST API **409** mapping and that trade log emission is skipped when actions are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
