### PR TITLE
feature/relayed_notifications_deep_linking_support

### DIFF
--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyMobileTradeNotificationService.java
@@ -338,7 +338,8 @@ public class BisqEasyMobileTradeNotificationService implements Service {
         String title = Res.get(titleKey, shortTradeId);
         String message = Res.get(messageKey, peerName);
         String notificationId = notificationIdFor(trade);
-        notificationService.dispatchMobileOnlyNotification(new MobileTradeNotification(notificationId, title, message));
+        notificationService.dispatchMobileOnlyNotification(
+                new MobileTradeNotification(notificationId, title, message, trade.getId()));
     }
 
     private void dispatchTerminal(BisqEasyTrade trade, String terminalI18nKey) {
@@ -348,7 +349,7 @@ public class BisqEasyMobileTradeNotificationService implements Service {
         String title = Res.get("bisqEasy.mobileNotifications.tradeCompleted.title", shortTradeId);
         String message = Res.get("bisqEasy.mobileNotifications.tradeCompleted.message", peerName, terminalLabel);
         notificationService.dispatchMobileOnlyNotification(
-                new MobileTradeNotification(notificationIdFor(trade), title, message));
+                new MobileTradeNotification(notificationIdFor(trade), title, message, trade.getId()));
     }
 
     @Nullable

--- a/bisq-easy/src/main/java/bisq/bisq_easy/MobileTradeNotification.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/MobileTradeNotification.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Optional;
+
 /**
  * Lightweight {@link Notification} carrying a per-trade mobile push payload built by
  * {@link BisqEasyMobileTradeNotificationService}. Not persisted — only used as a
@@ -34,15 +36,28 @@ public final class MobileTradeNotification implements Notification {
     private final String id;
     private final String title;
     private final String message;
+    /**
+     * Raw bisq2 trade id — surfaced to the mobile relay so taps on the push
+     * deep-link straight to the trade screen. {@link #id} is a derived
+     * notification id ({@code "bisq-easy-mobile-trade-<short>"}) which is NOT
+     * the routable trade id, so we carry the raw value alongside.
+     */
+    private final String tradeId;
 
-    public MobileTradeNotification(String id, String title, String message) {
+    public MobileTradeNotification(String id, String title, String message, String tradeId) {
         this.id = id;
         this.title = title;
         this.message = message;
+        this.tradeId = tradeId;
     }
 
     @Override
     public Category getCategory() {
         return Category.TRADE_UPDATE;
+    }
+
+    @Override
+    public Optional<String> getTradeId() {
+        return Optional.ofNullable(tradeId);
     }
 }

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotification.java
@@ -46,6 +46,16 @@ public class ChatNotification implements Notification, PersistableProto {
         return Category.CHAT_MESSAGE;
     }
 
+    /**
+     * Exposes the per-channel tradeId (already tracked as a domain field) to the
+     * mobile relay so taps on a chat-message push deep-link straight to the
+     * relevant trade chat instead of the generic open-trade list.
+     */
+    @Override
+    public Optional<String> getTradeId() {
+        return tradeId;
+    }
+
     private final String id;
     private final String title;
     private final String message;

--- a/notifications/src/main/java/bisq/notifications/Notification.java
+++ b/notifications/src/main/java/bisq/notifications/Notification.java
@@ -3,6 +3,8 @@ package bisq.notifications;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Optional;
+
 public interface Notification {
     String getId();
 
@@ -16,6 +18,20 @@ public interface Notification {
      * banner rather than mis-tagging. */
     default Category getCategory() {
         return Category.GENERAL;
+    }
+
+    /**
+     * Trade-scoped identifier surfaced to the mobile relay so the client can
+     * deep-link a notification tap straight to the relevant trade screen
+     * ({@code bisq://OpenTrade/<tradeId>}) instead of the generic trade list.
+     * <p>
+     * Default {@link Optional#empty()} keeps non-trade notifications (alerts,
+     * generic announcements) on the category-based fallback route — mobile
+     * clients use the category to choose the destination when no tradeId is
+     * present (see {@code BisqFirebaseMessagingService.deepLinkRouteFor}).
+     */
+    default Optional<String> getTradeId() {
+        return Optional.empty();
     }
 
     /**

--- a/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationPayload.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationPayload.java
@@ -19,6 +19,7 @@ package bisq.notifications.mobile;
 
 import bisq.notifications.Notification;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -42,17 +43,30 @@ public class MobileNotificationPayload {
      * that don't emit the field, and newer producers that introduce new ids).
      */
     private final Notification.Category category;
+    /**
+     * Optional bisq2 trade id. When present, the mobile client routes a tap on
+     * the push notification straight to the trade screen
+     * ({@code bisq://OpenTrade/<tradeId>}) instead of the generic open-trade
+     * list. Omitted from the wire payload when {@code null} so older mobile
+     * clients (that don't parse this field) are unaffected.
+     * <p>
+     * See bisq-network/bisq-mobile#1395.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String tradeId;
 
     @JsonCreator
     public MobileNotificationPayload(
             @JsonProperty("id") String id,
             @JsonProperty("title") String title,
             @JsonProperty("message") String message,
-            @JsonProperty("category") Notification.Category category
+            @JsonProperty("category") Notification.Category category,
+            @JsonProperty("tradeId") String tradeId
     ) {
         this.id = id;
         this.title = title;
         this.message = message;
         this.category = category == null ? Notification.Category.GENERAL : category;
+        this.tradeId = tradeId;
     }
 }

--- a/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationService.java
+++ b/notifications/src/main/java/bisq/notifications/mobile/MobileNotificationService.java
@@ -69,7 +69,8 @@ public class MobileNotificationService implements Service {
                     MobileNotificationPayload payload = new MobileNotificationPayload(notification.getId(),
                             notification.getTitle(),
                             notification.getMessage(),
-                            notification.getCategory());
+                            notification.getCategory(),
+                            notification.getTradeId().orElse(null));
                     try {
                         String json = JsonMapperProvider.get().writeValueAsString(payload);
 

--- a/notifications/src/test/java/bisq/notifications/mobile/MobileNotificationPayloadCategoryTest.java
+++ b/notifications/src/test/java/bisq/notifications/mobile/MobileNotificationPayloadCategoryTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -51,7 +52,8 @@ class MobileNotificationPayloadCategoryTest {
                 "channel.msg-123",
                 "Alice (Bisq Easy → Open Trades → Bob)",
                 "hey, account info incoming",
-                Notification.Category.CHAT_MESSAGE);
+                Notification.Category.CHAT_MESSAGE,
+                null);
 
         String json = mapper.writeValueAsString(original);
         assertTrue(json.contains("\"category\":\"chat_message\""),
@@ -68,7 +70,8 @@ class MobileNotificationPayloadCategoryTest {
                 "trade-id.abcd",
                 "Trade abcd1234",
                 "Peer confirmed fiat receipt",
-                Notification.Category.TRADE_UPDATE);
+                Notification.Category.TRADE_UPDATE,
+                null);
 
         String json = mapper.writeValueAsString(original);
         assertTrue(json.contains("\"category\":\"trade_update\""), json);
@@ -107,7 +110,7 @@ class MobileNotificationPayloadCategoryTest {
         // Constructor normalises null → GENERAL, so the payload field is never null
         // at serialization time. The mobile client can therefore assume the JSON
         // always carries a `category` key — no `null` and no missing key.
-        MobileNotificationPayload general = new MobileNotificationPayload("i", "t", "m", null);
+        MobileNotificationPayload general = new MobileNotificationPayload("i", "t", "m", null, null);
 
         String json = mapper.writeValueAsString(general);
         assertTrue(json.contains("\"category\":\"general\""),
@@ -127,5 +130,55 @@ class MobileNotificationPayloadCategoryTest {
         assertEquals("trade_update", Notification.Category.TRADE_UPDATE.getId());
         assertEquals("offer_update", Notification.Category.OFFER_UPDATE.getId());
         assertEquals("general", Notification.Category.GENERAL.getId());
+    }
+
+    // ---------- tradeId (bisq-network/bisq-mobile#1395) ----------
+
+    @Test
+    void tradeIdRoundTripsThroughJsonWhenPresent() throws Exception {
+        MobileNotificationPayload original = new MobileNotificationPayload(
+                "bisq-easy-mobile-trade-abcd",
+                "Trade abcd1234",
+                "Peer confirmed fiat receipt",
+                Notification.Category.TRADE_UPDATE,
+                "trade-id-abcd-1234");
+
+        String json = mapper.writeValueAsString(original);
+        assertTrue(json.contains("\"tradeId\":\"trade-id-abcd-1234\""),
+                "tradeId must be serialized when present so the mobile client can deep-link: " + json);
+
+        MobileNotificationPayload decoded = mapper.readValue(json, MobileNotificationPayload.class);
+        assertEquals("trade-id-abcd-1234", decoded.getTradeId());
+        assertEquals(original, decoded);
+    }
+
+    @Test
+    void tradeIdIsOmittedFromWireWhenNullForBackwardCompatibility() throws Exception {
+        // Older mobile clients (pre-#1395) don't parse `tradeId`. Emitting the key
+        // as `null` would be tolerated, but omitting it entirely keeps the wire
+        // payload identical to what those clients have always seen. This is what
+        // the @JsonInclude(NON_NULL) annotation guarantees.
+        MobileNotificationPayload payload = new MobileNotificationPayload(
+                "id", "title", "message", Notification.Category.GENERAL, null);
+
+        String json = mapper.writeValueAsString(payload);
+        assertFalse(json.contains("tradeId"),
+                "tradeId must NOT appear on the wire when null — older clients " +
+                        "must see exactly the pre-#1395 payload shape: " + json);
+    }
+
+    @Test
+    void absentTradeIdInJsonDeserializesAsNull() throws Exception {
+        // Mirror of the older-bisq2 scenario: a payload produced before #1395
+        // arrives at a new mobile client. The deserializer must treat the
+        // missing field as null (not throw) so the mobile client falls back to
+        // category-based routing.
+        String legacyJson =
+                "{\"id\":\"x\",\"title\":\"t\",\"message\":\"m\",\"category\":\"trade_update\"}";
+
+        MobileNotificationPayload decoded = mapper.readValue(legacyJson, MobileNotificationPayload.class);
+
+        assertNull(decoded.getTradeId());
+        assertEquals(Notification.Category.TRADE_UPDATE, decoded.getCategory());
     }
 }


### PR DESCRIPTION
 - add support for including tradeId in relayed-notifications to enable secure and precise deep-linking to trade on notification tap
 - add AI generated related tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile notifications now support trade-specific deep linking, enabling direct navigation to relevant trades from push notifications.
  * Notification payload structure enhanced to include trade identifiers for improved routing on mobile clients.

* **Tests**
  * Expanded test coverage for notification JSON serialization and backward compatibility with legacy client payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->