### PR TITLE
Add export to bisq easy history

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/TradesUtils.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/TradesUtils.java
@@ -1,4 +1,21 @@
-package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy;
 
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelService;
@@ -11,9 +28,11 @@ import bisq.desktop.common.utils.FileChooserUtil;
 import bisq.desktop.components.overlay.Popup;
 import bisq.i18n.Res;
 import bisq.offer.price.spec.FixPriceSpec;
-import bisq.offer.price.spec.PriceSpecFormatter;
+import bisq.offer.price.spec.FloatPriceSpec;
+import bisq.offer.price.spec.PriceSpec;
 import bisq.presentation.formatters.AmountFormatter;
 import bisq.presentation.formatters.DateFormatter;
+import bisq.presentation.formatters.PercentageFormatter;
 import bisq.presentation.formatters.PriceFormatter;
 import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
@@ -26,7 +45,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Slf4j
-public class OpenTradesUtils {
+public class TradesUtils {
 
     public static void exportTrade(BisqEasyTrade trade, Scene scene) {
         try {
@@ -41,46 +60,58 @@ public class OpenTradesUtils {
             String quoteCurrencyCode = trade.getOffer().getMarket().getQuoteCurrencyCode();
             long baseSideAmount = contract.getBaseSideAmount();
             long quoteSideAmount = contract.getQuoteSideAmount();
-            String formattedBaseAmount = AmountFormatter.formatBaseAmountWithCode(Coin.asBtcFromValue(baseSideAmount));
-            String formattedQuoteAmount = AmountFormatter.formatQuoteAmountWithCode(Fiat.from(quoteSideAmount, quoteCurrencyCode));
+            String formattedBaseAmount = AmountFormatter.formatBaseAmount(Coin.asBtcFromValue(baseSideAmount));
+            String formattedQuoteAmount = AmountFormatter.formatQuoteAmount(Fiat.from(quoteSideAmount, quoteCurrencyCode));
             String priceCodes = trade.getOffer().getMarket().getMarketCodes();
-            String priceSpec = trade.getOffer().getPriceSpec() instanceof FixPriceSpec ?
-                    "" :
-                    String.format("(%s)",
-                    PriceSpecFormatter.getFormattedPriceSpec(trade.getOffer().getPriceSpec(), true));
+            PriceSpec priceSpec = trade.getOffer().getPriceSpec();
+            String priceSpecString = priceSpec.getDisplayName();
             String price = PriceFormatter.format(contract.getPriceQuote());
-            price = String.format("%s %s %s", price, priceCodes, priceSpec);
+            String pricePercentage = priceSpec instanceof FixPriceSpec
+                    ? ""
+                    : PercentageFormatter.formatToPercentWithSignAndSymbol(
+                            priceSpec instanceof FloatPriceSpec floatPriceSpec
+                                    ? floatPriceSpec.getPercentage()
+                                    : 0
+                    );
             String paymentProof = trade.getPaymentProof().orElseGet(() -> Res.get("data.na"));
             String bitcoinPaymentData = trade.getBitcoinPaymentData().orElseGet(() -> Res.get("data.na"));
             String bitcoinMethod = contract.getBaseSidePaymentMethodSpec().getDisplayString();
             String fiatMethod = contract.getQuoteSidePaymentMethodSpec().getDisplayString();
-            String paymentMethod = bitcoinMethod + " / " + fiatMethod;
+            String paymentMethod = String.format("%s / %s", fiatMethod, bitcoinMethod);
             Long date = trade.getTradeCompletedDate().orElse(contract.getTakeOfferDate());
             String formattedDate = DateFormatter.formatDateTime(date);
             List<String> headers = List.of(
-                    Res.get("bisqEasy.openTrades.table.tradeId"),
-                    Res.get("bisqEasy.openTrades.table.makerTakerRole"),
-                    Res.get("bisqEasy.openTrades.csv.offerType"),
-                    Res.get("bisqEasy.openTrades.table.baseAmount"),
-                    Res.get("bisqEasy.openTrades.csv.quoteAmount", quoteCurrencyCode),
-                    Res.get("bisqEasy.openTrades.csv.price"),
-                    Res.get("bisqEasy.openTrades.csv.txIdOrPreimage"),
-                    Res.get("bisqEasy.openTrades.csv.receiverAddressOrInvoice"),
-                    Res.get("bisqEasy.openTrades.csv.paymentMethod"),
-                    Res.get("bisqEasy.openTrades.csv.date")
-            );
+                    Res.get("bisqEasy.openTrades.table.tradeId").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.csv.date").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.table.makerTakerRole").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.csv.offerType").toUpperCase(),
+                    Res.get("bisqEasy.history.table.csv.quoteAmount").toUpperCase(),
+                    Res.get("bisqEasy.history.table.csv.quoteAmountCurrencyCode").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.table.baseAmount").toUpperCase(),
+                    Res.get("bisqEasy.history.table.csv.tradePrice").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.csv.market").toUpperCase(),
+                    Res.get("bisqEasy.history.table.csv.pricePercentage").toUpperCase(),
+                    Res.get("bisqEasy.history.table.csv.priceModality").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.csv.paymentMethod").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.csv.receiverAddressOrInvoice").toUpperCase(),
+                    Res.get("bisqEasy.openTrades.csv.txIdOrPreimage").toUpperCase()
+                    );
             List<List<String>> tradeData = List.of(
                     List.of(
                             tradeId,
+                            formattedDate,
                             role,
                             offerType,
-                            formattedBaseAmount,
                             formattedQuoteAmount,
+                            quoteCurrencyCode,
+                            formattedBaseAmount,
                             price,
-                            paymentProof,
-                            bitcoinPaymentData,
+                            priceCodes,
+                            pricePercentage,
+                            priceSpecString,
                             paymentMethod,
-                            formattedDate
+                            bitcoinPaymentData,
+                            paymentProof
                     )
             );
             String csv = Csv.toCsv(headers, tradeData);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryController.java
@@ -27,7 +27,7 @@ import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
-import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.OpenTradesUtils;
+import bisq.desktop.main.content.bisq_easy.TradesUtils;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.i18n.Res;
 import bisq.settings.DontShowAgainService;
@@ -123,7 +123,7 @@ public class BisqEasyHistoryController implements Controller {
     }
 
     void onExportTradeData(BisqEasyTrade trade) {
-        OpenTradesUtils.exportTrade(trade, getView().getRoot().getScene());
+        TradesUtils.exportTrade(trade, getView().getRoot().getScene());
     }
 
     void onDeleteTrade(BisqEasyTrade trade) {
@@ -159,8 +159,8 @@ public class BisqEasyHistoryController implements Controller {
                 || item.getMarket().getBaseCurrencyCode().toLowerCase().contains(searchText)
                 || item.getMarket().getQuoteCurrencyCode().toLowerCase().contains(searchText)
                 || item.getBaseAmountString().toLowerCase().contains(searchText)
-                || item.getQuoteAmountString().toLowerCase().contains(searchText)
-                || item.getPriceString().toLowerCase().contains(searchText)
+                || item.getQuoteAmountWithCodeString().toLowerCase().contains(searchText)
+                || item.getPriceWithCodeString().toLowerCase().contains(searchText)
                 || item.getPaymentMethodAsString().toLowerCase().contains(searchText)
                 || item.getMyRole().toLowerCase().contains(searchText);
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryView.java
@@ -45,6 +45,9 @@ import javafx.scene.layout.VBox;
 import javafx.util.Callback;
 
 import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEasyHistoryController> {
     private static final double SIDE_PADDING = 40;
@@ -61,8 +64,6 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 Res.get("bisqEasy.history.numTrades"),
                 controller::applySearchPredicate);
         tableView.getStyleClass().add("bisq-easy-history-table");
-        tableView.getExportButton().setVisible(false);
-        tableView.getExportButton().setManaged(false);
         tableView.getTableView().setPlaceholder(placeholderLabel);
         configTableView();
 
@@ -74,6 +75,76 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
     protected void onViewAttached() {
         placeholderLabel.textProperty().bind(model.getPlaceholderText());
         tableView.initialize();
+
+        List<String> csvHeaders = tableView.buildCsvHeaders();
+        csvHeaders.add(Res.get("bisqEasy.history.table.tradeId").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.date").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.myRole").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.offerType").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.quoteAmount").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.quoteAmountCurrencyCode").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.baseAmount").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.tradePrice").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.market").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.pricePercentage").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.priceModality").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.payment").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.receiverAddressOrInvoice").toUpperCase());
+        csvHeaders.add(Res.get("bisqEasy.history.table.csv.txIdOrPreimage").toUpperCase());
+        tableView.setCsvHeaders(Optional.of(csvHeaders));
+
+        List<List<String>> csvData = tableView.getItems().stream()
+                .map(item -> {
+                    List<String> cellDataInRow = tableView.getBisqTableColumnsForCsv()
+                            .map(bisqTableColumn -> bisqTableColumn.resolveValueForCsv(item))
+                            .collect(Collectors.toList());
+
+                    // Add trade id
+                    cellDataInRow.add(item.getTradeId());
+
+                    // Add date
+                    cellDataInRow.add(item.getDateTimeString());
+
+                    // Add my role
+                    cellDataInRow.add(item.getMyRole());
+
+                    // Add offer type
+                    cellDataInRow.add(item.getOfferType());
+
+                    // Add quote amount
+                    cellDataInRow.add(item.getQuoteAmountString());
+
+                    // Add quote currency code
+                    cellDataInRow.add(item.getMarket().getQuoteCurrencyCode());
+
+                    // Add base amount
+                    cellDataInRow.add(item.getBaseAmountString());
+
+                    // Add price
+                    cellDataInRow.add(item.getPriceString());
+
+                    // Add market
+                    cellDataInRow.add(item.getMarket().getMarketCodes());
+
+                    // Add price percentage
+                    cellDataInRow.add(item.getPricePercentage());
+
+                    // Add price modality
+                    cellDataInRow.add(item.getPriceModality());
+
+                    // Add payment methods
+                    cellDataInRow.add(item.getPaymentMethodAsString());
+
+                    // Add receiver address or invoice
+                    cellDataInRow.add(item.getReceiverAddressOrInvoice());
+
+                    // Add transaction ID or preimage
+                    cellDataInRow.add(item.getTxIdOrPreimage());
+
+                    return cellDataInRow;
+                })
+                .collect(Collectors.toList());
+        tableView.setCsvData(Optional.of(csvData));
     }
 
     @Override
@@ -99,12 +170,14 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .left()
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getMyUserName))
                 .setCellFactory(getMyUserCellFactory())
+                .includeForCsv(false)
                 .build());
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
                 .minWidth(95)
                 .left()
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getDirectionalTitle))
                 .valueSupplier(BisqEasyTradeHistoryListItem::getDirectionalTitle)
+                .includeForCsv(false)
                 .build());
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
                 .title(Res.get("bisqEasy.openTrades.table.tradePeer"))
@@ -112,9 +185,19 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .left()
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getPeersUserName))
                 .setCellFactory(getTradePeerCellFactory())
+                .includeForCsv(false)
                 .build());
 
-        tableView.getColumns().add(DateColumnUtil.getDateColumn(tableView.getSortOrder()));
+        BisqTableColumn<BisqEasyTradeHistoryListItem> dateColumn = new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
+                .title(Res.get("bisqEasy.history.table.date"))
+                .fixWidth(85)
+                .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getDate))
+                .sortType(TableColumn.SortType.DESCENDING)
+                .setCellFactory(DateColumnUtil.getCellFactory())
+                .includeForCsv(false)
+                .build();
+        tableView.getColumns().add(dateColumn);
+        tableView.getSortOrder().add(dateColumn);
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
                 .title(Res.get("bisqEasy.history.table.tradeId"))
@@ -122,13 +205,15 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getTradeId))
                 .valueSupplier(BisqEasyTradeHistoryListItem::getShortTradeId)
                 .tooltipSupplier(BisqEasyTradeHistoryListItem::getTradeId)
+                .includeForCsv(false)
                 .build());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
                 .title(Res.get("bisqEasy.history.table.quoteAmount"))
                 .fixWidth(120)
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getQuoteAmount))
-                .valueSupplier(BisqEasyTradeHistoryListItem::getQuoteAmountString)
+                .valueSupplier(BisqEasyTradeHistoryListItem::getQuoteAmountWithCodeString)
+                .includeForCsv(false)
                 .build());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
@@ -136,6 +221,7 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .fixWidth(120)
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getBaseAmount))
                 .setCellFactory(getBaseAmountCellFactory())
+                .includeForCsv(false)
                 .build());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
@@ -143,6 +229,7 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .minWidth(260)
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getPrice))
                 .setCellFactory(getPriceCellFactory())
+                .includeForCsv(false)
                 .build());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
@@ -150,6 +237,7 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .minWidth(100)
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getPaymentMethodAsString))
                 .setCellFactory(getPaymentCellFactory())
+                .includeForCsv(false)
                 .build());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()
@@ -158,6 +246,7 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getMyRole))
                 .valueSupplier(BisqEasyTradeHistoryListItem::getMyRole)
                 .tooltipSupplier(BisqEasyTradeHistoryListItem::getMyRole)
+                .includeForCsv(false)
                 .build());
 
         tableView.getColumns().add(new BisqTableColumn.Builder<BisqEasyTradeHistoryListItem>()

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyHistoryView.java
@@ -245,7 +245,6 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 .minWidth(85)
                 .comparator(Comparator.comparing(BisqEasyTradeHistoryListItem::getMyRole))
                 .valueSupplier(BisqEasyTradeHistoryListItem::getMyRole)
-                .tooltipSupplier(BisqEasyTradeHistoryListItem::getMyRole)
                 .includeForCsv(false)
                 .build());
 
@@ -261,6 +260,7 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
             TableCell<BisqEasyTradeHistoryListItem, BisqEasyTradeHistoryListItem>> getMarketCellFactory() {
         return column -> new TableCell<>() {
             private final Label marketPairIcons = new Label();
+            private final Tooltip tooltip = new BisqTooltip();
 
             @Override
             protected void updateItem(BisqEasyTradeHistoryListItem item, boolean empty) {
@@ -269,8 +269,11 @@ public class BisqEasyHistoryView extends View<VBox, BisqEasyHistoryModel, BisqEa
                 if (item != null && !empty) {
                     marketPairIcons.setGraphic(MarketImageComposition.getMarketMenuPairIcons(item.getMarket().getBaseCurrencyCode(),
                             item.getMarket().getQuoteCurrencyCode()));
+                    tooltip.setText(item.getMarket().getMarketCodes());
+                    Tooltip.install(marketPairIcons, tooltip);
                     setGraphic(marketPairIcons);
                 } else {
+                    Tooltip.uninstall(marketPairIcons, tooltip);
                     setGraphic(null);
                 }
             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyTradeHistoryListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/history/BisqEasyTradeHistoryListItem.java
@@ -24,6 +24,7 @@ import bisq.common.data.Pair;
 import bisq.common.market.Market;
 import bisq.contract.bisq_easy.BisqEasyContract;
 import bisq.desktop.components.table.DateTableItem;
+import bisq.i18n.Res;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.offer.price.spec.FixPriceSpec;
 import bisq.offer.price.spec.PriceSpec;
@@ -46,8 +47,9 @@ import lombok.ToString;
 public class BisqEasyTradeHistoryListItem implements DateTableItem {
     @EqualsAndHashCode.Include
     private final BisqEasyTrade trade;
-    private final String myUserName, directionalTitle, peersUserName, tradeId, shortTradeId, dateString, timeString, tradeCompletedDateString, baseAmountString,
-            quoteAmountString, priceString, priceTooltip, myRole, paymentMethodAsString;
+    private final String myUserName, directionalTitle, peersUserName, tradeId, shortTradeId, dateString, timeString, dateTimeString,
+            tradeCompletedDateString, baseAmountString, quoteAmountString, quoteAmountWithCodeString, priceString, priceWithCodeString,
+            priceTooltip, pricePercentage, priceModality, myRole, paymentMethodAsString, offerType, receiverAddressOrInvoice, txIdOrPreimage;
     private final long date, price, baseAmount, quoteAmount;
     private final boolean hasFixPrice;
     private final Market market;
@@ -70,6 +72,7 @@ public class BisqEasyTradeHistoryListItem implements DateTableItem {
         date = trade.getTradeCompletedDate().orElse(contract.getTakeOfferDate());
         dateString = DateFormatter.formatDate(date);
         timeString = DateFormatter.formatTime(date);
+        dateTimeString = String.format("%s %s", dateString, timeString);
 
         // btc confirmed
         tradeCompletedDateString = trade.getTradeCompletedDate().map(DateFormatter::formatDate).orElse("N/A");
@@ -78,6 +81,12 @@ public class BisqEasyTradeHistoryListItem implements DateTableItem {
         myUserName = myUserProfile.getUserName();
 
         directionalTitle = BisqEasyTradeFormatter.getDirectionalTitle(trade);
+        offerType = trade.getOffer().getDirection().isBuy()
+                ? Res.get("bisqEasy.openTrades.csv.offerType.buy")
+                : Res.get("bisqEasy.openTrades.csv.offerType.sell");
+
+        receiverAddressOrInvoice = trade.getBitcoinPaymentData().orElseGet(() -> Res.get("data.na"));
+        txIdOrPreimage = trade.getPaymentProof().orElseGet(() -> Res.get("data.na"));
 
         peersUserProfile = closedTrade.peerUserProfile();
         peersUserName = peersUserProfile.getUserName();
@@ -87,7 +96,8 @@ public class BisqEasyTradeHistoryListItem implements DateTableItem {
         baseAmountString = BisqEasyTradeFormatter.formatBaseSideAmount(trade);
 
         quoteAmount = contract.getQuoteSideAmount();
-        quoteAmountString = BisqEasyTradeFormatter.formatQuoteSideAmountWithCode(trade);
+        quoteAmountString = BisqEasyTradeFormatter.formatQuoteSideAmount(trade);
+        quoteAmountWithCodeString = BisqEasyTradeFormatter.formatQuoteSideAmountWithCode(trade);
 
         price = trade.getPriceQuote().getValue();
         BisqEasyOffer offer = contract.getOffer();
@@ -95,12 +105,15 @@ public class BisqEasyTradeHistoryListItem implements DateTableItem {
         hasFixPrice = priceSpec instanceof FixPriceSpec;
         pricePair = PriceSpecFormatter.getFormattedPricePair(priceSpec, marketPriceService, offer.getMarket());
 
-        priceString = PriceFormatter.formatWithCode(trade.getPriceQuote());
-        priceTooltip = PriceSpecFormatter.getFormattedPriceSpecWithPrice(priceSpec, priceString);
+        priceString = PriceFormatter.format(trade.getPriceQuote());
+        priceWithCodeString = PriceFormatter.formatWithCode(trade.getPriceQuote());
+        priceTooltip = PriceSpecFormatter.getFormattedPriceSpecWithPrice(priceSpec, priceWithCodeString);
+        pricePercentage = pricePair.getSecond();
+        priceModality = priceSpec.getDisplayName();
 
         paymentMethod = contract.getQuoteSidePaymentMethodSpec().getPaymentMethod();
         settlementMethod = contract.getBaseSidePaymentMethodSpec().getPaymentMethod();
-        paymentMethodAsString = String.format("%s / %s", paymentMethod, settlementMethod);
+        paymentMethodAsString = String.format("%s / %s", paymentMethod.getDisplayString(), settlementMethod.getDisplayString());
 
         myRole = BisqEasyTradeFormatter.getMakerTakerRole(trade);
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradePhaseBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradePhaseBox.java
@@ -17,6 +17,7 @@
 
 package bisq.desktop.main.content.bisq_easy.open_trades.trade_state;
 
+import bisq.desktop.main.content.bisq_easy.TradesUtils;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannel;
 import bisq.chat.bisq_easy.open_trades.BisqEasyOpenTradeChannelService;
@@ -226,7 +227,7 @@ class TradePhaseBox {
         }
 
         void onRequestMediation() {
-            OpenTradesUtils.requestMediation(model.getSelectedChannel(),
+            TradesUtils.requestMediation(model.getSelectedChannel(),
                     model.getBisqEasyTrade().getContract(),
                     bisqEasyMediationRequestService, channelService);
         }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -34,6 +34,7 @@ import bisq.desktop.common.view.Controller;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.common.utils.TradeExceptionHandler;
 import bisq.desktop.components.overlay.Popup;
+import bisq.desktop.main.content.bisq_easy.TradesUtils;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState1a;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.states.BuyerState1b;
@@ -323,11 +324,11 @@ public class TradeStateController implements Controller {
     }
 
     void onExportTrade() {
-        OpenTradesUtils.exportTrade(model.getBisqEasyTrade().get(), getView().getRoot().getScene());
+        TradesUtils.exportTrade(model.getBisqEasyTrade().get(), getView().getRoot().getScene());
     }
 
     void onRequestMediation() {
-        OpenTradesUtils.requestMediation(model.getChannel().get(),
+        TradesUtils.requestMediation(model.getChannel().get(),
                 model.getBisqEasyTrade().get().getContract(),
                 bisqEasyMediationRequestService, channelService);
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/State4.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/states/State4.java
@@ -28,7 +28,7 @@ import bisq.desktop.common.utils.ClipboardUtil;
 import bisq.desktop.common.view.Navigation;
 import bisq.desktop.components.overlay.Popup;
 import bisq.desktop.main.content.bisq_easy.open_trades.trade_details.TradeDetailsController;
-import bisq.desktop.main.content.bisq_easy.open_trades.trade_state.OpenTradesUtils;
+import bisq.desktop.main.content.bisq_easy.TradesUtils;
 import bisq.desktop.main.content.components.UserProfileDisplay;
 import bisq.desktop.navigation.NavigationTarget;
 import bisq.i18n.Res;
@@ -151,7 +151,7 @@ public abstract class State4<C extends State4.Controller<?, ?>> extends BaseStat
         }
 
         protected void onExportTrade() {
-            OpenTradesUtils.exportTrade(model.getTrade(), getView().getRoot().getScene());
+            TradesUtils.exportTrade(model.getTrade(), getView().getRoot().getScene());
         }
 
         public void openExplorer() {

--- a/i18n/src/main/resources/application.properties
+++ b/i18n/src/main/resources/application.properties
@@ -384,6 +384,15 @@ video.mp4NotSupported.warning=You can watch the video in your browser at: [HYPER
 
 
 ################################################################################
+# Price Spec
+################################################################################
+
+priceSpec.fixPriceSpec=Fixed price
+priceSpec.floatPriceSpec=Relative price
+priceSpec.marketPriceSpec=Market price
+
+
+################################################################################
 # Price Spec Formatter
 ################################################################################
 

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -643,6 +643,7 @@ bisqEasy.openTrades.csv.txIdOrPreimage=Transaction ID/Preimage
 bisqEasy.openTrades.csv.receiverAddressOrInvoice=Receiver address/Invoice
 bisqEasy.openTrades.csv.paymentMethod=Payment method
 bisqEasy.openTrades.csv.date=Trade date
+bisqEasy.openTrades.csv.market=Market
 
 bisqEasy.openTrades.chat.peer.description=Chat peer
 bisqEasy.openTrades.chat.detach=Detach
@@ -697,6 +698,7 @@ bisqEasy.history.noTrades=You don't have any trade history yet
 bisqEasy.history.noMatchingTrades=No matching trade history entries were found
 
 bisqEasy.history.table.market=Market
+bisqEasy.history.table.date=Date
 bisqEasy.history.table.tradeId=Trade ID
 bisqEasy.history.table.baseAmount=Amount in BTC
 bisqEasy.history.table.quoteAmount=Amount
@@ -710,6 +712,17 @@ bisqEasy.history.table.actionButtons.deleteArchivedTrade.tooltip=Delete trade
 bisqEasy.history.table.actionButtons.deleteArchivedTrade.popup.info=All data related to this trade will be permanently deleted.\n\
   Do you want to proceed?
 bisqEasy.history.table.actionButtons.deleteArchivedTrade.popup.actionButton=Delete archived trade
+
+bisqEasy.history.table.csv.date=Trade date
+bisqEasy.history.table.csv.tradePrice=Trade price
+bisqEasy.history.table.csv.pricePercentage=Price percentage
+bisqEasy.history.table.csv.priceModality=Price modality
+bisqEasy.history.table.csv.offerType=Offer type
+bisqEasy.history.table.csv.quoteAmount=Fiat amount
+bisqEasy.history.table.csv.quoteAmountCurrencyCode=Fiat currency
+bisqEasy.history.table.csv.payment=Payment method
+bisqEasy.history.table.csv.txIdOrPreimage=Transaction ID/Preimage
+bisqEasy.history.table.csv.receiverAddressOrInvoice=Receiver address/Invoice
 
 
 ######################################################

--- a/offer/src/main/java/bisq/offer/price/spec/FixPriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/FixPriceSpec.java
@@ -18,6 +18,7 @@
 package bisq.offer.price.spec;
 
 import bisq.common.monetary.PriceQuote;
+import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -39,6 +40,11 @@ public final class FixPriceSpec implements PriceSpec {
 
     @Override
     public void verify() {
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Res.get("priceSpec.fixPriceSpec");
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/price/spec/FloatPriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/FloatPriceSpec.java
@@ -17,6 +17,7 @@
 
 package bisq.offer.price.spec;
 
+import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -47,6 +48,11 @@ public final class FloatPriceSpec implements PriceSpec {
     public void verify() {
         checkArgument(percentage >= -1 && percentage <= 1,
                 "Percentage must be in the range of -100% - 100%");
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Res.get("priceSpec.floatPriceSpec");
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/price/spec/MarketPriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/MarketPriceSpec.java
@@ -17,6 +17,7 @@
 
 package bisq.offer.price.spec;
 
+import bisq.i18n.Res;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -35,6 +36,11 @@ public final class MarketPriceSpec implements PriceSpec {
 
     @Override
     public void verify() {
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Res.get("priceSpec.marketPriceSpec");
     }
 
     @Override

--- a/offer/src/main/java/bisq/offer/price/spec/PriceSpec.java
+++ b/offer/src/main/java/bisq/offer/price/spec/PriceSpec.java
@@ -26,6 +26,8 @@ public interface PriceSpec extends NetworkProto {
         return bisq.offer.protobuf.PriceSpec.newBuilder();
     }
 
+    String getDisplayName();
+
     @Override
     bisq.offer.protobuf.PriceSpec toProto(boolean serializeForHash);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade history and open-trade exports now include richer CSV details, such as pricing breakdown, amount/currency codes, payment info, and transaction-related fields.
  * Price types now show localized display names for fixed, floating, and market pricing.
  * Trade history search matching now better recognizes amount and price values with currency codes.

* **Bug Fixes**
  * Improved trade history table formatting, sorting, and tooltip behavior for a clearer viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->