### PR TITLE
feature/dockerised_distrib_for_trusted_node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Keep the docker build context lean. The api-app image builds from source, so we
+# need the Gradle wrapper, build scripts and module sources — but not generated
+# output, caches, VCS or IDE files.
+.git
+.gradle
+**/build
+**/.gradle
+.idea
+*.iml
+.DS_Store
+**/.DS_Store
+*.log
+.sdkmanrc
+docs

--- a/apps/api-app/docker/Dockerfile
+++ b/apps/api-app/docker/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1
+#
+# Dockerised Bisq2 trusted node (api-app) — headless daemon for mobile clients.
+#
+# Build context MUST be the bisq2 repository root, e.g. from the repo root:
+#   docker build -f apps/api-app/docker/Dockerfile -t bisq2-api .
+#
+# Currently linux/amd64 only.
+# TODO(multi-arch): add linux/arm64 once the release pipeline does multi-arch builds.
+
+# ── Build stage: compile the api-app distribution from source ──────────────────
+# Self-contained: the image build runs the Gradle build itself, so no host build
+# step is required and the result is reproducible from the repo alone.
+#
+# Must be an Azul Zulu JDK 21: bisq2's Gradle toolchain pins vendor=AZUL
+# (e.g. :apps:desktop:bi2p), so a non-Azul JDK makes Gradle try to auto-download
+# Zulu — which fails (and picks the wrong arch) inside the container. This mirrors
+# the host's sdkman toolchain (.sdkmanrc -> java=21.x.fx-zulu).
+# TODO(build-speed): revisit this build strategy near the finish line — once a
+# release pipeline produces the distribution, this can switch to copying a
+# pre-built `installDist` artifact instead of rebuilding from source each time.
+#
+# Pinned by digest so the build is reproducible from the repo alone (the floating
+# :21 tag moves). Bump the digest when intentionally updating the build JDK.
+FROM azul/zulu-openjdk:21@sha256:fcf711e8fbcb7aa1371e1f831e5114c677e6e9134d9fdd2ee866c7d1027846e2 AS build
+WORKDIR /src
+COPY . .
+# installDist builds the api-app launcher plus every sibling module it depends on.
+# We deliberately do NOT run the full `build` task — packaging the daemon does not
+# need the whole repository's test suite.
+# auto-download=false forces Gradle to use the image's Azul JDK (auto-detected via
+# JAVA_HOME) rather than attempting to provision a toolchain (which fails in-container).
+# The --mount cache keeps the Gradle home (downloaded deps + compiled module output)
+# across builds, so a source change recompiles incrementally instead of from scratch.
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew --no-daemon \
+    -Dorg.gradle.java.installations.auto-download=false \
+    :apps:api-app:installDist
+
+# ── Runtime stage: minimal JRE + system Tor + the built distribution ───────────
+# Azul Zulu JRE to match the build JDK vendor (and bisq1's runtime), pinned by digest
+# for reproducibility. Bump the digest when intentionally updating the runtime JRE.
+FROM azul/zulu-openjdk:21-jre@sha256:97defd96b4ff0e00e3bce1ce66a3bc5a3d69dc05df04fc55030dc6f3b6376771
+
+LABEL org.opencontainers.image.title="Bisq2 trusted node (api-app)" \
+      org.opencontainers.image.description="Headless Bisq2 node exposing the api-app REST/WebSocket API, e.g. for mobile clients" \
+      org.opencontainers.image.source="https://github.com/bisq-network/bisq2" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
+
+# bisq2's bundled Tor mode on Linux launches the SYSTEM tor binary
+# (TorService#getTorBinaryPath -> EmbeddedTorProcess.getSystemTorPath()), so it must
+# be installed for the default (self-contained) Tor mode to work.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tor \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root runtime user. All persistent state lives under the /data mount.
+RUN useradd --system --create-home --home-dir /home/bisq --shell /usr/sbin/nologin bisq \
+    && mkdir -p /data \
+    && chown -R bisq:bisq /data
+
+# The trailing slash copies the distribution's CONTENTS (bin/, lib/) into
+# /opt/bisq2-api/, so the launcher lands at /opt/bisq2-api/bin/api-app.
+COPY --from=build /src/apps/api-app/build/install/api-app/ /opt/bisq2-api/
+# Fail the build early if the launcher isn't where the entrypoint expects it.
+RUN test -x /opt/bisq2-api/bin/api-app
+COPY apps/api-app/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER bisq
+WORKDIR /opt/bisq2-api
+
+# Single mount for all persistent state (identity, db, tor, pairing) so a host-level
+# backup of this one directory captures everything.
+ENV BISQ_DATA_DIR=/data
+VOLUME ["/data"]
+
+# WebSocket API. Bound to loopback inside the container by default; the host is
+# expected to forward/publish it as appropriate for the deployment.
+# TODO(healthcheck): add a HEALTHCHECK once the api-app exposes a dedicated health
+# endpoint — a plain GET on the WebSocket-only 8090 isn't a reliable liveness probe,
+# and the slim JRE base ships no curl/wget to call it with.
+EXPOSE 8090
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/apps/api-app/docker/README.md
+++ b/apps/api-app/docker/README.md
@@ -1,0 +1,71 @@
+# Dockerised Bisq2 trusted node (api-app)
+
+A headless Bisq2 trusted node (the `api-app`) packaged as a container, so a mobile
+client can pair with a self-hosted node without manually running a Java daemon.
+
+The shipped `api_app.conf` is already configured for headless operation: Tor
+transport, WebSocket-only API on `127.0.0.1:8090`, and it writes the pairing QR code
+to `pairing_qr_code.txt` in the data dir.
+
+> Currently **linux/amd64** only.
+> TODO(multi-arch): add `linux/arm64` once the release pipeline does multi-arch builds.
+
+## Build
+
+The build context is the **repository root** (the image builds the api-app from
+source). From the repo root:
+
+```bash
+docker build -f apps/api-app/docker/Dockerfile -t bisq2-api .
+```
+
+## Run
+
+All persistent state (identity, db, tor, pairing) lives under a single `/data` mount,
+so backing up that one directory captures everything.
+
+```bash
+docker run --rm \
+  -v bisq2-api-data:/data \
+  -p 8090:8090 \
+  bisq2-api
+```
+
+The node uses its **own bundled Tor** by default, so this works standalone. The
+pairing QR code is written to `/data/pairing_qr_code.txt`.
+
+> Always pass a named `-v <name>:/data` mount (as above). The image declares
+> `VOLUME /data`, so running without `-v` creates a fresh **anonymous** volume on
+> every `docker run` — your node identity/state is lost between runs and orphaned
+> volumes accumulate on the host.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BISQ_DATA_DIR` | `/data` | Data directory (single mount for all state). |
+| `PAIRING_TTL_SECONDS` | `86400` | Pairing-code lifetime (24h). |
+| `JAVA_OPTS` | — | Extra `-Dapplication.*` overrides, appended. |
+| `TOR_CONTROL_PORT` | — | If set, use an external Tor instead of the bundled one (see below). |
+| `TOR_CONTROL_HOST` | `127.0.0.1` | External Tor control host. |
+| `TOR_SOCKS_PORT` / `TOR_SOCKS_HOST` | — / `127.0.0.1` | External Tor SOCKS endpoint. |
+| `TOR_COOKIE_AUTH_FILE` | — | Path to the external Tor control auth cookie. |
+
+### External Tor
+
+Setting `TOR_CONTROL_PORT` makes the entrypoint write `${BISQ_DATA_DIR}/tor/external_tor.config`
+and enable external-Tor mode (`TOR_SKIP_LAUNCH=1`).
+
+> FIXME(external-tor): bisq2's external-Tor mode talks to Tor's **control port** (with
+> cookie auth) and discovers the SOCKS port from it — it does not just consume a SOCKS
+> port. `TorSocksProxyFactory` also hardcodes `127.0.0.1`, so the external Tor must be
+> reachable on the container's loopback. Reusing a host/shared Tor needs its control
+> port + auth cookie exposed on loopback inside the container; this is wired up when
+> integrating with the target self-hosting platform's bundled Tor.
+
+## Notes
+
+- Memory: set the container `mem_limit` to ~2g; the host should have ~4GB of free RAM.
+- TODO(build-speed): revisit the build-from-source approach near the finish line —
+  once a release pipeline produces the distribution, the Dockerfile can copy a
+  pre-built `installDist` instead of rebuilding from source.

--- a/apps/api-app/docker/entrypoint.sh
+++ b/apps/api-app/docker/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the dockerised Bisq2 trusted node (api-app).
+#
+# The shipped api_app.conf is already headless-correct (TOR transport, websocket
+# only, binds 127.0.0.1:8090, writes the pairing QR code to disk). This script only
+# points the app at the mounted data dir, applies a couple of deployment overrides,
+# and — optionally — wires it to an external Tor process.
+set -euo pipefail
+
+# All persistent state (identity, db, tor, pairing) lives under one mount so the
+# host's backup mechanism captures everything.
+DATA_DIR="${BISQ_DATA_DIR:-/data}"
+mkdir -p "${DATA_DIR}"
+
+# Config overrides are passed as `-Dapplication.*` JVM system properties (same
+# mechanism the repo's run_api.sh uses).
+JAVA_OPTS="${JAVA_OPTS:-} -Dapplication.baseDir=${DATA_DIR}"
+
+# Pairing-code lifetime. An always-on self-hosted node is paired only occasionally,
+# so default to 24h (override with PAIRING_TTL_SECONDS).
+JAVA_OPTS="${JAVA_OPTS} -Dapplication.api.pairing.ttlInSeconds=${PAIRING_TTL_SECONDS:-86400}"
+
+# ── Optional: use an external Tor process instead of the bundled one ───────────
+# Default is the bundled (system) Tor, so a plain `docker run` works standalone.
+# Set TOR_CONTROL_PORT to enable external-Tor mode.
+#
+# FIXME(external-tor): bisq2's external-Tor mode connects to Tor's CONTROL port with
+# cookie auth and discovers the SOCKS port from the control server (see TorService);
+# it does not simply consume a SOCKS port. TorSocksProxyFactory also hardcodes
+# 127.0.0.1, so the external Tor must be reachable on the container's loopback.
+# Reusing a host/shared Tor therefore requires its control port + auth cookie to be
+# made reachable on loopback inside the container — wire that up when integrating
+# with the target self-hosting platform's bundled Tor.
+if [ -n "${TOR_CONTROL_PORT:-}" ]; then
+    TOR_DIR="${DATA_DIR}/tor"
+    mkdir -p "${TOR_DIR}"
+    {
+        echo "UseExternalTor 1"
+        echo "ControlPort ${TOR_CONTROL_HOST:-127.0.0.1}:${TOR_CONTROL_PORT}"
+        if [ -n "${TOR_COOKIE_AUTH_FILE:-}" ]; then
+            echo "CookieAuthentication 1"
+            echo "CookieAuthFile ${TOR_COOKIE_AUTH_FILE}"
+        else
+            echo "CookieAuthentication 0"
+        fi
+        if [ -n "${TOR_SOCKS_PORT:-}" ]; then
+            echo "SocksPort ${TOR_SOCKS_HOST:-127.0.0.1}:${TOR_SOCKS_PORT}"
+        fi
+    } >"${TOR_DIR}/external_tor.config"
+    export TOR_SKIP_LAUNCH=1
+    echo "[entrypoint] external Tor enabled (control ${TOR_CONTROL_HOST:-127.0.0.1}:${TOR_CONTROL_PORT})"
+else
+    # No external Tor requested: drop any external_tor.config left by a previous
+    # external-Tor run, otherwise TorService reads its `UseExternalTor 1` and
+    # silently switches to external mode.
+    rm -f "${DATA_DIR}/tor/external_tor.config"
+    echo "[entrypoint] using bundled Tor"
+fi
+
+export JAVA_OPTS
+echo "[entrypoint] data dir: ${DATA_DIR}"
+
+exec /opt/bisq2-api/bin/api-app "$@"


### PR DESCRIPTION
 - contribs to https://github.com/bisq-network/bisq-mobile/issues/366

### Motivation

 - to distribute bisq2 api in popular Bitcoin-first app stores we need to be able to run it in a docker container. This is a first crucial step to achieve this goal. For devs this is useful, now images of the api can be added to a local docker

### dev logs

 - added docker setup for image generation of the api module (multi-staged, bundled tor, single data/ mount, non-root user)
 - added proper ignores and code comments
 - fully tested locally, can pair to the generated QR code and use the apps normally
 - expose default bisq-mobile websocket port 8090 for now (to be configurable in next PRs)
 - add README.md for docker + TODOs / FIXMEs for next steps
 
<img width="583" height="550" alt="Screenshot 2026-06-23 at 11 44 17" src="https://github.com/user-attachments/assets/6099aa8b-84f0-4414-8487-062b1816b296" />
<img width="996" height="116" alt="Screenshot 2026-06-23 at 11 34 26" src="https://github.com/user-attachments/assets/c7ccb629-eb8b-4b72-8019-37808f48c9eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Docker container support for the API app as a headless trusted node with persistent `/data`.
  * Exposes port **8090** and configures pairing TTL (default **86400s**).
  * Supports switching between bundled Tor and external Tor via environment settings; pairing QR output is written to the data directory.

* **Documentation**
  * Added a Docker README with build/run instructions, environment variable options, and operational notes (including memory guidance).

* **Chores**
  * Added a `.dockerignore` to reduce Docker build context and speed up builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->