### PR TITLE
Decide offer amount range on rounded fiat value

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/amount_and_price/amount/MuSigCreateOfferAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/amount_and_price/amount/MuSigCreateOfferAmountController.java
@@ -46,6 +46,7 @@ import bisq.settings.CookieKey;
 import bisq.settings.SettingsService;
 import bisq.user.identity.UserIdentityService;
 import bisq.user.reputation.ReputationService;
+import com.google.common.annotations.VisibleForTesting;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.scene.input.KeyEvent;
@@ -54,6 +55,8 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
+
+import javax.annotation.Nullable;
 
 import java.util.Comparator;
 import java.util.HashSet;
@@ -371,12 +374,35 @@ public class MuSigCreateOfferAmountController implements Controller {
 
     private void applyRangeOrFixedAmountSpec(Long minAmount, long maxOrFixAmount) {
         if (minAmount != null) {
-            if (minAmount.equals(maxOrFixAmount)) {
+            Market market = model.getMarket();
+            boolean isBtcFiatMarket = market != null && market.isBtcFiatMarket();
+            Monetary minQuote = amountSelectionController.getMinQuoteSideAmount().get();
+            Monetary maxQuote = amountSelectionController.getMaxOrFixedQuoteSideAmount().get();
+            if (isFixedAmount(isBtcFiatMarket, minQuote, maxQuote, minAmount, maxOrFixAmount)) {
                 applyFixedAmountSpec(maxOrFixAmount);
             } else {
                 applyRangeAmountSpec(minAmount, maxOrFixAmount);
             }
         }
+    }
+
+    // On a fiat market the base side (sats) of two quote side amounts that are equal
+    // once rounded to the fiat display precision can still differ by a few units due
+    // to price conversion rounding, which would create a spurious range offer.
+    // Decide on the rounded quote side value so a range only remains when the fiat
+    // amounts actually differ. Non-fiat markets, or missing quote amounts, keep the
+    // exact base side comparison. Package-private static so
+    // MuSigCreateOfferAmountControllerTest can exercise the decision directly.
+    @VisibleForTesting
+    static boolean isFixedAmount(boolean isBtcFiatMarket,
+                                 @Nullable Monetary minQuoteSideAmount,
+                                 @Nullable Monetary maxOrFixedQuoteSideAmount,
+                                 long minBaseAmount,
+                                 long maxOrFixedBaseAmount) {
+        if (isBtcFiatMarket && minQuoteSideAmount != null && maxOrFixedQuoteSideAmount != null) {
+            return minQuoteSideAmount.isEqual(maxOrFixedQuoteSideAmount, minQuoteSideAmount.getLowPrecision());
+        }
+        return minBaseAmount == maxOrFixedBaseAmount;
     }
 
     private void applyFixedAmountSpec(long maxOrFixAmount) {

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/mu_sig/offer/create_offer/amount_and_price/amount/MuSigCreateOfferAmountControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/mu_sig/offer/create_offer/amount_and_price/amount/MuSigCreateOfferAmountControllerTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.mu_sig.offer.create_offer.amount_and_price.amount;
+
+import bisq.common.monetary.Fiat;
+import bisq.common.monetary.Monetary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies MuSigCreateOfferAmountController#isFixedAmount, the range vs fixed
+ * decision when creating a MuSig offer.
+ *
+ * On a fiat market the decision must use the quote side value rounded to the fiat
+ * display precision, so two amounts that are equal in fiat but differ by a few sats
+ * on the base side (from price conversion rounding) collapse to a fixed offer instead
+ * of a spurious range. Non-fiat markets, or missing quote amounts, keep the exact
+ * base side comparison.
+ */
+class MuSigCreateOfferAmountControllerTest {
+    private static final long BASE_A = 5_000_000L;
+    private static final long BASE_B = 5_000_001L; // differs from BASE_A by 1 sat
+
+    private static Monetary eur(double faceValue) {
+        return Fiat.fromFaceValue(faceValue, "EUR");
+    }
+
+    @Test
+    void fiatEqualAfterRounding_withDifferentBaseAmounts_isFixed() {
+        // Both quote amounts round to 100.00, base side differs by 1 sat: the bug case.
+        assertTrue(MuSigCreateOfferAmountController.isFixedAmount(
+                true, eur(100.001), eur(100.004), BASE_A, BASE_B));
+    }
+
+    @Test
+    void fiatExactlyEqual_isFixed() {
+        assertTrue(MuSigCreateOfferAmountController.isFixedAmount(
+                true, eur(100.00), eur(100.00), BASE_A, BASE_B));
+    }
+
+    @Test
+    void fiatDifferentAfterRounding_isRange() {
+        // 100.00 and 100.05 are different fiat values.
+        assertFalse(MuSigCreateOfferAmountController.isFixedAmount(
+                true, eur(100.00), eur(100.05), BASE_A, BASE_A));
+    }
+
+    @Test
+    void fiatDifferentAcrossRoundingBoundary_isRange() {
+        // 100.004 rounds to 100.00, 100.006 rounds to 100.01, so they differ.
+        assertFalse(MuSigCreateOfferAmountController.isFixedAmount(
+                true, eur(100.004), eur(100.006), BASE_A, BASE_A));
+    }
+
+    @Test
+    void nonFiatMarket_usesExactBaseComparison() {
+        // Quote side is ignored for non-fiat markets: equal base -> fixed, differing base -> range.
+        assertTrue(MuSigCreateOfferAmountController.isFixedAmount(
+                false, eur(100.00), eur(100.05), BASE_A, BASE_A));
+        assertFalse(MuSigCreateOfferAmountController.isFixedAmount(
+                false, eur(100.00), eur(100.00), BASE_A, BASE_B));
+    }
+
+    @Test
+    void fiatMarketWithMissingQuoteAmounts_fallsBackToBaseComparison() {
+        assertTrue(MuSigCreateOfferAmountController.isFixedAmount(
+                true, null, null, BASE_A, BASE_A));
+        assertFalse(MuSigCreateOfferAmountController.isFixedAmount(
+                true, null, null, BASE_A, BASE_B));
+    }
+}


### PR DESCRIPTION
When creating a MuSig offer on a fiat market, the range vs fixed amount decision compared the base side amounts (sats). Two quote side amounts that are equal once rounded to the fiat display precision can still map to base side amounts that differ by a few sats due to price conversion rounding, so a range offer was created when the fiat min and max are effectively the same.

Decide on the rounded quote side value instead: a range only remains when the fiat amounts actually differ, otherwise the offer collapses to a fixed amount. Non-fiat markets keep the exact base side comparison.

Extract the decision to a package-private static isFixedAmount, unit tested for equal, near-equal and differing fiat amounts, non-fiat markets and missing quote amounts.

Part of #4410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how fixed vs. range offers are detected, especially for BTC/fiat markets.
  * Prevented offers from being shown as ranges when fiat-side values only differ due to display rounding.
  * Kept exact behavior for non-fiat markets and when quote-side values are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->