### PR TITLE
Don't record history for automatic tab selection

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/Navigation.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/Navigation.java
@@ -72,6 +72,11 @@ public class Navigation {
         currentNavigationTarget.set(navigationTarget);
     }
 
+    public static void navigateToWithoutAddingToHistory(NavigationTarget navigationTarget) {
+        dispatch(navigationTarget, Optional.empty());
+        currentNavigationTarget.set(navigationTarget);
+    }
+
     // Dispatches the target to each registered host along its navigation path, from the root down to
     // the target. Iterating the path in order (rather than the unordered controllers map) processes
     // parents before children, so a host that lazily creates a child host on its path registers that

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/common/view/TabController.java
@@ -39,25 +39,36 @@ public abstract class TabController<T extends TabModel> extends NavigationContro
     public void onActivateInternal() {
         super.onActivateInternal();
 
-        onTabSelected(model.getNavigationTarget());
+        selectTabWithoutHistory(model.getNavigationTarget());
     }
 
     @Override
     protected void onNavigationTargetApplied(NavigationTarget navigationTarget, Optional<Object> data) {
         if (model.getSelectedTabButton().get() != null &&
                 navigationTarget != model.getSelectedTabButton().get().getNavigationTarget()) {
-            onTabSelected(navigationTarget);
+            selectTabWithoutHistory(navigationTarget);
         }
     }
 
     void onTabSelected(NavigationTarget navigationTarget) {
-        findTabButton(navigationTarget).ifPresent(tabButton -> {
-            if (Objects.equals(model.getSelectedTabButton().get(), tabButton)) {
-                return;
-            }
-            model.getSelectedTabButton().set(tabButton);
+        if (selectTabButton(navigationTarget)) {
             Navigation.navigateTo(navigationTarget);
-        });
+        }
+    }
+
+    private void selectTabWithoutHistory(NavigationTarget navigationTarget) {
+        if (selectTabButton(navigationTarget)) {
+            Navigation.navigateToWithoutAddingToHistory(navigationTarget);
+        }
+    }
+
+    private boolean selectTabButton(NavigationTarget navigationTarget) {
+        Optional<TabButton> tabButton = findTabButton(navigationTarget);
+        if (tabButton.isEmpty() || Objects.equals(model.getSelectedTabButton().get(), tabButton.get())) {
+            return false;
+        }
+        model.getSelectedTabButton().set(tabButton.get());
+        return true;
     }
 
     void onTabButtonCreated(TabButton tabButton) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/AuthorizedRoleView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/authorized_role/AuthorizedRoleView.java
@@ -109,7 +109,8 @@ public class AuthorizedRoleView extends ContentTabView<AuthorizedRoleModel, Auth
                 break;
             }
         }
-        Navigation.navigateTo(model.getSelectedTabButton().get().getNavigationTarget());
+        // Automatic selection of the first visible role tab, not a user click, so skip history.
+        Navigation.navigateToWithoutAddingToHistory(model.getSelectedTabButton().get().getNavigationTarget());
     }
 
     @Override

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/common/view/NavigationControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/common/view/NavigationControllerTest.java
@@ -33,8 +33,37 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * unordered controllers map, so the lazily-created CHAT host could register after the dispatch had
  * already passed it and never received the target. Dispatch now follows the navigation path
  * (parents before children) so a host created by its parent mid-dispatch is reached afterwards.
+ * Also covers the history-recording behaviour behind #4821 (automatic tab selection must not push a
+ * history entry).
  */
 class NavigationControllerTest {
+
+    // --- history: automatic tab selection dispatches but must not record a history entry (#4821) ---
+
+    @Test
+    void navigateToWithoutAddingToHistoryDoesNotAffectBackNavigation() {
+        List<NavigationTarget> processOrder = new ArrayList<>();
+        RecordingController chat = new RecordingController(NavigationTarget.CHAT, processOrder);
+        Navigation.addNavigationController(NavigationTarget.CHAT, chat);
+        try {
+            // A user-initiated navigation records a history entry...
+            Navigation.navigateTo(NavigationTarget.CHAT_PRIVATE);
+            // ...while an automatic tab selection dispatches the target but must not record one.
+            Navigation.navigateToWithoutAddingToHistory(NavigationTarget.CHAT_DISCUSSION);
+
+            // Both were dispatched to the host.
+            assertEquals(List.of(NavigationTarget.CHAT_PRIVATE, NavigationTarget.CHAT_DISCUSSION),
+                    chat.received);
+
+            // Back returns to the recorded target (CHAT_PRIVATE), proving the automatic selection
+            // (CHAT_DISCUSSION) never entered the history.
+            Navigation.back();
+            assertEquals(List.of(NavigationTarget.CHAT_PRIVATE, NavigationTarget.CHAT_DISCUSSION,
+                    NavigationTarget.CHAT_PRIVATE), chat.received);
+        } finally {
+            Navigation.removeNavigationController(NavigationTarget.CHAT, chat);
+        }
+    }
 
     // --- dispatch ordering: a host registered by its parent mid-dispatch must still be reached ---
 


### PR DESCRIPTION
## Problem

Fixes #4821. A tab host auto-selects its default or persisted tab when it activates, and a deep-target dispatch later corrects that selection. Both paths went through `Navigation.navigateTo`, which records a navigation-history entry as if the user had clicked the tab.

In practice, opening a private chat from outside the Chat screen (the lazy Chat-host flow from #4114) records a spurious `CHAT_DISCUSSION` entry, the cold host's default tab, before correcting to `CHAT_PRIVATE`. A `back()` from there would land on the Discussion channel rather than the user's actual origin.

## Fix

Record a history entry only for user-initiated tab clicks. Automatic selections (the initial/persisted tab and deep-target corrections) now go through a new `Navigation.navigateToWithoutAddingToHistory`, which dispatches and updates the current target but leaves the history untouched, mirroring the existing `navigateTo(target, data)` overload.

`TabController` routes the user-click path and the two automatic paths through separate named methods (`onTabSelected` and `selectTabWithoutHistory`) sharing a `selectTabButton` helper, which avoids a boolean flag argument. `AuthorizedRoleView` auto-selects the first visible role tab directly (from view-attach and a role-list listener, never a user click), so it points at the same no-history method.

## Note

The history list is currently maintained on every navigation but not consumed by any UI control, since there is no back or forward affordance wired up today. This change keeps the history accurate for whenever one is added, and is the follow-up agreed in #4114.

## Testing

- New unit test `NavigationControllerTest.navigateToWithoutAddingToHistoryDoesNotAffectBackNavigation`: a user navigation and an automatic selection both dispatch to the host, but `back()` returns the user-navigated target, proving the automatic selection never entered the history. Reuses the existing `RecordingController` harness.
- Full `:apps:desktop:desktop:test` green (82 tests).
- Verified live by reading the running app's `Navigation.history` before and after the fix: without it the history contains the spurious `CHAT_DISCUSSION` entry (plus a duplicate `MU_SIG_OFFERBOOK` from the MuSig tab host's auto-select); with it, every entry corresponds to a real user navigation.
