### PR TITLE
Use O(1) lookups for trade item services

### DIFF
--- a/api/src/main/java/bisq/api/web_socket/domain/OpenTradeItemsService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/OpenTradeItemsService.java
@@ -56,6 +56,7 @@ public class OpenTradeItemsService implements Service {
     @Nullable
     private Pin channelsPin, tradesPin;
     private final Map<String, Pin> isInMediationPinMap = new HashMap<>();
+    private final Map<String, TradeItemPresentationDto> itemByTradeId = new HashMap<>();
 
     public OpenTradeItemsService(ChatService chatService,
                                  TradeService tradeService,
@@ -124,7 +125,7 @@ public class OpenTradeItemsService implements Service {
         }
         isInMediationPinMap.values().forEach(Pin::unbind);
         isInMediationPinMap.clear();
-        items.clear();
+        clearItems();
         return CompletableFuture.completedFuture(true);
     }
 
@@ -175,7 +176,7 @@ public class OpenTradeItemsService implements Service {
                                 log.warn("Channel with tradeId {} was removed but associated trade is not found but we still have the listItem with that trade. " +
                                         "We call handleTradeAndChannelRemoved.", tradeId);
 
-                                items.remove(listItem.get());
+                                removeItem(listItem.get());
                                 if (isInMediationPinMap.containsKey(tradeId)) {
                                     isInMediationPinMap.get(tradeId).unbind();
                                     isInMediationPinMap.remove(tradeId);
@@ -198,7 +199,7 @@ public class OpenTradeItemsService implements Service {
         }
 
         TradeItemPresentationDto item = TradeItemPresentationDtoFactory.create(trade, channel, userProfileService, reputationService);
-        items.add(item);
+        addItem(item);
 
         String tradeId = trade.getId();
         if (isInMediationPinMap.containsKey(tradeId)) {
@@ -221,7 +222,7 @@ public class OpenTradeItemsService implements Service {
         }
 
         TradeItemPresentationDto item = findListItem(trade).get();
-        items.remove(item);
+        removeItem(item);
 
         if (isInMediationPinMap.containsKey(tradeId)) {
             isInMediationPinMap.get(tradeId).unbind();
@@ -231,7 +232,7 @@ public class OpenTradeItemsService implements Service {
     }
 
     private void handleClearTradesAndChannels() {
-        items.clear();
+        clearItems();
 
         isInMediationPinMap.values().forEach(Pin::unbind);
         isInMediationPinMap.clear();
@@ -243,9 +244,23 @@ public class OpenTradeItemsService implements Service {
     }
 
     private Optional<TradeItemPresentationDto> findListItem(String tradeId) {
-        return items.stream()
-                .filter(item -> item.trade().id().equals(tradeId))
-                .findAny();
+        return Optional.ofNullable(itemByTradeId.get(tradeId));
+    }
+
+    // Keep the items list and the tradeId index in sync.
+    private void addItem(TradeItemPresentationDto item) {
+        items.add(item);
+        itemByTradeId.put(item.trade().id(), item);
+    }
+
+    private void removeItem(TradeItemPresentationDto item) {
+        items.remove(item);
+        itemByTradeId.remove(item.trade().id());
+    }
+
+    private void clearItems() {
+        items.clear();
+        itemByTradeId.clear();
     }
 
 

--- a/api/src/test/java/bisq/api/web_socket/domain/OpenTradeItemsServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/domain/OpenTradeItemsServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.domain;
+
+import bisq.api.dto.presentation.open_trades.TradeItemPresentationDto;
+import bisq.api.dto.presentation.open_trades.TradeItemPresentationDtoFactory;
+import bisq.api.dto.trade.bisq_easy.BisqEasyTradeDto;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
+import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelService;
+import bisq.common.observable.Observable;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.trade.TradeService;
+import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.bisq_easy.BisqEasyTradeService;
+import bisq.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the items list and the tradeId index stay in sync, so the O(1) findListItem lookups
+ * (dedup on add, retrieval on remove/clear) keep behaving like the previous linear scan.
+ */
+class OpenTradeItemsServiceTest {
+    private static final String TRADE_ID = "trade-1";
+
+    @Test
+    void addsItemOnceAndKeepsLookupInSyncOnRemove() {
+        ObservableSet<BisqEasyTrade> trades = new ObservableSet<>();
+        ObservableSet<BisqEasyOpenTradeChannel> channels = new ObservableSet<>();
+        BisqEasyTradeService bisqEasyTradeService = mock(BisqEasyTradeService.class);
+        BisqEasyOpenTradeChannelService channelService = mock(BisqEasyOpenTradeChannelService.class);
+        BisqEasyTrade trade = trade();
+        BisqEasyOpenTradeChannel channel = channel();
+        when(bisqEasyTradeService.findTrade(TRADE_ID)).thenReturn(Optional.of(trade));
+        when(channelService.findChannelByTradeId(TRADE_ID)).thenReturn(Optional.of(channel));
+
+        TradeItemPresentationDto itemDto = itemDto();
+        try (MockedStatic<TradeItemPresentationDtoFactory> factory = mockStatic(TradeItemPresentationDtoFactory.class)) {
+            factory.when(() -> TradeItemPresentationDtoFactory.create(any(), any(), any(), any()))
+                    .thenReturn(itemDto);
+            OpenTradeItemsService service = newService(trades, channels, bisqEasyTradeService, channelService);
+
+            // The same trade arrives via both the trade and the channel observer; the id index dedups it.
+            trades.add(trade);
+            channels.add(channel);
+            assertThat(service.getItems().size()).isEqualTo(1);
+
+            // Removing the trade clears the item, which only works if the id was still in the index.
+            trades.remove(trade);
+            assertThat(service.getItems().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    void clearAlsoClearsTheLookupIndex() {
+        ObservableSet<BisqEasyTrade> trades = new ObservableSet<>();
+        ObservableSet<BisqEasyOpenTradeChannel> channels = new ObservableSet<>();
+        BisqEasyTradeService bisqEasyTradeService = mock(BisqEasyTradeService.class);
+        BisqEasyOpenTradeChannelService channelService = mock(BisqEasyOpenTradeChannelService.class);
+        BisqEasyTrade trade = trade();
+        BisqEasyOpenTradeChannel channel = channel();
+        when(channelService.findChannelByTradeId(TRADE_ID)).thenReturn(Optional.of(channel));
+
+        TradeItemPresentationDto itemDto = itemDto();
+        try (MockedStatic<TradeItemPresentationDtoFactory> factory = mockStatic(TradeItemPresentationDtoFactory.class)) {
+            factory.when(() -> TradeItemPresentationDtoFactory.create(any(), any(), any(), any()))
+                    .thenReturn(itemDto);
+            OpenTradeItemsService service = newService(trades, channels, bisqEasyTradeService, channelService);
+
+            trades.add(trade);
+            assertThat(service.getItems().size()).isEqualTo(1);
+
+            trades.clear();
+            assertThat(service.getItems().isEmpty()).isTrue();
+
+            // Re-adding the same trade recreates the item; if the index had not been cleared it would be deduped away.
+            trades.add(trade);
+            assertThat(service.getItems().size()).isEqualTo(1);
+        }
+    }
+
+    private OpenTradeItemsService newService(ObservableSet<BisqEasyTrade> trades,
+                                             ObservableSet<BisqEasyOpenTradeChannel> channels,
+                                             BisqEasyTradeService bisqEasyTradeService,
+                                             BisqEasyOpenTradeChannelService channelService) {
+        when(bisqEasyTradeService.getTrades()).thenReturn(trades);
+        when(channelService.getChannels()).thenReturn(channels);
+
+        ChatService chatService = mock(ChatService.class);
+        when(chatService.getBisqEasyOpenTradeChannelService()).thenReturn(channelService);
+        TradeService tradeService = mock(TradeService.class);
+        when(tradeService.getBisqEasyTradeService()).thenReturn(bisqEasyTradeService);
+        UserService userService = mock(UserService.class, RETURNS_DEEP_STUBS);
+
+        OpenTradeItemsService service = new OpenTradeItemsService(chatService, tradeService, userService);
+        service.initialize().join();
+        return service;
+    }
+
+    private BisqEasyTrade trade() {
+        BisqEasyTrade trade = mock(BisqEasyTrade.class);
+        when(trade.getId()).thenReturn(TRADE_ID);
+        return trade;
+    }
+
+    private BisqEasyOpenTradeChannel channel() {
+        BisqEasyOpenTradeChannel channel = mock(BisqEasyOpenTradeChannel.class);
+        when(channel.getTradeId()).thenReturn(TRADE_ID);
+        when(channel.isInMediation()).thenReturn(false);
+        when(channel.isInMediationObservable()).thenReturn(new Observable<>(false));
+        return channel;
+    }
+
+    private TradeItemPresentationDto itemDto() {
+        BisqEasyTradeDto tradeDto = mock(BisqEasyTradeDto.class);
+        when(tradeDto.id()).thenReturn(TRADE_ID);
+        TradeItemPresentationDto item = mock(TradeItemPresentationDto.class);
+        when(item.trade()).thenReturn(tradeDto);
+        return item;
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryController.java
@@ -35,8 +35,10 @@ import bisq.trade.bisq_easy.protocol.BisqEasyClosedTrade;
 import bisq.user.reputation.ReputationService;
 import lombok.Getter;
 
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class BisqEasyHistoryController implements Controller {
@@ -49,6 +51,7 @@ public class BisqEasyHistoryController implements Controller {
     private final DontShowAgainService dontShowAgainService;
     private Pin closedTradesPin;
     private String searchText = "";
+    private final Set<String> knownTradeIds = new HashSet<>();
 
     public BisqEasyHistoryController(ServiceProvider serviceProvider) {
         model = new BisqEasyHistoryModel();
@@ -64,7 +67,7 @@ public class BisqEasyHistoryController implements Controller {
         closedTradesPin = bisqEasyTradeService.getClosedTrades().addObserver(new CollectionObserver<>() {
             @Override
             public void onAdded(BisqEasyClosedTrade closedTrade) {
-                if (findListItem(closedTrade.trade().getId()).isEmpty()) {
+                if (knownTradeIds.add(closedTrade.trade().getId())) {
                     model.getBisqEasyTradeHistoryListItems().add(
                             new BisqEasyTradeHistoryListItem(closedTrade, reputationService, marketPriceService));
                     updatePlaceholderText();
@@ -74,9 +77,8 @@ public class BisqEasyHistoryController implements Controller {
             @Override
             public void onRemoved(Object element) {
                 if (element instanceof BisqEasyClosedTrade closedTrade) {
-                    model.getBisqEasyTradeHistoryListItems().stream()
-                            .filter(item -> item.getTrade().equals(closedTrade.trade()))
-                            .findFirst()
+                    knownTradeIds.remove(closedTrade.trade().getId());
+                    findListItem(closedTrade.trade().getId())
                             .ifPresent(item -> model.getBisqEasyTradeHistoryListItems().remove(item));
                     updatePlaceholderText();
                 }
@@ -85,6 +87,7 @@ public class BisqEasyHistoryController implements Controller {
             @Override
             public void onCleared() {
                 model.getBisqEasyTradeHistoryListItems().clear();
+                knownTradeIds.clear();
                 updatePlaceholderText();
             }
         });


### PR DESCRIPTION
## What

Replaces the `O(n)` `findListItem` stream scans used to dedup and look up trade items by id with `O(1)` lookups.

- **`BisqEasyHistoryController`** keeps a `Set<String>` of known trade ids for the existence check on add.
- **`OpenTradeItemsService`** keeps a `Map<String, item>` so the by-id lookups it also does on update and remove are `O(1)`. All list mutations go through small `addItem`/`removeItem`/`clearItems` helpers so the map can't drift from the `items` list.

## Scope

The original target `ClosedTradeItemsService` no longer exists on `main` (it was dropped before #4700 merged). After checking with @rodvar, the agreed scope is `BisqEasyHistoryController` (Set) + `OpenTradeItemsService` (Map, since it retrieves items by id, not just checks existence). The two larger desktop controllers with the same pattern (`BisqEasyOpenTradesController`, `MuSigPendingTradesController`) are intentionally left as a follow-up — small lists, and not worth the churn here.

## Tests

Adds `OpenTradeItemsServiceTest` covering the add/dedup, remove and clear paths, so the items list and the id index can't fall out of sync. `BisqEasyHistoryController` is a UI controller with no test precedent, so it's covered by inspection only.

Fixes #4722


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of open trades so items stay consistent across updates, removals, and resets.
  * Fixed duplicate entries in trade history and made cleared/re-added trades appear correctly.
* **Quality**
  * Added automated coverage for trade item syncing and history deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->