### PR TITLE
Require explicit precision on crypto assets

### DIFF
--- a/common/src/main/java/bisq/common/asset/CryptoAsset.java
+++ b/common/src/main/java/bisq/common/asset/CryptoAsset.java
@@ -23,22 +23,34 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public final class CryptoAsset extends DigitalAsset {
 
     @Getter
+    @EqualsAndHashCode.Exclude
+    private final int precision;
+    @Getter
     private transient final Validation addressValidation;
     @Getter
     private transient final boolean supportAutoConf;
 
-    // For custom cryptoCurrencies not listed in Bisq
+    // For custom cryptoCurrencies not listed in Bisq. Their native precision is unknown, so we
+    // fall back to 8. Listed assets must state their precision explicitly (see the constructor
+    // below) so a coin with fewer than 8 decimals cannot silently use 8 and carry unsendable digits.
     public CryptoAsset(String code) {
-        this(code, code);
+        this(code, code, 8);
     }
 
-    public CryptoAsset(String code, String name) {
+    public CryptoAsset(String code, String name, int precision) {
         super(code, name);
+        // precision is the number of decimals Bisq trades the coin at; it must be <= the coin's
+        // native on-chain decimals (fewer is safe, coarser rounding). 12 (XMR) is the highest
+        // value Bisq currently uses and the ceiling that keeps amounts within a long.
+        checkArgument(precision >= 0 && precision <= 12, "precision must be within [0, 12] but was " + precision);
+        this.precision = precision;
         this.addressValidation = CryptoAddressValidationRepository.getValidation(code);
         supportAutoConf = CryptoAssetRepository.isAutoConfSupported(code);
     }
@@ -54,7 +66,11 @@ public final class CryptoAsset extends DigitalAsset {
     }
 
     public static CryptoAsset fromProto(bisq.common.protobuf.Asset baseProto) {
-        return new CryptoAsset(baseProto.getCode(), baseProto.getName());
+        // Precision is not part of the Asset proto; re-derive it from the repository (custom -> 8).
+        int precision = CryptoAssetRepository.find(baseProto.getCode())
+                .map(CryptoAsset::getPrecision)
+                .orElse(8);
+        return new CryptoAsset(baseProto.getCode(), baseProto.getName(), precision);
     }
 
     @Override

--- a/common/src/main/java/bisq/common/asset/CryptoAssetRepository.java
+++ b/common/src/main/java/bisq/common/asset/CryptoAssetRepository.java
@@ -29,17 +29,20 @@ import java.util.stream.Collectors;
 public class CryptoAssetRepository {
     private static final Set<String> AUTO_CONF_SUPPORTED_CODES = Set.of("XMR");
 
-    public static final CryptoAsset BITCOIN = new CryptoAsset("BTC", "Bitcoin");
-    public static final CryptoAsset XMR = new CryptoAsset("XMR", "Monero");
-    public static final CryptoAsset BSQ = new CryptoAsset("BSQ", "BSQ");
-    public static final CryptoAsset LTC = new CryptoAsset("LTC", "Litecoin");
-    public static final CryptoAsset ETH = new CryptoAsset("ETH", "Ether");
-    public static final CryptoAsset ETC = new CryptoAsset("ETC", "Ether Classic");
-    public static final CryptoAsset L_BTC = new CryptoAsset("L-BTC", "Liquid Bitcoin");
-    public static final CryptoAsset LN_BTC = new CryptoAsset("LN-BTC", "Lightning Network Bitcoin");
-    public static final CryptoAsset GRIN = new CryptoAsset("GRIN", "Grin");
-    public static final CryptoAsset ZEC = new CryptoAsset("ZEC", "Zcash");
-    public static final CryptoAsset DOGE = new CryptoAsset("DOGE", "Dogecoin");
+    // The precision is Bisq's trade precision for the coin (<= its native on-chain decimals).
+    // A coin with fewer than 8 decimals (e.g. a future 6-decimal stablecoin) must state it here
+    // so its trade amount stays sendable; see Coin.derivePrecision and the CryptoAsset constructor.
+    public static final CryptoAsset BITCOIN = new CryptoAsset("BTC", "Bitcoin", 8);
+    public static final CryptoAsset XMR = new CryptoAsset("XMR", "Monero", 12);
+    public static final CryptoAsset BSQ = new CryptoAsset("BSQ", "BSQ", 2);
+    public static final CryptoAsset LTC = new CryptoAsset("LTC", "Litecoin", 8);
+    public static final CryptoAsset ETH = new CryptoAsset("ETH", "Ether", 8);
+    public static final CryptoAsset ETC = new CryptoAsset("ETC", "Ether Classic", 8);
+    public static final CryptoAsset L_BTC = new CryptoAsset("L-BTC", "Liquid Bitcoin", 8);
+    public static final CryptoAsset LN_BTC = new CryptoAsset("LN-BTC", "Lightning Network Bitcoin", 8);
+    public static final CryptoAsset GRIN = new CryptoAsset("GRIN", "Grin", 8);
+    public static final CryptoAsset ZEC = new CryptoAsset("ZEC", "Zcash", 8);
+    public static final CryptoAsset DOGE = new CryptoAsset("DOGE", "Dogecoin", 8);
 
     private static final List<CryptoAsset> CRYPTO_ASSETS = List.of(
             BITCOIN,

--- a/common/src/main/java/bisq/common/monetary/Coin.java
+++ b/common/src/main/java/bisq/common/monetary/Coin.java
@@ -18,6 +18,7 @@
 package bisq.common.monetary;
 
 import bisq.common.asset.CryptoAssetRepository;
+import bisq.common.asset.CryptoAsset;
 import bisq.common.asset.Asset;
 import bisq.common.util.MathUtils;
 import com.google.common.math.LongMath;
@@ -141,14 +142,14 @@ public final class Coin extends Monetary {
         // We add a `c` as prefix for cryptocurrencies to avoid that we get a collusion with the code. 
         // It happened in the past that altcoins used a fiat code.
 
-        super(code + " [crypto]", value, code, precision, code.equals("BSQ") ? 2 : 4);
+        super(code + " [crypto]", value, code, precision, Math.min(precision, 4));
     }
 
     /**
      * @param faceValue Coin value as face value. E.g. 1.12345678 BTC
      */
     private Coin(double faceValue, String code, int precision) {
-        super(code + " [crypto]", faceValue, code, precision, code.equals("BSQ") ? 2 : 4);
+        super(code + " [crypto]", faceValue, code, precision, Math.min(precision, 4));
     }
 
     public Coin(String id, long value, String code, int precision, int lowPrecision) {
@@ -191,10 +192,12 @@ public final class Coin extends Monetary {
         return new Coin(this.value / divisor, this.code, this.precision);
     }
 
+    // Precision is a property of the crypto asset (see CryptoAsset). For a code not listed in
+    // the repository (a custom user crypto whose decimals are unknown) we fall back to 8.
     private static int derivePrecision(String code) {
-        if (code.equals("XMR")) return 12;
-        if (code.equals("BSQ")) return 2;
-        return 8;
+        return CryptoAssetRepository.find(code)
+                .map(CryptoAsset::getPrecision)
+                .orElse(8);
     }
 
     public Coin round(int roundPrecision) {

--- a/common/src/test/java/bisq/common/monetary/CoinPrecisionTest.java
+++ b/common/src/test/java/bisq/common/monetary/CoinPrecisionTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.monetary;
+
+import bisq.common.asset.CryptoAsset;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CoinPrecisionTest {
+
+    @Test
+    void precisionComesFromTheAssetRepository() {
+        // Behaviour-preserving: the values previously hardcoded in Coin.derivePrecision now come
+        // from CryptoAssetRepository via the asset's own precision.
+        assertEquals(12, Coin.fromFaceValue(1.0, "XMR").getPrecision());
+        assertEquals(2, Coin.fromFaceValue(1.0, "BSQ").getPrecision());
+        assertEquals(8, Coin.fromFaceValue(1.0, "BTC").getPrecision());
+        // A code not listed in the repository (custom crypto) falls back to 8.
+        assertEquals(8, Coin.fromFaceValue(1.0, "FOO").getPrecision());
+    }
+
+    @Test
+    void lowPrecisionNeverExceedsPrecision() {
+        // Display low precision is min(precision, 4); this also covers the former BSQ special case.
+        assertEquals(2, Coin.fromFaceValue(1.0, "BSQ").getLowPrecision());
+        assertEquals(4, Coin.fromFaceValue(1.0, "BTC").getLowPrecision());
+        assertEquals(4, Coin.fromFaceValue(1.0, "XMR").getLowPrecision());
+    }
+
+    @Test
+    void subEightDecimalAssetKeepsItsPrecision() {
+        // The point of the change: an asset with fewer than 8 decimals reports its real precision,
+        // so its trade amount stays sendable (a future 6-decimal stablecoin cannot silently use 8).
+        assertEquals(6, new CryptoAsset("USDC", "USDC", 6).getPrecision());
+    }
+
+    @Test
+    void customAssetDefaultsToEight() {
+        assertEquals(8, new CryptoAsset("FOO").getPrecision());
+    }
+
+    @Test
+    void precisionOutOfRangeIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new CryptoAsset("FOO", "Foo", 13));
+        assertThrows(IllegalArgumentException.class, () -> new CryptoAsset("FOO", "Foo", -1));
+    }
+}


### PR DESCRIPTION
## Problem

bisq2 derives a crypto amount's precision from a hardcoded switch in
`Coin.derivePrecision(code)`: XMR to 12, BSQ to 2, everything else to 8.
`CryptoAsset` carries only code and name, so an asset cannot state its
own precision. A coin with fewer than 8 decimals added to the repository
(for example USDC, which has 6) therefore silently gets precision 8, and
its trade amount carries digits the chain cannot send.

Nothing sub-8 is listed today except BSQ (handled), so this is latent.
But #4727 wires stablecoin trading (USDC, USDT, DAI) into Bisq Easy,
where a USDC quote amount would be built at precision 8 while USDC has
6 decimals.

The same class of problem in bisq1 is fixed in bisq-network/bisq#7960.
There the trade volume has to be rounded because the `Altcoin` type is
fixed at 8 decimals; here a correct per-asset precision is enough.

## Change

- Add a required `precision` to `CryptoAsset`, so a coin cannot be added
  without stating it. Repository entries now declare it (BTC, LTC and
  the rest = 8, XMR = 12, BSQ = 2).
- `Coin.derivePrecision(code)` reads the precision from
  `CryptoAssetRepository` instead of the hardcoded switch, which is
  removed. Custom (unlisted) coins keep the default 8.
- A `Coin`'s low display precision is `min(precision, 4)`, replacing
  the `BSQ` special case so it never exceeds the coin's own precision.

A `Coin` already stores its value at `10^-precision`, so a correct
precision makes the amount sendable by construction and no rounding
sites are needed. Precision is re-derived from the code via the
repository, not serialized, so there is no proto or persistence change.

## Open questions

- bisq1 effectively caps altcoin precision at 8 (its `Altcoin` storage
  exponent), XMR included. bisq2 already exceeds that (XMR = 12), so
  this treats precision as a per-asset property with a `[0, 12]` ceiling
  rather than a hard 8 cap. If a hard cap (say <= 8 except XMR) is the
  intended policy, the ceiling in the `CryptoAsset` constructor should
  be tightened instead. Which is intended?
- Stablecoins and CBDCs are also `DigitalAsset` subtypes and fall
  through `derivePrecision` to the same default 8 (their codes are not
  fiat, e.g. `USDC`, `eCNY`). They are not fixed in this PR because
  whether a stablecoin trade is denominated in the token (needs
  precision) or in its fiat peg (precision 4) is undecided. Related:
  #4727.
- `Fiat` is a separate but related case: a flat precision 4 / low
  precision 2 for every currency that ignores the currency's own
  fraction digits (EUR = 2, JPY = 0), so a fiat amount can show more
  decimals than the payment rail supports. Out of scope for this PR.

## Tests

`CoinPrecisionTest` covers that precision comes from the repository
(XMR = 12, BSQ = 2, BTC = 8, unknown = 8), that low precision never
exceeds precision, that a sub-8 asset keeps its precision, and that an
out-of-range precision is rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable decimal precision for crypto assets.
  * Supported assets now use their defined precision for amounts and trading values.
  * Custom assets default to 8 decimal places, while unknown assets safely fall back to the same precision.
  * Precision values are validated to remain within the supported range.

* **Bug Fixes**
  * Improved handling of assets with fewer than 8 decimal places.
  * Low-precision amount display is now capped appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->