### PR TITLE
Add copy offer action to MuSig offer lists

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookController.java
@@ -350,6 +350,14 @@ public class MuSigOfferbookController implements Controller {
                 .show();
     }
 
+    void onCopyOffer(MuSigOffer muSigOffer) {
+        new Popup().information(Res.get("muSig.offer.listing.copyOffer.confirmation"))
+                .actionButtonText(Res.get("confirmation.yes"))
+                .onAction(() -> doCopyOffer(muSigOffer))
+                .closeButtonText(Res.get("confirmation.no"))
+                .show();
+    }
+
     void onSortMarkets(MuSigMarketSortType marketSortType) {
         model.getSelectedMarketSortType().set(marketSortType);
         model.getSortedMarketItems().setComparator(marketSortType.getComparator());
@@ -453,6 +461,22 @@ public class MuSigOfferbookController implements Controller {
         } catch (RateLimitExceededException e) {
             UIThread.run(() -> {
                 new Popup().warning(Res.get("muSig.offer.listing.rateLimitsExceeded.removeOffer.warning")).show();
+            });
+        }
+    }
+
+    private void doCopyOffer(MuSigOffer muSigOffer) {
+        try {
+            MuSigOffer clonedOffer = muSigService.cloneOffer(muSigOffer);
+            muSigService.publishOffer(clonedOffer);
+            muSigService.getSelectedMuSigOffer().set(clonedOffer);
+        } catch (UserProfileBannedException e) {
+            UIThread.run(() -> {
+                // We do not inform banned users about being banned
+            });
+        } catch (RateLimitExceededException e) {
+            UIThread.run(() -> {
+                new Popup().warning(Res.get("muSig.offer.create.rateLimitsExceeded.publish.warning")).show();
             });
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookView.java
@@ -636,6 +636,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
                         }
                         setGraphic(myOfferMainBox);
                         showOfferDetails.setOnAction(e -> controller.onShowOfferDetails(item.getOffer()));
+                        copyOfferMenuItem.setOnAction(e -> controller.onCopyOffer(item.getOffer()));
                         removeOfferMenuItem.setOnAction(e -> controller.onRemoveOffer(item.getOffer()));
                     } else {
                         takeOfferButton.setText(item.getTakeOfferButtonText());
@@ -661,6 +662,7 @@ public final class MuSigOfferbookView extends View<VBox, MuSigOfferbookModel, Mu
                     takeOfferButton.setOnAction(null);
                     takeOfferButton.setOnContextMenuRequested(null);
                     showOfferDetails.setOnAction(null);
+                    copyOfferMenuItem.setOnAction(null);
                     removeOfferMenuItem.setOnAction(null);
                     setGraphic(null);
                 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/my_offers/MuSigMyOffersController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/my_offers/MuSigMyOffersController.java
@@ -161,6 +161,14 @@ public class MuSigMyOffersController implements Controller {
                 .show();
     }
 
+    void onCopyOffer(MuSigOffer muSigOffer) {
+        new Popup().information(Res.get("muSig.offer.listing.copyOffer.confirmation"))
+                .actionButtonText(Res.get("confirmation.yes"))
+                .onAction(() -> doCopyOffer(muSigOffer))
+                .closeButtonText(Res.get("confirmation.no"))
+                .show();
+    }
+
     void onGoToOffer(MuSigOffer muSigOffer) {
         muSigService.getSelectedMuSigOffer().set(muSigOffer);
         Navigation.navigateTo(NavigationTarget.MU_SIG_OFFERBOOK);
@@ -196,6 +204,22 @@ public class MuSigMyOffersController implements Controller {
         } catch (RateLimitExceededException e) {
             UIThread.run(() -> {
                 new Popup().warning(Res.get("muSig.offer.listing.rateLimitsExceeded.removeOffer.warning")).show();
+            });
+        }
+    }
+
+    private void doCopyOffer(MuSigOffer muSigOffer) {
+        try {
+            MuSigOffer clonedOffer = muSigService.cloneOffer(muSigOffer);
+            muSigService.publishOffer(clonedOffer);
+            muSigService.getSelectedMuSigOffer().set(clonedOffer);
+        } catch (UserProfileBannedException e) {
+            UIThread.run(() -> {
+                // We do not inform banned users about being banned
+            });
+        } catch (RateLimitExceededException e) {
+            UIThread.run(() -> {
+                new Popup().warning(Res.get("muSig.offer.create.rateLimitsExceeded.publish.warning")).show();
             });
         }
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/my_offers/MuSigMyOffersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/my_offers/MuSigMyOffersView.java
@@ -280,11 +280,13 @@ public class MuSigMyOffersView extends View<VBox, MuSigMyOffersModel, MuSigMyOff
                     setUpRowEventHandlersAndListeners();
                     setGraphic(myOfferMainBox);
                     goToOfferMenuItem.setOnAction(e -> controller.onGoToOffer(item.getOffer()));
+                    copyOfferMenuItem.setOnAction(e -> controller.onCopyOffer(item.getOffer()));
                     removeOfferMenuItem.setOnAction(e -> controller.onRemoveOffer(item.getOffer()));
                 } else {
                     resetRowEventHandlersAndListeners();
                     resetVisibilities();
                     goToOfferMenuItem.setOnAction(null);
+                    copyOfferMenuItem.setOnAction(null);
                     removeOfferMenuItem.setOnAction(null);
                     setGraphic(null);
                 }

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -301,6 +301,7 @@ muSig.offer.listing.table.cell.takeOffer.cannotTakeOfferReason.noAccountForOffer
   Do you want to create an account?
 
 muSig.offer.listing.removeOffer.confirmation=Are you sure you want to delete this offer?
+muSig.offer.listing.copyOffer.confirmation=Do you want to create a similar offer with the same terms?
 muSig.offer.listing.rateLimitsExceeded.removeOffer.warning=You cannot remove that offer because you have exceeded the rate limit.\n\
   Please try to use a different offer.
 

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigService.java
@@ -237,6 +237,11 @@ public class MuSigService extends LifecycleService {
                 MuSigProtocol.VERSION);
     }
 
+    public MuSigOffer cloneOffer(MuSigOffer muSigOffer) {
+        checkArgument(isActivated());
+        return muSigOfferService.cloneOffer(muSigOffer);
+    }
+
     public CompletableFuture<BroadcastResult> publishOffer(MuSigOffer muSigOffer) throws UserProfileBannedException, RateLimitExceededException {
         checkArgument(isActivated());
         validateUserProfile(muSigOffer.getMakersUserProfileId());

--- a/offer/src/main/java/bisq/offer/mu_sig/MuSigOffer.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MuSigOffer.java
@@ -77,6 +77,27 @@ public final class MuSigOffer extends Offer<PaymentMethodSpec<?>, PaymentMethodS
         );
     }
 
+    /**
+     * Creates a copy of the given offer with a new id and a current date, reusing all other terms.
+     * Used by the copy-offer feature to publish a similar offer.
+     */
+    public static MuSigOffer cloneWithNewId(MuSigOffer offer, String newId) {
+        return new MuSigOffer(newId,
+                System.currentTimeMillis(),
+                offer.getMakerNetworkId(),
+                offer.getDirection(),
+                offer.getMarket(),
+                offer.getAmountSpec(),
+                offer.getPriceSpec(),
+                offer.getProtocolTypes(),
+                offer.getBaseSidePaymentMethodSpecs(),
+                offer.getQuoteSidePaymentMethodSpecs(),
+                offer.getOfferOptions(),
+                VERSION,
+                offer.getTradeProtocolVersion(),
+                BuildVersion.VERSION);
+    }
+
     private MuSigOffer(String id,
                        long date,
                        NetworkId makerNetworkId,

--- a/offer/src/main/java/bisq/offer/mu_sig/MuSigOfferService.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MuSigOfferService.java
@@ -19,6 +19,7 @@ package bisq.offer.mu_sig;
 
 import bisq.common.application.Service;
 import bisq.common.timer.Scheduler;
+import bisq.common.util.StringUtils;
 import bisq.identity.IdentityService;
 import bisq.network.NetworkService;
 import bisq.network.p2p.services.data.BroadcastResult;
@@ -118,7 +119,7 @@ public class MuSigOfferService implements Service {
     }
 
     public MuSigOffer cloneOffer(MuSigOffer offer) {
-        return MuSigOffer.fromProto(offer.toProto(true));
+        return MuSigOffer.cloneWithNewId(offer, StringUtils.createUid());
     }
 
 

--- a/offer/src/test/java/bisq/offer/mu_sig/MuSigOfferTest.java
+++ b/offer/src/test/java/bisq/offer/mu_sig/MuSigOfferTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.mu_sig;
+
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.offer.Direction;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class MuSigOfferTest {
+
+    private MuSigOffer createOffer() {
+        Market market = MarketRepository.getDefaultBtcFiatMarket();
+        return new MuSigOffer("source-id",
+                null,
+                Direction.BUY,
+                market,
+                null,
+                null,
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER)),
+                List.of(),
+                "1.0.0");
+    }
+
+    @Test
+    void cloneWithNewIdGivesNewIdAndKeepsAllOtherTerms() {
+        MuSigOffer source = createOffer();
+        MuSigOffer clone = MuSigOffer.cloneWithNewId(source, "new-id");
+
+        assertEquals("new-id", clone.getId());
+        assertNotEquals(source.getId(), clone.getId());
+
+        assertEquals(source.getMakerNetworkId(), clone.getMakerNetworkId());
+        assertEquals(source.getDirection(), clone.getDirection());
+        assertEquals(source.getMarket(), clone.getMarket());
+        assertEquals(source.getAmountSpec(), clone.getAmountSpec());
+        assertEquals(source.getPriceSpec(), clone.getPriceSpec());
+        assertEquals(source.getProtocolTypes(), clone.getProtocolTypes());
+        assertEquals(source.getBaseSidePaymentMethodSpecs(), clone.getBaseSidePaymentMethodSpecs());
+        assertEquals(source.getQuoteSidePaymentMethodSpecs(), clone.getQuoteSidePaymentMethodSpecs());
+        assertEquals(source.getOfferOptions(), clone.getOfferOptions());
+        assertEquals(source.getTradeProtocolVersion(), clone.getTradeProtocolVersion());
+    }
+}


### PR DESCRIPTION
## What

Wires the previously inert **copy offer** action in the Bisq MuSig **My Offers** and **Offerbook** tables. Copying one of your own offers republishes it with the same terms (market, direction, amount, price, payment methods) under a fresh offer id and the current date and app version.

Part of #4133.

## Changes

- `MuSigOffer.cloneWithNewId(offer, newId)` — domain factory reusing the offer's specs/options with a new id, current date and app version.
- Repurpose the dead `MuSigOfferService.cloneOffer` (previously a same-id `fromProto(toProto)` no-op) to use it.
- `MuSigService.cloneOffer` passthrough, guarded by `isActivated`.
- Wire `onCopyOffer`/`doCopyOffer` in `MuSigMyOffersController` and `MuSigOfferbookController`, with a confirmation dialog and the same banned / rate-limit handling as remove. Copy is gated to own offers.
- `MuSigOfferTest` covering `cloneWithNewId`.

## Scope / follow-ups

- **Edit offer** (also requested in #4133) is **deferred until after the create-offer rewrite.** The create/take-offer area is mid-rewrite, so edit is best built on the new structure rather than now (confirmed with @HenrikJannsen). This PR is therefore the **copy** portion only — intentionally split out from the earlier combined PR #4351 so it ships without touching the rewrite area. #4133 stays open for edit.
- **Heads-up for reviewers:** the MuSig **My Offers** action icons (edit / copy / go-to / delete) are **pre-existingly clipped off the right edge at the default window width** — the action column is the `FLEX_LAST` column and the other columns consume the full table width, so it renders past the visible area. **Widening the window reveals them.** This is _not_ introduced by this PR (it affects the existing delete / go-to icons too) — copy works, the icon just isn't visible until the window is wide enough. I'll file this separately.

## Testing

- New `MuSigOfferTest` green; `mu-sig` and `desktop` compile.
- Manually verified at runtime: copying an own offer publishes a duplicate with a new offer id; the action icons render correctly (visible once the window is wide enough — see note above).

### Manual testing (Offerbook)

1. **Before** — own offer "Copy" on BTC/USD; sidebar shows "USD (3 offers)":
   <img width="900" alt="before copy — 3 offers" src="https://github.com/user-attachments/assets/933307a9-8581-48ee-879b-61ba53377f83" />

2. **Confirm** — the "Do you want to create a similar offer with the same terms?" dialog:
   <img width="900" alt="copy confirmation dialog" src="https://github.com/user-attachments/assets/5007696d-efd4-43d8-bab9-bb938755f98a" />

3. **After** — duplicate published; sidebar now "USD (4 offers)" with two identical "Copy" offers:
   <img width="900" alt="after copy — 4 offers" src="https://github.com/user-attachments/assets/063a2661-5e53-4f0c-b43e-4e5e0fa33341" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy offer functionality allowing users to duplicate existing offers with identical terms.
  * Copy action displays confirmation dialog before creating duplicates.
  * Includes error handling for rate limits and profile restrictions.

* **Tests**
  * Added unit tests validating offer cloning functionality.

* **Chores**
  * Added internationalization support for copy offer feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
