### PR TITLE
Fix crash on empty address when creating new crypto account

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/ValidatorBase.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/validator/ValidatorBase.java
@@ -83,11 +83,11 @@ public class ValidatorBase {
      */
     protected void eval() {
         TextInputControl textField = (TextInputControl) srcControl.get();
-        String address = textField.getText();
-        if (StringUtils.isNotEmpty(address)) {
-            hasErrors.set(!validation.isValid(address));
+        String value = textField.getText();
+        if (StringUtils.isEmpty(value)) {
+            hasErrors.set(true);
         } else {
-            hasErrors.set(false);
+            hasErrors.set(!validation.isValid(value));
         }
     }
 


### PR DESCRIPTION
fixes #4682 

Crash occurred for any crypto account. This treats empty values as invalid.
There is potential improvements for the subaddress section but I see it as todo, I guess it is being done somewhere already but I can follow up if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation error handling for empty input fields to properly display required field errors instead of suppressing them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->