### PR TITLE
Add missing `depositPsbt` field to `SetupTradeMessage_D` to fix API usage

### DIFF
--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/SetupTradeMessage_D.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/SetupTradeMessage_D.java
@@ -19,26 +19,31 @@ package bisq.trade.mu_sig.messages.network;
 
 import bisq.network.identity.NetworkId;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.PartialSignatures;
-import lombok.EqualsAndHashCode;
+import com.google.protobuf.ByteString;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 @Slf4j
 @ToString(callSuper = true)
 @Getter
-@EqualsAndHashCode(callSuper = true)
 public final class SetupTradeMessage_D extends MuSigTradeMessage {
     private final PartialSignatures partialSignatures;
+    private final byte[] depositPsbt;
 
     public SetupTradeMessage_D(String id,
                                String tradeId,
                                String protocolVersion,
                                NetworkId sender,
                                NetworkId receiver,
-                               PartialSignatures partialSignatures) {
+                               PartialSignatures partialSignatures,
+                               byte[] depositPsbt) {
         super(id, tradeId, protocolVersion, sender, receiver);
         this.partialSignatures = partialSignatures;
+        this.depositPsbt = depositPsbt;
 
         verify();
     }
@@ -61,7 +66,8 @@ public final class SetupTradeMessage_D extends MuSigTradeMessage {
 
     private bisq.trade.protobuf.SetupTradeMessage_D.Builder getSetupTradeMessage_D(boolean serializeForHash) {
         return bisq.trade.protobuf.SetupTradeMessage_D.newBuilder()
-                .setPartialSignatures(partialSignatures.toProto(serializeForHash));
+                .setPartialSignatures(partialSignatures.toProto(serializeForHash))
+                .setDepositPsbt(ByteString.copyFrom(depositPsbt));
     }
 
     public static SetupTradeMessage_D fromProto(bisq.trade.protobuf.TradeMessage proto) {
@@ -72,11 +78,27 @@ public final class SetupTradeMessage_D extends MuSigTradeMessage {
                 proto.getProtocolVersion(),
                 NetworkId.fromProto(proto.getSender()),
                 NetworkId.fromProto(proto.getReceiver()),
-                PartialSignatures.fromProto(muSigMessageProto.getPartialSignatures()));
+                PartialSignatures.fromProto(muSigMessageProto.getPartialSignatures()),
+                muSigMessageProto.getDepositPsbt().toByteArray());
     }
 
     @Override
     public double getCostFactor() {
         return getCostFactor(0.1, 0.3);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || o instanceof SetupTradeMessage_D that && super.equals(o) &&
+                Objects.equals(partialSignatures, that.partialSignatures) &&
+                Arrays.equals(depositPsbt, that.depositPsbt);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Objects.hashCode(partialSignatures);
+        result = 31 * result + Arrays.hashCode(depositPsbt);
+        return result;
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSetupTradeMessage_C_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/BaseSetupTradeMessage_C_Handler.java
@@ -93,7 +93,8 @@ public abstract class BaseSetupTradeMessage_C_Handler extends MuSigTradeMessageH
                 trade.getProtocolVersion(),
                 trade.getMyIdentity().getNetworkId(),
                 trade.getPeer().getNetworkId(),
-                getPartialSignatures()));
+                getPartialSignatures(),
+                myDepositPsbt.getDepositPsbt()));
     }
 
     protected abstract PartialSignatures getPartialSignatures();
@@ -103,6 +104,6 @@ public abstract class BaseSetupTradeMessage_C_Handler extends MuSigTradeMessageH
         String role = trade.isBuyer() ? "Maker (as buyer)" : "Maker (as seller)";
         sendLogMessage(role + " received peers nonceShares and partialSignatures.\n" +
                 role + " created his partialSignatures and depositPsbt.\n" +
-                role + " sent his partialSignatures to buyer.");
+                role + " sent his partialSignatures and depositPsbt to buyer.");
     }
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_D_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/taker/BaseSetupTradeMessage_D_Handler.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class BaseSetupTradeMessage_D_Handler extends MuSigTradeMessageHandlerAsMessageSender<MuSigTrade, SetupTradeMessage_D> {
     protected PartialSignatures peersPartialSignatures;
+    protected DepositPsbt peersDepositPsbt;
     protected DepositPsbt myDepositPsbt;
 
     public BaseSetupTradeMessage_D_Handler(ServiceProvider serviceProvider, MuSigTrade model) {
@@ -49,6 +50,7 @@ public abstract class BaseSetupTradeMessage_D_Handler extends MuSigTradeMessageH
     @Override
     protected void process(SetupTradeMessage_D message) {
         peersPartialSignatures = message.getPartialSignatures();
+        peersDepositPsbt = new DepositPsbt(message.getDepositPsbt());
 
         PartialSignaturesMessage peersPartialSignaturesMessage = PartialSignaturesMessage.from(peersPartialSignatures);
         DepositTxSignatureRequest depositTxSignatureRequest = DepositTxSignatureRequest.newBuilder()
@@ -59,7 +61,7 @@ public abstract class BaseSetupTradeMessage_D_Handler extends MuSigTradeMessageH
 
         PublishDepositTxRequest publishDepositTxRequest = PublishDepositTxRequest.newBuilder()
                 .setTradeId(trade.getId())
-                .setPeersDepositPsbt(myDepositPsbt.toProto(true))
+                .setPeersDepositPsbt(peersDepositPsbt.toProto(true))
                 .build();
         blockingStub.publishDepositTx(publishDepositTxRequest);
     }
@@ -71,6 +73,7 @@ public abstract class BaseSetupTradeMessage_D_Handler extends MuSigTradeMessageH
 
         mySelf.setMyDepositPsbt(myDepositPsbt);
         peer.setPeersPartialSignatures(peersPartialSignatures);
+        peer.setMyDepositPsbt(peersDepositPsbt);
     }
 
     @Override
@@ -93,7 +96,7 @@ public abstract class BaseSetupTradeMessage_D_Handler extends MuSigTradeMessageH
 
     @Override
     protected void sendLogMessage() {
-        sendLogMessage("Taker received peers partialSignatures.\n" +
+        sendLogMessage("Taker received peers partialSignatures and depositPsbt.\n" +
                 "Taker created depositPsbt.\n" +
                 "Taker published deposit tx.\n" +
                 "Taker sends deposit tx and account payload to maker");

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -297,6 +297,7 @@ message SetupTradeMessage_C {
 
 message SetupTradeMessage_D {
   PartialSignatures partialSignatures = 1;
+  bytes depositPsbt = 2;
 }
 
 message SendAccountPayloadAndDepositTxMessage {


### PR DESCRIPTION
Fix incorrect usage of the `Musig` gRPC API, whereby the trader's own Deposit PSBT (with only his input signatures) was passed back to the server in the `PublishDepositTx` call, instead of using the peer's Deposit PSBT, which should have been passed in `SetupTradeMessage_D`. This was causing an incompletely signed Deposit Tx to be mock-broadcast, which did not show up as an error in the server logs until recent extra validation was added to the Rust side.

Add the missing `SetupTradeMessage_D.depositPsbt` proto field needed to use the API correctly, typed as a raw byte array, and update the Message C & D handlers as appropriate.

--

Looking at the surrounding code, I wasn't sure of exactly the best type to use for the `SetupTradeMessage_D.depositPsbt` proto field, but could see three options:
1. Use a raw byte array, which has the advantage of defaulting to empty rather than null, avoiding any breakage from old persisted messages, but requires boilerplate `equals` & `hashCode` methods to be added;
2. Use a `common.ByteArray` proto to minimise boilerplate (and get a better `toString` implementation), but is technically a breaking change without added null-tolerance;
3. Add an extra (single-field) `DepositPsbt` value object to `trade.proto`, to mirror the `DepositPsbt` gRPC message, for consistency, but adding it to `SetupTradeMessage_D` is still technically a breaking change without null-tolerance.

I opted for (1) but could easily switch the code over to (2) or (3) if that would be better.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade setup messages now include the deposit PSBT alongside partial signatures.
  * The trade flow now carries and stores both pieces of data for the next step in the process.

* **Bug Fixes**
  * Improved consistency when comparing trade setup messages by including the deposit PSBT in equality and hashing.
  * Updated handoff handling so the received deposit PSBT is preserved and used correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->