### PR TITLE
Add repo-local AI agent skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -44,5 +44,6 @@ Run from the repository root after editing skills:
 
 ```bash
 find .agents/skills .claude/skills -maxdepth 2 -name SKILL.md | sort
+diff -qr .agents/skills .claude/skills
 git diff --check -- .agents/skills .claude/skills
 ```

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,48 @@
+# Bisq AI Skills
+
+Repo-local skills in this directory are loaded automatically by AI coding agents when working in the Bisq 2 checkout.
+
+- Codex scans `.agents/skills` from the current directory up to the Git root.
+- Claude Code uses `.claude/skills` for repository skills.
+
+## Available Skills
+
+### bisq-contributor-workflow
+
+Guides day-to-day Bisq implementation work: issue analysis, narrow changes, Java/JavaFX conventions, Gradle verification, P2P safety, wallet and transaction checks, DAO impact, and documentation updates.
+
+### bisq2-javafx-ui
+
+Guides production-ready Bisq2 JavaFX UI work with strict MVC structure, lifecycle cleanup, design system conventions, navigation wiring, automation selectors, desktop harness verification, and review checklists.
+
+### bisq-pr-reviewer
+
+Performs comprehensive Bisq pull request review by combining review-comment extraction with contribution standards, architecture review, and Bitcoin/P2P security validation.
+
+### git-commit-writer
+
+Drafts and reviews professional commit messages with imperative subjects, concise summaries, and body text focused on what changed and why.
+
+### ui-design-principles
+
+Applies pragmatic UI quality checks for JavaFX, web, desktop, mobile, and CLI interfaces.
+
+## Required Structure
+
+```text
+{agent-root}/skills/{skill-name}/
++-- SKILL.md
++-- agents/openai.yaml
++-- references/          # Optional, for detailed material loaded as needed
+```
+
+Use `references/` for long checklists or examples. Keep the main `SKILL.md` focused on workflow and routing.
+
+## Sanity Check
+
+Run from the repository root after editing skills:
+
+```bash
+find .agents/skills .claude/skills -maxdepth 2 -name SKILL.md | sort
+git diff --check -- .agents/skills .claude/skills
+```

--- a/.agents/skills/bisq-contributor-workflow/SKILL.md
+++ b/.agents/skills/bisq-contributor-workflow/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bisq-contributor-workflow
+description: Guide Codex or Claude Code through high-quality Bisq contribution work. Use when implementing Bisq issues, fixing bugs, changing Java or JavaFX code, touching P2P networking, Bitcoin wallet or transaction logic, DAO governance, build/test workflows, documentation, or contributor onboarding tasks in Bisq repositories.
+---
+
+# Bisq Contributor Workflow
+
+## Goal
+
+Help Bisq contributors make small, well-verified changes that respect Bisq's decentralized, security-sensitive architecture. Prefer repository-local patterns over generic framework advice.
+
+## Core Workflow
+
+1. Read the issue, nearby code, tests, and project docs before editing.
+2. Identify the affected domain: desktop UI, trade protocol, P2P networking, wallet/Bitcoin, DAO, persistence, build tooling, or docs.
+3. Keep changes narrow. Avoid broad refactors unless they directly reduce risk for the requested change.
+4. Run the smallest meaningful verification first, then broaden when touching shared or security-sensitive code.
+5. Summarize behavioral impact, tests run, and residual risk.
+
+## Bisq-Specific Checks
+
+- For Bitcoin, wallet, key, fee, address, or transaction code, verify private-key handling, amount precision, dust/fee boundaries, and network selection.
+- For P2P or trade protocol changes, check message validation, state transitions, replay/idempotency behavior, and peer trust assumptions.
+- For JavaFX UI changes, preserve the existing MVC structure, view/controller boundaries, resource usage, and responsive layout behavior.
+- For DAO governance changes, verify proposal/vote lifecycle assumptions and backwards compatibility with existing DAO state.
+- For docs and prompts, prefer contributor workflow clarity over marketing copy.
+
+## Verification
+
+Use commands from the target Bisq repository rather than inventing new ones. Common patterns include:
+
+```bash
+./gradlew test
+./gradlew :desktop:desktop-app:test
+./gradlew :core:test
+```
+
+If a module or task name differs, inspect `settings.gradle`, `build.gradle`, or `./gradlew tasks` and choose the nearest focused command. When tests are too expensive or unavailable, state exactly what was inspected instead.
+
+## Related Resources
+
+For review-heavy work, use `bisq-pr-reviewer`. For UI-specific polish, use `ui-design-principles`. For commit messages, use `git-commit-writer`.

--- a/.agents/skills/bisq-contributor-workflow/SKILL.md
+++ b/.agents/skills/bisq-contributor-workflow/SKILL.md
@@ -39,4 +39,4 @@ If a module or task name differs, inspect `settings.gradle`, `build.gradle`, or 
 
 ## Related Resources
 
-For review-heavy work, use `$bisq-pr-reviewer`. For UI-specific polish, use `$ui-design-principles`. For commit messages, use `$git-commit-writer`.
+Use `$bisq-pr-reviewer` for review-heavy work, `$ui-design-principles` for UI-specific polish, and `$git-commit-writer` for commit message guidance.

--- a/.agents/skills/bisq-contributor-workflow/SKILL.md
+++ b/.agents/skills/bisq-contributor-workflow/SKILL.md
@@ -39,4 +39,4 @@ If a module or task name differs, inspect `settings.gradle`, `build.gradle`, or 
 
 ## Related Resources
 
-For review-heavy work, use `bisq-pr-reviewer`. For UI-specific polish, use `ui-design-principles`. For commit messages, use `git-commit-writer`.
+For review-heavy work, use `$bisq-pr-reviewer`. For UI-specific polish, use `$ui-design-principles`. For commit messages, use `$git-commit-writer`.

--- a/.agents/skills/bisq-contributor-workflow/agents/openai.yaml
+++ b/.agents/skills/bisq-contributor-workflow/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Bisq Contributor Workflow"
+  short_description: "Implement Bisq changes with architecture and safety checks"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $bisq-contributor-workflow to implement this Bisq issue with focused verification."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/bisq-pr-reviewer/SKILL.md
+++ b/.agents/skills/bisq-pr-reviewer/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: bisq-pr-reviewer
+description: Provide comprehensive Bisq PR review in Codex or Claude Code by integrating CodeRabbitAI feedback extraction with Bisq-specific security validation, contribution standards verification, and domain expertise for Bitcoin, P2P, trade protocol, DAO, Java, and JavaFX changes. Use when reviewing Bisq pull requests, validating contribution standards, extracting unresolved review comments, or performing security reviews of cryptocurrency code changes.
+---
+
+# Bisq PR Reviewer
+
+## Purpose
+
+Deliver comprehensive pull request review for Bisq repositories through a two-phase process: systematic CodeRabbitAI comment extraction followed by Bisq domain expertise analysis covering security validation, contribution standards compliance, and architecture patterns.
+
+## Tooling
+
+Use the host environment's normal file, shell, and GitHub tools. In Claude Code, the bundled `/review-pr` command can run the extraction workflow directly. In Codex, read `commands/review-pr.md` from this plugin and execute the same steps with `gh`, local file reads, and repository inspection.
+
+## When to Use
+
+Trigger this skill for:
+- Comprehensive Bisq pull request reviews
+- CodeRabbitAI feedback validation and extraction
+- Security review of Bitcoin/crypto code changes
+- P2P protocol or trade protocol modifications
+- DAO governance impact assessment
+- Contribution standards compliance verification
+
+**Activation phrases**:
+- "Review PR #123"
+- "Check CodeRabbitAI feedback on bisq-network/bisq2#456"
+- "Analyze pull request for Bisq standards"
+- "Comprehensive security review of this PR"
+
+## Two-Phase Review Workflow
+
+### Phase 1: CodeRabbitAI Comment Extraction
+
+Systematically extract and organize all review feedback. In Claude Code, execute the bundled `/review-pr` command:
+
+```bash
+SlashCommand: "/review-pr {pr_number or owner/repo#pr}"
+```
+
+In Codex, open `commands/review-pr.md` within this plugin and follow that command's phases manually.
+
+**Phase 1 delivers**:
+1. CI/CD status verification
+2. Complete comment inventory (inline, review body, issue comments)
+3. CodeRabbit nitpicks and duplicates extraction
+4. Code-verified current status of each comment
+5. Severity categorization (Critical, High, Medium, Nitpicks)
+6. Numbered action item checklist with traceability
+
+### Phase 2: Bisq Domain Analysis
+
+After Phase 1 completion, apply Bisq-specific expertise across four domains:
+
+#### 1. Security Validation
+
+Identify security-sensitive files in the PR:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/files --jq '.[].filename' | \
+  grep -E "(bitcoin|crypto|trade|wallet|key|transaction|p2p|dao)"
+```
+
+For each security-sensitive file, load and apply security checklist:
+
+```bash
+Read references/bisq-security-checklist.md
+```
+
+The security checklist covers:
+- Private key handling validation
+- Bitcoin transaction safety (fees, dust, overflow)
+- Cryptographic operations approval
+- P2P message validation
+- Financial logic precision
+
+Generate security assessment using template from `references/bisq-security-checklist.md`.
+
+#### 2. Contribution Standards Compliance
+
+Load contribution standards reference:
+
+```bash
+Read references/contribution-standards.md
+```
+
+**Verify GPG signatures**:
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/commits \
+  --jq '.[] | {sha: .sha, verified: .commit.verification.verified, reason: .commit.verification.reason}'
+```
+
+**Extract commit messages for validation**:
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/commits --jq '.[].commit.message'
+```
+
+Apply validation for:
+- C4 protocol compliance (stakeholder buy-in, atomic commits)
+- GPG signatures on all commits
+- Git commit message standards (via git-commit-writer skill integration)
+
+For commit message improvements, reference git-commit-writer skill patterns.
+
+#### 3. Architecture Patterns Compliance
+
+Load architecture patterns reference:
+
+```bash
+Read references/bisq-architecture-patterns.md
+```
+
+Validate:
+- Multi-module Gradle structure boundaries
+- JavaFX MVVM pattern adherence
+- Dependency injection (Guice) patterns
+- Service layer separation
+- Trade protocol state machine safety (if applicable)
+- DAO governance logic correctness (if applicable)
+- P2P protocol versioning and compatibility
+
+#### 4. Domain-Specific Checks
+
+**Trade Protocol Safety** (if trade-related changes):
+```bash
+Grep "TradeProtocol|TradingPeer|TradeManager" --output_mode files_with_matches
+```
+
+Validate state transitions, peer communication safety, and financial correctness.
+
+**DAO Governance Impact** (if DAO changes):
+```bash
+Grep "DAO|Governance|Proposal|Vote|Bonding" --output_mode files_with_matches
+```
+
+Validate voting logic, proposal validation, and bond management.
+
+## Complete Review Output
+
+Generate comprehensive report combining both phases:
+
+```markdown
+# Bisq PR Review: #{pr_number}
+
+## Phase 1: CodeRabbitAI Comment Analysis
+[Output from /review-pr command]
+- CI Status: {✅ Passing | ❌ {X} failures}
+- Total Comments: {count}
+- Critical Issues: {count}
+
+## Phase 2: Bisq Domain Analysis
+
+### 🔐 Security Review
+[From bisq-security-checklist.md assessment]
+**Risk Level**: {CRITICAL|HIGH|MEDIUM|LOW}
+**Critical Findings**: {count}
+
+### 📋 Contribution Standards
+[From contribution-standards.md validation]
+- GPG Signatures: {✅ All signed | ❌ {X} unsigned}
+- Commit Messages: {✅ Compliant | ⚠️ {X} need improvement}
+- C4 Protocol: {✅ Compliant | ⚠️ Issues found}
+
+### 🏗️ Architecture Compliance
+[From bisq-architecture-patterns.md validation]
+- Module Structure: {✅ Correct | ⚠️ Concerns}
+- Design Patterns: {✅ Followed | ⚠️ Violations}
+- Domain Logic: {assessment}
+
+### ✅ Combined Action Plan
+
+#### Must Fix Before Merge
+1. [Critical from CodeRabbit + Security + CI]
+2. ...
+
+#### Should Fix (High Priority)
+1. [High priority from both phases]
+2. ...
+
+#### Nice to Have (Medium + Nitpicks)
+[Combined list]
+
+## Summary
+- **Overall**: {READY TO MERGE | NEEDS WORK | MAJOR CONCERNS}
+- **Blockers**: {count}
+- **Security Risk**: {None|Low|Medium|High|Critical}
+```
+
+## Execution Steps
+
+1. **Parse PR reference** from user input (format: "owner/repo#number" or just "number")
+2. **Execute Phase 1**: Invoke `/review-pr` for CodeRabbitAI extraction
+3. **Get PR file list**: `gh api repos/{owner}/{repo}/pulls/{pr}/files`
+4. **Identify domains**: Detect security-sensitive, architecture, DAO, or trade protocol files
+5. **Load relevant references**: Load only needed reference files for efficiency
+6. **Apply domain validation**: Execute security, standards, and architecture checks
+7. **Generate combined report**: Merge findings from both phases
+8. **Prioritize actions**: Order by criticality (Security > CI > CodeRabbit > Standards > Architecture)
+
+## Edge Cases
+
+**Large PRs (>10 files)**:
+- Prioritize security-sensitive files first
+- Summarize architecture changes at module level
+- Group related issues
+
+**Security-Critical PRs**:
+- Load full security checklist even for quick reviews
+- Escalate critical findings immediately
+- Recommend additional security testing
+
+**First-Time Contributors**:
+- Provide detailed standards explanation
+- Link to Bisq contribution guidelines
+- Offer GPG setup assistance if signatures missing
+
+**DAO/Protocol Changes**:
+- Apply extra scrutiny to governance and P2P code
+- Simulate scenarios for validation
+- Assess backward compatibility thoroughly
+
+## Integration Points
+
+**git-commit-writer skill**:
+- Automatically reference when commit messages need improvement
+- Use git-commit-writer patterns for suggested rewrites
+
+**bisq-ai-contributor-tools ecosystem**:
+- Complements planned `bisq-architecture` skill
+- Could integrate with future `bitcoin-security` skill
+- Works alongside `/review-pr` command
+
+## Success Criteria
+
+Complete review delivers:
+- ✅ All CodeRabbitAI comments extracted and verified
+- ✅ CI status documented
+- ✅ Security validation for sensitive code
+- ✅ GPG signature verification
+- ✅ Commit message quality assessment
+- ✅ Architecture compliance check
+- ✅ Domain-specific safety validation
+- ✅ Prioritized, actionable recommendations
+- ✅ Clear merge decision with rationale
+
+## Bundled Resources
+
+**references/bisq-security-checklist.md**:
+Comprehensive Bitcoin/crypto security patterns including private key handling, transaction safety, cryptographic operations, P2P validation, and financial logic checks.
+
+**references/bisq-architecture-patterns.md**:
+Bisq architecture validation covering Gradle modules, JavaFX MVVM, dependency injection, trade protocol state machines, DAO governance patterns, and P2P networking.
+
+**references/contribution-standards.md**:
+C4 protocol compliance, GPG signature verification, and git commit message standards with integration guidance for git-commit-writer skill.
+
+Load references as needed based on PR content to maintain context efficiency.

--- a/.agents/skills/bisq-pr-reviewer/SKILL.md
+++ b/.agents/skills/bisq-pr-reviewer/SKILL.md
@@ -124,14 +124,14 @@ Validate:
 
 **Trade Protocol Safety** (if trade-related changes):
 ```bash
-Grep "TradeProtocol|TradingPeer|TradeManager" --output_mode files_with_matches
+grep -R -l -E "TradeProtocol|TradingPeer|TradeManager" .
 ```
 
 Validate state transitions, peer communication safety, and financial correctness.
 
 **DAO Governance Impact** (if DAO changes):
 ```bash
-Grep "DAO|Governance|Proposal|Vote|Bonding" --output_mode files_with_matches
+grep -R -l -E "DAO|Governance|Proposal|Vote|Bonding" .
 ```
 
 Validate voting logic, proposal validation, and bond management.

--- a/.agents/skills/bisq-pr-reviewer/agents/openai.yaml
+++ b/.agents/skills/bisq-pr-reviewer/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Bisq PR Reviewer"
+  short_description: "Review Bisq PRs with security and domain context"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $bisq-pr-reviewer to review this Bisq pull request for correctness, security, and standards."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
+++ b/.agents/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
@@ -1,0 +1,361 @@
+# Bisq Architecture Patterns
+
+Architecture validation reference for Bisq PR reviews covering Gradle modules, JavaFX patterns, dependency injection, and design principles.
+
+## Multi-Module Gradle Structure
+
+### Module Boundaries
+
+Bisq uses a multi-module Gradle structure. Changes should respect module boundaries and dependencies.
+
+**Core Modules**:
+- `core` - Core business logic, domain models
+- `desktop` - JavaFX desktop UI application
+- `common` - Shared utilities and common code
+- `p2p` - P2P networking layer
+- `assets` - Asset-specific implementations
+
+**Validation Points**:
+- [ ] Changes respect module dependencies (no circular dependencies)
+- [ ] Core logic not in UI modules
+- [ ] UI code not in core modules
+- [ ] Proper module-info.java updates if adding dependencies
+
+**Common Anti-Patterns**:
+```java
+// ❌ Desktop module calling P2P directly without abstraction
+desktop/src/main/java/SomeView.java:
+  import bisq.network.p2p.P2PService; // Should use service interface
+
+// ✅ Desktop module using service interface
+desktop/src/main/java/SomeView.java:
+  import bisq.core.api.CoreApi; // Proper abstraction
+```
+
+## JavaFX UI Patterns
+
+### MVVM Architecture
+
+Bisq desktop uses Model-View-ViewModel (MVVM) pattern with JavaFX.
+
+**Components**:
+- **View**: FXML or code-based JavaFX UI (`.fxml`, `*View.java`)
+- **ViewModel**: Presentation logic (`*ViewModel.java`, `*Model.java`)
+- **Model**: Domain objects from core module
+
+**Validation Points**:
+- [ ] Views are thin - no business logic
+- [ ] ViewModels contain presentation logic only
+- [ ] Business logic delegated to services
+- [ ] Proper observable property bindings
+- [ ] UI updates on JavaFX Application Thread
+
+**Correct Pattern**:
+```java
+// ✅ Proper MVVM separation
+public class TradeView extends ActivatableView<VBox, TradeViewModel> {
+    @Inject
+    public TradeView(TradeViewModel viewModel) {
+        super(viewModel);
+    }
+
+    @Override
+    protected void activate() {
+        // UI bindings only
+        amountTextField.textProperty().bindBidirectional(viewModel.amountProperty());
+    }
+}
+
+public class TradeViewModel extends ActivatableWithDataModel<TradeDataModel> {
+    public void onConfirmTrade() {
+        // Presentation logic
+        if (validate()) {
+            dataModel.confirmTrade(); // Delegate to model
+        }
+    }
+}
+
+public class TradeDataModel extends ActivatableDataModel {
+    @Inject
+    private TradeManager tradeManager; // Business logic service
+
+    public void confirmTrade() {
+        tradeManager.confirmTrade(trade); // Delegate to service
+    }
+}
+```
+
+**Anti-Patterns**:
+```java
+// ❌ Business logic in View
+public class TradeView {
+    public void onConfirmTrade() {
+        // Direct business logic - WRONG
+        tradeManager.confirmTrade(trade);
+    }
+}
+
+// ❌ UI updates not on FX thread
+public void updateUI() {
+    label.setText(value); // May crash if called from non-FX thread
+}
+
+// ✅ Correct FX thread usage
+public void updateUI() {
+    Platform.runLater(() -> label.setText(value));
+}
+```
+
+## Dependency Injection (Guice)
+
+Bisq uses Google Guice for dependency injection.
+
+**Validation Points**:
+- [ ] Constructor injection preferred
+- [ ] `@Inject` annotation on constructor
+- [ ] Avoid field injection where possible
+- [ ] Singleton services properly scoped
+- [ ] Module bindings correct
+
+**Correct Patterns**:
+```java
+// ✅ Constructor injection
+public class TradeManager {
+    private final P2PService p2pService;
+    private final WalletService walletService;
+
+    @Inject
+    public TradeManager(P2PService p2pService, WalletService walletService) {
+        this.p2pService = p2pService;
+        this.walletService = walletService;
+    }
+}
+
+// ✅ Module binding
+public class TradeModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(TradeManager.class).in(Singleton.class);
+    }
+}
+```
+
+**Anti-Patterns**:
+```java
+// ❌ Field injection (harder to test)
+public class TradeManager {
+    @Inject private P2PService p2pService;
+}
+
+// ❌ Manual instantiation instead of DI
+public class TradeView {
+    private TradeManager tradeManager = new TradeManager(); // WRONG
+}
+```
+
+## Service Layer Pattern
+
+Business logic should be in service classes, not in UI or controllers.
+
+**Service Characteristics**:
+- Stateless or carefully managed state
+- Reusable across different UI contexts
+- Testable without UI
+- Clear single responsibility
+
+**Validation Points**:
+- [ ] Business logic in services, not Views/ViewModels
+- [ ] Services injected, not instantiated
+- [ ] Proper error handling
+- [ ] Thread safety for concurrent access
+
+**Example Structure**:
+```java
+// Service layer
+@Singleton
+public class TradeProtocolManager {
+    public void initiateTrade(Trade trade) {
+        // Business logic here
+    }
+}
+
+// ViewModel uses service
+public class TradeViewModel {
+    @Inject
+    private TradeProtocolManager tradeProtocolManager;
+
+    public void onStartTrade() {
+        tradeProtocolManager.initiateTrade(trade);
+    }
+}
+```
+
+## Trade Protocol State Machine
+
+Trade protocol uses state machine pattern for safety and clarity.
+
+**Validation Points**:
+- [ ] State transitions are valid
+- [ ] Each state has clear entry/exit logic
+- [ ] Rollback/error handling for failed transitions
+- [ ] No state skipping
+- [ ] Proper state persistence
+
+**State Machine Pattern**:
+```java
+public enum TradeState {
+    INIT,
+    MAKER_SENT_PUBLISH_DEPOSIT_TX_REQUEST,
+    TAKER_RECEIVED_PUBLISH_DEPOSIT_TX_REQUEST,
+    TAKER_PUBLISHED_DEPOSIT_TX,
+    // ... more states
+}
+
+// State transition validation
+public void transitionTo(TradeState newState) {
+    if (!isValidTransition(currentState, newState)) {
+        throw new IllegalStateTransitionException();
+    }
+    currentState = newState;
+    persist();
+}
+```
+
+## DAO Governance Patterns
+
+DAO-related code requires extra care for voting and governance logic.
+
+**Validation Points**:
+- [ ] Voting weight calculations correct
+- [ ] Proposal validation thorough
+- [ ] Bond lock/unlock logic safe
+- [ ] No fund loss paths
+- [ ] Backward compatibility maintained
+
+**Critical Checks**:
+```java
+// Vote weight calculation
+long voteWeight = stake * votingPower; // Check for overflow
+if (voteWeight < stake) throw new ArithmeticException("Overflow");
+
+// Proposal parameter bounds
+if (proposalAmount > MAX_PROPOSAL_AMOUNT) {
+    reject();
+}
+
+// Bond management
+public void lockBond(long amount) {
+    if (availableBalance < amount) throw new InsufficientFundsException();
+    lockedBalance += amount;
+    availableBalance -= amount;
+    assert lockedBalance + availableBalance == totalBalance; // Invariant check
+}
+```
+
+## P2P Networking Architecture
+
+P2P layer has specific patterns for reliability and security.
+
+**Validation Points**:
+- [ ] Protocol versioning for backward compatibility
+- [ ] Message serialization safe
+- [ ] Connection management proper
+- [ ] Peer discovery logic correct
+- [ ] Bootstrap nodes handling
+
+**Protocol Versioning**:
+```java
+// Version compatibility check
+public boolean isCompatible(int peerVersion) {
+    return peerVersion >= MIN_SUPPORTED_VERSION
+        && peerVersion <= CURRENT_VERSION;
+}
+
+// Graceful handling of version differences
+if (!isCompatible(peer.getVersion())) {
+    if (peer.getVersion() < MIN_SUPPORTED_VERSION) {
+        disconnect(peer, "Outdated version");
+    } else {
+        // Future version - log but allow
+        log.warn("Peer has newer version: {}", peer.getVersion());
+    }
+}
+```
+
+## Code Quality Standards
+
+**General Patterns**:
+- [ ] Immutability preferred (final fields, immutable collections)
+- [ ] Defensive copying for mutable data
+- [ ] Null safety (Optional, @Nullable annotations)
+- [ ] Proper exception handling (don't swallow exceptions)
+- [ ] Logging at appropriate levels
+
+**Immutability Example**:
+```java
+// ✅ Immutable class
+public final class Trade {
+    private final String tradeId;
+    private final Coin amount;
+
+    public Trade(String tradeId, Coin amount) {
+        this.tradeId = requireNonNull(tradeId);
+        this.amount = requireNonNull(amount);
+    }
+
+    // No setters, only getters
+}
+
+// ❌ Mutable shared state
+public class TradeManager {
+    public List<Trade> trades = new ArrayList<>(); // WRONG: public mutable
+}
+```
+
+## Architecture Review Template
+
+```markdown
+## Bisq Architecture Review for PR #{number}
+
+### Module Structure
+- **Modules Modified**: {list}
+- **Dependency Changes**: {describe}
+- **Findings**:
+  - Module boundaries: {✅|⚠️|❌} {details}
+  - Circular dependencies: {✅ None|❌ Found} {details}
+
+### UI Layer (JavaFX)
+- **MVVM Compliance**: {✅|⚠️|❌}
+  - Views thin: {details}
+  - ViewModels appropriate: {details}
+  - Business logic in services: {details}
+- **Threading**: {✅|⚠️|❌}
+  - FX thread usage correct: {details}
+
+### Dependency Injection
+- **Injection Pattern**: {✅|⚠️|❌}
+  - Constructor injection: {details}
+  - Proper scoping: {details}
+
+### Trade Protocol
+- **State Machine**: {✅|⚠️|❌}
+  - Valid transitions: {details}
+  - Error handling: {details}
+  - Persistence: {details}
+
+### DAO Governance
+- **If DAO changes present**:
+  - Voting logic: {✅|⚠️|❌} {details}
+  - Proposal validation: {✅|⚠️|❌} {details}
+  - Fund safety: {✅|⚠️|❌} {details}
+
+### Code Quality
+- **Immutability**: {✅|⚠️|❌}
+- **Null safety**: {✅|⚠️|❌}
+- **Exception handling**: {✅|⚠️|❌}
+
+### Overall Architecture Assessment
+- **Compliance Level**: {FULL|PARTIAL|NEEDS WORK}
+- **Architectural Concerns**: {count}
+- **Recommendation**: {specific guidance}
+```

--- a/.agents/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
+++ b/.agents/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
@@ -181,8 +181,12 @@ public class TradeProtocolManager {
 
 // ViewModel uses service
 public class TradeViewModel {
+    private final TradeProtocolManager tradeProtocolManager;
+
     @Inject
-    private TradeProtocolManager tradeProtocolManager;
+    public TradeViewModel(TradeProtocolManager tradeProtocolManager) {
+        this.tradeProtocolManager = tradeProtocolManager;
+    }
 
     public void onStartTrade() {
         tradeProtocolManager.initiateTrade(trade);
@@ -235,8 +239,7 @@ DAO-related code requires extra care for voting and governance logic.
 **Critical Checks**:
 ```java
 // Vote weight calculation
-long voteWeight = stake * votingPower; // Check for overflow
-if (voteWeight < stake) throw new ArithmeticException("Overflow");
+long voteWeight = Math.multiplyExact(stake, votingPower);
 
 // Proposal parameter bounds
 if (proposalAmount > MAX_PROPOSAL_AMOUNT) {
@@ -246,9 +249,11 @@ if (proposalAmount > MAX_PROPOSAL_AMOUNT) {
 // Bond management
 public void lockBond(long amount) {
     if (availableBalance < amount) throw new InsufficientFundsException();
-    lockedBalance += amount;
-    availableBalance -= amount;
-    assert lockedBalance + availableBalance == totalBalance; // Invariant check
+    lockedBalance = Math.addExact(lockedBalance, amount);
+    availableBalance = Math.subtractExact(availableBalance, amount);
+    if (Math.addExact(lockedBalance, availableBalance) != totalBalance) {
+        throw new IllegalStateException("Balance invariant violated");
+    }
 }
 ```
 

--- a/.agents/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
+++ b/.agents/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
@@ -1,0 +1,207 @@
+# Bisq Security Review Checklist
+
+Comprehensive security validation patterns for Bitcoin/cryptocurrency code in Bisq PRs.
+
+## Critical Security Domains
+
+### 1. Private Key Handling
+
+**Validation Points**:
+- [ ] No private keys in source code
+- [ ] No keys in log statements or error messages
+- [ ] No keys in exception stack traces
+- [ ] Memory cleared after key usage (if applicable)
+- [ ] Key derivation uses approved methods (BIP32/BIP39)
+
+**File Patterns to Check**:
+```bash
+grep -E "(bitcoin|crypto|wallet|key|seed|mnemonic)" --output_mode files_with_matches
+```
+
+**Common Vulnerabilities**:
+- Hardcoded keys or seeds
+- Logging sensitive key material
+- Insecure key storage mechanisms
+- Missing key zeroization after use
+
+### 2. Bitcoin Transaction Safety
+
+**Validation Points**:
+- [ ] Transaction fee calculation uses satoshi arithmetic (no floating point)
+- [ ] Dust threshold enforcement (546 satoshis minimum output)
+- [ ] Transaction size limits respected
+- [ ] Input validation for amounts (no negative, no overflow)
+- [ ] Proper UTXO selection logic
+- [ ] Change address generation is correct
+- [ ] RBF (Replace-By-Fee) handling if applicable
+
+**Critical Checks**:
+```java
+// Fee calculation - must use satoshis, not BTC
+long fee = (long)(txSize * feeRatePerByte); // ✅ Correct
+double fee = txSize * feeRatePerBTC;        // ❌ Floating point risk
+
+// Dust threshold
+if (outputValue < 546) { /* reject */ }     // ✅ Correct
+
+// Overflow protection
+long total = amount1 + amount2;             // ❌ Can overflow
+long total = Math.addExact(amount1, amount2); // ✅ Throws on overflow
+```
+
+**Common Vulnerabilities**:
+- Floating-point arithmetic in fee calculations
+- Missing dust threshold checks
+- Integer overflow in amount addition
+- Incorrect change calculation
+- Missing transaction validation
+
+### 3. Cryptographic Operations
+
+**Validation Points**:
+- [ ] Using approved algorithms (Ed25519, secp256k1)
+- [ ] No deprecated crypto (MD5, SHA1 for security)
+- [ ] Proper random number generation (SecureRandom)
+- [ ] No hardcoded IVs or salts
+- [ ] Signature verification before trust
+- [ ] Constant-time comparison for secrets
+
+**Approved Algorithms**:
+- **Signatures**: Ed25519, ECDSA (secp256k1)
+- **Hashing**: SHA-256, SHA-512, RIPEMD-160
+- **Encryption**: AES-GCM, ChaCha20-Poly1305
+- **Key Derivation**: PBKDF2, scrypt, Argon2
+
+**Common Vulnerabilities**:
+```java
+// Random number generation
+Random rng = new Random();              // ❌ Predictable
+SecureRandom rng = new SecureRandom();  // ✅ Cryptographically secure
+
+// Comparison timing attacks
+if (hmac.equals(expected)) { }          // ❌ Timing attack
+if (MessageDigest.isEqual(hmac, expected)) { } // ✅ Constant-time
+```
+
+### 4. P2P Message Validation
+
+**Validation Points**:
+- [ ] Message size limits enforced (prevent DoS)
+- [ ] Input sanitization on all peer data
+- [ ] Deserialization safety (no arbitrary code execution)
+- [ ] Protocol version compatibility checks
+- [ ] Message signature verification
+- [ ] Rate limiting on message processing
+
+**Size Limits**:
+```java
+// Maximum message sizes
+public static final int MAX_MESSAGE_SIZE = 1024 * 1024; // 1 MB
+public static final int MAX_PEER_ADDRESSES = 1000;
+
+if (message.length() > MAX_MESSAGE_SIZE) {
+    throw new MessageSizeException();
+}
+```
+
+**Common Vulnerabilities**:
+- No message size validation (DoS risk)
+- Trusting peer-provided data without validation
+- Unsafe deserialization (object injection)
+- Missing protocol version checks
+- No rate limiting on expensive operations
+
+### 5. Financial Logic Safety
+
+**Validation Points**:
+- [ ] Trade amount calculations use proper precision
+- [ ] Percentage calculations avoid floating point
+- [ ] Security deposit calculations correct
+- [ ] Escrow amount validation
+- [ ] Maker/Taker fee calculations accurate
+- [ ] BSQ (Bisq token) amount handling correct
+
+**Precision Handling**:
+```java
+// Use basis points for percentages (10000 = 100%)
+long fee = (amount * feeRateBasisPoints) / 10000; // ✅ Integer math
+
+// Avoid floating point
+double fee = amount * 0.001; // ❌ Precision loss risk
+```
+
+**Common Vulnerabilities**:
+- Floating-point precision loss in financial calculations
+- Rounding errors in fee calculations
+- Integer overflow in multiplication
+- Division before multiplication (precision loss)
+- Missing boundary checks on amounts
+
+## Security Review Template
+
+Use this template when reviewing security-sensitive code:
+
+```markdown
+## Bisq Security Analysis for PR #{number}
+
+### Bitcoin Transaction Code
+- **Files Changed**: {list}
+- **Risk Assessment**: {CRITICAL|HIGH|MEDIUM|LOW}
+- **Findings**:
+  - Fee calculation: {✅|⚠️|❌} {details}
+  - Dust threshold: {✅|⚠️|❌} {details}
+  - Overflow protection: {✅|⚠️|❌} {details}
+  - UTXO handling: {✅|⚠️|❌} {details}
+
+### Cryptographic Operations
+- **Files Changed**: {list}
+- **Findings**:
+  - Algorithm approval: {✅|⚠️|❌} {details}
+  - Random generation: {✅|⚠️|❌} {details}
+  - Signature verification: {✅|⚠️|❌} {details}
+
+### P2P Protocol Changes
+- **Files Changed**: {list}
+- **Findings**:
+  - Message size limits: {✅|⚠️|❌} {details}
+  - Input validation: {✅|⚠️|❌} {details}
+  - Deserialization safety: {✅|⚠️|❌} {details}
+
+### Financial Logic
+- **Files Changed**: {list}
+- **Findings**:
+  - Precision handling: {✅|⚠️|❌} {details}
+  - Overflow checks: {✅|⚠️|❌} {details}
+  - Fee calculations: {✅|⚠️|❌} {details}
+
+### Overall Security Assessment
+- **Critical Issues**: {count}
+- **High Priority**: {count}
+- **Risk Level**: {CRITICAL|HIGH|MEDIUM|LOW}
+- **Recommendation**: {BLOCK MERGE|REQUEST CHANGES|APPROVE WITH NOTES|APPROVE}
+```
+
+## Risk Categorization
+
+**CRITICAL** (Block merge immediately):
+- Private key exposure
+- Arbitrary code execution vulnerabilities
+- Fund loss risks
+- Weak cryptography in security-critical paths
+
+**HIGH** (Must fix before merge):
+- Missing overflow checks in financial code
+- Insufficient input validation
+- Missing message size limits
+- Deprecated crypto algorithms
+
+**MEDIUM** (Should fix):
+- Suboptimal random number generation
+- Missing rate limiting
+- Incomplete validation logic
+- Performance issues in crypto operations
+
+**LOW** (Nice to have):
+- Code style in security code
+- Missing code comments
+- Documentation updates

--- a/.agents/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
+++ b/.agents/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
@@ -15,7 +15,7 @@ Comprehensive security validation patterns for Bitcoin/cryptocurrency code in Bi
 
 **File Patterns to Check**:
 ```bash
-grep -E "(bitcoin|crypto|wallet|key|seed|mnemonic)" --output_mode files_with_matches
+grep -R -l -E "(bitcoin|crypto|wallet|key|seed|mnemonic)" .
 ```
 
 **Common Vulnerabilities**:

--- a/.agents/skills/bisq-pr-reviewer/references/contribution-standards.md
+++ b/.agents/skills/bisq-pr-reviewer/references/contribution-standards.md
@@ -1,0 +1,317 @@
+# Bisq Contribution Standards
+
+Reference for C4 protocol compliance, GPG signatures, and commit message standards.
+
+## C4 Protocol (Collective Code Construction Contract)
+
+Bisq follows the C4 protocol for collaborative development.
+
+### Core Principles
+
+**1. Change-Oriented Development**
+- Problems are identified as issues
+- Solutions are proposed as patches (pull requests)
+- Patches should solve exactly one identified problem
+
+**2. Patch Requirements**
+- [ ] Addresses a specific issue or adds stated value
+- [ ] Follows project coding standards
+- [ ] Includes tests where applicable
+- [ ] Does not break existing tests
+- [ ] Commit message explains the problem and solution
+
+**3. Stakeholder Buy-In**
+
+Contributors should consult with stakeholders before significant work:
+- **Channels**: Keybase, GitHub discussions, mailing list
+- **Why**: Ensures maintainer interest and community value
+- **When**: Before starting work on major features or refactorings
+
+**Validation**:
+```markdown
+## Stakeholder Buy-In Check
+
+Evidence of discussion:
+- [ ] GitHub issue: #{issue_number}
+- [ ] Keybase discussion: {date, participants}
+- [ ] Mailing list thread: {subject, date}
+- [ ] Maintainer acknowledgment: {who, when}
+
+If no evidence found:
+- For major changes (>100 lines): ⚠️ Request stakeholder confirmation
+- For minor changes (<100 lines): ✅ Acceptable to proceed
+```
+
+**4. Atomic Commits**
+
+Each commit should represent a single logical change:
+- ✅ "Fix null pointer in TradeManager.confirmTrade()"
+- ✅ "Add validation for trade amounts"
+- ❌ "Fix bugs and add features" (too broad)
+
+**Validation**:
+```bash
+# Check if commit touches multiple unrelated concerns
+gh api repos/{owner}/{repo}/pulls/{pr}/commits --jq '.[].files | length'
+
+# If single commit changes >10 files in different modules, investigate atomicity
+```
+
+**5. Mergeable State**
+
+PR must be ready for immediate merge:
+- [ ] No WIP commits
+- [ ] No placeholder code ("TODO: implement")
+- [ ] No debugging/test code left in
+- [ ] All requested changes addressed
+- [ ] CI passing
+
+## GPG Commit Signatures
+
+All commits to Bisq must be GPG-signed for authenticity.
+
+### Verification Process
+
+```bash
+# Check all commits in PR for GPG signatures
+gh api repos/{owner}/{repo}/pulls/{pr}/commits \
+  --jq '.[] | {
+    sha: .sha,
+    message: .commit.message | split("\n")[0],
+    verified: .commit.verification.verified,
+    reason: .commit.verification.reason
+  }'
+```
+
+### Expected Output
+
+**✅ All Signed**:
+```json
+{
+  "sha": "abc123",
+  "message": "Fix trade protocol state transition",
+  "verified": true,
+  "reason": "valid"
+}
+```
+
+**❌ Unsigned Commit**:
+```json
+{
+  "sha": "def456",
+  "message": "Add fee validation",
+  "verified": false,
+  "reason": "unsigned"
+}
+```
+
+### Verification Report Template
+
+```markdown
+## GPG Signature Verification
+
+**Total Commits**: {count}
+**Signed Commits**: {signed_count}
+**Unsigned Commits**: {unsigned_count}
+
+### Status: {✅ All Signed | ⚠️ Partially Signed | ❌ None Signed}
+
+{if unsigned commits exist:}
+**Unsigned Commits**:
+- `{sha}`: {first_line_of_message} - Reason: {verification_reason}
+- ...
+
+**Action Required**:
+1. Set up GPG signing: https://docs.bisq.network/contributor-checklist#1-set-up-gpg
+2. Amend commits with signatures
+3. Force push to update PR
+```
+
+## Git Commit Message Standards
+
+Bisq follows Chris Beams' "7 Rules of a Great Git Commit Message".
+
+### The Seven Rules
+
+1. **Separate subject from body with blank line**
+2. **Limit subject line to 50 characters**
+3. **Capitalize the subject line**
+4. **Do not end subject line with a period**
+5. **Use imperative mood in subject line**
+6. **Wrap body at 72 characters**
+7. **Use body to explain what and why, not how**
+
+### Integration with git-commit-writer Skill
+
+The `git-commit-writer` skill provides detailed guidance on these rules. Reference it when commit messages need improvement:
+
+```markdown
+❌ **Poor Commit Message**:
+```
+fixed stuff
+```
+
+✅ **Suggested Improvement** (using git-commit-writer standards):
+```
+Fix memory leak in P2P message handler
+
+The message handler was not releasing buffer memory after
+processing peer messages, causing gradual memory growth
+under high peer count conditions.
+
+This commit adds proper cleanup in the finally block and
+adds a unit test to verify memory is released.
+
+Fixes #1234
+```
+```
+
+### Validation Checklist
+
+```bash
+# Extract all commit messages from PR
+gh api repos/{owner}/{repo}/pulls/{pr}/commits \
+  --jq '.[].commit.message' > /tmp/commit_messages.txt
+```
+
+For each commit message, validate:
+
+**Subject Line**:
+- [ ] ≤ 50 characters
+- [ ] Starts with capital letter
+- [ ] No ending period
+- [ ] Uses imperative mood ("Fix" not "Fixed", "Fixes", or "Fixing")
+
+**Body** (if present):
+- [ ] Blank line after subject
+- [ ] Lines wrapped at 72 characters
+- [ ] Explains "what" and "why", not "how"
+- [ ] References related issues (Fixes #123, Closes #456)
+
+**Common Issues**:
+
+| Issue | Example | Fix |
+|-------|---------|-----|
+| Too long subject | "Fix the bug that was causing crashes when..." | Shorten to "Fix crash in trade confirmation dialog" |
+| Wrong tense | "Fixed null pointer exception" | Change to "Fix null pointer exception" |
+| Not capitalized | "fix trade protocol bug" | Change to "Fix trade protocol bug" |
+| Has period | "Add validation logic." | Remove period: "Add validation logic" |
+| Vague | "Update code" | Be specific: "Add overflow check to fee calculation" |
+
+### Commit Message Quality Report
+
+```markdown
+## Commit Message Standards Review
+
+**Total Commits**: {count}
+**Compliant**: {compliant_count}
+**Need Improvement**: {needs_improvement_count}
+
+### Issues Found:
+
+#### Commit {sha} - "{subject}"
+- ❌ Subject too long (67 chars, limit 50)
+- ✅ Capitalization correct
+- ❌ Uses past tense ("Fixed" should be "Fix")
+- ⚠️ No body explanation for non-trivial change
+
+**Suggested Rewrite**:
+```
+Fix null pointer in TradeManager.confirmTrade()
+
+The confirmTrade method did not check if the trade object
+was null before accessing its properties, causing crashes
+when called with invalid trade references.
+
+This commit adds null check and throws IllegalArgumentException
+with descriptive message for debugging.
+
+Fixes #1234
+```
+```
+
+### Edge Cases
+
+**Merge Commits**:
+- Auto-generated merge commit messages are acceptable
+- Custom merge messages should follow same rules
+
+**Revert Commits**:
+- Git-generated revert messages are acceptable
+- Should add explanation in body about why revert is needed
+
+**Multi-Paragraph Bodies**:
+- Acceptable for complex changes
+- Each paragraph should focus on single aspect
+- Maintain 72-character line wrap
+
+**Issue References**:
+- "Fixes #123" - closes issue when merged
+- "Relates to #456" - references without closing
+- "Part of #789" - for multi-PR features
+
+## Contribution Standards Report Template
+
+```markdown
+## Bisq Contribution Standards Review for PR #{number}
+
+### C4 Protocol Compliance
+
+**Stakeholder Buy-In**:
+- Evidence: {GitHub issue, Keybase, mailing list}
+- Status: {✅ Confirmed | ⚠️ Recommended | ❌ Required}
+
+**Atomic Commits**:
+- Single logical changes: {✅|⚠️|❌}
+- Issues found: {details}
+
+**Mergeable State**:
+- No WIP commits: {✅|❌}
+- No placeholders: {✅|❌}
+- CI passing: {✅|❌}
+
+### GPG Signatures
+
+**Status**: {✅ All Signed | ⚠️ {X} Unsigned | ❌ None Signed}
+
+{if issues}
+**Unsigned Commits**: {list with details}
+**Action**: Setup GPG and amend commits
+
+### Commit Messages
+
+**Compliance**: {✅ All Good | ⚠️ {X} Need Improvement | ❌ Major Issues}
+
+{if issues}
+**Issues Found**:
+- Commit {sha}: {specific issues}
+
+**Recommendations**:
+{specific rewrites using git-commit-writer patterns}
+
+### Overall Contribution Standards Assessment
+
+**Level**: {EXCELLENT | GOOD | NEEDS WORK | NON-COMPLIANT}
+**Blockers**: {count} (must fix before merge)
+**Recommendations**: {count} (should fix)
+**Optional**: {count} (nice to have)
+```
+
+## Quick Reference
+
+**Pre-PR Checklist** (for contributors):
+- [ ] Discussed with stakeholders for major changes
+- [ ] Each commit is atomic and well-described
+- [ ] All commits GPG-signed
+- [ ] Commit messages follow 7 rules
+- [ ] No WIP or TODO code
+- [ ] Tests pass
+- [ ] Ready for immediate merge
+
+**Reviewer Checklist**:
+- [ ] Verify stakeholder buy-in for major changes
+- [ ] Check commit atomicity
+- [ ] Validate GPG signatures on all commits
+- [ ] Review commit message quality
+- [ ] Confirm no placeholders or WIP code
+- [ ] Check CI status

--- a/.agents/skills/bisq-pr-reviewer/references/contribution-standards.md
+++ b/.agents/skills/bisq-pr-reviewer/references/contribution-standards.md
@@ -52,7 +52,7 @@ Each commit should represent a single logical change:
 **Validation**:
 ```bash
 # Check if commit touches multiple unrelated concerns
-gh api repos/{owner}/{repo}/pulls/{pr}/commits --jq '.[].files | length'
+gh api repos/{owner}/{repo}/pulls/{pr}/files --paginate --slurp --jq 'map(length) | add'
 
 # If single commit changes >10 files in different modules, investigate atomicity
 ```
@@ -145,7 +145,7 @@ Bisq follows Chris Beams' "7 Rules of a Great Git Commit Message".
 
 The `git-commit-writer` skill provides detailed guidance on these rules. Reference it when commit messages need improvement:
 
-```markdown
+````markdown
 ❌ **Poor Commit Message**:
 ```
 fixed stuff
@@ -164,7 +164,7 @@ adds a unit test to verify memory is released.
 
 Fixes #1234
 ```
-```
+````
 
 ### Validation Checklist
 
@@ -200,7 +200,7 @@ For each commit message, validate:
 
 ### Commit Message Quality Report
 
-```markdown
+````markdown
 ## Commit Message Standards Review
 
 **Total Commits**: {count}
@@ -228,7 +228,7 @@ with descriptive message for debugging.
 
 Fixes #1234
 ```
-```
+````
 
 ### Edge Cases
 

--- a/.agents/skills/bisq2-javafx-ui/SKILL.md
+++ b/.agents/skills/bisq2-javafx-ui/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: bisq2-javafx-ui
+description: Create production-ready JavaFX UI code following Bisq2's strict MVC architecture, design system, UX principles, and desktop UI automation harness workflow. Use this skill when building new UI components, views, controllers, overlays, modifying existing JavaFX interfaces, adding or validating automation selectors, or running JavaFX UI smoke/scenario checks. Triggers include UI feature requests, component creation, view implementation, navigation additions, form building, table/list views, overlay/dialog work, desktop UI harness work, and any JavaFX-related development in the Bisq2 desktop application.
+---
+
+# Bisq2 JavaFX UI Development
+
+## Overview
+
+Use this skill to implement or review JavaFX UI work in Bisq2 with repository-accurate patterns.
+
+Primary goals:
+- Ship UI that matches Bisq2 MVC architecture and navigation framework.
+- Reuse existing controls, CSS classes, formatters, validators, and bindings.
+- Prevent lifecycle leaks, threading bugs, and stale async UI updates.
+
+## When to Use
+
+Activate for:
+- New Controller/Model/View triads.
+- Tab or navigation-target additions.
+- Overlay/dialog/wizard UI.
+- Forms, validation, converters, table/list UIs.
+- UI refactors and UI code reviews.
+
+## Working Method
+
+1. Identify task type (leaf view, navigation container, tab view, overlay, form, table).
+2. Read only the matching reference file(s) from `references/` (see map below).
+3. Implement with existing Bisq components and CSS classes first, custom controls only if necessary.
+4. When the change affects user-visible interaction, add or update harness selectors and verify with the desktop UI automation harness.
+5. Apply lifecycle cleanup and threading safeguards before finishing.
+6. Run a self-review using `references/navigation-review-checklist.md`.
+
+## Reference Map
+
+- MVC architecture, lifecycle, caching, threading contract:
+  - `references/architecture-lifecycle.md`
+- Component templates, bindings, forms, tables, anti-patterns:
+  - `references/component-patterns.md`
+- Visual language, CSS tokens/classes, animation and advanced UX tactics:
+  - `references/design-system-ux.md`
+- Navigation changes, final review checklist, key source paths:
+  - `references/navigation-review-checklist.md`
+- Desktop UI automation harness selectors, binders, scenarios, and local verification:
+  - `references/ui-automation-harness.md`
+- Example dry-run audit (prompt + rubric + scored result):
+  - `references/dry-run-audit-2026-02-19.md`
+
+## Non-Negotiables
+
+- Controller updates model state; view reacts via bindings.
+- View never accesses domain services directly.
+- Follow existing controller wiring style in this repo: use `View<..., ..., ConcreteController>` for view/controller typing.
+- Do not introduce per-view action interfaces (e.g. `XxxActions`) unless that local module already uses that pattern.
+- Cleanup everything on detach/deactivate (bindings, pins, subscriptions, handlers, schedulers).
+- All cross-thread UI changes go through `UIThread` (or `FxBindings` that marshal automatically).
+- For layout-dependent reads, defer with `UIThread.runOnNextRenderFrame(...)`.
+- Use `addTab(...)` (not `createTab(...)`).
+- Prefer `ManagedDuration` and `Transitions` for animation timing and animation-disable behavior.
+- Pair visibility and layout participation (`setVisible` + `setManaged`) when toggling layout nodes.
+- Use `Res.get(...)` for user-facing strings.
+- Use converters for typed text bindings; avoid ad-hoc parsing in views.
+- Keep automation selectors out of production views: expose package-private semantic accessors and bind selectors in `desktop-ui-harness-app`.
+- Do not use JavaFX `Node.id` as the automation contract; the current harness uses scoped selectors (`scope/automationId`).
+
+## Output Contract
+
+When asked to generate UI code, produce:
+- `XxxController` with domain interaction and lifecycle wiring.
+- `XxxModel` with JavaFX properties (and only lightweight helper logic).
+- `XxxView` with layout, bindings, event delegation, and full detach cleanup.
+
+For navigation work, also include:
+- `NavigationTarget` entries (with persistence flag decision).
+- Parent `createController(...)` switch registration.
+- Tab/menu wiring in the parent view when needed.
+
+For UI changes with an interaction path, also include:
+- Package-private semantic view accessors for controls the harness must address.
+- A harness binder in `apps/desktop/desktop-ui-harness-app/src/main/java` under the same Java package as the production view.
+- Binder registration in `DesktopAutomationViewObserver` and a binder unit test.
+- Local verification commands or harness scenario steps used to exercise the change.
+
+For reviews, prioritize:
+- Regressions, leaks, race conditions, threading violations, navigation/caching mistakes.

--- a/.agents/skills/bisq2-javafx-ui/agents/openai.yaml
+++ b/.agents/skills/bisq2-javafx-ui/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Bisq2 JavaFX UI"
+  short_description: "Build Bisq2 JavaFX screens with MVC and harness checks"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $bisq2-javafx-ui to implement or review this Bisq2 JavaFX UI change."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/bisq2-javafx-ui/references/architecture-lifecycle.md
+++ b/.agents/skills/bisq2-javafx-ui/references/architecture-lifecycle.md
@@ -1,0 +1,76 @@
+# Architecture And Lifecycle
+
+## MVC Contract In Bisq2
+
+Triad:
+- `XxxController`: behavior, service access, event handlers.
+- `XxxModel`: JavaFX properties for presentation state.
+- `XxxView`: visual tree, bindings, event delegation.
+
+Repository-specific rules:
+- Controller should not directly mutate view widget state; set model and let bindings render.
+- Passing `getView().getRoot()` for composition/utilities is acceptable and used widely.
+- Model may contain lightweight helper methods (`reset`, derived flags), but no service/domain calls.
+- View must not call services directly.
+
+## Base Framework Types
+
+- `Controller`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/Controller.java`
+- `View`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/View.java`
+- `NavigationController`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/NavigationController.java`
+- `TabController`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabController.java`
+- `NavigationView`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/NavigationView.java`
+- `TabView`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabView.java`
+- `FillStageView` marker: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/FillStageView.java`
+
+## Lifecycle Order (Critical)
+
+From `View` internals:
+- Attach:
+  - `controller.onActivateInternal()`
+  - `view.onViewAttachedInternal()`
+- Detach:
+  - `controller.onDeactivateInternal()`
+  - `view.onViewDetachedInternal()`
+
+Implication:
+- Controller can initialize model before view binds.
+- Detach cleanup must handle partial attachment safety.
+
+## Caching Semantics
+
+- Default: `Controller.useCaching() == true`.
+- `NavigationController` caches child controllers by `NavigationTarget`.
+- Use `useCaching() == false` for transient flows:
+  - overlays/wizards
+  - `InitWithDataController` flows
+  - one-shot states where stale state is risky
+
+If non-cached, expect recreation on next navigation.
+
+## Cleanup Responsibilities
+
+In `Controller.onDeactivate()`:
+- `Pin.unbind()` for domain observers/FxBindings.
+- Remove scene/application event handlers.
+- Stop/clear controller-owned schedulers/timelines/futures.
+
+In `View.onViewDetached()`:
+- `unbind()` and `unbindBidirectional()` JavaFX bindings.
+- `Subscription.unsubscribe()` for EasyBind.
+- Null event handlers (`setOnAction(null)`, etc.).
+- Dispose transient child controls/popups if allocated in view.
+
+## Threading And Render Frames
+
+- Any UI mutation from async/background code: `UIThread.run(...)`.
+- Layout-dependent work (sizes/bounds/scroll position): `UIThread.runOnNextRenderFrame(...)`.
+- `FxBindings` marshals to UI thread; avoid wrapping again unless needed.
+
+## Keyboard And Focus Contract
+
+Prefer centralized helpers:
+- `KeyHandlerUtil.handleEscapeKeyEvent(...)`
+- `KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(...)`
+
+Register key handlers on activate; always remove on deactivate.

--- a/.agents/skills/bisq2-javafx-ui/references/component-patterns.md
+++ b/.agents/skills/bisq2-javafx-ui/references/component-patterns.md
@@ -1,0 +1,94 @@
+# Component Patterns
+
+## Leaf MVC Triad (Default)
+
+Controller:
+- Construct model/view.
+- Bind domain observables in `onActivate()`.
+- Unbind pins in `onDeactivate()`.
+- Expose user handlers (`onXxx`) called by view.
+
+Model:
+- JavaFX properties (`StringProperty`, `BooleanProperty`, `ObjectProperty`, lists).
+
+View:
+- Build node tree and style classes in constructor.
+- Bind in `onViewAttached()`.
+- Fully unbind/unsubscribe/unset handlers in `onViewDetached()`.
+
+## Navigation Container
+
+Use `NavigationController` when a host selects child views by `NavigationTarget`.
+
+Implement:
+- `createController(NavigationTarget)` switch.
+- `NavigationModel#getDefaultNavigationTarget()`.
+
+## Tab Views
+
+Use `TabController` + `TabView`.
+
+Important:
+- Add tabs with `addTab(...)` (actual API), not `createTab(...)`.
+- Let framework manage selected tab button + marker transitions.
+
+## Domain To UI Binding
+
+Preferred patterns:
+
+1) `FxBindings` mapping pipelines
+```java
+Pin p = FxBindings.bind(model.getItems())
+        .filter(...)
+        .map(...)
+        .to(service.getObservableSet());
+```
+
+2) Direct observers when no pipeline needed
+```java
+Pin p = service.getFlag().addObserver(v -> UIThread.run(() -> model.getFlag().set(v)));
+```
+
+3) JavaFX direct bindings in view
+```java
+label.textProperty().bind(model.getTitle());
+field.textProperty().bindBidirectional(model.getInput());
+```
+
+## Forms, Validation, Converters
+
+- Use `MaterialTextField` and validator classes in `components/controls/validator`.
+- Validate on submit and surface inline errors.
+- Prefer typed bidirectional bindings with converters for numeric/network fields:
+```java
+textField.textProperty().bindBidirectional(model.getValue(), model.getValueConverter());
+```
+
+## Table/List Patterns
+
+- Use `BisqTableView` and `BisqTableColumn.Builder`.
+- Keep raw domain objects out of view cells when presentation mapping is needed; map into list items.
+- Set comparator on sorted list in controller/model.
+
+## Async Race Guard (Expert)
+
+Avoid stale completion writes:
+```java
+private final AtomicLong seq = new AtomicLong();
+
+void refresh() {
+    long s = seq.incrementAndGet();
+    service.load().whenComplete((result, err) -> UIThread.run(() -> {
+        if (s != seq.get()) return;
+        if (err == null) model.getItems().setAll(result);
+    }));
+}
+```
+
+## Anti-Patterns To Avoid
+
+- View calling services.
+- Missing unbind/unsubscribe on detach.
+- UI changes from background threads.
+- Hiding nodes with `setVisible(false)` only when layout gap should collapse.
+- Manual string parsing for typed settings when converter exists.

--- a/.agents/skills/bisq2-javafx-ui/references/component-patterns.md
+++ b/.agents/skills/bisq2-javafx-ui/references/component-patterns.md
@@ -38,15 +38,24 @@ Preferred patterns:
 
 1) `FxBindings` mapping pipelines
 ```java
+// Controller onActivate(): translate model state into service input.
+// The view stays out of the service call; it only observes model properties.
 Pin p = FxBindings.bind(model.getItems())
-        .filter(...)
-        .map(...)
+        .filter(Item::isEnabled)
+        .map(Item::getDomainValue)
         .to(service.getObservableSet());
 ```
 
 2) Direct observers when no pipeline needed
 ```java
-Pin p = service.getFlag().addObserver(v -> UIThread.run(() -> model.getFlag().set(v)));
+Pin p = service.getFlag().addObserver(v -> UIThread.run(() -> {
+    try {
+        model.getFlag().set(v);
+        model.getErrorMessage().set(null);
+    } catch (RuntimeException e) {
+        model.getErrorMessage().set(e.getMessage());
+    }
+}));
 ```
 
 3) JavaFX direct bindings in view
@@ -80,7 +89,12 @@ void refresh() {
     long s = seq.incrementAndGet();
     service.load().whenComplete((result, err) -> UIThread.run(() -> {
         if (s != seq.get()) return;
-        if (err == null) model.getItems().setAll(result);
+        if (err == null) {
+            model.getItems().setAll(result);
+            model.getErrorMessage().set(null);
+        } else {
+            model.getErrorMessage().set(err.getMessage());
+        }
     }));
 }
 ```

--- a/.agents/skills/bisq2-javafx-ui/references/design-system-ux.md
+++ b/.agents/skills/bisq2-javafx-ui/references/design-system-ux.md
@@ -1,0 +1,82 @@
+# Design System And UX
+
+## CSS Sources
+
+- `base.css`, `text.css`, `controls.css`, `containers.css`, `application.css`,
+  `chat.css`, `user.css`, `bisq_easy.css`, `mu_sig.css`, `trade_apps.css`, `images.css`, `markets.css`
+- Load order source: `apps/desktop/desktop/src/main/java/bisq/desktop/CssConfig.java`
+
+## Core Visual Tokens
+
+From `base.css`:
+- `-bisq2-green: #56ae48`
+- `-bisq2-yellow: #d0831f`
+- `-bisq2-red: #d23246`
+- `-bisq-white: #fafafa`
+- `-bisq-dark-grey-20: #1c1c1c`
+- `-bisq-dark-grey-40: #2b2b2b`
+- `-bisq-dark-grey-50: #383838`
+- `-bisq-mid-grey-20: #808080`
+
+## Typography Anchors
+
+From `text.css`:
+- `bisq-text-headline-1`: 4.1em
+- `bisq-text-headline-2`: 1.7em
+- `bisq-text-headline-5`: 2.5em
+- `bisq-text-1`: 1.25em
+- `bisq-text-7`: 0.92em
+
+Families:
+- IBM Plex Sans, Light, Medium, SemiBold, Mono
+
+## Spacing And Sizing Anchors
+
+- `Layout.SPACING = 20`
+- Tab side padding: `TabView.SIDE_PADDING = 40`
+- Button padding: `5 32 5 32`
+- Radius: 4px controls, 8px cards
+- Table row height: 54px
+- Table header height: 34px
+
+## Interaction And Motion
+
+Use `Transitions` + `ManagedDuration`.
+
+Examples:
+```java
+Transitions.fadeIn(node);
+Transitions.slideOutRight(node, onDone);
+Transitions.blurStrong(owner, -0.5);
+Transitions.removeEffect(owner);
+```
+
+Respect animation settings:
+```java
+Duration d = ManagedDuration.getHalfOfDefaultDuration();
+if (Transitions.useAnimations()) {
+    // animated path
+} else {
+    // immediate end state
+}
+```
+
+## Elite JavaFX UX Practices
+
+1. Render-frame discipline:
+- Defer bounds/width-dependent layout to next frame.
+
+2. Stable layout under async:
+- Reserve space for loaders/status if jump is undesirable.
+
+3. Keyboard determinism:
+- Enter/Escape behavior should remain predictable regardless of focused text input.
+
+4. Truncation discoverability:
+- Add tooltip on truncated labels (`TooltipUtil.showTooltipIfTruncated(...)`).
+
+5. Weak listeners in custom controls:
+- Use weak listeners/handlers for long-lived controls.
+
+6. Avoid inline style strings:
+- Prefer reusable CSS classes except truly dynamic values.

--- a/.agents/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
+++ b/.agents/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
@@ -1,0 +1,114 @@
+# Dry-Run Audit - 2026-02-19
+
+## Scope
+
+Goal: Verify the refactored skill reliably yields repository-correct JavaFX scaffolding.
+
+Audit date: 2026-02-19
+
+## Simulated Prompt
+
+"Add a new `NetworkHealth` tab under `NETWORK` in desktop app. Build `NetworkHealthController`, `NetworkHealthModel`, and `NetworkHealthView`. Show a table of peers with status, a refresh button, loading spinner, and enter/escape keyboard handling for refresh/close behavior where applicable. Follow existing Bisq styles and lifecycle cleanup."
+
+## Expected Output Contract
+
+- New MVC triad (`Controller`, `Model`, `View`).
+- Parent navigation registration and tab wiring.
+- Uses `addTab(...)` for tab insertion.
+- Proper lifecycle cleanup.
+- Thread-safe and race-safe async update path.
+- Reuses CSS classes and existing controls.
+
+## Candidate Scaffold (Condensed)
+
+```java
+// NetworkHealthController.java
+public class NetworkHealthController implements Controller {
+    private final NetworkHealthModel model;
+    @Getter private final NetworkHealthView view;
+    private final NetworkService networkService;
+    private Pin peersPin;
+    private final AtomicLong refreshSeq = new AtomicLong();
+
+    public NetworkHealthController(ServiceProvider sp) {
+        networkService = sp.getNetworkService();
+        model = new NetworkHealthModel();
+        view = new NetworkHealthView(model, this);
+    }
+
+    @Override
+    public void onActivate() {
+        onRefresh();
+    }
+
+    @Override
+    public void onDeactivate() {
+        if (peersPin != null) peersPin.unbind();
+    }
+
+    void onRefresh() {
+        long seq = refreshSeq.incrementAndGet();
+        model.getIsLoading().set(true);
+        networkService.fetchPeerSnapshots().whenComplete((snapshots, err) -> UIThread.run(() -> {
+            if (seq != refreshSeq.get()) return;
+            model.getIsLoading().set(false);
+            if (err == null) model.getPeers().setAll(snapshots.stream().map(NetworkHealthItem::new).toList());
+        }));
+    }
+}
+
+// NetworkHealthModel.java
+@Getter
+public class NetworkHealthModel implements Model {
+    private final BooleanProperty isLoading = new SimpleBooleanProperty();
+    private final ObservableList<NetworkHealthItem> peers = FXCollections.observableArrayList();
+    private final SortedList<NetworkHealthItem> sortedPeers = new SortedList<>(peers);
+}
+
+// NetworkHealthView.java
+public class NetworkHealthView extends View<VBox, NetworkHealthModel, NetworkHealthController> {
+    private final Button refreshButton = new Button(Res.get("action.refresh"));
+    private final BusyAnimation busy = new BusyAnimation(false);
+    private final BisqTableView<NetworkHealthItem> table = new BisqTableView<>(model.getSortedPeers());
+
+    @Override
+    protected void onViewAttached() {
+        refreshButton.disableProperty().bind(model.getIsLoading());
+        busy.isRunningProperty().bind(model.getIsLoading());
+        refreshButton.setOnAction(e -> controller.onRefresh());
+    }
+
+    @Override
+    protected void onViewDetached() {
+        refreshButton.disableProperty().unbind();
+        busy.isRunningProperty().unbind();
+        refreshButton.setOnAction(null);
+    }
+}
+```
+
+## Rubric And Result
+
+1. MVC architecture compliance: PASS
+2. Lifecycle cleanup completeness: PASS (bindings + pin cleanup present)
+3. Threading safety: PASS (`UIThread.run`)
+4. Async staleness guard: PASS (`refreshSeq`)
+5. Navigation/tab API correctness: PASS (`addTab(...)` requirement satisfied)
+6. Styling/control reuse: PASS (`BusyAnimation`, `BisqTableView`, `Res.get`)
+7. Likely regressions/leaks: LOW risk
+
+Overall: PASS
+
+## Concrete Checks Against Repository APIs
+
+- Tab API: `addTab(...)` exists in `TabView`.
+- Animation setting check should use `Transitions.useAnimations()` / `ManagedDuration`, not `settingsService.getDontUseAnimations()`.
+- CSS load order includes `mu_sig.css`, `trade_apps.css`, `markets.css`.
+
+## Remaining Gaps
+
+- Prompt did not force localization-key existence validation.
+- Prompt did not include `NavigationTarget` enum edits explicitly.
+
+Recommendation:
+- When generating production patches, include key existence and enum wiring tasks explicitly in the prompt.

--- a/.agents/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
+++ b/.agents/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
@@ -107,10 +107,10 @@ Overall: PARTIAL PASS
 
 ## Remaining Gaps
 
-- Candidate scaffold did not demonstrate Enter/Escape handlers.
-- Prompt did not force localization-key existence validation.
-- Prompt did not include `NavigationTarget` enum edits explicitly.
-- Prompt did not show concrete `addTab(...)` calls in the scaffold.
+- Enter/Escape handlers were not demonstrated in the candidate scaffold.
+- Localization-key existence validation was not enforced by the prompt.
+- `NavigationTarget` enum edits were missing from the prompt.
+- Concrete `addTab(...)` calls and parent wiring were not shown in the scaffold.
 
 Recommendation:
 - When generating production patches, include key existence and enum wiring tasks explicitly in the prompt.

--- a/.agents/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
+++ b/.agents/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
@@ -89,15 +89,15 @@ public class NetworkHealthView extends View<VBox, NetworkHealthModel, NetworkHea
 
 ## Rubric And Result
 
-1. MVC architecture compliance: PASS
+1. MVC architecture compliance: PARTIAL (triad shape shown; full navigation wiring not demonstrated)
 2. Lifecycle cleanup completeness: PASS (bindings + pin cleanup present)
 3. Threading safety: PASS (`UIThread.run`)
-4. Async staleness guard: PASS (`refreshSeq`)
-5. Navigation/tab API correctness: PASS (`addTab(...)` requirement satisfied)
+4. Async staleness guard: PARTIAL (`refreshSeq` shown; failure and cancellation paths not fully exercised)
+5. Navigation/tab API correctness: PARTIAL (`addTab(...)` requirement noted; `NavigationTarget` enum wiring not shown)
 6. Styling/control reuse: PASS (`BusyAnimation`, `BisqTableView`, `Res.get`)
 7. Likely regressions/leaks: LOW risk
 
-Overall: PASS
+Overall: PARTIAL PASS
 
 ## Concrete Checks Against Repository APIs
 
@@ -107,8 +107,10 @@ Overall: PASS
 
 ## Remaining Gaps
 
+- Candidate scaffold did not demonstrate Enter/Escape handlers.
 - Prompt did not force localization-key existence validation.
 - Prompt did not include `NavigationTarget` enum edits explicitly.
+- Prompt did not show concrete `addTab(...)` calls in the scaffold.
 
 Recommendation:
 - When generating production patches, include key existence and enum wiring tasks explicitly in the prompt.

--- a/.agents/skills/bisq2-javafx-ui/references/navigation-review-checklist.md
+++ b/.agents/skills/bisq2-javafx-ui/references/navigation-review-checklist.md
@@ -1,0 +1,69 @@
+# Navigation And Review Checklist
+
+## Navigation Target Changes
+
+1. Add new entries in `NavigationTarget`.
+- Use parent relationship correctly.
+- Set `allowPersistence=false` for transient overlay/wizard steps.
+
+Example:
+```java
+MY_FEATURE(CONTENT),
+MY_FEATURE_STEP(MY_FEATURE),
+MY_TRANSIENT_STEP(OVERLAY, false),
+```
+
+2. Register controller creation in parent `NavigationController#createController(...)`.
+
+3. Add tab/menu wiring in parent view where needed.
+
+4. Decide controller caching policy (`useCaching()`).
+
+## Navigation APIs
+
+- `Navigation.navigateTo(target)`
+- `Navigation.navigateTo(target, initData)` for init-with-data flows
+- `Navigation.back()`
+
+## Final Review Checklist
+
+Architecture:
+- [ ] View has no service/domain access.
+- [ ] Controller mutates model state, not raw widget state.
+- [ ] Model only has UI state and lightweight helper logic.
+- [ ] User-facing strings are via `Res.get(...)`.
+
+Lifecycle:
+- [ ] All `Pin` unbound in `onDeactivate()`.
+- [ ] All bindings/subscriptions cleaned in `onViewDetached()`.
+- [ ] Event handlers removed/nullified.
+- [ ] Schedulers/timelines/futures cleaned.
+
+Threading:
+- [ ] All UI mutations on JavaFX thread.
+- [ ] Render-frame deferral for layout-dependent reads.
+- [ ] Async staleness guards where concurrent refreshes can race.
+
+Styling/UX:
+- [ ] Existing CSS classes reused.
+- [ ] Design tokens and spacing align with repo CSS.
+- [ ] Animation uses `Transitions`/`ManagedDuration`.
+- [ ] Keyboard flow deterministic and focus-safe.
+
+Data and input:
+- [ ] FxBindings/direct observers bridge domain to UI.
+- [ ] Formatters used for amounts/prices/date/time.
+- [ ] Validators and converters applied where appropriate.
+
+## Key Source Paths
+
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/observable/FxBindings.java`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/threading/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/converters/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/components/table/`
+- `apps/desktop/desktop/src/main/resources/css/`
+- `presentation/src/main/java/bisq/presentation/formatters/`
+- `common/src/main/java/bisq/common/observable/`

--- a/.agents/skills/bisq2-javafx-ui/references/ui-automation-harness.md
+++ b/.agents/skills/bisq2-javafx-ui/references/ui-automation-harness.md
@@ -1,0 +1,143 @@
+# Desktop UI Automation Harness
+
+Use this reference when JavaFX work changes an interactive path, needs visual smoke verification, or requires new automation selectors.
+
+## Current Model
+
+- The harness is the dedicated `desktop-ui-harness-app`; the production `desktop-app` does not start the automation server.
+- Build it before use:
+  ```bash
+  ./gradlew :apps:desktop:desktop-ui-harness-app:installDist
+  ```
+- Start/stop and inspect with:
+  ```bash
+  make desktop-ui-start
+  make desktop-ui-status
+  make desktop-ui-nodes
+  make desktop-ui-validate
+  make desktop-ui-stop
+  ```
+- Direct script equivalents live in `scripts/desktop-ui-harness.bash`.
+- The wrapper starts a deterministic desktop by default: fixed `1440x900` window, isolated data under `/tmp/bisq2-ui-harness`, fresh data on each start, and isolated CLEAR networking with an auto-selected local P2P port.
+
+## Selector Contract
+
+- Selectors are scoped strings: `<scope>/<automationId>`, for example `chat-message-container/input`.
+- JavaFX `Node.id` is not the automation contract. Use it only for CSS/styling when needed.
+- Scopes must be globally unique across all showing JavaFX scenes/windows.
+- Automation ids only need to be unique inside their scope.
+- Use `make desktop-ui-nodes` to inspect addressable nodes and `make desktop-ui-validate` to catch duplicate or invalid selector metadata.
+
+## Adding Selectors
+
+Keep selector metadata in the harness app, not in production view constructors.
+
+1. Add package-private semantic accessors to the production view when a stable node is not exposed:
+   ```java
+   TextInputControl messageInput() {
+       return inputField;
+   }
+
+   Node sendMessageAction() {
+       return sendButton;
+   }
+   ```
+2. Add or update a binder in `apps/desktop/desktop-ui-harness-app/src/main/java` under the same Java package as the production view:
+   ```java
+   package bisq.desktop.main.content.chat.message_container;
+
+   import bisq.desktop_ui_harness_app.AbstractDesktopAutomationViewBinder;
+
+   public final class ChatMessageContainerAutomationBinder
+           extends AbstractDesktopAutomationViewBinder<ChatMessageContainerView> {
+       @Override
+       public Class<ChatMessageContainerView> viewType() {
+           return ChatMessageContainerView.class;
+       }
+
+       @Override
+       public void bind(ChatMessageContainerView view) {
+           scope(view.getRoot(), "chat-message-container");
+           id(view.messageInput(), "input");
+           id(view.sendMessageAction(), "send");
+       }
+   }
+   ```
+3. Register the binder in `DesktopAutomationViewObserver`.
+4. Add a binder unit test in `apps/desktop/desktop-ui-harness-app/src/test/java` under the same Java package.
+5. Run:
+   ```bash
+   ./gradlew :apps:desktop:desktop-ui-harness-app:test
+   ```
+
+Do not add public view getters, annotations, `DesktopAutomationMetadata` calls in production source, or selectors for decorative/recycled/text-only nodes.
+
+## Local Interaction Loop
+
+Use the harness after UI changes:
+
+```bash
+./gradlew :apps:desktop:desktop-ui-harness-app:installDist
+make desktop-ui-start
+make desktop-ui-nodes
+make desktop-ui-validate
+```
+
+Use commands like these once the target screen is visible:
+
+```bash
+make desktop-ui-wait-node selector=splash/logo timeout_ms=30000 visible=true
+make desktop-ui-click selector=chat-message-container/send
+make desktop-ui-type selector=chat-message-container/input text="test prompt"
+make desktop-ui-press-key key=ENTER selector=chat-message-container/input
+make desktop-ui-screenshot name=after-change
+make desktop-ui-stop
+```
+
+Prefer screenshots for visual review after meaningful layout or styling changes.
+
+## Scenarios
+
+Run the default first-run smoke scenario:
+
+```bash
+make desktop-ui-scenario file=scripts/scenarios/desktop-ui-smoke.scenario
+```
+
+The default smoke scenario expects fresh harness data, accepts the two-step TAC flow, creates `SmokeUser`, waits for `left-nav/dashboard`, and captures `smoke-main`.
+
+Scenario files support:
+
+- `health`
+- `validate`
+- `wait-node <selector> [timeout_ms] [visible]`
+- `click <selector>`
+- `type <selector> <text...>`
+- `press-key <key> [selector]`
+- `screenshot <name>`
+- `sleep <ms>`
+
+Use quoted text in scenario files when the typed text contains spaces.
+
+## Persistent And Local-Network Runs
+
+For iterative work with an existing profile:
+
+```bash
+HARNESS_RESET_ON_START=0 APP_NAME=bisq2_gui1 DATA_DIR=/tmp/bisq2-local-3node/desktop make desktop-ui-start
+```
+
+When connecting to the local 3-node clearnet stack, prefer `HARNESS_NETWORK_OPTS` instead of ad-hoc JVM args:
+
+```bash
+HARNESS_NETWORK_OPTS="-Dapplication.network.supportedTransportTypes.0=CLEAR -Dapplication.network.configByTransportType.clear.defaultNodePort=18003 -Dapplication.network.seedAddressByTransportType.clear.0=127.0.0.1:18000 -Dapplication.network.seedAddressByTransportType.clear.1=127.0.0.1:18000" \
+make desktop-ui-start
+```
+
+## Verification Checklist
+
+- `./gradlew :apps:desktop:desktop-ui-harness-app:test`
+- `bash -n scripts/desktop-ui-harness.bash` when editing the wrapper
+- `make desktop-ui-validate` on the target screen
+- Targeted `click`/`type`/`press-key` commands or a scenario for the changed workflow
+- Screenshot artifact for visual changes

--- a/.agents/skills/git-commit-writer/SKILL.md
+++ b/.agents/skills/git-commit-writer/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: git-commit-writer
+description: Guide Codex or Claude Code to write professional, informative Git commit messages following industry best practices. Use this skill when writing commit messages, reviewing proposed commits, helping users improve commit message quality, or handling git, version control, or contribution documentation tasks.
+---
+
+# Git Commit Writer
+
+## Overview
+
+This skill enables writing professional Git commit messages that follow industry best practices based on Chris Beams' widely-adopted guidelines. Well-crafted commit messages preserve institutional knowledge, improve code maintainability, and make collaboration more effective in either Codex or Claude Code.
+
+## When to Use This Skill
+
+Activate this skill when:
+- Writing a new commit message for code changes
+- Reviewing or improving an existing commit message
+- User asks "how should I write this commit message?"
+- User provides a poor commit message and needs help improving it
+- User mentions git commit, version control, or commit standards
+- User is about to commit code and needs guidance
+
+## The Seven Core Rules
+
+Apply these rules to every commit message:
+
+### 1. Separate subject from body with a blank line
+
+Place one blank line between the subject line and the body text. Git tools rely on this separation.
+
+```
+Fix authentication bug in user login
+
+The bcrypt comparison was using the wrong salt parameter.
+This commit corrects the parameter and adds unit tests.
+```
+
+### 2. Limit the subject line to 50 characters
+
+Keep subjects concise and scannable. GitHub warns beyond 50 characters and truncates at 72.
+
+✅ Good: `Add user authentication with JWT tokens`
+❌ Too long: `Add comprehensive user authentication system with JWT tokens and refresh`
+
+### 3. Capitalize the subject line
+
+Start with a capital letter for consistency.
+
+✅ Good: `Refactor authentication module`
+❌ Bad: `refactor authentication module`
+
+### 4. Do not end the subject line with a period
+
+Periods waste space in the 50-character limit.
+
+✅ Good: `Fix memory leak in sync process`
+❌ Bad: `Fix memory leak in sync process.`
+
+### 5. Use the imperative mood in the subject line
+
+Write commands, not descriptions of what was done.
+
+**The golden test:** Complete this sentence:
+"If applied, this commit will **[your subject line]**"
+
+✅ Imperative: `Fix bug in user login`
+✅ Test: "If applied, this commit will **fix bug in user login**"
+
+❌ Past tense: `Fixed bug in user login`
+❌ Test: "If applied, this commit will **fixed bug in user login**" (grammatically incorrect)
+
+**Common imperative forms:**
+- Fix, Add, Remove, Update, Refactor, Improve
+- Merge, Revert, Document, Extract, Consolidate
+
+**Avoid:**
+- Fixed, Added, Removed (past tense)
+- Fixes, Adds, Removes (present tense)
+- Fixing, Adding, Removing (present participle)
+- I fixed, I added (first person)
+
+### 6. Wrap the body at 72 characters
+
+Hard-wrap body text at 72 characters for proper display in terminals and Git tools.
+
+### 7. Use the body to explain what and why vs. how
+
+The code shows **how** something was done. The commit message explains:
+- **What** was changed
+- **Why** it was changed
+- What problem was being solved
+- Why this solution was chosen
+
+## Workflow for Writing Commit Messages
+
+### Step 1: Understand the Changes
+
+Before writing the commit message, review what was changed:
+- What files were modified?
+- What functionality was added, removed, or fixed?
+- Is this a single logical change (atomic commit)?
+
+### Step 2: Craft the Subject Line
+
+Write a subject line that:
+1. Completes: "If applied, this commit will **[subject]**"
+2. Uses imperative mood (Fix, Add, Remove, Update, etc.)
+3. Stays under 50 characters
+4. Starts with a capital letter
+5. Has no ending period
+
+**Subject line patterns:**
+
+| Pattern | Example |
+|---------|---------|
+| Fix [issue] in [area] | `Fix race condition in cache invalidation` |
+| Add [feature] to [area] | `Add dark mode support to user interface` |
+| Remove [thing] from [area] | `Remove deprecated authentication methods` |
+| Update [thing] to [state] | `Update dependencies to latest versions` |
+| Refactor [area] for [reason] | `Refactor auth logic for maintainability` |
+| Improve [aspect] of [area] | `Improve error messages in validation` |
+
+### Step 3: Decide If a Body Is Needed
+
+**Body is required when:**
+- The change is not self-explanatory from the subject and diff
+- There's important context or reasoning to preserve
+- The change fixes a bug with non-obvious root cause
+- Trade-offs or alternatives were considered
+- The change has side effects or consequences
+
+**Body is optional for:**
+- Simple, obvious changes
+- Typo fixes (though consider if body would help)
+- Very small refactorings with clear purpose
+
+### Step 4: Write the Body (If Needed)
+
+Structure the body to answer:
+
+1. **What was the problem or motivation?**
+   - What bug occurred or what was missing?
+   - What user need is being addressed?
+
+2. **Why this solution?**
+   - Why was this approach chosen?
+   - What alternatives were considered?
+
+3. **What are the effects?**
+   - Are there side effects or consequences?
+   - Does this enable future changes?
+
+4. **References**
+   - Link to related issues: `Fixes #123`
+   - Link to PRs: `Related to PR #456`
+   - Link to documentation or discussions
+
+**Example template:**
+```
+[Subject line]
+
+[What was the problem - 1-2 sentences]
+
+[Why this solution - 1-3 sentences explaining the approach]
+
+[Optional: Effects, consequences, or next steps]
+
+Fixes #123
+```
+
+### Step 5: Apply Final Checks
+
+Before committing, verify:
+- [ ] Subject line is 50 characters or less
+- [ ] Subject uses imperative mood
+- [ ] Subject is capitalized with no ending period
+- [ ] Blank line separates subject from body
+- [ ] Body is wrapped at 72 characters
+- [ ] Body explains what and why, not how
+- [ ] Related issues are referenced
+
+## Common Scenarios and Examples
+
+### Scenario 1: Simple Bug Fix
+
+**User request:** "I fixed a login bug, what should my commit say?"
+
+**Response pattern:**
+```
+Subject: Fix authentication bug in user login
+
+Body (optional):
+The password validation was failing due to incorrect bcrypt
+salt parameter. This commit corrects the parameter and adds
+unit tests to prevent regression.
+
+Fixes #789
+```
+
+### Scenario 2: Feature Addition
+
+**User request:** "I just added dark mode support"
+
+**Response pattern:**
+```
+Subject: Add dark mode support to user interface
+
+Body:
+Implements a dark color theme toggleable in user preferences.
+The theme persists across sessions and follows WCAG 2.1
+Level AA contrast requirements for accessibility.
+
+Uses CSS custom properties for instant theme switching without
+page reload.
+
+Closes #567
+```
+
+### Scenario 3: Refactoring
+
+**User request:** "I cleaned up the authentication code"
+
+**Response pattern:**
+```
+Subject: Extract authentication logic into separate service
+
+Body:
+Authentication code was scattered across multiple controllers,
+making it difficult to maintain and test. This commit
+consolidates all authentication logic into a dedicated
+AuthService.
+
+Benefits:
+- Single responsibility principle compliance
+- Easier unit testing with dependency injection
+- Consistent authentication behavior across endpoints
+
+No functional changes to authentication behavior.
+```
+
+### Scenario 4: Reviewing a Poor Commit
+
+**User provides:** `"Fixed stuff"`
+
+**Response pattern:**
+Suggest improvement:
+```
+The commit message "Fixed stuff" is too vague. Consider a more
+descriptive subject like:
+
+Fix memory leak in background sync process
+
+And add body text explaining:
+- What was the memory leak?
+- What was causing it?
+- How does this fix address it?
+```
+
+## Handling Edge Cases
+
+### Multiple Related Changes
+
+If multiple related changes are in one commit:
+- List them in the body with bullet points
+- Ensure they're logically related (otherwise split commits)
+
+```
+Update authentication system for security
+
+- Add rate limiting to login endpoint
+- Implement JWT token refresh mechanism
+- Update bcrypt rounds to current best practice
+
+These changes work together to improve authentication security
+after the security audit recommendations.
+```
+
+### Merge Commits
+
+Git creates these automatically, typically don't need custom messages. If customizing:
+
+```
+Merge branch 'feature/dark-mode' into main
+
+Brings dark mode support with accessibility compliance.
+All tests passing and code reviewed.
+```
+
+### Reverting Commits
+
+Use `git revert` which auto-generates messages, but enhance with context:
+
+```
+Revert "Add experimental caching layer"
+
+This reverts commit abc123def456.
+
+The caching layer caused data inconsistencies in production
+under high concurrent load. Reverting while we investigate
+the race condition issue.
+
+Related to incident #2345
+```
+
+## Resources
+
+This skill includes:
+
+### references/detailed-guide.md
+
+Comprehensive guide with:
+- Detailed explanations of all seven rules
+- Extensive examples and anti-patterns
+- Common scenarios and edge cases
+- Links to authoritative sources
+
+Load this reference when:
+- User asks for detailed explanations
+- User needs examples of specific patterns
+- Helping with complex commit scenarios
+- User wants to understand the "why" behind rules
+
+## Project-Specific Considerations
+
+When working in specific projects:
+- Check for existing commit message conventions in CONTRIBUTING.md or similar files
+- Follow established patterns in the project's git history
+- Note any project-specific prefixes (e.g., `feat:`, `fix:`, `docs:`)
+- Respect team decisions that differ from these guidelines (consistency matters more than personal preference)
+
+## Anti-Patterns to Avoid
+
+Never accept these commit message patterns:
+- ❌ Vague: `Fix stuff`, `Update code`, `Changes`, `WIP`
+- ❌ Non-imperative: `Fixed bug`, `Updating code`, `I added feature`
+- ❌ Too long subjects: Anything over 72 characters
+- ❌ Implementation details in subject: `Change function X to use Y instead of Z`
+- ❌ Missing context: `Fix bug` (which bug? what was broken?)
+- ❌ Casual language: `Finally got this working!`, `asdfasdf`
+
+## Success Criteria
+
+A well-written commit message should:
+1. Allow future developers to understand the change without reading the code
+2. Explain the reasoning and context behind decisions
+3. Enable quick scanning of git history
+4. Preserve institutional knowledge
+5. Make code reviews and debugging easier

--- a/.agents/skills/git-commit-writer/SKILL.md
+++ b/.agents/skills/git-commit-writer/SKILL.md
@@ -27,7 +27,7 @@ Apply these rules to every commit message:
 
 Place one blank line between the subject line and the body text. Git tools rely on this separation.
 
-```
+```text
 Fix authentication bug in user login
 
 The bcrypt comparison was using the wrong salt parameter.
@@ -155,7 +155,7 @@ Structure the body to answer:
    - Link to documentation or discussions
 
 **Example template:**
-```
+```text
 [Subject line]
 
 [What was the problem - 1-2 sentences]
@@ -185,7 +185,7 @@ Before committing, verify:
 **User request:** "I fixed a login bug, what should my commit say?"
 
 **Response pattern:**
-```
+```text
 Subject: Fix authentication bug in user login
 
 Body (optional):
@@ -201,7 +201,7 @@ Fixes #789
 **User request:** "I just added dark mode support"
 
 **Response pattern:**
-```
+```text
 Subject: Add dark mode support to user interface
 
 Body:
@@ -220,7 +220,7 @@ Closes #567
 **User request:** "I cleaned up the authentication code"
 
 **Response pattern:**
-```
+```text
 Subject: Extract authentication logic into separate service
 
 Body:
@@ -243,7 +243,7 @@ No functional changes to authentication behavior.
 
 **Response pattern:**
 Suggest improvement:
-```
+```text
 The commit message "Fixed stuff" is too vague. Consider a more
 descriptive subject like:
 
@@ -263,7 +263,7 @@ If multiple related changes are in one commit:
 - List them in the body with bullet points
 - Ensure they're logically related (otherwise split commits)
 
-```
+```text
 Update authentication system for security
 
 - Add rate limiting to login endpoint
@@ -278,7 +278,7 @@ after the security audit recommendations.
 
 Git creates these automatically, typically don't need custom messages. If customizing:
 
-```
+```text
 Merge branch 'feature/dark-mode' into main
 
 Brings dark mode support with accessibility compliance.
@@ -289,7 +289,7 @@ All tests passing and code reviewed.
 
 Use `git revert` which auto-generates messages, but enhance with context:
 
-```
+```text
 Revert "Add experimental caching layer"
 
 This reverts commit abc123def456.

--- a/.agents/skills/git-commit-writer/agents/openai.yaml
+++ b/.agents/skills/git-commit-writer/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Git Commit Writer"
+  short_description: "Write clear, reviewable commit messages"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $git-commit-writer to draft a concise commit message for my staged changes."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/git-commit-writer/references/detailed-guide.md
+++ b/.agents/skills/git-commit-writer/references/detailed-guide.md
@@ -1,0 +1,373 @@
+# Complete Guide to Writing Git Commit Messages
+
+This comprehensive guide is based on [Chris Beams' definitive article](https://cbea.ms/git-commit/) on writing good commit messages. Reference this document for detailed explanations, examples, and the reasoning behind each rule.
+
+## The Seven Rules of a Great Git Commit Message
+
+### Rule 1: Separate subject from body with a blank line
+
+Git uses the blank line between the subject and body as a delimiter. This allows Git tools to properly parse commits for different contexts.
+
+**Why it matters:**
+- `git log --oneline` shows only the subject line
+- `git shortlog` groups commits by user with subject lines only
+- Email-formatted patches use the subject as the email subject line
+- GitHub's UI displays subjects and bodies separately
+
+**Example:**
+```
+Fix authentication bug in user login
+
+Users were unable to log in due to a validation error in the
+password hashing function. The bcrypt comparison was using the
+wrong salt parameter, causing all login attempts to fail.
+
+This commit corrects the salt parameter and adds unit tests to
+prevent regression.
+```
+
+Without the blank line, Git tools can't distinguish where the subject ends and the body begins.
+
+### Rule 2: Limit the subject line to 50 characters
+
+50 characters is not a hard limit, but a guideline to ensure readability.
+
+**Why it matters:**
+- Forces you to think concisely about the change
+- GitHub warns beyond 50 characters
+- GitHub truncates subject lines at 72 characters
+- `git log --oneline` becomes difficult to scan with long subjects
+
+**Tips:**
+- If struggling to summarize, the commit may be doing too much (split into multiple commits)
+- Sacrifice complete sentences for brevity when needed
+
+**Examples:**
+
+✅ Good (50 characters or less):
+```
+Add user authentication with JWT tokens
+Fix memory leak in background sync process
+Update dependencies to latest versions
+```
+
+❌ Too long:
+```
+Add comprehensive user authentication system with JWT tokens and refresh token rotation
+```
+
+### Rule 3: Capitalize the subject line
+
+Simple consistency rule that improves readability.
+
+**Examples:**
+
+✅ Good:
+```
+Accelerate to 88 miles per hour
+```
+
+❌ Bad:
+```
+accelerate to 88 miles per hour
+```
+
+### Rule 4: Do not end the subject line with a period
+
+Trailing punctuation wastes precious character space in the 50-character limit.
+
+**Examples:**
+
+✅ Good:
+```
+Open the pod bay doors
+```
+
+❌ Bad:
+```
+Open the pod bay doors.
+```
+
+### Rule 5: Use the imperative mood in the subject line
+
+**Imperative mood** means "spoken or written as if giving a command or instruction."
+
+**Examples of imperative mood:**
+- Clean your room
+- Close the door
+- Refactor the authentication module
+
+**Why imperative mood:**
+- Git itself uses imperative mood when creating commits automatically
+- It matches the convention Git established (e.g., "Merge branch 'feature'")
+- It tells someone what applying the commit will do, not what you did
+
+**The golden test:**
+Your subject line should complete this sentence:
+> If applied, this commit will **[your subject line]**
+
+**Examples:**
+
+✅ Good (imperative mood):
+```
+If applied, this commit will refactor authentication module
+If applied, this commit will remove deprecated methods
+If applied, this commit will fix bug in user login
+If applied, this commit will update dependencies
+```
+
+❌ Bad (not imperative):
+```
+If applied, this commit will fixed bug in user login          (past tense)
+If applied, this commit will fixes bug in user login          (present tense)
+If applied, this commit will fixing bug in user login         (present participle)
+If applied, this commit will I fixed the bug in user login    (first person)
+```
+
+**Correct forms:**
+
+| ✅ Imperative | ❌ Other Forms |
+|---------------|----------------|
+| Refactor authentication for clarity | Refactored authentication, Refactors authentication, Refactoring authentication |
+| Remove deprecated methods | Removed deprecated methods, Removes deprecated methods, Removing deprecated methods |
+| Update getting started documentation | Updated getting started documentation, Updates documentation, Updating documentation |
+| Merge pull request #123 from user/branch | Merged pull request, Merges pull request |
+
+**Note:** Using imperative mood can feel awkward in writing because we don't normally speak that way. But it's perfect for Git commit subjects. Git itself uses it, so following the convention maintains consistency.
+
+### Rule 6: Wrap the body at 72 characters
+
+Git does not wrap text automatically. When you wrap text manually at 72 characters, Git can indent text while still keeping everything under 80 characters total.
+
+**Why 72 characters:**
+- Allows for Git's indentation while staying under 80 character terminals
+- Improves readability in various contexts (emails, GitHub, terminal)
+- Matches the standard Git convention
+
+**How to wrap:**
+- Most text editors can be configured to hard-wrap at 72 characters
+- Use manual line breaks at logical points in your sentences
+
+**Example:**
+```
+Fix authentication bug in user login
+
+Users were unable to log in due to a validation error in the
+password hashing function. The bcrypt comparison was using the
+wrong salt parameter, causing all login attempts to fail.
+
+This commit corrects the salt parameter and adds unit tests to
+prevent regression. The tests verify both successful login
+attempts and failed attempts with invalid credentials.
+```
+
+### Rule 7: Use the body to explain what and why vs. how
+
+The code shows **how** a change was made. The commit message should explain:
+- **What** was changed
+- **Why** it was changed
+- What was the problem being solved
+- Why this solution was chosen over alternatives
+
+**Why it matters:**
+- Preserves institutional knowledge
+- Helps future maintainers understand reasoning
+- Provides context that code alone cannot convey
+- Documents trade-offs and decisions
+
+**Example comparing before/after:**
+
+❌ Uninformative:
+```
+Fix bug
+```
+
+✅ Informative:
+```
+Fix authentication timeout in Safari
+
+Safari has a stricter cookie security policy that was causing
+session tokens to expire prematurely on the login page. The
+previous implementation set cookies without the SameSite
+attribute, which Safari treats as SameSite=Lax by default.
+
+This commit explicitly sets SameSite=None with the Secure flag,
+allowing the session token to persist correctly across the
+authentication flow in Safari while maintaining security in
+other browsers.
+
+Fixes #456
+```
+
+**What to include in the body:**
+- The problem or bug being addressed
+- Why this approach was chosen
+- Side effects or consequences of the change
+- Links to relevant issues or documentation
+- Anything that would help future developers understand the change
+
+**What NOT to include:**
+- How the code works (that's what the code itself shows)
+- Changes that are obvious from the diff
+- Implementation details that are self-evident
+
+## Additional Best Practices
+
+### Atomic Commits
+
+Make commits that represent a single logical change. This makes:
+- Commit messages easier to write (one clear purpose)
+- Code reviews simpler (focused changes)
+- Reverting easier if needed
+- History more understandable
+
+### Use the Command Line
+
+While IDE integrations are convenient, they often limit access to Git's full power. Learning the command-line Git workflow provides:
+- Better understanding of Git's concepts
+- Access to advanced features
+- Ability to write proper multi-line commit messages
+- More control over staging and committing
+
+### Reference Issues and PRs
+
+When commits relate to issues or pull requests, reference them in the body:
+
+```
+Fix memory leak in background sync
+
+The background sync process was accumulating WebSocket connections
+without properly closing them. This caused memory to grow unbounded
+over time, eventually leading to application crashes after several
+hours of operation.
+
+This commit ensures all WebSocket connections are properly closed
+in a finally block, preventing the leak.
+
+Fixes #789
+Related to PR #790
+```
+
+### Be Consistent
+
+If working on a team, establish conventions and follow them:
+- Decide on subject line length limits
+- Agree on when to use body text
+- Standardize format for issue references
+- Choose imperative mood consistently
+
+### Learn Git Deeply
+
+Reading [Pro Git](https://git-scm.com/book/en/v2) (available free online) provides deep understanding of Git's design philosophy and why these conventions matter.
+
+## Common Anti-Patterns to Avoid
+
+❌ **Vague subjects:**
+```
+Fix stuff
+Update code
+Changes
+WIP
+asdfasdf
+```
+
+❌ **Describing implementation instead of purpose:**
+```
+Change UserController.login() to use bcrypt.compare() with correct parameters
+```
+
+Better:
+```
+Fix authentication bug in user login
+
+Corrected bcrypt salt parameter to fix validation errors preventing
+users from logging in.
+```
+
+❌ **Including irrelevant information:**
+```
+Fix login bug (worked on this all day, finally figured it out!)
+```
+
+❌ **Not using imperative mood:**
+```
+Fixed login bug
+Fixing login bug
+This fixes the login bug
+I fixed the login bug
+```
+
+## Examples of Great Commit Messages
+
+### Example 1: Bug Fix
+```
+Fix race condition in cache invalidation
+
+The previous implementation used separate read and write operations
+for cache invalidation, creating a race condition where two threads
+could both read stale data before either wrote the update. This
+caused intermittent data inconsistencies in production.
+
+This commit wraps the read-invalidate-write sequence in a lock,
+ensuring atomic execution. Performance impact is minimal since
+cache operations are infrequent.
+
+Fixes #1234
+```
+
+### Example 2: Feature Addition
+```
+Add dark mode support to user interface
+
+Implements a dark color theme that can be toggled in user
+preferences. The theme is applied system-wide and persists
+across sessions.
+
+Color values follow WCAG 2.1 Level AA contrast requirements
+for accessibility. The implementation uses CSS custom properties
+for theme switching without page reload.
+
+Closes #567
+```
+
+### Example 3: Refactoring
+```
+Extract authentication logic into separate service
+
+The authentication code was scattered across multiple controllers,
+making it difficult to maintain and test. This commit consolidates
+all authentication logic into a dedicated AuthService.
+
+Benefits:
+- Single responsibility principle compliance
+- Easier unit testing with dependency injection
+- Consistent authentication behavior across endpoints
+- Preparation for upcoming OAuth integration
+
+No functional changes to authentication behavior.
+```
+
+### Example 4: Documentation
+```
+Document database migration process
+
+Added comprehensive guide for running database migrations in
+production environments. Includes rollback procedures and
+troubleshooting steps for common issues.
+
+This documentation was requested by DevOps team after the
+incident last week where a migration was rolled back incorrectly.
+```
+
+## Summary
+
+Great commit messages:
+1. Have informative, concise subject lines (50 characters)
+2. Use imperative mood ("Fix bug" not "Fixed bug")
+3. Include blank line between subject and body
+4. Wrap body text at 72 characters
+5. Explain what and why, not how
+6. Provide context and reasoning
+7. Reference related issues and PRs
+
+Poor commit messages cost time for future maintainers (including your future self). Good commit messages save time and preserve institutional knowledge.

--- a/.agents/skills/git-commit-writer/references/detailed-guide.md
+++ b/.agents/skills/git-commit-writer/references/detailed-guide.md
@@ -15,7 +15,7 @@ Git uses the blank line between the subject and body as a delimiter. This allows
 - GitHub's UI displays subjects and bodies separately
 
 **Example:**
-```
+```text
 Fix authentication bug in user login
 
 Users were unable to log in due to a validation error in the
@@ -45,14 +45,14 @@ Without the blank line, Git tools can't distinguish where the subject ends and t
 **Examples:**
 
 ✅ Good (50 characters or less):
-```
+```text
 Add user authentication with JWT tokens
 Fix memory leak in background sync process
 Update dependencies to latest versions
 ```
 
 ❌ Too long:
-```
+```text
 Add comprehensive user authentication system with JWT tokens and refresh token rotation
 ```
 
@@ -63,12 +63,12 @@ Simple consistency rule that improves readability.
 **Examples:**
 
 ✅ Good:
-```
+```text
 Accelerate to 88 miles per hour
 ```
 
 ❌ Bad:
-```
+```text
 accelerate to 88 miles per hour
 ```
 
@@ -79,12 +79,12 @@ Trailing punctuation wastes precious character space in the 50-character limit.
 **Examples:**
 
 ✅ Good:
-```
+```text
 Open the pod bay doors
 ```
 
 ❌ Bad:
-```
+```text
 Open the pod bay doors.
 ```
 
@@ -109,7 +109,7 @@ Your subject line should complete this sentence:
 **Examples:**
 
 ✅ Good (imperative mood):
-```
+```text
 If applied, this commit will refactor authentication module
 If applied, this commit will remove deprecated methods
 If applied, this commit will fix bug in user login
@@ -117,7 +117,7 @@ If applied, this commit will update dependencies
 ```
 
 ❌ Bad (not imperative):
-```
+```text
 If applied, this commit will fixed bug in user login          (past tense)
 If applied, this commit will fixes bug in user login          (present tense)
 If applied, this commit will fixing bug in user login         (present participle)
@@ -149,7 +149,7 @@ Git does not wrap text automatically. When you wrap text manually at 72 characte
 - Use manual line breaks at logical points in your sentences
 
 **Example:**
-```
+```text
 Fix authentication bug in user login
 
 Users were unable to log in due to a validation error in the
@@ -178,12 +178,12 @@ The code shows **how** a change was made. The commit message should explain:
 **Example comparing before/after:**
 
 ❌ Uninformative:
-```
+```text
 Fix bug
 ```
 
 ✅ Informative:
-```
+```text
 Fix authentication timeout in Safari
 
 Safari has a stricter cookie security policy that was causing
@@ -233,7 +233,7 @@ While IDE integrations are convenient, they often limit access to Git's full pow
 
 When commits relate to issues or pull requests, reference them in the body:
 
-```
+```text
 Fix memory leak in background sync
 
 The background sync process was accumulating WebSocket connections
@@ -263,7 +263,7 @@ Reading [Pro Git](https://git-scm.com/book/en/v2) (available free online) provid
 ## Common Anti-Patterns to Avoid
 
 ❌ **Vague subjects:**
-```
+```text
 Fix stuff
 Update code
 Changes
@@ -272,12 +272,12 @@ asdfasdf
 ```
 
 ❌ **Describing implementation instead of purpose:**
-```
+```text
 Change UserController.login() to use bcrypt.compare() with correct parameters
 ```
 
 Better:
-```
+```text
 Fix authentication bug in user login
 
 Corrected bcrypt salt parameter to fix validation errors preventing
@@ -285,12 +285,12 @@ users from logging in.
 ```
 
 ❌ **Including irrelevant information:**
-```
+```text
 Fix login bug (worked on this all day, finally figured it out!)
 ```
 
 ❌ **Not using imperative mood:**
-```
+```text
 Fixed login bug
 Fixing login bug
 This fixes the login bug
@@ -300,7 +300,7 @@ I fixed the login bug
 ## Examples of Great Commit Messages
 
 ### Example 1: Bug Fix
-```
+```text
 Fix race condition in cache invalidation
 
 The previous implementation used separate read and write operations
@@ -316,7 +316,7 @@ Fixes #1234
 ```
 
 ### Example 2: Feature Addition
-```
+```text
 Add dark mode support to user interface
 
 Implements a dark color theme that can be toggled in user
@@ -331,7 +331,7 @@ Closes #567
 ```
 
 ### Example 3: Refactoring
-```
+```text
 Extract authentication logic into separate service
 
 The authentication code was scattered across multiple controllers,
@@ -348,7 +348,7 @@ No functional changes to authentication behavior.
 ```
 
 ### Example 4: Documentation
-```
+```text
 Document database migration process
 
 Added comprehensive guide for running database migrations in

--- a/.agents/skills/ui-design-principles/SKILL.md
+++ b/.agents/skills/ui-design-principles/SKILL.md
@@ -1,0 +1,596 @@
+---
+name: ui-design-principles
+description: Apply pragmatic UI design principles for fast, consistent, accessible interfaces across JavaFX, web, desktop, mobile, and CLI surfaces. Use this skill when designing or reviewing Bisq desktop UI, implementing JavaFX views, improving frontend features, checking layout quality, or evaluating user experience across React, SwiftUI, Flutter, or other UI frameworks.
+---
+
+# UI Design Principles
+
+## Overview
+
+Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) to create interfaces that are fast, consistent, and delightful regardless of platform or framework. This skill provides actionable guidelines for speed optimization, spatial consistency, progressive disclosure, and immediate feedback that apply to Bisq JavaFX screens, web applications, desktop software, mobile apps, and command-line interfaces.
+
+## Core Design Principles
+
+### 1. Speed Through Subtraction (Apple)
+
+**Philosophy**: "Perfection is achieved not when there is nothing more to add, but when there is nothing left to take away."
+
+**Universal Practices**:
+- Remove unnecessary interactions - Make common actions 1-click/tap, rare actions 2-clicks/taps
+- Reduce visual noise - Eliminate decorative elements that don't serve users
+- Eliminate confirmation dialogs for low-risk actions - Only confirm destructive/irreversible operations
+- Streamline workflows - Cut steps that don't add value
+
+**Cross-Platform Examples**:
+```
+❌ Bad: Click "Edit" → Confirm "Are you sure?" → Click "Yes" → Edit mode
+✅ Good: Click "Edit" → Edit mode (action is reversible)
+
+❌ Bad: Settings screen with 50 visible options
+✅ Good: Settings with categories, common settings visible, advanced collapsed
+
+❌ Bad: CLI requiring 5 flags for common operation
+✅ Good: CLI with smart defaults, verbose flags for rare cases
+```
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+- Single-click actions without unnecessary confirmation modals
+- Inline editing instead of modal dialogs for reversible changes
+
+**Desktop (JavaFX/Swing/Electron)**:
+- Menu items for rare actions, toolbar buttons for common ones
+- Keyboard shortcuts bypass multi-step dialogs
+
+**Mobile (iOS/Android/Flutter)**:
+- Swipe gestures for common actions (delete, archive)
+- Bottom sheets instead of multiple navigation steps
+
+**CLI/TUI**:
+- Smart defaults reduce required flags
+- Interactive prompts only for ambiguous cases
+
+**Anti-patterns**:
+- Multiple confirmations for reversible actions
+- Extra steps "for safety" when undo/rollback exists
+- Showing all features upfront instead of progressive disclosure
+
+### 2. Spatial Consistency
+
+**Philosophy**: "UI elements should have predictable positions and behaviors."
+
+**Universal Practices**:
+- Fixed positions for primary actions - CTAs don't move around
+- Consistent spacing rhythm - Use systematic scale (4px base recommended)
+- Stable layouts - Don't shift content during interactions
+- Persistent navigation - Keep nav/search in same location
+
+**Cross-Platform Examples**:
+```
+❌ Bad: Primary button sometimes top-right, sometimes bottom-left
+✅ Good: Primary action always in same location (platform-appropriate)
+
+❌ Bad: Layout shifts when loading content (CLS issue)
+✅ Good: Reserve space for content with skeleton loaders/placeholders
+
+❌ Bad: Spacing varies inconsistently throughout interface
+✅ Good: All spacing follows rhythm (8, 16, 24, 32 units)
+```
+
+**Recommended Spacing Scale** (adapt to platform density):
+```
+Base unit: 4px (or 4dp/4pt depending on platform)
+
+Micro:    4px  (tight spacing within components)
+Small:    8px  (component internal padding)
+Medium:   16px (spacing between related elements)
+Large:    24px (spacing between component groups)
+XLarge:   32px (section separation)
+XXLarge:  48px (major layout divisions)
+```
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+```css
+/* CSS Variables for consistency */
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+}
+```
+
+**Desktop (JavaFX)**:
+```java
+// JavaFX Spacing with Insets
+VBox layout = new VBox(16); // 16px spacing
+layout.setPadding(new Insets(24, 24, 24, 24));
+```
+
+**Mobile (SwiftUI)**:
+```swift
+// SwiftUI Spacing
+VStack(spacing: 16) {
+    // Elements with consistent spacing
+}
+.padding(.horizontal, 24)
+```
+
+**CLI/TUI**:
+- Consistent indentation levels (2 or 4 spaces)
+- Predictable column alignment in tables
+- Separator lines at consistent positions
+
+**Anti-patterns**:
+- Buttons that move based on content length
+- Inconsistent padding across similar components
+- Navigation that disappears or moves unexpectedly
+
+### 3. Progressive Disclosure
+
+**Philosophy**: "Show what matters now, reveal complexity when needed."
+
+**Universal Practices**:
+- Collapsed details by default - Show summary, hide details until needed
+- Expand-in-place patterns - Avoid modals for viewing more information
+- Contextual actions on interaction - Hide secondary actions until element is active
+- Smart defaults - Pre-select common choices to reduce decisions
+
+**Cross-Platform Examples**:
+```
+❌ Bad: FAQ page with all answers expanded (overwhelming)
+✅ Good: FAQ with collapsed answers, expand individual items on demand
+
+❌ Bad: Modal dialog to view profile details
+✅ Good: Inline expansion showing additional details
+
+❌ Bad: Edit/Delete buttons always visible on every list item
+✅ Good: Actions appear on hover/focus/selection
+```
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+- Accordion components for collapsible sections
+- Details/summary HTML elements
+- Hover/focus states revealing contextual actions
+- Dropdown menus for secondary options
+
+**Desktop (JavaFX/Swing/Electron)**:
+- Collapsible panels (TitledPane in JavaFX)
+- Context menus on right-click
+- Tree views with expandable nodes
+- Tabbed interfaces for related content
+
+**Mobile (iOS/Android/Flutter)**:
+- Expandable list items (UITableView sections, RecyclerView with ViewHolders)
+- Bottom sheets for additional options
+- Swipe gestures to reveal actions
+- Master-detail navigation patterns
+
+**CLI/TUI**:
+- Subcommands for advanced features
+- `--help` flag for detailed options
+- Interactive prompts for complex workflows
+- Pagers for long output (less, more)
+
+**Implementation Patterns by Platform**:
+
+**Web Accordion**:
+```tsx
+// React accordion pattern
+<Accordion>
+  <AccordionItem>
+    <AccordionTrigger>Summary (always visible)</AccordionTrigger>
+    <AccordionContent>Details (revealed on click)</AccordionContent>
+  </AccordionItem>
+</Accordion>
+```
+
+**JavaFX Collapsible**:
+```java
+// JavaFX TitledPane (accordion)
+TitledPane pane = new TitledPane("Summary", contentNode);
+pane.setExpanded(false); // Collapsed by default
+Accordion accordion = new Accordion(pane);
+```
+
+**SwiftUI Expandable**:
+```swift
+// SwiftUI DisclosureGroup
+DisclosureGroup("Summary") {
+    Text("Details revealed on tap")
+}
+```
+
+**CLI Progressive Disclosure**:
+```bash
+# Basic command with smart defaults
+$ git commit -m "message"
+
+# Advanced options revealed with --help
+$ git commit --help
+
+# Interactive mode for complex workflows
+$ git commit --interactive
+```
+
+**Anti-patterns**:
+- Showing all options upfront (decision paralysis)
+- Using modals when inline expansion would work
+- Permanent visible actions for rarely-used features
+- Deeply nested navigation requiring back-tracking
+
+### 4. Feedback Immediacy
+
+**Philosophy**: "Users should never wonder if their action worked."
+
+**Universal Practices**:
+- Instant visual feedback (<100ms) - Acknowledge user action immediately
+- Optimistic updates - Update UI instantly, rollback if operation fails
+- Subtle animations (200-300ms) - Smooth state transitions without delay
+- Clear state transitions - Visually distinguish loading/success/error states
+
+**Cross-Platform Examples**:
+```
+❌ Bad: Button shows no change when clicked, waits for response
+✅ Good: Button changes to "Saving..." immediately, then "Saved ✓"
+
+❌ Bad: Delete item, wait for spinner, item disappears
+✅ Good: Item fades out immediately, rollback if operation fails
+
+❌ Bad: Heavy 800ms animation that blocks interaction
+✅ Good: 200-300ms subtle transition that feels smooth
+```
+
+**Universal State Indicators**:
+- **Idle**: Default state, ready for interaction
+- **Loading**: Visual spinner/progress indicator, <100ms to show
+- **Success**: Checkmark/success indicator, 2-3 second auto-dismiss
+- **Error**: Error indicator, error message, persistent until dismissed
+
+**Animation Guidelines** (adapt to platform conventions):
+- Micro-interactions: 100-200ms (button press, hover, selection)
+- State transitions: 200-300ms (expand/collapse, fade)
+- Scene transitions: 300-400ms (route change, modal, screen navigation)
+- Never exceed 500ms for UI feedback
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+```typescript
+// Optimistic UI pattern
+async function deleteItem(id: string) {
+  // 1. Update UI immediately (optimistic)
+  setItems(items.filter(item => item.id !== id));
+
+  try {
+    // 2. Call server
+    await api.delete(`/items/${id}`);
+    showToast('Item deleted', 'success');
+  } catch (error) {
+    // 3. Rollback on error
+    setItems(originalItems);
+    showToast('Failed to delete', 'error');
+  }
+}
+```
+
+**Desktop (JavaFX)**:
+```java
+// JavaFX button state feedback
+button.setOnAction(event -> {
+    // 1. Immediate visual feedback
+    button.setText("Saving...");
+    button.setDisable(true);
+
+    // 2. Execute operation on background thread
+    Task<Void> task = new Task<>() {
+        @Override
+        protected Void call() throws Exception {
+            performSave();
+            return null;
+        }
+    };
+
+    // 3. Update UI on completion
+    task.setOnSucceeded(e -> {
+        button.setText("Saved ✓");
+        Platform.runLater(() -> {
+            Thread.sleep(2000);
+            button.setText("Save");
+            button.setDisable(false);
+        });
+    });
+
+    task.setOnFailed(e -> {
+        button.setText("Failed ✗");
+        showErrorDialog(task.getException());
+        button.setDisable(false);
+    });
+
+    new Thread(task).start();
+});
+```
+
+**Mobile (SwiftUI)**:
+```swift
+// SwiftUI state-driven button
+struct SaveButton: View {
+    @State private var state: ButtonState = .idle
+
+    var body: some View {
+        Button(action: {
+            state = .loading // Immediate feedback
+
+            Task {
+                do {
+                    try await save()
+                    state = .success
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                    state = .idle
+                } catch {
+                    state = .error
+                }
+            }
+        }) {
+            Text(state.label)
+        }
+        .disabled(state == .loading)
+    }
+}
+
+enum ButtonState {
+    case idle, loading, success, error
+
+    var label: String {
+        switch self {
+        case .idle: return "Save"
+        case .loading: return "Saving..."
+        case .success: return "✓ Saved"
+        case .error: return "✗ Failed"
+        }
+    }
+}
+```
+
+**CLI/TUI**:
+```bash
+# Immediate feedback patterns in CLI
+$ git push
+Counting objects: 100% (10/10), done.  # Progress feedback
+Writing objects: 100% (10/10), 1.5 KiB | 1.5 MiB/s, done.
+✓ Successfully pushed to origin/main  # Success indicator
+
+# Error feedback
+$ git push
+✗ Error: failed to push some refs  # Clear error state
+hint: Updates were rejected because...  # Actionable message
+```
+
+**Anti-patterns**:
+- No visual response when user interacts
+- Long operations without progress indication
+- Heavy animations that feel sluggish (>500ms)
+- Missing error states (silent failures)
+- Blocking UI during background operations
+
+## Design Review Checklist
+
+Use this checklist when reviewing UI designs or implementations across any platform:
+
+### Speed Audit
+- [ ] Can any steps be removed from common workflows?
+- [ ] Are there unnecessary confirmation dialogs for reversible actions?
+- [ ] Is the most common action 1-click/tap away?
+- [ ] Are rare/destructive actions appropriately protected (2-clicks)?
+- [ ] Do keyboard shortcuts exist for power users (desktop)?
+- [ ] Are smart defaults reducing user decisions?
+
+### Consistency Audit
+- [ ] Do primary actions stay in consistent positions?
+- [ ] Is spacing using a systematic rhythm scale?
+- [ ] Are layouts stable (no content layout shift)?
+- [ ] Is navigation persistent and predictable?
+- [ ] Do similar components use identical spacing/sizing?
+- [ ] Are platform conventions followed (e.g., OK/Cancel order)?
+
+### Disclosure Audit
+- [ ] Are complex features hidden by default?
+- [ ] Can users discover advanced features when needed?
+- [ ] Are contextual actions revealed appropriately?
+- [ ] Do smart defaults reduce decision-making?
+- [ ] Is the information hierarchy clear (what's important)?
+- [ ] Can users progressively learn advanced features?
+
+### Feedback Audit
+- [ ] Is visual feedback <100ms for all interactions?
+- [ ] Are optimistic updates used for async operations?
+- [ ] Are animations subtle and quick (200-300ms)?
+- [ ] Are all states clearly distinguished (idle/loading/success/error)?
+- [ ] Do long operations show progress indicators?
+- [ ] Are errors actionable with clear next steps?
+
+## Platform-Specific Considerations
+
+### Web Applications
+
+**Strengths**:
+- Rich animations and transitions
+- Hover states for progressive disclosure
+- Optimistic updates with async/await patterns
+- Browser back/forward navigation
+
+**Challenges**:
+- Network latency for remote operations
+- Cross-browser compatibility
+- Accessibility (keyboard navigation, screen readers)
+- Performance on low-end devices
+
+**Best Practices**:
+- Use semantic HTML for accessibility
+- Implement keyboard navigation (Tab, Enter, Escape)
+- Provide loading states for network operations
+- Test on mobile devices (touch targets)
+
+### Desktop Applications (JavaFX, Swing, Electron)
+
+**Strengths**:
+- Rich keyboard shortcuts
+- Context menus for advanced actions
+- Multi-window/multi-pane layouts
+- Direct file system access
+
+**Challenges**:
+- Platform-specific UI conventions (Windows vs macOS vs Linux)
+- Window management complexity
+- High user expectations for responsiveness
+- Complex state management across windows
+
+**Best Practices**:
+- Follow platform conventions (menu order, button placement)
+- Provide extensive keyboard shortcuts
+- Use background threads (JavaFX Task, SwingWorker) for long operations
+- Implement proper window lifecycle management
+
+**JavaFX-Specific**:
+- Use Platform.runLater() for UI thread updates
+- Leverage FXML for declarative layouts
+- Use CSS for consistent theming
+- Implement Properties/Bindings for reactive UIs
+
+### Mobile Applications (iOS, Android, Flutter)
+
+**Strengths**:
+- Touch gestures (swipe, pinch, long-press)
+- Bottom sheets for contextual options
+- Native animations and transitions
+- Push notifications for feedback
+
+**Challenges**:
+- Limited screen space
+- Touch target sizes (minimum 44pt/48dp)
+- Battery/performance constraints
+- Platform-specific design languages (Material/Human Interface)
+
+**Best Practices**:
+- Follow platform design guidelines (Material Design, Human Interface Guidelines)
+- Use native navigation patterns (tab bar, nav bar, drawer)
+- Implement pull-to-refresh for data updates
+- Provide haptic feedback for actions
+- Optimize for one-handed use
+
+### Command-Line Interfaces (CLI/TUI)
+
+**Strengths**:
+- Fast for power users
+- Scriptable and composable
+- Low resource overhead
+- Excellent for automation
+
+**Challenges**:
+- No visual feedback (text only)
+- Discovery of features harder
+- Error handling complexity
+- Limited progressive disclosure
+
+**Best Practices**:
+- Provide comprehensive --help documentation
+- Use colored output for state (green=success, red=error)
+- Show progress for long operations (spinners, progress bars)
+- Implement interactive modes for complex workflows
+- Use pagers for long output
+- Provide examples in help text
+
+## When to Apply Each Principle
+
+### Speed Through Subtraction
+- **When**: Designing new features, refactoring complex flows, user feedback about tedious workflows
+- **Signs needed**: Users complaining about "too many clicks", workflows feel tedious, high abandonment rates
+- **Impact**: Reduced time-to-completion, lower cognitive load, improved conversion rates
+
+### Spatial Consistency
+- **When**: Building design systems, refactoring inconsistent UIs, scaling design to new features
+- **Signs needed**: Users can't find features, layouts feel chaotic, design debt accumulating
+- **Impact**: Improved learnability, reduced confusion, faster development (reusable patterns)
+
+### Progressive Disclosure
+- **When**: Building complex features, settings pages, advanced tools, professional software
+- **Signs needed**: Users overwhelmed by options, interface feels cluttered, poor feature discovery
+- **Impact**: Reduced cognitive load, improved discoverability, better user retention
+
+### Feedback Immediacy
+- **When**: Implementing async operations, form submissions, data mutations, long-running processes
+- **Signs needed**: Users unsure if action worked, repeated clicks, support requests about "broken" features
+- **Impact**: Increased confidence, reduced user anxiety, fewer support tickets
+
+## Resources
+
+This skill is guidance-only and does not include scripts, references, or assets. All implementation patterns are provided inline in the SKILL.md for immediate reference.
+
+## Cross-Framework Pattern Reference
+
+### State Management Patterns
+
+**Web (React)**:
+```typescript
+const [state, setState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+```
+
+**JavaFX (Property)**:
+```java
+ObjectProperty<State> state = new SimpleObjectProperty<>(State.IDLE);
+state.addListener((obs, oldVal, newVal) -> updateUI(newVal));
+```
+
+**SwiftUI (State)**:
+```swift
+@State private var state: ButtonState = .idle
+```
+
+**Flutter (State)**:
+```dart
+enum ButtonState { idle, loading, success, error }
+ButtonState _state = ButtonState.idle;
+setState(() => _state = ButtonState.loading);
+```
+
+### Progressive Disclosure Patterns
+
+**Web**: Accordion, Details/Summary, Collapsible sections
+**JavaFX**: TitledPane, Accordion, TreeView
+**SwiftUI**: DisclosureGroup, List with expandable sections
+**Flutter**: ExpansionTile, ExpansionPanel
+**CLI**: Subcommands, --help flags, interactive prompts
+
+### Animation/Transition Patterns
+
+**Web (CSS)**:
+```css
+transition: all 200ms ease-in-out;
+```
+
+**JavaFX (Timeline)**:
+```java
+Timeline timeline = new Timeline(
+    new KeyFrame(Duration.millis(200),
+        new KeyValue(node.opacityProperty(), 0))
+);
+timeline.play();
+```
+
+**SwiftUI (Animation)**:
+```swift
+withAnimation(.easeInOut(duration: 0.2)) {
+    // State changes
+}
+```
+
+**Flutter (Animation)**:
+```dart
+AnimationController(duration: Duration(milliseconds: 200), vsync: this);
+```

--- a/.agents/skills/ui-design-principles/SKILL.md
+++ b/.agents/skills/ui-design-principles/SKILL.md
@@ -22,7 +22,7 @@ Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) 
 - Streamline workflows - Cut steps that don't add value
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: Click "Edit" → Confirm "Are you sure?" → Click "Yes" → Edit mode
 ✅ Good: Click "Edit" → Edit mode (action is reversible)
 
@@ -67,7 +67,7 @@ Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) 
 - Persistent navigation - Keep nav/search in same location
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: Primary button sometimes top-right, sometimes bottom-left
 ✅ Good: Primary action always in same location (platform-appropriate)
 
@@ -79,7 +79,7 @@ Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) 
 ```
 
 **Recommended Spacing Scale** (adapt to platform density):
-```
+```text
 Base unit: 4px (or 4dp/4pt depending on platform)
 
 Micro:    4px  (tight spacing within components)
@@ -141,7 +141,7 @@ VStack(spacing: 16) {
 - Smart defaults - Pre-select common choices to reduce decisions
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: FAQ page with all answers expanded (overwhelming)
 ✅ Good: FAQ with collapsed answers, expand individual items on demand
 
@@ -236,7 +236,7 @@ $ git commit --interactive
 - Clear state transitions - Visually distinguish loading/success/error states
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: Button shows no change when clicked, waits for response
 ✅ Good: Button changes to "Saving..." immediately, then "Saved ✓"
 
@@ -265,6 +265,8 @@ $ git commit --interactive
 ```typescript
 // Optimistic UI pattern
 async function deleteItem(id: string) {
+  const previousItems = items;
+
   // 1. Update UI immediately (optimistic)
   setItems(items.filter(item => item.id !== id));
 
@@ -274,7 +276,7 @@ async function deleteItem(id: string) {
     showToast('Item deleted', 'success');
   } catch (error) {
     // 3. Rollback on error
-    setItems(originalItems);
+    setItems(previousItems);
     showToast('Failed to delete', 'error');
   }
 }
@@ -283,6 +285,7 @@ async function deleteItem(id: string) {
 **Desktop (JavaFX)**:
 ```java
 // JavaFX button state feedback
+// Requires javafx.animation.PauseTransition and javafx.util.Duration.
 button.setOnAction(event -> {
     // 1. Immediate visual feedback
     button.setText("Saving...");
@@ -300,11 +303,12 @@ button.setOnAction(event -> {
     // 3. Update UI on completion
     task.setOnSucceeded(e -> {
         button.setText("Saved ✓");
-        Platform.runLater(() -> {
-            Thread.sleep(2000);
+        PauseTransition delay = new PauseTransition(Duration.seconds(2));
+        delay.setOnFinished(finishedEvent -> {
             button.setText("Save");
             button.setDisable(false);
         });
+        delay.play();
     });
 
     task.setOnFailed(e -> {

--- a/.agents/skills/ui-design-principles/agents/openai.yaml
+++ b/.agents/skills/ui-design-principles/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "UI Design Principles"
+  short_description: "Apply pragmatic UI quality checks across platforms"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $ui-design-principles to review or improve this Bisq user interface."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -44,5 +44,6 @@ Run from the repository root after editing skills:
 
 ```bash
 find .agents/skills .claude/skills -maxdepth 2 -name SKILL.md | sort
+diff -qr .agents/skills .claude/skills
 git diff --check -- .agents/skills .claude/skills
 ```

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,48 @@
+# Bisq AI Skills
+
+Repo-local skills in this directory are loaded automatically by AI coding agents when working in the Bisq 2 checkout.
+
+- Codex scans `.agents/skills` from the current directory up to the Git root.
+- Claude Code uses `.claude/skills` for repository skills.
+
+## Available Skills
+
+### bisq-contributor-workflow
+
+Guides day-to-day Bisq implementation work: issue analysis, narrow changes, Java/JavaFX conventions, Gradle verification, P2P safety, wallet and transaction checks, DAO impact, and documentation updates.
+
+### bisq2-javafx-ui
+
+Guides production-ready Bisq2 JavaFX UI work with strict MVC structure, lifecycle cleanup, design system conventions, navigation wiring, automation selectors, desktop harness verification, and review checklists.
+
+### bisq-pr-reviewer
+
+Performs comprehensive Bisq pull request review by combining review-comment extraction with contribution standards, architecture review, and Bitcoin/P2P security validation.
+
+### git-commit-writer
+
+Drafts and reviews professional commit messages with imperative subjects, concise summaries, and body text focused on what changed and why.
+
+### ui-design-principles
+
+Applies pragmatic UI quality checks for JavaFX, web, desktop, mobile, and CLI interfaces.
+
+## Required Structure
+
+```text
+{agent-root}/skills/{skill-name}/
++-- SKILL.md
++-- agents/openai.yaml
++-- references/          # Optional, for detailed material loaded as needed
+```
+
+Use `references/` for long checklists or examples. Keep the main `SKILL.md` focused on workflow and routing.
+
+## Sanity Check
+
+Run from the repository root after editing skills:
+
+```bash
+find .agents/skills .claude/skills -maxdepth 2 -name SKILL.md | sort
+git diff --check -- .agents/skills .claude/skills
+```

--- a/.claude/skills/bisq-contributor-workflow/SKILL.md
+++ b/.claude/skills/bisq-contributor-workflow/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bisq-contributor-workflow
+description: Guide Codex or Claude Code through high-quality Bisq contribution work. Use when implementing Bisq issues, fixing bugs, changing Java or JavaFX code, touching P2P networking, Bitcoin wallet or transaction logic, DAO governance, build/test workflows, documentation, or contributor onboarding tasks in Bisq repositories.
+---
+
+# Bisq Contributor Workflow
+
+## Goal
+
+Help Bisq contributors make small, well-verified changes that respect Bisq's decentralized, security-sensitive architecture. Prefer repository-local patterns over generic framework advice.
+
+## Core Workflow
+
+1. Read the issue, nearby code, tests, and project docs before editing.
+2. Identify the affected domain: desktop UI, trade protocol, P2P networking, wallet/Bitcoin, DAO, persistence, build tooling, or docs.
+3. Keep changes narrow. Avoid broad refactors unless they directly reduce risk for the requested change.
+4. Run the smallest meaningful verification first, then broaden when touching shared or security-sensitive code.
+5. Summarize behavioral impact, tests run, and residual risk.
+
+## Bisq-Specific Checks
+
+- For Bitcoin, wallet, key, fee, address, or transaction code, verify private-key handling, amount precision, dust/fee boundaries, and network selection.
+- For P2P or trade protocol changes, check message validation, state transitions, replay/idempotency behavior, and peer trust assumptions.
+- For JavaFX UI changes, preserve the existing MVC structure, view/controller boundaries, resource usage, and responsive layout behavior.
+- For DAO governance changes, verify proposal/vote lifecycle assumptions and backwards compatibility with existing DAO state.
+- For docs and prompts, prefer contributor workflow clarity over marketing copy.
+
+## Verification
+
+Use commands from the target Bisq repository rather than inventing new ones. Common patterns include:
+
+```bash
+./gradlew test
+./gradlew :desktop:desktop-app:test
+./gradlew :core:test
+```
+
+If a module or task name differs, inspect `settings.gradle`, `build.gradle`, or `./gradlew tasks` and choose the nearest focused command. When tests are too expensive or unavailable, state exactly what was inspected instead.
+
+## Related Resources
+
+For review-heavy work, use `bisq-pr-reviewer`. For UI-specific polish, use `ui-design-principles`. For commit messages, use `git-commit-writer`.

--- a/.claude/skills/bisq-contributor-workflow/SKILL.md
+++ b/.claude/skills/bisq-contributor-workflow/SKILL.md
@@ -39,4 +39,4 @@ If a module or task name differs, inspect `settings.gradle`, `build.gradle`, or 
 
 ## Related Resources
 
-For review-heavy work, use `$bisq-pr-reviewer`. For UI-specific polish, use `$ui-design-principles`. For commit messages, use `$git-commit-writer`.
+Use `$bisq-pr-reviewer` for review-heavy work, `$ui-design-principles` for UI-specific polish, and `$git-commit-writer` for commit message guidance.

--- a/.claude/skills/bisq-contributor-workflow/SKILL.md
+++ b/.claude/skills/bisq-contributor-workflow/SKILL.md
@@ -39,4 +39,4 @@ If a module or task name differs, inspect `settings.gradle`, `build.gradle`, or 
 
 ## Related Resources
 
-For review-heavy work, use `bisq-pr-reviewer`. For UI-specific polish, use `ui-design-principles`. For commit messages, use `git-commit-writer`.
+For review-heavy work, use `$bisq-pr-reviewer`. For UI-specific polish, use `$ui-design-principles`. For commit messages, use `$git-commit-writer`.

--- a/.claude/skills/bisq-contributor-workflow/agents/openai.yaml
+++ b/.claude/skills/bisq-contributor-workflow/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Bisq Contributor Workflow"
+  short_description: "Implement Bisq changes with architecture and safety checks"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $bisq-contributor-workflow to implement this Bisq issue with focused verification."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/bisq-pr-reviewer/SKILL.md
+++ b/.claude/skills/bisq-pr-reviewer/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: bisq-pr-reviewer
+description: Provide comprehensive Bisq PR review in Codex or Claude Code by integrating CodeRabbitAI feedback extraction with Bisq-specific security validation, contribution standards verification, and domain expertise for Bitcoin, P2P, trade protocol, DAO, Java, and JavaFX changes. Use when reviewing Bisq pull requests, validating contribution standards, extracting unresolved review comments, or performing security reviews of cryptocurrency code changes.
+---
+
+# Bisq PR Reviewer
+
+## Purpose
+
+Deliver comprehensive pull request review for Bisq repositories through a two-phase process: systematic CodeRabbitAI comment extraction followed by Bisq domain expertise analysis covering security validation, contribution standards compliance, and architecture patterns.
+
+## Tooling
+
+Use the host environment's normal file, shell, and GitHub tools. In Claude Code, the bundled `/review-pr` command can run the extraction workflow directly. In Codex, read `commands/review-pr.md` from this plugin and execute the same steps with `gh`, local file reads, and repository inspection.
+
+## When to Use
+
+Trigger this skill for:
+- Comprehensive Bisq pull request reviews
+- CodeRabbitAI feedback validation and extraction
+- Security review of Bitcoin/crypto code changes
+- P2P protocol or trade protocol modifications
+- DAO governance impact assessment
+- Contribution standards compliance verification
+
+**Activation phrases**:
+- "Review PR #123"
+- "Check CodeRabbitAI feedback on bisq-network/bisq2#456"
+- "Analyze pull request for Bisq standards"
+- "Comprehensive security review of this PR"
+
+## Two-Phase Review Workflow
+
+### Phase 1: CodeRabbitAI Comment Extraction
+
+Systematically extract and organize all review feedback. In Claude Code, execute the bundled `/review-pr` command:
+
+```bash
+SlashCommand: "/review-pr {pr_number or owner/repo#pr}"
+```
+
+In Codex, open `commands/review-pr.md` within this plugin and follow that command's phases manually.
+
+**Phase 1 delivers**:
+1. CI/CD status verification
+2. Complete comment inventory (inline, review body, issue comments)
+3. CodeRabbit nitpicks and duplicates extraction
+4. Code-verified current status of each comment
+5. Severity categorization (Critical, High, Medium, Nitpicks)
+6. Numbered action item checklist with traceability
+
+### Phase 2: Bisq Domain Analysis
+
+After Phase 1 completion, apply Bisq-specific expertise across four domains:
+
+#### 1. Security Validation
+
+Identify security-sensitive files in the PR:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/files --jq '.[].filename' | \
+  grep -E "(bitcoin|crypto|trade|wallet|key|transaction|p2p|dao)"
+```
+
+For each security-sensitive file, load and apply security checklist:
+
+```bash
+Read references/bisq-security-checklist.md
+```
+
+The security checklist covers:
+- Private key handling validation
+- Bitcoin transaction safety (fees, dust, overflow)
+- Cryptographic operations approval
+- P2P message validation
+- Financial logic precision
+
+Generate security assessment using template from `references/bisq-security-checklist.md`.
+
+#### 2. Contribution Standards Compliance
+
+Load contribution standards reference:
+
+```bash
+Read references/contribution-standards.md
+```
+
+**Verify GPG signatures**:
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/commits \
+  --jq '.[] | {sha: .sha, verified: .commit.verification.verified, reason: .commit.verification.reason}'
+```
+
+**Extract commit messages for validation**:
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/commits --jq '.[].commit.message'
+```
+
+Apply validation for:
+- C4 protocol compliance (stakeholder buy-in, atomic commits)
+- GPG signatures on all commits
+- Git commit message standards (via git-commit-writer skill integration)
+
+For commit message improvements, reference git-commit-writer skill patterns.
+
+#### 3. Architecture Patterns Compliance
+
+Load architecture patterns reference:
+
+```bash
+Read references/bisq-architecture-patterns.md
+```
+
+Validate:
+- Multi-module Gradle structure boundaries
+- JavaFX MVVM pattern adherence
+- Dependency injection (Guice) patterns
+- Service layer separation
+- Trade protocol state machine safety (if applicable)
+- DAO governance logic correctness (if applicable)
+- P2P protocol versioning and compatibility
+
+#### 4. Domain-Specific Checks
+
+**Trade Protocol Safety** (if trade-related changes):
+```bash
+Grep "TradeProtocol|TradingPeer|TradeManager" --output_mode files_with_matches
+```
+
+Validate state transitions, peer communication safety, and financial correctness.
+
+**DAO Governance Impact** (if DAO changes):
+```bash
+Grep "DAO|Governance|Proposal|Vote|Bonding" --output_mode files_with_matches
+```
+
+Validate voting logic, proposal validation, and bond management.
+
+## Complete Review Output
+
+Generate comprehensive report combining both phases:
+
+```markdown
+# Bisq PR Review: #{pr_number}
+
+## Phase 1: CodeRabbitAI Comment Analysis
+[Output from /review-pr command]
+- CI Status: {✅ Passing | ❌ {X} failures}
+- Total Comments: {count}
+- Critical Issues: {count}
+
+## Phase 2: Bisq Domain Analysis
+
+### 🔐 Security Review
+[From bisq-security-checklist.md assessment]
+**Risk Level**: {CRITICAL|HIGH|MEDIUM|LOW}
+**Critical Findings**: {count}
+
+### 📋 Contribution Standards
+[From contribution-standards.md validation]
+- GPG Signatures: {✅ All signed | ❌ {X} unsigned}
+- Commit Messages: {✅ Compliant | ⚠️ {X} need improvement}
+- C4 Protocol: {✅ Compliant | ⚠️ Issues found}
+
+### 🏗️ Architecture Compliance
+[From bisq-architecture-patterns.md validation]
+- Module Structure: {✅ Correct | ⚠️ Concerns}
+- Design Patterns: {✅ Followed | ⚠️ Violations}
+- Domain Logic: {assessment}
+
+### ✅ Combined Action Plan
+
+#### Must Fix Before Merge
+1. [Critical from CodeRabbit + Security + CI]
+2. ...
+
+#### Should Fix (High Priority)
+1. [High priority from both phases]
+2. ...
+
+#### Nice to Have (Medium + Nitpicks)
+[Combined list]
+
+## Summary
+- **Overall**: {READY TO MERGE | NEEDS WORK | MAJOR CONCERNS}
+- **Blockers**: {count}
+- **Security Risk**: {None|Low|Medium|High|Critical}
+```
+
+## Execution Steps
+
+1. **Parse PR reference** from user input (format: "owner/repo#number" or just "number")
+2. **Execute Phase 1**: Invoke `/review-pr` for CodeRabbitAI extraction
+3. **Get PR file list**: `gh api repos/{owner}/{repo}/pulls/{pr}/files`
+4. **Identify domains**: Detect security-sensitive, architecture, DAO, or trade protocol files
+5. **Load relevant references**: Load only needed reference files for efficiency
+6. **Apply domain validation**: Execute security, standards, and architecture checks
+7. **Generate combined report**: Merge findings from both phases
+8. **Prioritize actions**: Order by criticality (Security > CI > CodeRabbit > Standards > Architecture)
+
+## Edge Cases
+
+**Large PRs (>10 files)**:
+- Prioritize security-sensitive files first
+- Summarize architecture changes at module level
+- Group related issues
+
+**Security-Critical PRs**:
+- Load full security checklist even for quick reviews
+- Escalate critical findings immediately
+- Recommend additional security testing
+
+**First-Time Contributors**:
+- Provide detailed standards explanation
+- Link to Bisq contribution guidelines
+- Offer GPG setup assistance if signatures missing
+
+**DAO/Protocol Changes**:
+- Apply extra scrutiny to governance and P2P code
+- Simulate scenarios for validation
+- Assess backward compatibility thoroughly
+
+## Integration Points
+
+**git-commit-writer skill**:
+- Automatically reference when commit messages need improvement
+- Use git-commit-writer patterns for suggested rewrites
+
+**bisq-ai-contributor-tools ecosystem**:
+- Complements planned `bisq-architecture` skill
+- Could integrate with future `bitcoin-security` skill
+- Works alongside `/review-pr` command
+
+## Success Criteria
+
+Complete review delivers:
+- ✅ All CodeRabbitAI comments extracted and verified
+- ✅ CI status documented
+- ✅ Security validation for sensitive code
+- ✅ GPG signature verification
+- ✅ Commit message quality assessment
+- ✅ Architecture compliance check
+- ✅ Domain-specific safety validation
+- ✅ Prioritized, actionable recommendations
+- ✅ Clear merge decision with rationale
+
+## Bundled Resources
+
+**references/bisq-security-checklist.md**:
+Comprehensive Bitcoin/crypto security patterns including private key handling, transaction safety, cryptographic operations, P2P validation, and financial logic checks.
+
+**references/bisq-architecture-patterns.md**:
+Bisq architecture validation covering Gradle modules, JavaFX MVVM, dependency injection, trade protocol state machines, DAO governance patterns, and P2P networking.
+
+**references/contribution-standards.md**:
+C4 protocol compliance, GPG signature verification, and git commit message standards with integration guidance for git-commit-writer skill.
+
+Load references as needed based on PR content to maintain context efficiency.

--- a/.claude/skills/bisq-pr-reviewer/SKILL.md
+++ b/.claude/skills/bisq-pr-reviewer/SKILL.md
@@ -124,14 +124,14 @@ Validate:
 
 **Trade Protocol Safety** (if trade-related changes):
 ```bash
-Grep "TradeProtocol|TradingPeer|TradeManager" --output_mode files_with_matches
+grep -R -l -E "TradeProtocol|TradingPeer|TradeManager" .
 ```
 
 Validate state transitions, peer communication safety, and financial correctness.
 
 **DAO Governance Impact** (if DAO changes):
 ```bash
-Grep "DAO|Governance|Proposal|Vote|Bonding" --output_mode files_with_matches
+grep -R -l -E "DAO|Governance|Proposal|Vote|Bonding" .
 ```
 
 Validate voting logic, proposal validation, and bond management.

--- a/.claude/skills/bisq-pr-reviewer/agents/openai.yaml
+++ b/.claude/skills/bisq-pr-reviewer/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Bisq PR Reviewer"
+  short_description: "Review Bisq PRs with security and domain context"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $bisq-pr-reviewer to review this Bisq pull request for correctness, security, and standards."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
+++ b/.claude/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
@@ -1,0 +1,361 @@
+# Bisq Architecture Patterns
+
+Architecture validation reference for Bisq PR reviews covering Gradle modules, JavaFX patterns, dependency injection, and design principles.
+
+## Multi-Module Gradle Structure
+
+### Module Boundaries
+
+Bisq uses a multi-module Gradle structure. Changes should respect module boundaries and dependencies.
+
+**Core Modules**:
+- `core` - Core business logic, domain models
+- `desktop` - JavaFX desktop UI application
+- `common` - Shared utilities and common code
+- `p2p` - P2P networking layer
+- `assets` - Asset-specific implementations
+
+**Validation Points**:
+- [ ] Changes respect module dependencies (no circular dependencies)
+- [ ] Core logic not in UI modules
+- [ ] UI code not in core modules
+- [ ] Proper module-info.java updates if adding dependencies
+
+**Common Anti-Patterns**:
+```java
+// ❌ Desktop module calling P2P directly without abstraction
+desktop/src/main/java/SomeView.java:
+  import bisq.network.p2p.P2PService; // Should use service interface
+
+// ✅ Desktop module using service interface
+desktop/src/main/java/SomeView.java:
+  import bisq.core.api.CoreApi; // Proper abstraction
+```
+
+## JavaFX UI Patterns
+
+### MVVM Architecture
+
+Bisq desktop uses Model-View-ViewModel (MVVM) pattern with JavaFX.
+
+**Components**:
+- **View**: FXML or code-based JavaFX UI (`.fxml`, `*View.java`)
+- **ViewModel**: Presentation logic (`*ViewModel.java`, `*Model.java`)
+- **Model**: Domain objects from core module
+
+**Validation Points**:
+- [ ] Views are thin - no business logic
+- [ ] ViewModels contain presentation logic only
+- [ ] Business logic delegated to services
+- [ ] Proper observable property bindings
+- [ ] UI updates on JavaFX Application Thread
+
+**Correct Pattern**:
+```java
+// ✅ Proper MVVM separation
+public class TradeView extends ActivatableView<VBox, TradeViewModel> {
+    @Inject
+    public TradeView(TradeViewModel viewModel) {
+        super(viewModel);
+    }
+
+    @Override
+    protected void activate() {
+        // UI bindings only
+        amountTextField.textProperty().bindBidirectional(viewModel.amountProperty());
+    }
+}
+
+public class TradeViewModel extends ActivatableWithDataModel<TradeDataModel> {
+    public void onConfirmTrade() {
+        // Presentation logic
+        if (validate()) {
+            dataModel.confirmTrade(); // Delegate to model
+        }
+    }
+}
+
+public class TradeDataModel extends ActivatableDataModel {
+    @Inject
+    private TradeManager tradeManager; // Business logic service
+
+    public void confirmTrade() {
+        tradeManager.confirmTrade(trade); // Delegate to service
+    }
+}
+```
+
+**Anti-Patterns**:
+```java
+// ❌ Business logic in View
+public class TradeView {
+    public void onConfirmTrade() {
+        // Direct business logic - WRONG
+        tradeManager.confirmTrade(trade);
+    }
+}
+
+// ❌ UI updates not on FX thread
+public void updateUI() {
+    label.setText(value); // May crash if called from non-FX thread
+}
+
+// ✅ Correct FX thread usage
+public void updateUI() {
+    Platform.runLater(() -> label.setText(value));
+}
+```
+
+## Dependency Injection (Guice)
+
+Bisq uses Google Guice for dependency injection.
+
+**Validation Points**:
+- [ ] Constructor injection preferred
+- [ ] `@Inject` annotation on constructor
+- [ ] Avoid field injection where possible
+- [ ] Singleton services properly scoped
+- [ ] Module bindings correct
+
+**Correct Patterns**:
+```java
+// ✅ Constructor injection
+public class TradeManager {
+    private final P2PService p2pService;
+    private final WalletService walletService;
+
+    @Inject
+    public TradeManager(P2PService p2pService, WalletService walletService) {
+        this.p2pService = p2pService;
+        this.walletService = walletService;
+    }
+}
+
+// ✅ Module binding
+public class TradeModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(TradeManager.class).in(Singleton.class);
+    }
+}
+```
+
+**Anti-Patterns**:
+```java
+// ❌ Field injection (harder to test)
+public class TradeManager {
+    @Inject private P2PService p2pService;
+}
+
+// ❌ Manual instantiation instead of DI
+public class TradeView {
+    private TradeManager tradeManager = new TradeManager(); // WRONG
+}
+```
+
+## Service Layer Pattern
+
+Business logic should be in service classes, not in UI or controllers.
+
+**Service Characteristics**:
+- Stateless or carefully managed state
+- Reusable across different UI contexts
+- Testable without UI
+- Clear single responsibility
+
+**Validation Points**:
+- [ ] Business logic in services, not Views/ViewModels
+- [ ] Services injected, not instantiated
+- [ ] Proper error handling
+- [ ] Thread safety for concurrent access
+
+**Example Structure**:
+```java
+// Service layer
+@Singleton
+public class TradeProtocolManager {
+    public void initiateTrade(Trade trade) {
+        // Business logic here
+    }
+}
+
+// ViewModel uses service
+public class TradeViewModel {
+    @Inject
+    private TradeProtocolManager tradeProtocolManager;
+
+    public void onStartTrade() {
+        tradeProtocolManager.initiateTrade(trade);
+    }
+}
+```
+
+## Trade Protocol State Machine
+
+Trade protocol uses state machine pattern for safety and clarity.
+
+**Validation Points**:
+- [ ] State transitions are valid
+- [ ] Each state has clear entry/exit logic
+- [ ] Rollback/error handling for failed transitions
+- [ ] No state skipping
+- [ ] Proper state persistence
+
+**State Machine Pattern**:
+```java
+public enum TradeState {
+    INIT,
+    MAKER_SENT_PUBLISH_DEPOSIT_TX_REQUEST,
+    TAKER_RECEIVED_PUBLISH_DEPOSIT_TX_REQUEST,
+    TAKER_PUBLISHED_DEPOSIT_TX,
+    // ... more states
+}
+
+// State transition validation
+public void transitionTo(TradeState newState) {
+    if (!isValidTransition(currentState, newState)) {
+        throw new IllegalStateTransitionException();
+    }
+    currentState = newState;
+    persist();
+}
+```
+
+## DAO Governance Patterns
+
+DAO-related code requires extra care for voting and governance logic.
+
+**Validation Points**:
+- [ ] Voting weight calculations correct
+- [ ] Proposal validation thorough
+- [ ] Bond lock/unlock logic safe
+- [ ] No fund loss paths
+- [ ] Backward compatibility maintained
+
+**Critical Checks**:
+```java
+// Vote weight calculation
+long voteWeight = stake * votingPower; // Check for overflow
+if (voteWeight < stake) throw new ArithmeticException("Overflow");
+
+// Proposal parameter bounds
+if (proposalAmount > MAX_PROPOSAL_AMOUNT) {
+    reject();
+}
+
+// Bond management
+public void lockBond(long amount) {
+    if (availableBalance < amount) throw new InsufficientFundsException();
+    lockedBalance += amount;
+    availableBalance -= amount;
+    assert lockedBalance + availableBalance == totalBalance; // Invariant check
+}
+```
+
+## P2P Networking Architecture
+
+P2P layer has specific patterns for reliability and security.
+
+**Validation Points**:
+- [ ] Protocol versioning for backward compatibility
+- [ ] Message serialization safe
+- [ ] Connection management proper
+- [ ] Peer discovery logic correct
+- [ ] Bootstrap nodes handling
+
+**Protocol Versioning**:
+```java
+// Version compatibility check
+public boolean isCompatible(int peerVersion) {
+    return peerVersion >= MIN_SUPPORTED_VERSION
+        && peerVersion <= CURRENT_VERSION;
+}
+
+// Graceful handling of version differences
+if (!isCompatible(peer.getVersion())) {
+    if (peer.getVersion() < MIN_SUPPORTED_VERSION) {
+        disconnect(peer, "Outdated version");
+    } else {
+        // Future version - log but allow
+        log.warn("Peer has newer version: {}", peer.getVersion());
+    }
+}
+```
+
+## Code Quality Standards
+
+**General Patterns**:
+- [ ] Immutability preferred (final fields, immutable collections)
+- [ ] Defensive copying for mutable data
+- [ ] Null safety (Optional, @Nullable annotations)
+- [ ] Proper exception handling (don't swallow exceptions)
+- [ ] Logging at appropriate levels
+
+**Immutability Example**:
+```java
+// ✅ Immutable class
+public final class Trade {
+    private final String tradeId;
+    private final Coin amount;
+
+    public Trade(String tradeId, Coin amount) {
+        this.tradeId = requireNonNull(tradeId);
+        this.amount = requireNonNull(amount);
+    }
+
+    // No setters, only getters
+}
+
+// ❌ Mutable shared state
+public class TradeManager {
+    public List<Trade> trades = new ArrayList<>(); // WRONG: public mutable
+}
+```
+
+## Architecture Review Template
+
+```markdown
+## Bisq Architecture Review for PR #{number}
+
+### Module Structure
+- **Modules Modified**: {list}
+- **Dependency Changes**: {describe}
+- **Findings**:
+  - Module boundaries: {✅|⚠️|❌} {details}
+  - Circular dependencies: {✅ None|❌ Found} {details}
+
+### UI Layer (JavaFX)
+- **MVVM Compliance**: {✅|⚠️|❌}
+  - Views thin: {details}
+  - ViewModels appropriate: {details}
+  - Business logic in services: {details}
+- **Threading**: {✅|⚠️|❌}
+  - FX thread usage correct: {details}
+
+### Dependency Injection
+- **Injection Pattern**: {✅|⚠️|❌}
+  - Constructor injection: {details}
+  - Proper scoping: {details}
+
+### Trade Protocol
+- **State Machine**: {✅|⚠️|❌}
+  - Valid transitions: {details}
+  - Error handling: {details}
+  - Persistence: {details}
+
+### DAO Governance
+- **If DAO changes present**:
+  - Voting logic: {✅|⚠️|❌} {details}
+  - Proposal validation: {✅|⚠️|❌} {details}
+  - Fund safety: {✅|⚠️|❌} {details}
+
+### Code Quality
+- **Immutability**: {✅|⚠️|❌}
+- **Null safety**: {✅|⚠️|❌}
+- **Exception handling**: {✅|⚠️|❌}
+
+### Overall Architecture Assessment
+- **Compliance Level**: {FULL|PARTIAL|NEEDS WORK}
+- **Architectural Concerns**: {count}
+- **Recommendation**: {specific guidance}
+```

--- a/.claude/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
+++ b/.claude/skills/bisq-pr-reviewer/references/bisq-architecture-patterns.md
@@ -181,8 +181,12 @@ public class TradeProtocolManager {
 
 // ViewModel uses service
 public class TradeViewModel {
+    private final TradeProtocolManager tradeProtocolManager;
+
     @Inject
-    private TradeProtocolManager tradeProtocolManager;
+    public TradeViewModel(TradeProtocolManager tradeProtocolManager) {
+        this.tradeProtocolManager = tradeProtocolManager;
+    }
 
     public void onStartTrade() {
         tradeProtocolManager.initiateTrade(trade);
@@ -235,8 +239,7 @@ DAO-related code requires extra care for voting and governance logic.
 **Critical Checks**:
 ```java
 // Vote weight calculation
-long voteWeight = stake * votingPower; // Check for overflow
-if (voteWeight < stake) throw new ArithmeticException("Overflow");
+long voteWeight = Math.multiplyExact(stake, votingPower);
 
 // Proposal parameter bounds
 if (proposalAmount > MAX_PROPOSAL_AMOUNT) {
@@ -246,9 +249,11 @@ if (proposalAmount > MAX_PROPOSAL_AMOUNT) {
 // Bond management
 public void lockBond(long amount) {
     if (availableBalance < amount) throw new InsufficientFundsException();
-    lockedBalance += amount;
-    availableBalance -= amount;
-    assert lockedBalance + availableBalance == totalBalance; // Invariant check
+    lockedBalance = Math.addExact(lockedBalance, amount);
+    availableBalance = Math.subtractExact(availableBalance, amount);
+    if (Math.addExact(lockedBalance, availableBalance) != totalBalance) {
+        throw new IllegalStateException("Balance invariant violated");
+    }
 }
 ```
 

--- a/.claude/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
+++ b/.claude/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
@@ -1,0 +1,207 @@
+# Bisq Security Review Checklist
+
+Comprehensive security validation patterns for Bitcoin/cryptocurrency code in Bisq PRs.
+
+## Critical Security Domains
+
+### 1. Private Key Handling
+
+**Validation Points**:
+- [ ] No private keys in source code
+- [ ] No keys in log statements or error messages
+- [ ] No keys in exception stack traces
+- [ ] Memory cleared after key usage (if applicable)
+- [ ] Key derivation uses approved methods (BIP32/BIP39)
+
+**File Patterns to Check**:
+```bash
+grep -E "(bitcoin|crypto|wallet|key|seed|mnemonic)" --output_mode files_with_matches
+```
+
+**Common Vulnerabilities**:
+- Hardcoded keys or seeds
+- Logging sensitive key material
+- Insecure key storage mechanisms
+- Missing key zeroization after use
+
+### 2. Bitcoin Transaction Safety
+
+**Validation Points**:
+- [ ] Transaction fee calculation uses satoshi arithmetic (no floating point)
+- [ ] Dust threshold enforcement (546 satoshis minimum output)
+- [ ] Transaction size limits respected
+- [ ] Input validation for amounts (no negative, no overflow)
+- [ ] Proper UTXO selection logic
+- [ ] Change address generation is correct
+- [ ] RBF (Replace-By-Fee) handling if applicable
+
+**Critical Checks**:
+```java
+// Fee calculation - must use satoshis, not BTC
+long fee = (long)(txSize * feeRatePerByte); // ✅ Correct
+double fee = txSize * feeRatePerBTC;        // ❌ Floating point risk
+
+// Dust threshold
+if (outputValue < 546) { /* reject */ }     // ✅ Correct
+
+// Overflow protection
+long total = amount1 + amount2;             // ❌ Can overflow
+long total = Math.addExact(amount1, amount2); // ✅ Throws on overflow
+```
+
+**Common Vulnerabilities**:
+- Floating-point arithmetic in fee calculations
+- Missing dust threshold checks
+- Integer overflow in amount addition
+- Incorrect change calculation
+- Missing transaction validation
+
+### 3. Cryptographic Operations
+
+**Validation Points**:
+- [ ] Using approved algorithms (Ed25519, secp256k1)
+- [ ] No deprecated crypto (MD5, SHA1 for security)
+- [ ] Proper random number generation (SecureRandom)
+- [ ] No hardcoded IVs or salts
+- [ ] Signature verification before trust
+- [ ] Constant-time comparison for secrets
+
+**Approved Algorithms**:
+- **Signatures**: Ed25519, ECDSA (secp256k1)
+- **Hashing**: SHA-256, SHA-512, RIPEMD-160
+- **Encryption**: AES-GCM, ChaCha20-Poly1305
+- **Key Derivation**: PBKDF2, scrypt, Argon2
+
+**Common Vulnerabilities**:
+```java
+// Random number generation
+Random rng = new Random();              // ❌ Predictable
+SecureRandom rng = new SecureRandom();  // ✅ Cryptographically secure
+
+// Comparison timing attacks
+if (hmac.equals(expected)) { }          // ❌ Timing attack
+if (MessageDigest.isEqual(hmac, expected)) { } // ✅ Constant-time
+```
+
+### 4. P2P Message Validation
+
+**Validation Points**:
+- [ ] Message size limits enforced (prevent DoS)
+- [ ] Input sanitization on all peer data
+- [ ] Deserialization safety (no arbitrary code execution)
+- [ ] Protocol version compatibility checks
+- [ ] Message signature verification
+- [ ] Rate limiting on message processing
+
+**Size Limits**:
+```java
+// Maximum message sizes
+public static final int MAX_MESSAGE_SIZE = 1024 * 1024; // 1 MB
+public static final int MAX_PEER_ADDRESSES = 1000;
+
+if (message.length() > MAX_MESSAGE_SIZE) {
+    throw new MessageSizeException();
+}
+```
+
+**Common Vulnerabilities**:
+- No message size validation (DoS risk)
+- Trusting peer-provided data without validation
+- Unsafe deserialization (object injection)
+- Missing protocol version checks
+- No rate limiting on expensive operations
+
+### 5. Financial Logic Safety
+
+**Validation Points**:
+- [ ] Trade amount calculations use proper precision
+- [ ] Percentage calculations avoid floating point
+- [ ] Security deposit calculations correct
+- [ ] Escrow amount validation
+- [ ] Maker/Taker fee calculations accurate
+- [ ] BSQ (Bisq token) amount handling correct
+
+**Precision Handling**:
+```java
+// Use basis points for percentages (10000 = 100%)
+long fee = (amount * feeRateBasisPoints) / 10000; // ✅ Integer math
+
+// Avoid floating point
+double fee = amount * 0.001; // ❌ Precision loss risk
+```
+
+**Common Vulnerabilities**:
+- Floating-point precision loss in financial calculations
+- Rounding errors in fee calculations
+- Integer overflow in multiplication
+- Division before multiplication (precision loss)
+- Missing boundary checks on amounts
+
+## Security Review Template
+
+Use this template when reviewing security-sensitive code:
+
+```markdown
+## Bisq Security Analysis for PR #{number}
+
+### Bitcoin Transaction Code
+- **Files Changed**: {list}
+- **Risk Assessment**: {CRITICAL|HIGH|MEDIUM|LOW}
+- **Findings**:
+  - Fee calculation: {✅|⚠️|❌} {details}
+  - Dust threshold: {✅|⚠️|❌} {details}
+  - Overflow protection: {✅|⚠️|❌} {details}
+  - UTXO handling: {✅|⚠️|❌} {details}
+
+### Cryptographic Operations
+- **Files Changed**: {list}
+- **Findings**:
+  - Algorithm approval: {✅|⚠️|❌} {details}
+  - Random generation: {✅|⚠️|❌} {details}
+  - Signature verification: {✅|⚠️|❌} {details}
+
+### P2P Protocol Changes
+- **Files Changed**: {list}
+- **Findings**:
+  - Message size limits: {✅|⚠️|❌} {details}
+  - Input validation: {✅|⚠️|❌} {details}
+  - Deserialization safety: {✅|⚠️|❌} {details}
+
+### Financial Logic
+- **Files Changed**: {list}
+- **Findings**:
+  - Precision handling: {✅|⚠️|❌} {details}
+  - Overflow checks: {✅|⚠️|❌} {details}
+  - Fee calculations: {✅|⚠️|❌} {details}
+
+### Overall Security Assessment
+- **Critical Issues**: {count}
+- **High Priority**: {count}
+- **Risk Level**: {CRITICAL|HIGH|MEDIUM|LOW}
+- **Recommendation**: {BLOCK MERGE|REQUEST CHANGES|APPROVE WITH NOTES|APPROVE}
+```
+
+## Risk Categorization
+
+**CRITICAL** (Block merge immediately):
+- Private key exposure
+- Arbitrary code execution vulnerabilities
+- Fund loss risks
+- Weak cryptography in security-critical paths
+
+**HIGH** (Must fix before merge):
+- Missing overflow checks in financial code
+- Insufficient input validation
+- Missing message size limits
+- Deprecated crypto algorithms
+
+**MEDIUM** (Should fix):
+- Suboptimal random number generation
+- Missing rate limiting
+- Incomplete validation logic
+- Performance issues in crypto operations
+
+**LOW** (Nice to have):
+- Code style in security code
+- Missing code comments
+- Documentation updates

--- a/.claude/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
+++ b/.claude/skills/bisq-pr-reviewer/references/bisq-security-checklist.md
@@ -15,7 +15,7 @@ Comprehensive security validation patterns for Bitcoin/cryptocurrency code in Bi
 
 **File Patterns to Check**:
 ```bash
-grep -E "(bitcoin|crypto|wallet|key|seed|mnemonic)" --output_mode files_with_matches
+grep -R -l -E "(bitcoin|crypto|wallet|key|seed|mnemonic)" .
 ```
 
 **Common Vulnerabilities**:

--- a/.claude/skills/bisq-pr-reviewer/references/contribution-standards.md
+++ b/.claude/skills/bisq-pr-reviewer/references/contribution-standards.md
@@ -1,0 +1,317 @@
+# Bisq Contribution Standards
+
+Reference for C4 protocol compliance, GPG signatures, and commit message standards.
+
+## C4 Protocol (Collective Code Construction Contract)
+
+Bisq follows the C4 protocol for collaborative development.
+
+### Core Principles
+
+**1. Change-Oriented Development**
+- Problems are identified as issues
+- Solutions are proposed as patches (pull requests)
+- Patches should solve exactly one identified problem
+
+**2. Patch Requirements**
+- [ ] Addresses a specific issue or adds stated value
+- [ ] Follows project coding standards
+- [ ] Includes tests where applicable
+- [ ] Does not break existing tests
+- [ ] Commit message explains the problem and solution
+
+**3. Stakeholder Buy-In**
+
+Contributors should consult with stakeholders before significant work:
+- **Channels**: Keybase, GitHub discussions, mailing list
+- **Why**: Ensures maintainer interest and community value
+- **When**: Before starting work on major features or refactorings
+
+**Validation**:
+```markdown
+## Stakeholder Buy-In Check
+
+Evidence of discussion:
+- [ ] GitHub issue: #{issue_number}
+- [ ] Keybase discussion: {date, participants}
+- [ ] Mailing list thread: {subject, date}
+- [ ] Maintainer acknowledgment: {who, when}
+
+If no evidence found:
+- For major changes (>100 lines): ⚠️ Request stakeholder confirmation
+- For minor changes (<100 lines): ✅ Acceptable to proceed
+```
+
+**4. Atomic Commits**
+
+Each commit should represent a single logical change:
+- ✅ "Fix null pointer in TradeManager.confirmTrade()"
+- ✅ "Add validation for trade amounts"
+- ❌ "Fix bugs and add features" (too broad)
+
+**Validation**:
+```bash
+# Check if commit touches multiple unrelated concerns
+gh api repos/{owner}/{repo}/pulls/{pr}/commits --jq '.[].files | length'
+
+# If single commit changes >10 files in different modules, investigate atomicity
+```
+
+**5. Mergeable State**
+
+PR must be ready for immediate merge:
+- [ ] No WIP commits
+- [ ] No placeholder code ("TODO: implement")
+- [ ] No debugging/test code left in
+- [ ] All requested changes addressed
+- [ ] CI passing
+
+## GPG Commit Signatures
+
+All commits to Bisq must be GPG-signed for authenticity.
+
+### Verification Process
+
+```bash
+# Check all commits in PR for GPG signatures
+gh api repos/{owner}/{repo}/pulls/{pr}/commits \
+  --jq '.[] | {
+    sha: .sha,
+    message: .commit.message | split("\n")[0],
+    verified: .commit.verification.verified,
+    reason: .commit.verification.reason
+  }'
+```
+
+### Expected Output
+
+**✅ All Signed**:
+```json
+{
+  "sha": "abc123",
+  "message": "Fix trade protocol state transition",
+  "verified": true,
+  "reason": "valid"
+}
+```
+
+**❌ Unsigned Commit**:
+```json
+{
+  "sha": "def456",
+  "message": "Add fee validation",
+  "verified": false,
+  "reason": "unsigned"
+}
+```
+
+### Verification Report Template
+
+```markdown
+## GPG Signature Verification
+
+**Total Commits**: {count}
+**Signed Commits**: {signed_count}
+**Unsigned Commits**: {unsigned_count}
+
+### Status: {✅ All Signed | ⚠️ Partially Signed | ❌ None Signed}
+
+{if unsigned commits exist:}
+**Unsigned Commits**:
+- `{sha}`: {first_line_of_message} - Reason: {verification_reason}
+- ...
+
+**Action Required**:
+1. Set up GPG signing: https://docs.bisq.network/contributor-checklist#1-set-up-gpg
+2. Amend commits with signatures
+3. Force push to update PR
+```
+
+## Git Commit Message Standards
+
+Bisq follows Chris Beams' "7 Rules of a Great Git Commit Message".
+
+### The Seven Rules
+
+1. **Separate subject from body with blank line**
+2. **Limit subject line to 50 characters**
+3. **Capitalize the subject line**
+4. **Do not end subject line with a period**
+5. **Use imperative mood in subject line**
+6. **Wrap body at 72 characters**
+7. **Use body to explain what and why, not how**
+
+### Integration with git-commit-writer Skill
+
+The `git-commit-writer` skill provides detailed guidance on these rules. Reference it when commit messages need improvement:
+
+```markdown
+❌ **Poor Commit Message**:
+```
+fixed stuff
+```
+
+✅ **Suggested Improvement** (using git-commit-writer standards):
+```
+Fix memory leak in P2P message handler
+
+The message handler was not releasing buffer memory after
+processing peer messages, causing gradual memory growth
+under high peer count conditions.
+
+This commit adds proper cleanup in the finally block and
+adds a unit test to verify memory is released.
+
+Fixes #1234
+```
+```
+
+### Validation Checklist
+
+```bash
+# Extract all commit messages from PR
+gh api repos/{owner}/{repo}/pulls/{pr}/commits \
+  --jq '.[].commit.message' > /tmp/commit_messages.txt
+```
+
+For each commit message, validate:
+
+**Subject Line**:
+- [ ] ≤ 50 characters
+- [ ] Starts with capital letter
+- [ ] No ending period
+- [ ] Uses imperative mood ("Fix" not "Fixed", "Fixes", or "Fixing")
+
+**Body** (if present):
+- [ ] Blank line after subject
+- [ ] Lines wrapped at 72 characters
+- [ ] Explains "what" and "why", not "how"
+- [ ] References related issues (Fixes #123, Closes #456)
+
+**Common Issues**:
+
+| Issue | Example | Fix |
+|-------|---------|-----|
+| Too long subject | "Fix the bug that was causing crashes when..." | Shorten to "Fix crash in trade confirmation dialog" |
+| Wrong tense | "Fixed null pointer exception" | Change to "Fix null pointer exception" |
+| Not capitalized | "fix trade protocol bug" | Change to "Fix trade protocol bug" |
+| Has period | "Add validation logic." | Remove period: "Add validation logic" |
+| Vague | "Update code" | Be specific: "Add overflow check to fee calculation" |
+
+### Commit Message Quality Report
+
+```markdown
+## Commit Message Standards Review
+
+**Total Commits**: {count}
+**Compliant**: {compliant_count}
+**Need Improvement**: {needs_improvement_count}
+
+### Issues Found:
+
+#### Commit {sha} - "{subject}"
+- ❌ Subject too long (67 chars, limit 50)
+- ✅ Capitalization correct
+- ❌ Uses past tense ("Fixed" should be "Fix")
+- ⚠️ No body explanation for non-trivial change
+
+**Suggested Rewrite**:
+```
+Fix null pointer in TradeManager.confirmTrade()
+
+The confirmTrade method did not check if the trade object
+was null before accessing its properties, causing crashes
+when called with invalid trade references.
+
+This commit adds null check and throws IllegalArgumentException
+with descriptive message for debugging.
+
+Fixes #1234
+```
+```
+
+### Edge Cases
+
+**Merge Commits**:
+- Auto-generated merge commit messages are acceptable
+- Custom merge messages should follow same rules
+
+**Revert Commits**:
+- Git-generated revert messages are acceptable
+- Should add explanation in body about why revert is needed
+
+**Multi-Paragraph Bodies**:
+- Acceptable for complex changes
+- Each paragraph should focus on single aspect
+- Maintain 72-character line wrap
+
+**Issue References**:
+- "Fixes #123" - closes issue when merged
+- "Relates to #456" - references without closing
+- "Part of #789" - for multi-PR features
+
+## Contribution Standards Report Template
+
+```markdown
+## Bisq Contribution Standards Review for PR #{number}
+
+### C4 Protocol Compliance
+
+**Stakeholder Buy-In**:
+- Evidence: {GitHub issue, Keybase, mailing list}
+- Status: {✅ Confirmed | ⚠️ Recommended | ❌ Required}
+
+**Atomic Commits**:
+- Single logical changes: {✅|⚠️|❌}
+- Issues found: {details}
+
+**Mergeable State**:
+- No WIP commits: {✅|❌}
+- No placeholders: {✅|❌}
+- CI passing: {✅|❌}
+
+### GPG Signatures
+
+**Status**: {✅ All Signed | ⚠️ {X} Unsigned | ❌ None Signed}
+
+{if issues}
+**Unsigned Commits**: {list with details}
+**Action**: Setup GPG and amend commits
+
+### Commit Messages
+
+**Compliance**: {✅ All Good | ⚠️ {X} Need Improvement | ❌ Major Issues}
+
+{if issues}
+**Issues Found**:
+- Commit {sha}: {specific issues}
+
+**Recommendations**:
+{specific rewrites using git-commit-writer patterns}
+
+### Overall Contribution Standards Assessment
+
+**Level**: {EXCELLENT | GOOD | NEEDS WORK | NON-COMPLIANT}
+**Blockers**: {count} (must fix before merge)
+**Recommendations**: {count} (should fix)
+**Optional**: {count} (nice to have)
+```
+
+## Quick Reference
+
+**Pre-PR Checklist** (for contributors):
+- [ ] Discussed with stakeholders for major changes
+- [ ] Each commit is atomic and well-described
+- [ ] All commits GPG-signed
+- [ ] Commit messages follow 7 rules
+- [ ] No WIP or TODO code
+- [ ] Tests pass
+- [ ] Ready for immediate merge
+
+**Reviewer Checklist**:
+- [ ] Verify stakeholder buy-in for major changes
+- [ ] Check commit atomicity
+- [ ] Validate GPG signatures on all commits
+- [ ] Review commit message quality
+- [ ] Confirm no placeholders or WIP code
+- [ ] Check CI status

--- a/.claude/skills/bisq-pr-reviewer/references/contribution-standards.md
+++ b/.claude/skills/bisq-pr-reviewer/references/contribution-standards.md
@@ -52,7 +52,7 @@ Each commit should represent a single logical change:
 **Validation**:
 ```bash
 # Check if commit touches multiple unrelated concerns
-gh api repos/{owner}/{repo}/pulls/{pr}/commits --jq '.[].files | length'
+gh api repos/{owner}/{repo}/pulls/{pr}/files --paginate --slurp --jq 'map(length) | add'
 
 # If single commit changes >10 files in different modules, investigate atomicity
 ```
@@ -145,7 +145,7 @@ Bisq follows Chris Beams' "7 Rules of a Great Git Commit Message".
 
 The `git-commit-writer` skill provides detailed guidance on these rules. Reference it when commit messages need improvement:
 
-```markdown
+````markdown
 ❌ **Poor Commit Message**:
 ```
 fixed stuff
@@ -164,7 +164,7 @@ adds a unit test to verify memory is released.
 
 Fixes #1234
 ```
-```
+````
 
 ### Validation Checklist
 
@@ -200,7 +200,7 @@ For each commit message, validate:
 
 ### Commit Message Quality Report
 
-```markdown
+````markdown
 ## Commit Message Standards Review
 
 **Total Commits**: {count}
@@ -228,7 +228,7 @@ with descriptive message for debugging.
 
 Fixes #1234
 ```
-```
+````
 
 ### Edge Cases
 

--- a/.claude/skills/bisq2-javafx-ui/SKILL.md
+++ b/.claude/skills/bisq2-javafx-ui/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: bisq2-javafx-ui
+description: Create production-ready JavaFX UI code following Bisq2's strict MVC architecture, design system, UX principles, and desktop UI automation harness workflow. Use this skill when building new UI components, views, controllers, overlays, modifying existing JavaFX interfaces, adding or validating automation selectors, or running JavaFX UI smoke/scenario checks. Triggers include UI feature requests, component creation, view implementation, navigation additions, form building, table/list views, overlay/dialog work, desktop UI harness work, and any JavaFX-related development in the Bisq2 desktop application.
+---
+
+# Bisq2 JavaFX UI Development
+
+## Overview
+
+Use this skill to implement or review JavaFX UI work in Bisq2 with repository-accurate patterns.
+
+Primary goals:
+- Ship UI that matches Bisq2 MVC architecture and navigation framework.
+- Reuse existing controls, CSS classes, formatters, validators, and bindings.
+- Prevent lifecycle leaks, threading bugs, and stale async UI updates.
+
+## When to Use
+
+Activate for:
+- New Controller/Model/View triads.
+- Tab or navigation-target additions.
+- Overlay/dialog/wizard UI.
+- Forms, validation, converters, table/list UIs.
+- UI refactors and UI code reviews.
+
+## Working Method
+
+1. Identify task type (leaf view, navigation container, tab view, overlay, form, table).
+2. Read only the matching reference file(s) from `references/` (see map below).
+3. Implement with existing Bisq components and CSS classes first, custom controls only if necessary.
+4. When the change affects user-visible interaction, add or update harness selectors and verify with the desktop UI automation harness.
+5. Apply lifecycle cleanup and threading safeguards before finishing.
+6. Run a self-review using `references/navigation-review-checklist.md`.
+
+## Reference Map
+
+- MVC architecture, lifecycle, caching, threading contract:
+  - `references/architecture-lifecycle.md`
+- Component templates, bindings, forms, tables, anti-patterns:
+  - `references/component-patterns.md`
+- Visual language, CSS tokens/classes, animation and advanced UX tactics:
+  - `references/design-system-ux.md`
+- Navigation changes, final review checklist, key source paths:
+  - `references/navigation-review-checklist.md`
+- Desktop UI automation harness selectors, binders, scenarios, and local verification:
+  - `references/ui-automation-harness.md`
+- Example dry-run audit (prompt + rubric + scored result):
+  - `references/dry-run-audit-2026-02-19.md`
+
+## Non-Negotiables
+
+- Controller updates model state; view reacts via bindings.
+- View never accesses domain services directly.
+- Follow existing controller wiring style in this repo: use `View<..., ..., ConcreteController>` for view/controller typing.
+- Do not introduce per-view action interfaces (e.g. `XxxActions`) unless that local module already uses that pattern.
+- Cleanup everything on detach/deactivate (bindings, pins, subscriptions, handlers, schedulers).
+- All cross-thread UI changes go through `UIThread` (or `FxBindings` that marshal automatically).
+- For layout-dependent reads, defer with `UIThread.runOnNextRenderFrame(...)`.
+- Use `addTab(...)` (not `createTab(...)`).
+- Prefer `ManagedDuration` and `Transitions` for animation timing and animation-disable behavior.
+- Pair visibility and layout participation (`setVisible` + `setManaged`) when toggling layout nodes.
+- Use `Res.get(...)` for user-facing strings.
+- Use converters for typed text bindings; avoid ad-hoc parsing in views.
+- Keep automation selectors out of production views: expose package-private semantic accessors and bind selectors in `desktop-ui-harness-app`.
+- Do not use JavaFX `Node.id` as the automation contract; the current harness uses scoped selectors (`scope/automationId`).
+
+## Output Contract
+
+When asked to generate UI code, produce:
+- `XxxController` with domain interaction and lifecycle wiring.
+- `XxxModel` with JavaFX properties (and only lightweight helper logic).
+- `XxxView` with layout, bindings, event delegation, and full detach cleanup.
+
+For navigation work, also include:
+- `NavigationTarget` entries (with persistence flag decision).
+- Parent `createController(...)` switch registration.
+- Tab/menu wiring in the parent view when needed.
+
+For UI changes with an interaction path, also include:
+- Package-private semantic view accessors for controls the harness must address.
+- A harness binder in `apps/desktop/desktop-ui-harness-app/src/main/java` under the same Java package as the production view.
+- Binder registration in `DesktopAutomationViewObserver` and a binder unit test.
+- Local verification commands or harness scenario steps used to exercise the change.
+
+For reviews, prioritize:
+- Regressions, leaks, race conditions, threading violations, navigation/caching mistakes.

--- a/.claude/skills/bisq2-javafx-ui/agents/openai.yaml
+++ b/.claude/skills/bisq2-javafx-ui/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Bisq2 JavaFX UI"
+  short_description: "Build Bisq2 JavaFX screens with MVC and harness checks"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $bisq2-javafx-ui to implement or review this Bisq2 JavaFX UI change."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/bisq2-javafx-ui/references/architecture-lifecycle.md
+++ b/.claude/skills/bisq2-javafx-ui/references/architecture-lifecycle.md
@@ -1,0 +1,76 @@
+# Architecture And Lifecycle
+
+## MVC Contract In Bisq2
+
+Triad:
+- `XxxController`: behavior, service access, event handlers.
+- `XxxModel`: JavaFX properties for presentation state.
+- `XxxView`: visual tree, bindings, event delegation.
+
+Repository-specific rules:
+- Controller should not directly mutate view widget state; set model and let bindings render.
+- Passing `getView().getRoot()` for composition/utilities is acceptable and used widely.
+- Model may contain lightweight helper methods (`reset`, derived flags), but no service/domain calls.
+- View must not call services directly.
+
+## Base Framework Types
+
+- `Controller`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/Controller.java`
+- `View`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/View.java`
+- `NavigationController`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/NavigationController.java`
+- `TabController`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabController.java`
+- `NavigationView`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/NavigationView.java`
+- `TabView`: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabView.java`
+- `FillStageView` marker: `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/FillStageView.java`
+
+## Lifecycle Order (Critical)
+
+From `View` internals:
+- Attach:
+  - `controller.onActivateInternal()`
+  - `view.onViewAttachedInternal()`
+- Detach:
+  - `controller.onDeactivateInternal()`
+  - `view.onViewDetachedInternal()`
+
+Implication:
+- Controller can initialize model before view binds.
+- Detach cleanup must handle partial attachment safety.
+
+## Caching Semantics
+
+- Default: `Controller.useCaching() == true`.
+- `NavigationController` caches child controllers by `NavigationTarget`.
+- Use `useCaching() == false` for transient flows:
+  - overlays/wizards
+  - `InitWithDataController` flows
+  - one-shot states where stale state is risky
+
+If non-cached, expect recreation on next navigation.
+
+## Cleanup Responsibilities
+
+In `Controller.onDeactivate()`:
+- `Pin.unbind()` for domain observers/FxBindings.
+- Remove scene/application event handlers.
+- Stop/clear controller-owned schedulers/timelines/futures.
+
+In `View.onViewDetached()`:
+- `unbind()` and `unbindBidirectional()` JavaFX bindings.
+- `Subscription.unsubscribe()` for EasyBind.
+- Null event handlers (`setOnAction(null)`, etc.).
+- Dispose transient child controls/popups if allocated in view.
+
+## Threading And Render Frames
+
+- Any UI mutation from async/background code: `UIThread.run(...)`.
+- Layout-dependent work (sizes/bounds/scroll position): `UIThread.runOnNextRenderFrame(...)`.
+- `FxBindings` marshals to UI thread; avoid wrapping again unless needed.
+
+## Keyboard And Focus Contract
+
+Prefer centralized helpers:
+- `KeyHandlerUtil.handleEscapeKeyEvent(...)`
+- `KeyHandlerUtil.handleEnterKeyEventWithTextInputFocusCheck(...)`
+
+Register key handlers on activate; always remove on deactivate.

--- a/.claude/skills/bisq2-javafx-ui/references/component-patterns.md
+++ b/.claude/skills/bisq2-javafx-ui/references/component-patterns.md
@@ -1,0 +1,94 @@
+# Component Patterns
+
+## Leaf MVC Triad (Default)
+
+Controller:
+- Construct model/view.
+- Bind domain observables in `onActivate()`.
+- Unbind pins in `onDeactivate()`.
+- Expose user handlers (`onXxx`) called by view.
+
+Model:
+- JavaFX properties (`StringProperty`, `BooleanProperty`, `ObjectProperty`, lists).
+
+View:
+- Build node tree and style classes in constructor.
+- Bind in `onViewAttached()`.
+- Fully unbind/unsubscribe/unset handlers in `onViewDetached()`.
+
+## Navigation Container
+
+Use `NavigationController` when a host selects child views by `NavigationTarget`.
+
+Implement:
+- `createController(NavigationTarget)` switch.
+- `NavigationModel#getDefaultNavigationTarget()`.
+
+## Tab Views
+
+Use `TabController` + `TabView`.
+
+Important:
+- Add tabs with `addTab(...)` (actual API), not `createTab(...)`.
+- Let framework manage selected tab button + marker transitions.
+
+## Domain To UI Binding
+
+Preferred patterns:
+
+1) `FxBindings` mapping pipelines
+```java
+Pin p = FxBindings.bind(model.getItems())
+        .filter(...)
+        .map(...)
+        .to(service.getObservableSet());
+```
+
+2) Direct observers when no pipeline needed
+```java
+Pin p = service.getFlag().addObserver(v -> UIThread.run(() -> model.getFlag().set(v)));
+```
+
+3) JavaFX direct bindings in view
+```java
+label.textProperty().bind(model.getTitle());
+field.textProperty().bindBidirectional(model.getInput());
+```
+
+## Forms, Validation, Converters
+
+- Use `MaterialTextField` and validator classes in `components/controls/validator`.
+- Validate on submit and surface inline errors.
+- Prefer typed bidirectional bindings with converters for numeric/network fields:
+```java
+textField.textProperty().bindBidirectional(model.getValue(), model.getValueConverter());
+```
+
+## Table/List Patterns
+
+- Use `BisqTableView` and `BisqTableColumn.Builder`.
+- Keep raw domain objects out of view cells when presentation mapping is needed; map into list items.
+- Set comparator on sorted list in controller/model.
+
+## Async Race Guard (Expert)
+
+Avoid stale completion writes:
+```java
+private final AtomicLong seq = new AtomicLong();
+
+void refresh() {
+    long s = seq.incrementAndGet();
+    service.load().whenComplete((result, err) -> UIThread.run(() -> {
+        if (s != seq.get()) return;
+        if (err == null) model.getItems().setAll(result);
+    }));
+}
+```
+
+## Anti-Patterns To Avoid
+
+- View calling services.
+- Missing unbind/unsubscribe on detach.
+- UI changes from background threads.
+- Hiding nodes with `setVisible(false)` only when layout gap should collapse.
+- Manual string parsing for typed settings when converter exists.

--- a/.claude/skills/bisq2-javafx-ui/references/component-patterns.md
+++ b/.claude/skills/bisq2-javafx-ui/references/component-patterns.md
@@ -38,15 +38,24 @@ Preferred patterns:
 
 1) `FxBindings` mapping pipelines
 ```java
+// Controller onActivate(): translate model state into service input.
+// The view stays out of the service call; it only observes model properties.
 Pin p = FxBindings.bind(model.getItems())
-        .filter(...)
-        .map(...)
+        .filter(Item::isEnabled)
+        .map(Item::getDomainValue)
         .to(service.getObservableSet());
 ```
 
 2) Direct observers when no pipeline needed
 ```java
-Pin p = service.getFlag().addObserver(v -> UIThread.run(() -> model.getFlag().set(v)));
+Pin p = service.getFlag().addObserver(v -> UIThread.run(() -> {
+    try {
+        model.getFlag().set(v);
+        model.getErrorMessage().set(null);
+    } catch (RuntimeException e) {
+        model.getErrorMessage().set(e.getMessage());
+    }
+}));
 ```
 
 3) JavaFX direct bindings in view
@@ -80,7 +89,12 @@ void refresh() {
     long s = seq.incrementAndGet();
     service.load().whenComplete((result, err) -> UIThread.run(() -> {
         if (s != seq.get()) return;
-        if (err == null) model.getItems().setAll(result);
+        if (err == null) {
+            model.getItems().setAll(result);
+            model.getErrorMessage().set(null);
+        } else {
+            model.getErrorMessage().set(err.getMessage());
+        }
     }));
 }
 ```

--- a/.claude/skills/bisq2-javafx-ui/references/design-system-ux.md
+++ b/.claude/skills/bisq2-javafx-ui/references/design-system-ux.md
@@ -1,0 +1,82 @@
+# Design System And UX
+
+## CSS Sources
+
+- `base.css`, `text.css`, `controls.css`, `containers.css`, `application.css`,
+  `chat.css`, `user.css`, `bisq_easy.css`, `mu_sig.css`, `trade_apps.css`, `images.css`, `markets.css`
+- Load order source: `apps/desktop/desktop/src/main/java/bisq/desktop/CssConfig.java`
+
+## Core Visual Tokens
+
+From `base.css`:
+- `-bisq2-green: #56ae48`
+- `-bisq2-yellow: #d0831f`
+- `-bisq2-red: #d23246`
+- `-bisq-white: #fafafa`
+- `-bisq-dark-grey-20: #1c1c1c`
+- `-bisq-dark-grey-40: #2b2b2b`
+- `-bisq-dark-grey-50: #383838`
+- `-bisq-mid-grey-20: #808080`
+
+## Typography Anchors
+
+From `text.css`:
+- `bisq-text-headline-1`: 4.1em
+- `bisq-text-headline-2`: 1.7em
+- `bisq-text-headline-5`: 2.5em
+- `bisq-text-1`: 1.25em
+- `bisq-text-7`: 0.92em
+
+Families:
+- IBM Plex Sans, Light, Medium, SemiBold, Mono
+
+## Spacing And Sizing Anchors
+
+- `Layout.SPACING = 20`
+- Tab side padding: `TabView.SIDE_PADDING = 40`
+- Button padding: `5 32 5 32`
+- Radius: 4px controls, 8px cards
+- Table row height: 54px
+- Table header height: 34px
+
+## Interaction And Motion
+
+Use `Transitions` + `ManagedDuration`.
+
+Examples:
+```java
+Transitions.fadeIn(node);
+Transitions.slideOutRight(node, onDone);
+Transitions.blurStrong(owner, -0.5);
+Transitions.removeEffect(owner);
+```
+
+Respect animation settings:
+```java
+Duration d = ManagedDuration.getHalfOfDefaultDuration();
+if (Transitions.useAnimations()) {
+    // animated path
+} else {
+    // immediate end state
+}
+```
+
+## Elite JavaFX UX Practices
+
+1. Render-frame discipline:
+- Defer bounds/width-dependent layout to next frame.
+
+2. Stable layout under async:
+- Reserve space for loaders/status if jump is undesirable.
+
+3. Keyboard determinism:
+- Enter/Escape behavior should remain predictable regardless of focused text input.
+
+4. Truncation discoverability:
+- Add tooltip on truncated labels (`TooltipUtil.showTooltipIfTruncated(...)`).
+
+5. Weak listeners in custom controls:
+- Use weak listeners/handlers for long-lived controls.
+
+6. Avoid inline style strings:
+- Prefer reusable CSS classes except truly dynamic values.

--- a/.claude/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
+++ b/.claude/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
@@ -1,0 +1,114 @@
+# Dry-Run Audit - 2026-02-19
+
+## Scope
+
+Goal: Verify the refactored skill reliably yields repository-correct JavaFX scaffolding.
+
+Audit date: 2026-02-19
+
+## Simulated Prompt
+
+"Add a new `NetworkHealth` tab under `NETWORK` in desktop app. Build `NetworkHealthController`, `NetworkHealthModel`, and `NetworkHealthView`. Show a table of peers with status, a refresh button, loading spinner, and enter/escape keyboard handling for refresh/close behavior where applicable. Follow existing Bisq styles and lifecycle cleanup."
+
+## Expected Output Contract
+
+- New MVC triad (`Controller`, `Model`, `View`).
+- Parent navigation registration and tab wiring.
+- Uses `addTab(...)` for tab insertion.
+- Proper lifecycle cleanup.
+- Thread-safe and race-safe async update path.
+- Reuses CSS classes and existing controls.
+
+## Candidate Scaffold (Condensed)
+
+```java
+// NetworkHealthController.java
+public class NetworkHealthController implements Controller {
+    private final NetworkHealthModel model;
+    @Getter private final NetworkHealthView view;
+    private final NetworkService networkService;
+    private Pin peersPin;
+    private final AtomicLong refreshSeq = new AtomicLong();
+
+    public NetworkHealthController(ServiceProvider sp) {
+        networkService = sp.getNetworkService();
+        model = new NetworkHealthModel();
+        view = new NetworkHealthView(model, this);
+    }
+
+    @Override
+    public void onActivate() {
+        onRefresh();
+    }
+
+    @Override
+    public void onDeactivate() {
+        if (peersPin != null) peersPin.unbind();
+    }
+
+    void onRefresh() {
+        long seq = refreshSeq.incrementAndGet();
+        model.getIsLoading().set(true);
+        networkService.fetchPeerSnapshots().whenComplete((snapshots, err) -> UIThread.run(() -> {
+            if (seq != refreshSeq.get()) return;
+            model.getIsLoading().set(false);
+            if (err == null) model.getPeers().setAll(snapshots.stream().map(NetworkHealthItem::new).toList());
+        }));
+    }
+}
+
+// NetworkHealthModel.java
+@Getter
+public class NetworkHealthModel implements Model {
+    private final BooleanProperty isLoading = new SimpleBooleanProperty();
+    private final ObservableList<NetworkHealthItem> peers = FXCollections.observableArrayList();
+    private final SortedList<NetworkHealthItem> sortedPeers = new SortedList<>(peers);
+}
+
+// NetworkHealthView.java
+public class NetworkHealthView extends View<VBox, NetworkHealthModel, NetworkHealthController> {
+    private final Button refreshButton = new Button(Res.get("action.refresh"));
+    private final BusyAnimation busy = new BusyAnimation(false);
+    private final BisqTableView<NetworkHealthItem> table = new BisqTableView<>(model.getSortedPeers());
+
+    @Override
+    protected void onViewAttached() {
+        refreshButton.disableProperty().bind(model.getIsLoading());
+        busy.isRunningProperty().bind(model.getIsLoading());
+        refreshButton.setOnAction(e -> controller.onRefresh());
+    }
+
+    @Override
+    protected void onViewDetached() {
+        refreshButton.disableProperty().unbind();
+        busy.isRunningProperty().unbind();
+        refreshButton.setOnAction(null);
+    }
+}
+```
+
+## Rubric And Result
+
+1. MVC architecture compliance: PASS
+2. Lifecycle cleanup completeness: PASS (bindings + pin cleanup present)
+3. Threading safety: PASS (`UIThread.run`)
+4. Async staleness guard: PASS (`refreshSeq`)
+5. Navigation/tab API correctness: PASS (`addTab(...)` requirement satisfied)
+6. Styling/control reuse: PASS (`BusyAnimation`, `BisqTableView`, `Res.get`)
+7. Likely regressions/leaks: LOW risk
+
+Overall: PASS
+
+## Concrete Checks Against Repository APIs
+
+- Tab API: `addTab(...)` exists in `TabView`.
+- Animation setting check should use `Transitions.useAnimations()` / `ManagedDuration`, not `settingsService.getDontUseAnimations()`.
+- CSS load order includes `mu_sig.css`, `trade_apps.css`, `markets.css`.
+
+## Remaining Gaps
+
+- Prompt did not force localization-key existence validation.
+- Prompt did not include `NavigationTarget` enum edits explicitly.
+
+Recommendation:
+- When generating production patches, include key existence and enum wiring tasks explicitly in the prompt.

--- a/.claude/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
+++ b/.claude/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
@@ -107,10 +107,10 @@ Overall: PARTIAL PASS
 
 ## Remaining Gaps
 
-- Candidate scaffold did not demonstrate Enter/Escape handlers.
-- Prompt did not force localization-key existence validation.
-- Prompt did not include `NavigationTarget` enum edits explicitly.
-- Prompt did not show concrete `addTab(...)` calls in the scaffold.
+- Enter/Escape handlers were not demonstrated in the candidate scaffold.
+- Localization-key existence validation was not enforced by the prompt.
+- `NavigationTarget` enum edits were missing from the prompt.
+- Concrete `addTab(...)` calls and parent wiring were not shown in the scaffold.
 
 Recommendation:
 - When generating production patches, include key existence and enum wiring tasks explicitly in the prompt.

--- a/.claude/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
+++ b/.claude/skills/bisq2-javafx-ui/references/dry-run-audit-2026-02-19.md
@@ -89,15 +89,15 @@ public class NetworkHealthView extends View<VBox, NetworkHealthModel, NetworkHea
 
 ## Rubric And Result
 
-1. MVC architecture compliance: PASS
+1. MVC architecture compliance: PARTIAL (triad shape shown; full navigation wiring not demonstrated)
 2. Lifecycle cleanup completeness: PASS (bindings + pin cleanup present)
 3. Threading safety: PASS (`UIThread.run`)
-4. Async staleness guard: PASS (`refreshSeq`)
-5. Navigation/tab API correctness: PASS (`addTab(...)` requirement satisfied)
+4. Async staleness guard: PARTIAL (`refreshSeq` shown; failure and cancellation paths not fully exercised)
+5. Navigation/tab API correctness: PARTIAL (`addTab(...)` requirement noted; `NavigationTarget` enum wiring not shown)
 6. Styling/control reuse: PASS (`BusyAnimation`, `BisqTableView`, `Res.get`)
 7. Likely regressions/leaks: LOW risk
 
-Overall: PASS
+Overall: PARTIAL PASS
 
 ## Concrete Checks Against Repository APIs
 
@@ -107,8 +107,10 @@ Overall: PASS
 
 ## Remaining Gaps
 
+- Candidate scaffold did not demonstrate Enter/Escape handlers.
 - Prompt did not force localization-key existence validation.
 - Prompt did not include `NavigationTarget` enum edits explicitly.
+- Prompt did not show concrete `addTab(...)` calls in the scaffold.
 
 Recommendation:
 - When generating production patches, include key existence and enum wiring tasks explicitly in the prompt.

--- a/.claude/skills/bisq2-javafx-ui/references/navigation-review-checklist.md
+++ b/.claude/skills/bisq2-javafx-ui/references/navigation-review-checklist.md
@@ -1,0 +1,69 @@
+# Navigation And Review Checklist
+
+## Navigation Target Changes
+
+1. Add new entries in `NavigationTarget`.
+- Use parent relationship correctly.
+- Set `allowPersistence=false` for transient overlay/wizard steps.
+
+Example:
+```java
+MY_FEATURE(CONTENT),
+MY_FEATURE_STEP(MY_FEATURE),
+MY_TRANSIENT_STEP(OVERLAY, false),
+```
+
+2. Register controller creation in parent `NavigationController#createController(...)`.
+
+3. Add tab/menu wiring in parent view where needed.
+
+4. Decide controller caching policy (`useCaching()`).
+
+## Navigation APIs
+
+- `Navigation.navigateTo(target)`
+- `Navigation.navigateTo(target, initData)` for init-with-data flows
+- `Navigation.back()`
+
+## Final Review Checklist
+
+Architecture:
+- [ ] View has no service/domain access.
+- [ ] Controller mutates model state, not raw widget state.
+- [ ] Model only has UI state and lightweight helper logic.
+- [ ] User-facing strings are via `Res.get(...)`.
+
+Lifecycle:
+- [ ] All `Pin` unbound in `onDeactivate()`.
+- [ ] All bindings/subscriptions cleaned in `onViewDetached()`.
+- [ ] Event handlers removed/nullified.
+- [ ] Schedulers/timelines/futures cleaned.
+
+Threading:
+- [ ] All UI mutations on JavaFX thread.
+- [ ] Render-frame deferral for layout-dependent reads.
+- [ ] Async staleness guards where concurrent refreshes can race.
+
+Styling/UX:
+- [ ] Existing CSS classes reused.
+- [ ] Design tokens and spacing align with repo CSS.
+- [ ] Animation uses `Transitions`/`ManagedDuration`.
+- [ ] Keyboard flow deterministic and focus-safe.
+
+Data and input:
+- [ ] FxBindings/direct observers bridge domain to UI.
+- [ ] Formatters used for amounts/prices/date/time.
+- [ ] Validators and converters applied where appropriate.
+
+## Key Source Paths
+
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/view/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/observable/FxBindings.java`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/threading/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/utils/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/common/converters/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/`
+- `apps/desktop/desktop/src/main/java/bisq/desktop/components/table/`
+- `apps/desktop/desktop/src/main/resources/css/`
+- `presentation/src/main/java/bisq/presentation/formatters/`
+- `common/src/main/java/bisq/common/observable/`

--- a/.claude/skills/bisq2-javafx-ui/references/ui-automation-harness.md
+++ b/.claude/skills/bisq2-javafx-ui/references/ui-automation-harness.md
@@ -1,0 +1,143 @@
+# Desktop UI Automation Harness
+
+Use this reference when JavaFX work changes an interactive path, needs visual smoke verification, or requires new automation selectors.
+
+## Current Model
+
+- The harness is the dedicated `desktop-ui-harness-app`; the production `desktop-app` does not start the automation server.
+- Build it before use:
+  ```bash
+  ./gradlew :apps:desktop:desktop-ui-harness-app:installDist
+  ```
+- Start/stop and inspect with:
+  ```bash
+  make desktop-ui-start
+  make desktop-ui-status
+  make desktop-ui-nodes
+  make desktop-ui-validate
+  make desktop-ui-stop
+  ```
+- Direct script equivalents live in `scripts/desktop-ui-harness.bash`.
+- The wrapper starts a deterministic desktop by default: fixed `1440x900` window, isolated data under `/tmp/bisq2-ui-harness`, fresh data on each start, and isolated CLEAR networking with an auto-selected local P2P port.
+
+## Selector Contract
+
+- Selectors are scoped strings: `<scope>/<automationId>`, for example `chat-message-container/input`.
+- JavaFX `Node.id` is not the automation contract. Use it only for CSS/styling when needed.
+- Scopes must be globally unique across all showing JavaFX scenes/windows.
+- Automation ids only need to be unique inside their scope.
+- Use `make desktop-ui-nodes` to inspect addressable nodes and `make desktop-ui-validate` to catch duplicate or invalid selector metadata.
+
+## Adding Selectors
+
+Keep selector metadata in the harness app, not in production view constructors.
+
+1. Add package-private semantic accessors to the production view when a stable node is not exposed:
+   ```java
+   TextInputControl messageInput() {
+       return inputField;
+   }
+
+   Node sendMessageAction() {
+       return sendButton;
+   }
+   ```
+2. Add or update a binder in `apps/desktop/desktop-ui-harness-app/src/main/java` under the same Java package as the production view:
+   ```java
+   package bisq.desktop.main.content.chat.message_container;
+
+   import bisq.desktop_ui_harness_app.AbstractDesktopAutomationViewBinder;
+
+   public final class ChatMessageContainerAutomationBinder
+           extends AbstractDesktopAutomationViewBinder<ChatMessageContainerView> {
+       @Override
+       public Class<ChatMessageContainerView> viewType() {
+           return ChatMessageContainerView.class;
+       }
+
+       @Override
+       public void bind(ChatMessageContainerView view) {
+           scope(view.getRoot(), "chat-message-container");
+           id(view.messageInput(), "input");
+           id(view.sendMessageAction(), "send");
+       }
+   }
+   ```
+3. Register the binder in `DesktopAutomationViewObserver`.
+4. Add a binder unit test in `apps/desktop/desktop-ui-harness-app/src/test/java` under the same Java package.
+5. Run:
+   ```bash
+   ./gradlew :apps:desktop:desktop-ui-harness-app:test
+   ```
+
+Do not add public view getters, annotations, `DesktopAutomationMetadata` calls in production source, or selectors for decorative/recycled/text-only nodes.
+
+## Local Interaction Loop
+
+Use the harness after UI changes:
+
+```bash
+./gradlew :apps:desktop:desktop-ui-harness-app:installDist
+make desktop-ui-start
+make desktop-ui-nodes
+make desktop-ui-validate
+```
+
+Use commands like these once the target screen is visible:
+
+```bash
+make desktop-ui-wait-node selector=splash/logo timeout_ms=30000 visible=true
+make desktop-ui-click selector=chat-message-container/send
+make desktop-ui-type selector=chat-message-container/input text="test prompt"
+make desktop-ui-press-key key=ENTER selector=chat-message-container/input
+make desktop-ui-screenshot name=after-change
+make desktop-ui-stop
+```
+
+Prefer screenshots for visual review after meaningful layout or styling changes.
+
+## Scenarios
+
+Run the default first-run smoke scenario:
+
+```bash
+make desktop-ui-scenario file=scripts/scenarios/desktop-ui-smoke.scenario
+```
+
+The default smoke scenario expects fresh harness data, accepts the two-step TAC flow, creates `SmokeUser`, waits for `left-nav/dashboard`, and captures `smoke-main`.
+
+Scenario files support:
+
+- `health`
+- `validate`
+- `wait-node <selector> [timeout_ms] [visible]`
+- `click <selector>`
+- `type <selector> <text...>`
+- `press-key <key> [selector]`
+- `screenshot <name>`
+- `sleep <ms>`
+
+Use quoted text in scenario files when the typed text contains spaces.
+
+## Persistent And Local-Network Runs
+
+For iterative work with an existing profile:
+
+```bash
+HARNESS_RESET_ON_START=0 APP_NAME=bisq2_gui1 DATA_DIR=/tmp/bisq2-local-3node/desktop make desktop-ui-start
+```
+
+When connecting to the local 3-node clearnet stack, prefer `HARNESS_NETWORK_OPTS` instead of ad-hoc JVM args:
+
+```bash
+HARNESS_NETWORK_OPTS="-Dapplication.network.supportedTransportTypes.0=CLEAR -Dapplication.network.configByTransportType.clear.defaultNodePort=18003 -Dapplication.network.seedAddressByTransportType.clear.0=127.0.0.1:18000 -Dapplication.network.seedAddressByTransportType.clear.1=127.0.0.1:18000" \
+make desktop-ui-start
+```
+
+## Verification Checklist
+
+- `./gradlew :apps:desktop:desktop-ui-harness-app:test`
+- `bash -n scripts/desktop-ui-harness.bash` when editing the wrapper
+- `make desktop-ui-validate` on the target screen
+- Targeted `click`/`type`/`press-key` commands or a scenario for the changed workflow
+- Screenshot artifact for visual changes

--- a/.claude/skills/git-commit-writer/SKILL.md
+++ b/.claude/skills/git-commit-writer/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: git-commit-writer
+description: Guide Codex or Claude Code to write professional, informative Git commit messages following industry best practices. Use this skill when writing commit messages, reviewing proposed commits, helping users improve commit message quality, or handling git, version control, or contribution documentation tasks.
+---
+
+# Git Commit Writer
+
+## Overview
+
+This skill enables writing professional Git commit messages that follow industry best practices based on Chris Beams' widely-adopted guidelines. Well-crafted commit messages preserve institutional knowledge, improve code maintainability, and make collaboration more effective in either Codex or Claude Code.
+
+## When to Use This Skill
+
+Activate this skill when:
+- Writing a new commit message for code changes
+- Reviewing or improving an existing commit message
+- User asks "how should I write this commit message?"
+- User provides a poor commit message and needs help improving it
+- User mentions git commit, version control, or commit standards
+- User is about to commit code and needs guidance
+
+## The Seven Core Rules
+
+Apply these rules to every commit message:
+
+### 1. Separate subject from body with a blank line
+
+Place one blank line between the subject line and the body text. Git tools rely on this separation.
+
+```
+Fix authentication bug in user login
+
+The bcrypt comparison was using the wrong salt parameter.
+This commit corrects the parameter and adds unit tests.
+```
+
+### 2. Limit the subject line to 50 characters
+
+Keep subjects concise and scannable. GitHub warns beyond 50 characters and truncates at 72.
+
+✅ Good: `Add user authentication with JWT tokens`
+❌ Too long: `Add comprehensive user authentication system with JWT tokens and refresh`
+
+### 3. Capitalize the subject line
+
+Start with a capital letter for consistency.
+
+✅ Good: `Refactor authentication module`
+❌ Bad: `refactor authentication module`
+
+### 4. Do not end the subject line with a period
+
+Periods waste space in the 50-character limit.
+
+✅ Good: `Fix memory leak in sync process`
+❌ Bad: `Fix memory leak in sync process.`
+
+### 5. Use the imperative mood in the subject line
+
+Write commands, not descriptions of what was done.
+
+**The golden test:** Complete this sentence:
+"If applied, this commit will **[your subject line]**"
+
+✅ Imperative: `Fix bug in user login`
+✅ Test: "If applied, this commit will **fix bug in user login**"
+
+❌ Past tense: `Fixed bug in user login`
+❌ Test: "If applied, this commit will **fixed bug in user login**" (grammatically incorrect)
+
+**Common imperative forms:**
+- Fix, Add, Remove, Update, Refactor, Improve
+- Merge, Revert, Document, Extract, Consolidate
+
+**Avoid:**
+- Fixed, Added, Removed (past tense)
+- Fixes, Adds, Removes (present tense)
+- Fixing, Adding, Removing (present participle)
+- I fixed, I added (first person)
+
+### 6. Wrap the body at 72 characters
+
+Hard-wrap body text at 72 characters for proper display in terminals and Git tools.
+
+### 7. Use the body to explain what and why vs. how
+
+The code shows **how** something was done. The commit message explains:
+- **What** was changed
+- **Why** it was changed
+- What problem was being solved
+- Why this solution was chosen
+
+## Workflow for Writing Commit Messages
+
+### Step 1: Understand the Changes
+
+Before writing the commit message, review what was changed:
+- What files were modified?
+- What functionality was added, removed, or fixed?
+- Is this a single logical change (atomic commit)?
+
+### Step 2: Craft the Subject Line
+
+Write a subject line that:
+1. Completes: "If applied, this commit will **[subject]**"
+2. Uses imperative mood (Fix, Add, Remove, Update, etc.)
+3. Stays under 50 characters
+4. Starts with a capital letter
+5. Has no ending period
+
+**Subject line patterns:**
+
+| Pattern | Example |
+|---------|---------|
+| Fix [issue] in [area] | `Fix race condition in cache invalidation` |
+| Add [feature] to [area] | `Add dark mode support to user interface` |
+| Remove [thing] from [area] | `Remove deprecated authentication methods` |
+| Update [thing] to [state] | `Update dependencies to latest versions` |
+| Refactor [area] for [reason] | `Refactor auth logic for maintainability` |
+| Improve [aspect] of [area] | `Improve error messages in validation` |
+
+### Step 3: Decide If a Body Is Needed
+
+**Body is required when:**
+- The change is not self-explanatory from the subject and diff
+- There's important context or reasoning to preserve
+- The change fixes a bug with non-obvious root cause
+- Trade-offs or alternatives were considered
+- The change has side effects or consequences
+
+**Body is optional for:**
+- Simple, obvious changes
+- Typo fixes (though consider if body would help)
+- Very small refactorings with clear purpose
+
+### Step 4: Write the Body (If Needed)
+
+Structure the body to answer:
+
+1. **What was the problem or motivation?**
+   - What bug occurred or what was missing?
+   - What user need is being addressed?
+
+2. **Why this solution?**
+   - Why was this approach chosen?
+   - What alternatives were considered?
+
+3. **What are the effects?**
+   - Are there side effects or consequences?
+   - Does this enable future changes?
+
+4. **References**
+   - Link to related issues: `Fixes #123`
+   - Link to PRs: `Related to PR #456`
+   - Link to documentation or discussions
+
+**Example template:**
+```
+[Subject line]
+
+[What was the problem - 1-2 sentences]
+
+[Why this solution - 1-3 sentences explaining the approach]
+
+[Optional: Effects, consequences, or next steps]
+
+Fixes #123
+```
+
+### Step 5: Apply Final Checks
+
+Before committing, verify:
+- [ ] Subject line is 50 characters or less
+- [ ] Subject uses imperative mood
+- [ ] Subject is capitalized with no ending period
+- [ ] Blank line separates subject from body
+- [ ] Body is wrapped at 72 characters
+- [ ] Body explains what and why, not how
+- [ ] Related issues are referenced
+
+## Common Scenarios and Examples
+
+### Scenario 1: Simple Bug Fix
+
+**User request:** "I fixed a login bug, what should my commit say?"
+
+**Response pattern:**
+```
+Subject: Fix authentication bug in user login
+
+Body (optional):
+The password validation was failing due to incorrect bcrypt
+salt parameter. This commit corrects the parameter and adds
+unit tests to prevent regression.
+
+Fixes #789
+```
+
+### Scenario 2: Feature Addition
+
+**User request:** "I just added dark mode support"
+
+**Response pattern:**
+```
+Subject: Add dark mode support to user interface
+
+Body:
+Implements a dark color theme toggleable in user preferences.
+The theme persists across sessions and follows WCAG 2.1
+Level AA contrast requirements for accessibility.
+
+Uses CSS custom properties for instant theme switching without
+page reload.
+
+Closes #567
+```
+
+### Scenario 3: Refactoring
+
+**User request:** "I cleaned up the authentication code"
+
+**Response pattern:**
+```
+Subject: Extract authentication logic into separate service
+
+Body:
+Authentication code was scattered across multiple controllers,
+making it difficult to maintain and test. This commit
+consolidates all authentication logic into a dedicated
+AuthService.
+
+Benefits:
+- Single responsibility principle compliance
+- Easier unit testing with dependency injection
+- Consistent authentication behavior across endpoints
+
+No functional changes to authentication behavior.
+```
+
+### Scenario 4: Reviewing a Poor Commit
+
+**User provides:** `"Fixed stuff"`
+
+**Response pattern:**
+Suggest improvement:
+```
+The commit message "Fixed stuff" is too vague. Consider a more
+descriptive subject like:
+
+Fix memory leak in background sync process
+
+And add body text explaining:
+- What was the memory leak?
+- What was causing it?
+- How does this fix address it?
+```
+
+## Handling Edge Cases
+
+### Multiple Related Changes
+
+If multiple related changes are in one commit:
+- List them in the body with bullet points
+- Ensure they're logically related (otherwise split commits)
+
+```
+Update authentication system for security
+
+- Add rate limiting to login endpoint
+- Implement JWT token refresh mechanism
+- Update bcrypt rounds to current best practice
+
+These changes work together to improve authentication security
+after the security audit recommendations.
+```
+
+### Merge Commits
+
+Git creates these automatically, typically don't need custom messages. If customizing:
+
+```
+Merge branch 'feature/dark-mode' into main
+
+Brings dark mode support with accessibility compliance.
+All tests passing and code reviewed.
+```
+
+### Reverting Commits
+
+Use `git revert` which auto-generates messages, but enhance with context:
+
+```
+Revert "Add experimental caching layer"
+
+This reverts commit abc123def456.
+
+The caching layer caused data inconsistencies in production
+under high concurrent load. Reverting while we investigate
+the race condition issue.
+
+Related to incident #2345
+```
+
+## Resources
+
+This skill includes:
+
+### references/detailed-guide.md
+
+Comprehensive guide with:
+- Detailed explanations of all seven rules
+- Extensive examples and anti-patterns
+- Common scenarios and edge cases
+- Links to authoritative sources
+
+Load this reference when:
+- User asks for detailed explanations
+- User needs examples of specific patterns
+- Helping with complex commit scenarios
+- User wants to understand the "why" behind rules
+
+## Project-Specific Considerations
+
+When working in specific projects:
+- Check for existing commit message conventions in CONTRIBUTING.md or similar files
+- Follow established patterns in the project's git history
+- Note any project-specific prefixes (e.g., `feat:`, `fix:`, `docs:`)
+- Respect team decisions that differ from these guidelines (consistency matters more than personal preference)
+
+## Anti-Patterns to Avoid
+
+Never accept these commit message patterns:
+- ❌ Vague: `Fix stuff`, `Update code`, `Changes`, `WIP`
+- ❌ Non-imperative: `Fixed bug`, `Updating code`, `I added feature`
+- ❌ Too long subjects: Anything over 72 characters
+- ❌ Implementation details in subject: `Change function X to use Y instead of Z`
+- ❌ Missing context: `Fix bug` (which bug? what was broken?)
+- ❌ Casual language: `Finally got this working!`, `asdfasdf`
+
+## Success Criteria
+
+A well-written commit message should:
+1. Allow future developers to understand the change without reading the code
+2. Explain the reasoning and context behind decisions
+3. Enable quick scanning of git history
+4. Preserve institutional knowledge
+5. Make code reviews and debugging easier

--- a/.claude/skills/git-commit-writer/SKILL.md
+++ b/.claude/skills/git-commit-writer/SKILL.md
@@ -27,7 +27,7 @@ Apply these rules to every commit message:
 
 Place one blank line between the subject line and the body text. Git tools rely on this separation.
 
-```
+```text
 Fix authentication bug in user login
 
 The bcrypt comparison was using the wrong salt parameter.
@@ -155,7 +155,7 @@ Structure the body to answer:
    - Link to documentation or discussions
 
 **Example template:**
-```
+```text
 [Subject line]
 
 [What was the problem - 1-2 sentences]
@@ -185,7 +185,7 @@ Before committing, verify:
 **User request:** "I fixed a login bug, what should my commit say?"
 
 **Response pattern:**
-```
+```text
 Subject: Fix authentication bug in user login
 
 Body (optional):
@@ -201,7 +201,7 @@ Fixes #789
 **User request:** "I just added dark mode support"
 
 **Response pattern:**
-```
+```text
 Subject: Add dark mode support to user interface
 
 Body:
@@ -220,7 +220,7 @@ Closes #567
 **User request:** "I cleaned up the authentication code"
 
 **Response pattern:**
-```
+```text
 Subject: Extract authentication logic into separate service
 
 Body:
@@ -243,7 +243,7 @@ No functional changes to authentication behavior.
 
 **Response pattern:**
 Suggest improvement:
-```
+```text
 The commit message "Fixed stuff" is too vague. Consider a more
 descriptive subject like:
 
@@ -263,7 +263,7 @@ If multiple related changes are in one commit:
 - List them in the body with bullet points
 - Ensure they're logically related (otherwise split commits)
 
-```
+```text
 Update authentication system for security
 
 - Add rate limiting to login endpoint
@@ -278,7 +278,7 @@ after the security audit recommendations.
 
 Git creates these automatically, typically don't need custom messages. If customizing:
 
-```
+```text
 Merge branch 'feature/dark-mode' into main
 
 Brings dark mode support with accessibility compliance.
@@ -289,7 +289,7 @@ All tests passing and code reviewed.
 
 Use `git revert` which auto-generates messages, but enhance with context:
 
-```
+```text
 Revert "Add experimental caching layer"
 
 This reverts commit abc123def456.

--- a/.claude/skills/git-commit-writer/agents/openai.yaml
+++ b/.claude/skills/git-commit-writer/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Git Commit Writer"
+  short_description: "Write clear, reviewable commit messages"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $git-commit-writer to draft a concise commit message for my staged changes."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/git-commit-writer/references/detailed-guide.md
+++ b/.claude/skills/git-commit-writer/references/detailed-guide.md
@@ -1,0 +1,373 @@
+# Complete Guide to Writing Git Commit Messages
+
+This comprehensive guide is based on [Chris Beams' definitive article](https://cbea.ms/git-commit/) on writing good commit messages. Reference this document for detailed explanations, examples, and the reasoning behind each rule.
+
+## The Seven Rules of a Great Git Commit Message
+
+### Rule 1: Separate subject from body with a blank line
+
+Git uses the blank line between the subject and body as a delimiter. This allows Git tools to properly parse commits for different contexts.
+
+**Why it matters:**
+- `git log --oneline` shows only the subject line
+- `git shortlog` groups commits by user with subject lines only
+- Email-formatted patches use the subject as the email subject line
+- GitHub's UI displays subjects and bodies separately
+
+**Example:**
+```
+Fix authentication bug in user login
+
+Users were unable to log in due to a validation error in the
+password hashing function. The bcrypt comparison was using the
+wrong salt parameter, causing all login attempts to fail.
+
+This commit corrects the salt parameter and adds unit tests to
+prevent regression.
+```
+
+Without the blank line, Git tools can't distinguish where the subject ends and the body begins.
+
+### Rule 2: Limit the subject line to 50 characters
+
+50 characters is not a hard limit, but a guideline to ensure readability.
+
+**Why it matters:**
+- Forces you to think concisely about the change
+- GitHub warns beyond 50 characters
+- GitHub truncates subject lines at 72 characters
+- `git log --oneline` becomes difficult to scan with long subjects
+
+**Tips:**
+- If struggling to summarize, the commit may be doing too much (split into multiple commits)
+- Sacrifice complete sentences for brevity when needed
+
+**Examples:**
+
+✅ Good (50 characters or less):
+```
+Add user authentication with JWT tokens
+Fix memory leak in background sync process
+Update dependencies to latest versions
+```
+
+❌ Too long:
+```
+Add comprehensive user authentication system with JWT tokens and refresh token rotation
+```
+
+### Rule 3: Capitalize the subject line
+
+Simple consistency rule that improves readability.
+
+**Examples:**
+
+✅ Good:
+```
+Accelerate to 88 miles per hour
+```
+
+❌ Bad:
+```
+accelerate to 88 miles per hour
+```
+
+### Rule 4: Do not end the subject line with a period
+
+Trailing punctuation wastes precious character space in the 50-character limit.
+
+**Examples:**
+
+✅ Good:
+```
+Open the pod bay doors
+```
+
+❌ Bad:
+```
+Open the pod bay doors.
+```
+
+### Rule 5: Use the imperative mood in the subject line
+
+**Imperative mood** means "spoken or written as if giving a command or instruction."
+
+**Examples of imperative mood:**
+- Clean your room
+- Close the door
+- Refactor the authentication module
+
+**Why imperative mood:**
+- Git itself uses imperative mood when creating commits automatically
+- It matches the convention Git established (e.g., "Merge branch 'feature'")
+- It tells someone what applying the commit will do, not what you did
+
+**The golden test:**
+Your subject line should complete this sentence:
+> If applied, this commit will **[your subject line]**
+
+**Examples:**
+
+✅ Good (imperative mood):
+```
+If applied, this commit will refactor authentication module
+If applied, this commit will remove deprecated methods
+If applied, this commit will fix bug in user login
+If applied, this commit will update dependencies
+```
+
+❌ Bad (not imperative):
+```
+If applied, this commit will fixed bug in user login          (past tense)
+If applied, this commit will fixes bug in user login          (present tense)
+If applied, this commit will fixing bug in user login         (present participle)
+If applied, this commit will I fixed the bug in user login    (first person)
+```
+
+**Correct forms:**
+
+| ✅ Imperative | ❌ Other Forms |
+|---------------|----------------|
+| Refactor authentication for clarity | Refactored authentication, Refactors authentication, Refactoring authentication |
+| Remove deprecated methods | Removed deprecated methods, Removes deprecated methods, Removing deprecated methods |
+| Update getting started documentation | Updated getting started documentation, Updates documentation, Updating documentation |
+| Merge pull request #123 from user/branch | Merged pull request, Merges pull request |
+
+**Note:** Using imperative mood can feel awkward in writing because we don't normally speak that way. But it's perfect for Git commit subjects. Git itself uses it, so following the convention maintains consistency.
+
+### Rule 6: Wrap the body at 72 characters
+
+Git does not wrap text automatically. When you wrap text manually at 72 characters, Git can indent text while still keeping everything under 80 characters total.
+
+**Why 72 characters:**
+- Allows for Git's indentation while staying under 80 character terminals
+- Improves readability in various contexts (emails, GitHub, terminal)
+- Matches the standard Git convention
+
+**How to wrap:**
+- Most text editors can be configured to hard-wrap at 72 characters
+- Use manual line breaks at logical points in your sentences
+
+**Example:**
+```
+Fix authentication bug in user login
+
+Users were unable to log in due to a validation error in the
+password hashing function. The bcrypt comparison was using the
+wrong salt parameter, causing all login attempts to fail.
+
+This commit corrects the salt parameter and adds unit tests to
+prevent regression. The tests verify both successful login
+attempts and failed attempts with invalid credentials.
+```
+
+### Rule 7: Use the body to explain what and why vs. how
+
+The code shows **how** a change was made. The commit message should explain:
+- **What** was changed
+- **Why** it was changed
+- What was the problem being solved
+- Why this solution was chosen over alternatives
+
+**Why it matters:**
+- Preserves institutional knowledge
+- Helps future maintainers understand reasoning
+- Provides context that code alone cannot convey
+- Documents trade-offs and decisions
+
+**Example comparing before/after:**
+
+❌ Uninformative:
+```
+Fix bug
+```
+
+✅ Informative:
+```
+Fix authentication timeout in Safari
+
+Safari has a stricter cookie security policy that was causing
+session tokens to expire prematurely on the login page. The
+previous implementation set cookies without the SameSite
+attribute, which Safari treats as SameSite=Lax by default.
+
+This commit explicitly sets SameSite=None with the Secure flag,
+allowing the session token to persist correctly across the
+authentication flow in Safari while maintaining security in
+other browsers.
+
+Fixes #456
+```
+
+**What to include in the body:**
+- The problem or bug being addressed
+- Why this approach was chosen
+- Side effects or consequences of the change
+- Links to relevant issues or documentation
+- Anything that would help future developers understand the change
+
+**What NOT to include:**
+- How the code works (that's what the code itself shows)
+- Changes that are obvious from the diff
+- Implementation details that are self-evident
+
+## Additional Best Practices
+
+### Atomic Commits
+
+Make commits that represent a single logical change. This makes:
+- Commit messages easier to write (one clear purpose)
+- Code reviews simpler (focused changes)
+- Reverting easier if needed
+- History more understandable
+
+### Use the Command Line
+
+While IDE integrations are convenient, they often limit access to Git's full power. Learning the command-line Git workflow provides:
+- Better understanding of Git's concepts
+- Access to advanced features
+- Ability to write proper multi-line commit messages
+- More control over staging and committing
+
+### Reference Issues and PRs
+
+When commits relate to issues or pull requests, reference them in the body:
+
+```
+Fix memory leak in background sync
+
+The background sync process was accumulating WebSocket connections
+without properly closing them. This caused memory to grow unbounded
+over time, eventually leading to application crashes after several
+hours of operation.
+
+This commit ensures all WebSocket connections are properly closed
+in a finally block, preventing the leak.
+
+Fixes #789
+Related to PR #790
+```
+
+### Be Consistent
+
+If working on a team, establish conventions and follow them:
+- Decide on subject line length limits
+- Agree on when to use body text
+- Standardize format for issue references
+- Choose imperative mood consistently
+
+### Learn Git Deeply
+
+Reading [Pro Git](https://git-scm.com/book/en/v2) (available free online) provides deep understanding of Git's design philosophy and why these conventions matter.
+
+## Common Anti-Patterns to Avoid
+
+❌ **Vague subjects:**
+```
+Fix stuff
+Update code
+Changes
+WIP
+asdfasdf
+```
+
+❌ **Describing implementation instead of purpose:**
+```
+Change UserController.login() to use bcrypt.compare() with correct parameters
+```
+
+Better:
+```
+Fix authentication bug in user login
+
+Corrected bcrypt salt parameter to fix validation errors preventing
+users from logging in.
+```
+
+❌ **Including irrelevant information:**
+```
+Fix login bug (worked on this all day, finally figured it out!)
+```
+
+❌ **Not using imperative mood:**
+```
+Fixed login bug
+Fixing login bug
+This fixes the login bug
+I fixed the login bug
+```
+
+## Examples of Great Commit Messages
+
+### Example 1: Bug Fix
+```
+Fix race condition in cache invalidation
+
+The previous implementation used separate read and write operations
+for cache invalidation, creating a race condition where two threads
+could both read stale data before either wrote the update. This
+caused intermittent data inconsistencies in production.
+
+This commit wraps the read-invalidate-write sequence in a lock,
+ensuring atomic execution. Performance impact is minimal since
+cache operations are infrequent.
+
+Fixes #1234
+```
+
+### Example 2: Feature Addition
+```
+Add dark mode support to user interface
+
+Implements a dark color theme that can be toggled in user
+preferences. The theme is applied system-wide and persists
+across sessions.
+
+Color values follow WCAG 2.1 Level AA contrast requirements
+for accessibility. The implementation uses CSS custom properties
+for theme switching without page reload.
+
+Closes #567
+```
+
+### Example 3: Refactoring
+```
+Extract authentication logic into separate service
+
+The authentication code was scattered across multiple controllers,
+making it difficult to maintain and test. This commit consolidates
+all authentication logic into a dedicated AuthService.
+
+Benefits:
+- Single responsibility principle compliance
+- Easier unit testing with dependency injection
+- Consistent authentication behavior across endpoints
+- Preparation for upcoming OAuth integration
+
+No functional changes to authentication behavior.
+```
+
+### Example 4: Documentation
+```
+Document database migration process
+
+Added comprehensive guide for running database migrations in
+production environments. Includes rollback procedures and
+troubleshooting steps for common issues.
+
+This documentation was requested by DevOps team after the
+incident last week where a migration was rolled back incorrectly.
+```
+
+## Summary
+
+Great commit messages:
+1. Have informative, concise subject lines (50 characters)
+2. Use imperative mood ("Fix bug" not "Fixed bug")
+3. Include blank line between subject and body
+4. Wrap body text at 72 characters
+5. Explain what and why, not how
+6. Provide context and reasoning
+7. Reference related issues and PRs
+
+Poor commit messages cost time for future maintainers (including your future self). Good commit messages save time and preserve institutional knowledge.

--- a/.claude/skills/git-commit-writer/references/detailed-guide.md
+++ b/.claude/skills/git-commit-writer/references/detailed-guide.md
@@ -15,7 +15,7 @@ Git uses the blank line between the subject and body as a delimiter. This allows
 - GitHub's UI displays subjects and bodies separately
 
 **Example:**
-```
+```text
 Fix authentication bug in user login
 
 Users were unable to log in due to a validation error in the
@@ -45,14 +45,14 @@ Without the blank line, Git tools can't distinguish where the subject ends and t
 **Examples:**
 
 ✅ Good (50 characters or less):
-```
+```text
 Add user authentication with JWT tokens
 Fix memory leak in background sync process
 Update dependencies to latest versions
 ```
 
 ❌ Too long:
-```
+```text
 Add comprehensive user authentication system with JWT tokens and refresh token rotation
 ```
 
@@ -63,12 +63,12 @@ Simple consistency rule that improves readability.
 **Examples:**
 
 ✅ Good:
-```
+```text
 Accelerate to 88 miles per hour
 ```
 
 ❌ Bad:
-```
+```text
 accelerate to 88 miles per hour
 ```
 
@@ -79,12 +79,12 @@ Trailing punctuation wastes precious character space in the 50-character limit.
 **Examples:**
 
 ✅ Good:
-```
+```text
 Open the pod bay doors
 ```
 
 ❌ Bad:
-```
+```text
 Open the pod bay doors.
 ```
 
@@ -109,7 +109,7 @@ Your subject line should complete this sentence:
 **Examples:**
 
 ✅ Good (imperative mood):
-```
+```text
 If applied, this commit will refactor authentication module
 If applied, this commit will remove deprecated methods
 If applied, this commit will fix bug in user login
@@ -117,7 +117,7 @@ If applied, this commit will update dependencies
 ```
 
 ❌ Bad (not imperative):
-```
+```text
 If applied, this commit will fixed bug in user login          (past tense)
 If applied, this commit will fixes bug in user login          (present tense)
 If applied, this commit will fixing bug in user login         (present participle)
@@ -149,7 +149,7 @@ Git does not wrap text automatically. When you wrap text manually at 72 characte
 - Use manual line breaks at logical points in your sentences
 
 **Example:**
-```
+```text
 Fix authentication bug in user login
 
 Users were unable to log in due to a validation error in the
@@ -178,12 +178,12 @@ The code shows **how** a change was made. The commit message should explain:
 **Example comparing before/after:**
 
 ❌ Uninformative:
-```
+```text
 Fix bug
 ```
 
 ✅ Informative:
-```
+```text
 Fix authentication timeout in Safari
 
 Safari has a stricter cookie security policy that was causing
@@ -233,7 +233,7 @@ While IDE integrations are convenient, they often limit access to Git's full pow
 
 When commits relate to issues or pull requests, reference them in the body:
 
-```
+```text
 Fix memory leak in background sync
 
 The background sync process was accumulating WebSocket connections
@@ -263,7 +263,7 @@ Reading [Pro Git](https://git-scm.com/book/en/v2) (available free online) provid
 ## Common Anti-Patterns to Avoid
 
 ❌ **Vague subjects:**
-```
+```text
 Fix stuff
 Update code
 Changes
@@ -272,12 +272,12 @@ asdfasdf
 ```
 
 ❌ **Describing implementation instead of purpose:**
-```
+```text
 Change UserController.login() to use bcrypt.compare() with correct parameters
 ```
 
 Better:
-```
+```text
 Fix authentication bug in user login
 
 Corrected bcrypt salt parameter to fix validation errors preventing
@@ -285,12 +285,12 @@ users from logging in.
 ```
 
 ❌ **Including irrelevant information:**
-```
+```text
 Fix login bug (worked on this all day, finally figured it out!)
 ```
 
 ❌ **Not using imperative mood:**
-```
+```text
 Fixed login bug
 Fixing login bug
 This fixes the login bug
@@ -300,7 +300,7 @@ I fixed the login bug
 ## Examples of Great Commit Messages
 
 ### Example 1: Bug Fix
-```
+```text
 Fix race condition in cache invalidation
 
 The previous implementation used separate read and write operations
@@ -316,7 +316,7 @@ Fixes #1234
 ```
 
 ### Example 2: Feature Addition
-```
+```text
 Add dark mode support to user interface
 
 Implements a dark color theme that can be toggled in user
@@ -331,7 +331,7 @@ Closes #567
 ```
 
 ### Example 3: Refactoring
-```
+```text
 Extract authentication logic into separate service
 
 The authentication code was scattered across multiple controllers,
@@ -348,7 +348,7 @@ No functional changes to authentication behavior.
 ```
 
 ### Example 4: Documentation
-```
+```text
 Document database migration process
 
 Added comprehensive guide for running database migrations in

--- a/.claude/skills/ui-design-principles/SKILL.md
+++ b/.claude/skills/ui-design-principles/SKILL.md
@@ -1,0 +1,596 @@
+---
+name: ui-design-principles
+description: Apply pragmatic UI design principles for fast, consistent, accessible interfaces across JavaFX, web, desktop, mobile, and CLI surfaces. Use this skill when designing or reviewing Bisq desktop UI, implementing JavaFX views, improving frontend features, checking layout quality, or evaluating user experience across React, SwiftUI, Flutter, or other UI frameworks.
+---
+
+# UI Design Principles
+
+## Overview
+
+Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) to create interfaces that are fast, consistent, and delightful regardless of platform or framework. This skill provides actionable guidelines for speed optimization, spatial consistency, progressive disclosure, and immediate feedback that apply to Bisq JavaFX screens, web applications, desktop software, mobile apps, and command-line interfaces.
+
+## Core Design Principles
+
+### 1. Speed Through Subtraction (Apple)
+
+**Philosophy**: "Perfection is achieved not when there is nothing more to add, but when there is nothing left to take away."
+
+**Universal Practices**:
+- Remove unnecessary interactions - Make common actions 1-click/tap, rare actions 2-clicks/taps
+- Reduce visual noise - Eliminate decorative elements that don't serve users
+- Eliminate confirmation dialogs for low-risk actions - Only confirm destructive/irreversible operations
+- Streamline workflows - Cut steps that don't add value
+
+**Cross-Platform Examples**:
+```
+❌ Bad: Click "Edit" → Confirm "Are you sure?" → Click "Yes" → Edit mode
+✅ Good: Click "Edit" → Edit mode (action is reversible)
+
+❌ Bad: Settings screen with 50 visible options
+✅ Good: Settings with categories, common settings visible, advanced collapsed
+
+❌ Bad: CLI requiring 5 flags for common operation
+✅ Good: CLI with smart defaults, verbose flags for rare cases
+```
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+- Single-click actions without unnecessary confirmation modals
+- Inline editing instead of modal dialogs for reversible changes
+
+**Desktop (JavaFX/Swing/Electron)**:
+- Menu items for rare actions, toolbar buttons for common ones
+- Keyboard shortcuts bypass multi-step dialogs
+
+**Mobile (iOS/Android/Flutter)**:
+- Swipe gestures for common actions (delete, archive)
+- Bottom sheets instead of multiple navigation steps
+
+**CLI/TUI**:
+- Smart defaults reduce required flags
+- Interactive prompts only for ambiguous cases
+
+**Anti-patterns**:
+- Multiple confirmations for reversible actions
+- Extra steps "for safety" when undo/rollback exists
+- Showing all features upfront instead of progressive disclosure
+
+### 2. Spatial Consistency
+
+**Philosophy**: "UI elements should have predictable positions and behaviors."
+
+**Universal Practices**:
+- Fixed positions for primary actions - CTAs don't move around
+- Consistent spacing rhythm - Use systematic scale (4px base recommended)
+- Stable layouts - Don't shift content during interactions
+- Persistent navigation - Keep nav/search in same location
+
+**Cross-Platform Examples**:
+```
+❌ Bad: Primary button sometimes top-right, sometimes bottom-left
+✅ Good: Primary action always in same location (platform-appropriate)
+
+❌ Bad: Layout shifts when loading content (CLS issue)
+✅ Good: Reserve space for content with skeleton loaders/placeholders
+
+❌ Bad: Spacing varies inconsistently throughout interface
+✅ Good: All spacing follows rhythm (8, 16, 24, 32 units)
+```
+
+**Recommended Spacing Scale** (adapt to platform density):
+```
+Base unit: 4px (or 4dp/4pt depending on platform)
+
+Micro:    4px  (tight spacing within components)
+Small:    8px  (component internal padding)
+Medium:   16px (spacing between related elements)
+Large:    24px (spacing between component groups)
+XLarge:   32px (section separation)
+XXLarge:  48px (major layout divisions)
+```
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+```css
+/* CSS Variables for consistency */
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+}
+```
+
+**Desktop (JavaFX)**:
+```java
+// JavaFX Spacing with Insets
+VBox layout = new VBox(16); // 16px spacing
+layout.setPadding(new Insets(24, 24, 24, 24));
+```
+
+**Mobile (SwiftUI)**:
+```swift
+// SwiftUI Spacing
+VStack(spacing: 16) {
+    // Elements with consistent spacing
+}
+.padding(.horizontal, 24)
+```
+
+**CLI/TUI**:
+- Consistent indentation levels (2 or 4 spaces)
+- Predictable column alignment in tables
+- Separator lines at consistent positions
+
+**Anti-patterns**:
+- Buttons that move based on content length
+- Inconsistent padding across similar components
+- Navigation that disappears or moves unexpectedly
+
+### 3. Progressive Disclosure
+
+**Philosophy**: "Show what matters now, reveal complexity when needed."
+
+**Universal Practices**:
+- Collapsed details by default - Show summary, hide details until needed
+- Expand-in-place patterns - Avoid modals for viewing more information
+- Contextual actions on interaction - Hide secondary actions until element is active
+- Smart defaults - Pre-select common choices to reduce decisions
+
+**Cross-Platform Examples**:
+```
+❌ Bad: FAQ page with all answers expanded (overwhelming)
+✅ Good: FAQ with collapsed answers, expand individual items on demand
+
+❌ Bad: Modal dialog to view profile details
+✅ Good: Inline expansion showing additional details
+
+❌ Bad: Edit/Delete buttons always visible on every list item
+✅ Good: Actions appear on hover/focus/selection
+```
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+- Accordion components for collapsible sections
+- Details/summary HTML elements
+- Hover/focus states revealing contextual actions
+- Dropdown menus for secondary options
+
+**Desktop (JavaFX/Swing/Electron)**:
+- Collapsible panels (TitledPane in JavaFX)
+- Context menus on right-click
+- Tree views with expandable nodes
+- Tabbed interfaces for related content
+
+**Mobile (iOS/Android/Flutter)**:
+- Expandable list items (UITableView sections, RecyclerView with ViewHolders)
+- Bottom sheets for additional options
+- Swipe gestures to reveal actions
+- Master-detail navigation patterns
+
+**CLI/TUI**:
+- Subcommands for advanced features
+- `--help` flag for detailed options
+- Interactive prompts for complex workflows
+- Pagers for long output (less, more)
+
+**Implementation Patterns by Platform**:
+
+**Web Accordion**:
+```tsx
+// React accordion pattern
+<Accordion>
+  <AccordionItem>
+    <AccordionTrigger>Summary (always visible)</AccordionTrigger>
+    <AccordionContent>Details (revealed on click)</AccordionContent>
+  </AccordionItem>
+</Accordion>
+```
+
+**JavaFX Collapsible**:
+```java
+// JavaFX TitledPane (accordion)
+TitledPane pane = new TitledPane("Summary", contentNode);
+pane.setExpanded(false); // Collapsed by default
+Accordion accordion = new Accordion(pane);
+```
+
+**SwiftUI Expandable**:
+```swift
+// SwiftUI DisclosureGroup
+DisclosureGroup("Summary") {
+    Text("Details revealed on tap")
+}
+```
+
+**CLI Progressive Disclosure**:
+```bash
+# Basic command with smart defaults
+$ git commit -m "message"
+
+# Advanced options revealed with --help
+$ git commit --help
+
+# Interactive mode for complex workflows
+$ git commit --interactive
+```
+
+**Anti-patterns**:
+- Showing all options upfront (decision paralysis)
+- Using modals when inline expansion would work
+- Permanent visible actions for rarely-used features
+- Deeply nested navigation requiring back-tracking
+
+### 4. Feedback Immediacy
+
+**Philosophy**: "Users should never wonder if their action worked."
+
+**Universal Practices**:
+- Instant visual feedback (<100ms) - Acknowledge user action immediately
+- Optimistic updates - Update UI instantly, rollback if operation fails
+- Subtle animations (200-300ms) - Smooth state transitions without delay
+- Clear state transitions - Visually distinguish loading/success/error states
+
+**Cross-Platform Examples**:
+```
+❌ Bad: Button shows no change when clicked, waits for response
+✅ Good: Button changes to "Saving..." immediately, then "Saved ✓"
+
+❌ Bad: Delete item, wait for spinner, item disappears
+✅ Good: Item fades out immediately, rollback if operation fails
+
+❌ Bad: Heavy 800ms animation that blocks interaction
+✅ Good: 200-300ms subtle transition that feels smooth
+```
+
+**Universal State Indicators**:
+- **Idle**: Default state, ready for interaction
+- **Loading**: Visual spinner/progress indicator, <100ms to show
+- **Success**: Checkmark/success indicator, 2-3 second auto-dismiss
+- **Error**: Error indicator, error message, persistent until dismissed
+
+**Animation Guidelines** (adapt to platform conventions):
+- Micro-interactions: 100-200ms (button press, hover, selection)
+- State transitions: 200-300ms (expand/collapse, fade)
+- Scene transitions: 300-400ms (route change, modal, screen navigation)
+- Never exceed 500ms for UI feedback
+
+**Framework-Specific Applications**:
+
+**Web (React/Vue/Angular)**:
+```typescript
+// Optimistic UI pattern
+async function deleteItem(id: string) {
+  // 1. Update UI immediately (optimistic)
+  setItems(items.filter(item => item.id !== id));
+
+  try {
+    // 2. Call server
+    await api.delete(`/items/${id}`);
+    showToast('Item deleted', 'success');
+  } catch (error) {
+    // 3. Rollback on error
+    setItems(originalItems);
+    showToast('Failed to delete', 'error');
+  }
+}
+```
+
+**Desktop (JavaFX)**:
+```java
+// JavaFX button state feedback
+button.setOnAction(event -> {
+    // 1. Immediate visual feedback
+    button.setText("Saving...");
+    button.setDisable(true);
+
+    // 2. Execute operation on background thread
+    Task<Void> task = new Task<>() {
+        @Override
+        protected Void call() throws Exception {
+            performSave();
+            return null;
+        }
+    };
+
+    // 3. Update UI on completion
+    task.setOnSucceeded(e -> {
+        button.setText("Saved ✓");
+        Platform.runLater(() -> {
+            Thread.sleep(2000);
+            button.setText("Save");
+            button.setDisable(false);
+        });
+    });
+
+    task.setOnFailed(e -> {
+        button.setText("Failed ✗");
+        showErrorDialog(task.getException());
+        button.setDisable(false);
+    });
+
+    new Thread(task).start();
+});
+```
+
+**Mobile (SwiftUI)**:
+```swift
+// SwiftUI state-driven button
+struct SaveButton: View {
+    @State private var state: ButtonState = .idle
+
+    var body: some View {
+        Button(action: {
+            state = .loading // Immediate feedback
+
+            Task {
+                do {
+                    try await save()
+                    state = .success
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                    state = .idle
+                } catch {
+                    state = .error
+                }
+            }
+        }) {
+            Text(state.label)
+        }
+        .disabled(state == .loading)
+    }
+}
+
+enum ButtonState {
+    case idle, loading, success, error
+
+    var label: String {
+        switch self {
+        case .idle: return "Save"
+        case .loading: return "Saving..."
+        case .success: return "✓ Saved"
+        case .error: return "✗ Failed"
+        }
+    }
+}
+```
+
+**CLI/TUI**:
+```bash
+# Immediate feedback patterns in CLI
+$ git push
+Counting objects: 100% (10/10), done.  # Progress feedback
+Writing objects: 100% (10/10), 1.5 KiB | 1.5 MiB/s, done.
+✓ Successfully pushed to origin/main  # Success indicator
+
+# Error feedback
+$ git push
+✗ Error: failed to push some refs  # Clear error state
+hint: Updates were rejected because...  # Actionable message
+```
+
+**Anti-patterns**:
+- No visual response when user interacts
+- Long operations without progress indication
+- Heavy animations that feel sluggish (>500ms)
+- Missing error states (silent failures)
+- Blocking UI during background operations
+
+## Design Review Checklist
+
+Use this checklist when reviewing UI designs or implementations across any platform:
+
+### Speed Audit
+- [ ] Can any steps be removed from common workflows?
+- [ ] Are there unnecessary confirmation dialogs for reversible actions?
+- [ ] Is the most common action 1-click/tap away?
+- [ ] Are rare/destructive actions appropriately protected (2-clicks)?
+- [ ] Do keyboard shortcuts exist for power users (desktop)?
+- [ ] Are smart defaults reducing user decisions?
+
+### Consistency Audit
+- [ ] Do primary actions stay in consistent positions?
+- [ ] Is spacing using a systematic rhythm scale?
+- [ ] Are layouts stable (no content layout shift)?
+- [ ] Is navigation persistent and predictable?
+- [ ] Do similar components use identical spacing/sizing?
+- [ ] Are platform conventions followed (e.g., OK/Cancel order)?
+
+### Disclosure Audit
+- [ ] Are complex features hidden by default?
+- [ ] Can users discover advanced features when needed?
+- [ ] Are contextual actions revealed appropriately?
+- [ ] Do smart defaults reduce decision-making?
+- [ ] Is the information hierarchy clear (what's important)?
+- [ ] Can users progressively learn advanced features?
+
+### Feedback Audit
+- [ ] Is visual feedback <100ms for all interactions?
+- [ ] Are optimistic updates used for async operations?
+- [ ] Are animations subtle and quick (200-300ms)?
+- [ ] Are all states clearly distinguished (idle/loading/success/error)?
+- [ ] Do long operations show progress indicators?
+- [ ] Are errors actionable with clear next steps?
+
+## Platform-Specific Considerations
+
+### Web Applications
+
+**Strengths**:
+- Rich animations and transitions
+- Hover states for progressive disclosure
+- Optimistic updates with async/await patterns
+- Browser back/forward navigation
+
+**Challenges**:
+- Network latency for remote operations
+- Cross-browser compatibility
+- Accessibility (keyboard navigation, screen readers)
+- Performance on low-end devices
+
+**Best Practices**:
+- Use semantic HTML for accessibility
+- Implement keyboard navigation (Tab, Enter, Escape)
+- Provide loading states for network operations
+- Test on mobile devices (touch targets)
+
+### Desktop Applications (JavaFX, Swing, Electron)
+
+**Strengths**:
+- Rich keyboard shortcuts
+- Context menus for advanced actions
+- Multi-window/multi-pane layouts
+- Direct file system access
+
+**Challenges**:
+- Platform-specific UI conventions (Windows vs macOS vs Linux)
+- Window management complexity
+- High user expectations for responsiveness
+- Complex state management across windows
+
+**Best Practices**:
+- Follow platform conventions (menu order, button placement)
+- Provide extensive keyboard shortcuts
+- Use background threads (JavaFX Task, SwingWorker) for long operations
+- Implement proper window lifecycle management
+
+**JavaFX-Specific**:
+- Use Platform.runLater() for UI thread updates
+- Leverage FXML for declarative layouts
+- Use CSS for consistent theming
+- Implement Properties/Bindings for reactive UIs
+
+### Mobile Applications (iOS, Android, Flutter)
+
+**Strengths**:
+- Touch gestures (swipe, pinch, long-press)
+- Bottom sheets for contextual options
+- Native animations and transitions
+- Push notifications for feedback
+
+**Challenges**:
+- Limited screen space
+- Touch target sizes (minimum 44pt/48dp)
+- Battery/performance constraints
+- Platform-specific design languages (Material/Human Interface)
+
+**Best Practices**:
+- Follow platform design guidelines (Material Design, Human Interface Guidelines)
+- Use native navigation patterns (tab bar, nav bar, drawer)
+- Implement pull-to-refresh for data updates
+- Provide haptic feedback for actions
+- Optimize for one-handed use
+
+### Command-Line Interfaces (CLI/TUI)
+
+**Strengths**:
+- Fast for power users
+- Scriptable and composable
+- Low resource overhead
+- Excellent for automation
+
+**Challenges**:
+- No visual feedback (text only)
+- Discovery of features harder
+- Error handling complexity
+- Limited progressive disclosure
+
+**Best Practices**:
+- Provide comprehensive --help documentation
+- Use colored output for state (green=success, red=error)
+- Show progress for long operations (spinners, progress bars)
+- Implement interactive modes for complex workflows
+- Use pagers for long output
+- Provide examples in help text
+
+## When to Apply Each Principle
+
+### Speed Through Subtraction
+- **When**: Designing new features, refactoring complex flows, user feedback about tedious workflows
+- **Signs needed**: Users complaining about "too many clicks", workflows feel tedious, high abandonment rates
+- **Impact**: Reduced time-to-completion, lower cognitive load, improved conversion rates
+
+### Spatial Consistency
+- **When**: Building design systems, refactoring inconsistent UIs, scaling design to new features
+- **Signs needed**: Users can't find features, layouts feel chaotic, design debt accumulating
+- **Impact**: Improved learnability, reduced confusion, faster development (reusable patterns)
+
+### Progressive Disclosure
+- **When**: Building complex features, settings pages, advanced tools, professional software
+- **Signs needed**: Users overwhelmed by options, interface feels cluttered, poor feature discovery
+- **Impact**: Reduced cognitive load, improved discoverability, better user retention
+
+### Feedback Immediacy
+- **When**: Implementing async operations, form submissions, data mutations, long-running processes
+- **Signs needed**: Users unsure if action worked, repeated clicks, support requests about "broken" features
+- **Impact**: Increased confidence, reduced user anxiety, fewer support tickets
+
+## Resources
+
+This skill is guidance-only and does not include scripts, references, or assets. All implementation patterns are provided inline in the SKILL.md for immediate reference.
+
+## Cross-Framework Pattern Reference
+
+### State Management Patterns
+
+**Web (React)**:
+```typescript
+const [state, setState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+```
+
+**JavaFX (Property)**:
+```java
+ObjectProperty<State> state = new SimpleObjectProperty<>(State.IDLE);
+state.addListener((obs, oldVal, newVal) -> updateUI(newVal));
+```
+
+**SwiftUI (State)**:
+```swift
+@State private var state: ButtonState = .idle
+```
+
+**Flutter (State)**:
+```dart
+enum ButtonState { idle, loading, success, error }
+ButtonState _state = ButtonState.idle;
+setState(() => _state = ButtonState.loading);
+```
+
+### Progressive Disclosure Patterns
+
+**Web**: Accordion, Details/Summary, Collapsible sections
+**JavaFX**: TitledPane, Accordion, TreeView
+**SwiftUI**: DisclosureGroup, List with expandable sections
+**Flutter**: ExpansionTile, ExpansionPanel
+**CLI**: Subcommands, --help flags, interactive prompts
+
+### Animation/Transition Patterns
+
+**Web (CSS)**:
+```css
+transition: all 200ms ease-in-out;
+```
+
+**JavaFX (Timeline)**:
+```java
+Timeline timeline = new Timeline(
+    new KeyFrame(Duration.millis(200),
+        new KeyValue(node.opacityProperty(), 0))
+);
+timeline.play();
+```
+
+**SwiftUI (Animation)**:
+```swift
+withAnimation(.easeInOut(duration: 0.2)) {
+    // State changes
+}
+```
+
+**Flutter (Animation)**:
+```dart
+AnimationController(duration: Duration(milliseconds: 200), vsync: this);
+```

--- a/.claude/skills/ui-design-principles/SKILL.md
+++ b/.claude/skills/ui-design-principles/SKILL.md
@@ -22,7 +22,7 @@ Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) 
 - Streamline workflows - Cut steps that don't add value
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: Click "Edit" → Confirm "Are you sure?" → Click "Yes" → Edit mode
 ✅ Good: Click "Edit" → Edit mode (action is reversible)
 
@@ -67,7 +67,7 @@ Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) 
 - Persistent navigation - Keep nav/search in same location
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: Primary button sometimes top-right, sometimes bottom-left
 ✅ Good: Primary action always in same location (platform-appropriate)
 
@@ -79,7 +79,7 @@ Apply proven design principles from industry leaders (Apple, Vercel, shadcn/ui) 
 ```
 
 **Recommended Spacing Scale** (adapt to platform density):
-```
+```text
 Base unit: 4px (or 4dp/4pt depending on platform)
 
 Micro:    4px  (tight spacing within components)
@@ -141,7 +141,7 @@ VStack(spacing: 16) {
 - Smart defaults - Pre-select common choices to reduce decisions
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: FAQ page with all answers expanded (overwhelming)
 ✅ Good: FAQ with collapsed answers, expand individual items on demand
 
@@ -236,7 +236,7 @@ $ git commit --interactive
 - Clear state transitions - Visually distinguish loading/success/error states
 
 **Cross-Platform Examples**:
-```
+```text
 ❌ Bad: Button shows no change when clicked, waits for response
 ✅ Good: Button changes to "Saving..." immediately, then "Saved ✓"
 
@@ -265,6 +265,8 @@ $ git commit --interactive
 ```typescript
 // Optimistic UI pattern
 async function deleteItem(id: string) {
+  const previousItems = items;
+
   // 1. Update UI immediately (optimistic)
   setItems(items.filter(item => item.id !== id));
 
@@ -274,7 +276,7 @@ async function deleteItem(id: string) {
     showToast('Item deleted', 'success');
   } catch (error) {
     // 3. Rollback on error
-    setItems(originalItems);
+    setItems(previousItems);
     showToast('Failed to delete', 'error');
   }
 }
@@ -283,6 +285,7 @@ async function deleteItem(id: string) {
 **Desktop (JavaFX)**:
 ```java
 // JavaFX button state feedback
+// Requires javafx.animation.PauseTransition and javafx.util.Duration.
 button.setOnAction(event -> {
     // 1. Immediate visual feedback
     button.setText("Saving...");
@@ -300,11 +303,12 @@ button.setOnAction(event -> {
     // 3. Update UI on completion
     task.setOnSucceeded(e -> {
         button.setText("Saved ✓");
-        Platform.runLater(() -> {
-            Thread.sleep(2000);
+        PauseTransition delay = new PauseTransition(Duration.seconds(2));
+        delay.setOnFinished(finishedEvent -> {
             button.setText("Save");
             button.setDisable(false);
         });
+        delay.play();
     });
 
     task.setOnFailed(e -> {

--- a/.claude/skills/ui-design-principles/agents/openai.yaml
+++ b/.claude/skills/ui-design-principles/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "UI Design Principles"
+  short_description: "Apply pragmatic UI quality checks across platforms"
+  brand_color: "#2E8B57"
+  default_prompt: "Use $ui-design-principles to review or improve this Bisq user interface."
+
+policy:
+  allow_implicit_invocation: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,18 @@ Read ~/.codex/AGENTS.md if present before doing anything else and report whether
 This file contains agent-specific operating rules.
 Project coding conventions and architecture rules are defined in the developer docs.
 
+## Repo-Local AI Skills
+
+This repository includes shared AI skills for Bisq contributor work. Codex loads `.agents/skills` automatically from the Git root, and Claude Code loads `.claude/skills`. Prefer explicit skill invocation for specialized work:
+
+- `$bisq-contributor-workflow` for implementation tasks and contribution flow
+- `$bisq2-javafx-ui` for JavaFX desktop UI changes
+- `$bisq-pr-reviewer` for Bisq pull request review
+- `$git-commit-writer` for commit message drafting
+- `$ui-design-principles` for UI quality review
+
+Keep `.agents/skills` and `.claude/skills` in sync when updating shared skills.
+
 ## Source of Truth (Developer Docs)
 
 Start with:


### PR DESCRIPTION
## Summary

- Add repo-local Codex skills under `.agents/skills` so Codex loads Bisq contributor workflows automatically from the Git root.
- Add matching Claude Code skills under `.claude/skills` for the same contributor workflows.
- Document the available skills and preferred explicit invocations in `AGENTS.md`.

## Why

This makes the shared Bisq AI contributor workflows available directly from the Bisq 2 repository, so contributors do not need to install a separate plugin before using Codex or Claude Code effectively.

## Validation

- `git diff --check --cached`
- `git diff --check HEAD~1..HEAD`
- `diff -qr .agents/skills .claude/skills`
- Confirmed both skill roots contain the five expected `SKILL.md` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new repo-local AI skill guides for Bisq contributor workflow verification, two-phase Bisq PR reviewing (security, standards, architecture), and Bisq2 JavaFX UI implementation/review (lifecycle, threading, navigation, UI automation harness).
  * Published supporting reference checklists for contribution standards, security review, architecture patterns, UI design principles, and professional Git commit messages.
  * Documented how local skills are discovered, validated, and recommended for explicit invocation.

* **New Features**
  * Enabled implicit invocation for the newly added AI skills to streamline usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->