### PR TITLE
Avoid exception if no price found for a market

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/direction_and_market/TradeWizardDirectionAndMarketController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/direction_and_market/TradeWizardDirectionAndMarketController.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.trade_wizard.direction_and_market;
 
 import bisq.bisq_easy.BisqEasyTradeAmountLimits;
 import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
@@ -42,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -101,15 +103,6 @@ public class TradeWizardDirectionAndMarketController implements Controller {
         applyShowReputationInfo();
 
         model.getSearchText().set("");
-        if (model.getSelectedMarket().get() == null) {
-            // Use selected public channel or if private channel is selected we use any of the public channels for
-            // setting the default market
-            Optional.ofNullable(bisqEasyOfferbookSelectionService.getSelectedChannel().get())
-                    .filter(channel -> channel instanceof BisqEasyOfferbookChannel)
-                    .map(channel -> (BisqEasyOfferbookChannel) channel)
-                    .map(BisqEasyOfferbookChannel::getMarket)
-                    .ifPresent(market -> model.getSelectedMarket().set(market));
-        }
 
         model.getListItems().setAll(MarketRepository.getAllFiatMarkets().stream()
                 .filter(market -> marketPriceService.getMarketPriceByCurrencyMap().containsKey(market))
@@ -126,11 +119,7 @@ public class TradeWizardDirectionAndMarketController implements Controller {
                             .map(ChatMessage::getAuthorUserProfileId)
                             .distinct()
                             .count();
-                    TradeWizardDirectionAndMarketView.ListItem item = new TradeWizardDirectionAndMarketView.ListItem(market, numOffersInChannel, numUsersInChannel);
-                    if (market.equals(model.getSelectedMarket().get())) {
-                        model.getSelectedMarketListItem().set(item);
-                    }
-                    return item;
+                    return new TradeWizardDirectionAndMarketView.ListItem(market, numOffersInChannel, numUsersInChannel);
                 })
                 .collect(Collectors.toList()));
 
@@ -146,6 +135,16 @@ public class TradeWizardDirectionAndMarketController implements Controller {
                 );
             }
         });
+
+        // Use the market from the selected public channel, or fall back to the service's default channel,
+        // or the first available market list item
+        findMarketListItem(bisqEasyOfferbookSelectionService.getSelectedChannel().get())
+                .or(() -> bisqEasyOfferbookChannelService.getDefaultChannel().flatMap(this::findMarketListItem))
+                .or(this::findFirstMarketListItem)
+                .ifPresentOrElse(
+                        this::onMarketListItemClicked,
+                        () -> log.error("No market list item found to select.")
+                );
     }
 
     @Override
@@ -226,5 +225,22 @@ public class TradeWizardDirectionAndMarketController implements Controller {
     private void showReputationInfoOverlay() {
         navigationButtonsVisibleHandler.accept(false);
         model.getShowReputationInfo().set(true);
+    }
+
+    private Optional<TradeWizardDirectionAndMarketView.ListItem> findMarketListItem(@Nullable ChatChannel<?> channel) {
+        if (channel instanceof BisqEasyOfferbookChannel) {
+            return findMarketListItem(((BisqEasyOfferbookChannel) channel).getMarket());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<TradeWizardDirectionAndMarketView.ListItem> findMarketListItem(Market market) {
+        return model.getListItems().stream()
+                .filter(item -> item.getMarket().equals(market))
+                .findAny();
+    }
+
+    private Optional<TradeWizardDirectionAndMarketView.ListItem> findFirstMarketListItem() {
+        return model.getListItems().stream().findFirst();
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/direction_and_market/MuSigCreateOfferDirectionAndMarketController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/create_offer/direction_and_market/MuSigCreateOfferDirectionAndMarketController.java
@@ -34,10 +34,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static bisq.desktop.main.content.mu_sig.offer.create_offer.direction_and_market.MuSigCreateOfferDirectionAndMarketModel.MARKET_ICON_CACHE;
+import static com.google.common.base.Preconditions.checkArgument;
 
 @Slf4j
 public class MuSigCreateOfferDirectionAndMarketController implements Controller {
@@ -147,14 +150,14 @@ public class MuSigCreateOfferDirectionAndMarketController implements Controller 
         onNextHandler.run();
     }
 
-    void onMarketListItemClicked(MarketListItem item) {
+    void onMarketListItemClicked(@Nullable MarketListItem item) {
         if (item == null || item.equals(model.getSelectedMarketListItem().get())) {
             return;
         }
         setSelectedMarketAndListItem(item.getMarket());
     }
 
-    void onMarketTypeListItemSelected(MarketTypeListItem listItem) {
+    void onMarketTypeListItemSelected(@Nullable MarketTypeListItem listItem) {
         if (listItem == null || listItem.equals(model.getSelectedMarketTypeListItem().get())) {
             return;
         }
@@ -164,56 +167,67 @@ public class MuSigCreateOfferDirectionAndMarketController implements Controller 
     }
 
     private void updateWithLastSelectedOrDefaultMarket(MarketType marketType) {
-        if (marketType == MarketType.FIAT) {
-            setSelectedMarketAndListItem(settingsService.getMuSigLastSelectedFiatMarket().get());
-        } else {
-            setSelectedMarketAndListItem(settingsService.getMuSigLastSelectedOtherMarket().get());
-        }
+        Optional<Market> lastSelected = switch (marketType) {
+            case FIAT -> Optional.ofNullable(settingsService.getMuSigLastSelectedFiatMarket().get());
+            case OTHER -> Optional.ofNullable(settingsService.getMuSigLastSelectedOtherMarket().get());
+        };
+
+        lastSelected.filter(marketPriceService::hasMarketPrice)
+                .or(() -> {
+                    Optional<Market> fallback = findFallbackMarket(marketType);
+                    log.warn("No market price available for the stored '{}' market, using fallback '{}' market.",
+                            lastSelected.orElse(null), fallback.orElse(null));
+                    return fallback;
+                })
+                .ifPresent(this::setSelectedMarketAndListItem);
+    }
+
+    private Optional<Market> findFallbackMarket(MarketType marketType) {
+        checkArgument(marketType == model.getSelectedMarketTypeListItem().get().getMarketType(),
+                "marketType must not be different from the selected market type in the model");
+        return model.getMarketListItems().stream().findFirst().map(MarketListItem::getMarket);
     }
 
     private void setSelectedMarketAndListItem(Market market) {
-        if (market != null) {
-            updateSelectedMarket(market);
-            settingsService.setSelectedMuSigMarket(market);
-            if (market.isBtcFiatMarket()) {
-                settingsService.setMuSigLastSelectedFiatMarket(market);
-            } else {
-                settingsService.setMuSigLastSelectedOtherMarket(market);
-            }
+        updateSelectedMarket(market);
+        settingsService.setSelectedMuSigMarket(market);
+        if (market.isBtcFiatMarket()) {
+            settingsService.setMuSigLastSelectedFiatMarket(market);
+        } else {
+            settingsService.setMuSigLastSelectedOtherMarket(market);
         }
     }
 
     private void initializeMarketSelection() {
-        Market market = settingsService.getSelectedMuSigMarket().get();
-        if (market != null) {
-            updateSelectedMarket(market);
-            if (market.isBtcFiatMarket()) {
-                model.getSelectedMarketTypeListItem().set(new MarketTypeListItem(MarketType.FIAT));
-            } else {
-                model.getSelectedMarketTypeListItem().set(new MarketTypeListItem(MarketType.OTHER));
-            }
-        } else {
-            updateWithLastSelectedOrDefaultMarket(MarketType.FIAT);
-        }
+        Optional<Market> market = Optional.ofNullable(settingsService.getSelectedMuSigMarket().get());
+        MarketType marketType = market.map(Market::isBtcFiatMarket)
+                .map(fiat -> fiat ? MarketType.FIAT : MarketType.OTHER).orElse(MarketType.FIAT);
+        model.getSelectedMarketTypeListItem().set(new MarketTypeListItem(marketType));
+        market.filter(marketPriceService::hasMarketPrice)
+                .ifPresentOrElse(
+                        this::updateSelectedMarket,
+                        () -> updateWithLastSelectedOrDefaultMarket(marketType)
+                );
     }
 
     private void updateSelectedMarket(Market market) {
-        if (market != null) {
-            model.getSelectedMarket().set(market);
-            model.getTradePairImage().set(MarketImageComposition.getMarketIcons(market, MARKET_ICON_CACHE));
+        checkArgument(marketPriceService.hasMarketPrice(market),
+                "There is no market price available for the '%s' market", market);
 
-            MarketListItem item = model.getMarketListItems().stream()
-                    .filter(m -> m.getMarket().equals(market))
-                    .findAny()
-                    .orElse(null);
-            model.getSelectedMarketListItem().set(item);
+        model.getSelectedMarket().set(market);
+        model.getTradePairImage().set(MarketImageComposition.getMarketIcons(market, MARKET_ICON_CACHE));
 
-            String baseCurrencyName = market.getBaseCurrencyName();
-            model.getHeadlineText().set(Res.get("muSig.offer.create.directionAndMarket.headline",
-                    baseCurrencyName, market.getQuoteCurrencyName()));
-            model.getBuyButtonText().set(Res.get("muSig.offer.create.directionAndMarket.buyButton", baseCurrencyName));
-            model.getSellButtonText().set(Res.get("muSig.offer.create.directionAndMarket.sellButton", baseCurrencyName));
-        }
+        MarketListItem item = model.getMarketListItems().stream()
+                .filter(m -> m.getMarket().equals(market))
+                .findAny()
+                .orElse(null);
+        model.getSelectedMarketListItem().set(item);
+
+        String baseCurrencyName = market.getBaseCurrencyName();
+        model.getHeadlineText().set(Res.get("muSig.offer.create.directionAndMarket.headline",
+                baseCurrencyName, market.getQuoteCurrencyName()));
+        model.getBuyButtonText().set(Res.get("muSig.offer.create.directionAndMarket.buyButton", baseCurrencyName));
+        model.getSellButtonText().set(Res.get("muSig.offer.create.directionAndMarket.sellButton", baseCurrencyName));
     }
 
     private void setDisplayDirection(Direction direction) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigMarketItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigMarketItem.java
@@ -146,4 +146,8 @@ public class MuSigMarketItem {
     private void removeFromFavourites() {
         favouriteMarketsService.removeFavourite(getMarket());
     }
+
+    boolean hasMarketPrice() {
+        return marketPriceService.hasMarketPrice(getMarket());
+    }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookController.java
@@ -67,8 +67,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 @Slf4j
 public class MuSigOfferbookController implements Controller {
     @Getter
@@ -272,9 +270,7 @@ public class MuSigOfferbookController implements Controller {
 
         selectedMarketFromModelPin = EasyBind.subscribe(model.getSelectedMarket(), market -> {
             if (market != null) {
-                UIThread.run(() -> {
-                    findMarketItem(market).ifPresent(item -> model.getSelectedMarketItem().set(item));
-                });
+                UIThread.run(() -> findMarketItem(market).ifPresent(item -> model.getSelectedMarketItem().set(item)));
             }
         });
 
@@ -326,7 +322,15 @@ public class MuSigOfferbookController implements Controller {
 
     void onCreateOffer() {
         MuSigMarketItem marketItem = model.getSelectedMarketItem().get();
-        checkArgument(marketItem != null, "No selected market item");
+
+        if (marketItem == null) {
+            new Popup().warning(Res.get("muSig.offer.listing.createOffer.noSelectedMarketItem")).show();
+            return;
+        } else if (!marketItem.hasMarketPrice()) {
+            new Popup().warning(Res.get("muSig.offer.listing.createOffer.noPricedMarketItem", marketItem.getMarket())).show();
+            return;
+        }
+
         Navigation.navigateTo(NavigationTarget.MU_SIG_CREATE_OFFER, new MuSigCreateOfferController.InitData(marketItem.getMarket()));
     }
 
@@ -466,9 +470,7 @@ public class MuSigOfferbookController implements Controller {
                 // We do not inform banned users about being banned
             });
         } catch (RateLimitExceededException e) {
-            UIThread.run(() -> {
-                new Popup().warning(Res.get("muSig.offer.listing.rateLimitsExceeded.removeOffer.warning")).show();
-            });
+            UIThread.run(() -> new Popup().warning(Res.get("muSig.offer.listing.rateLimitsExceeded.removeOffer.warning")).show());
         }
     }
 
@@ -480,7 +482,7 @@ public class MuSigOfferbookController implements Controller {
     }
 
     private MuSigMarketItem getFirstMarketItem() {
-        return !model.getSortedMarketItems().isEmpty() ? model.getSortedMarketItems().get(0) : null;
+        return !model.getSortedMarketItems().isEmpty() ? model.getSortedMarketItems().getFirst() : null;
     }
 
     private void updateFilteredMuSigOfferListItems() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/my_offers/MuSigMyOffersController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/my_offers/MuSigMyOffersController.java
@@ -149,6 +149,12 @@ public class MuSigMyOffersController implements Controller {
         Market market = model.getMuSigMarket() != null
                 ? model.getMuSigMarket()
                 : MarketRepository.getDefaultBtcFiatMarket();
+
+        if (!marketPriceService.hasMarketPrice(market)) {
+            new Popup().warning(Res.get("muSig.offer.listing.createOffer.noPricedMarketItem", market)).show();
+            return;
+        }
+
         Navigation.navigateTo(NavigationTarget.MU_SIG_CREATE_OFFER,
                 new MuSigCreateOfferController.InitData(market));
     }

--- a/i18n/src/main/resources/mu_sig.properties
+++ b/i18n/src/main/resources/mu_sig.properties
@@ -300,6 +300,13 @@ muSig.offer.listing.table.cell.takeOffer.cannotTakeOfferReason.noAccountForOffer
   because you don''t have any matching ''{0}'' account for the offer''s payment method(s).\n\n\
   Do you want to create an account?
 
+muSig.offer.listing.createOffer.noSelectedMarketItem=You cannot create an offer because no market is selected.\n\n\
+  Please select a market.
+
+muSig.offer.listing.createOffer.noPricedMarketItem=You cannot create an offer for the {0} market \
+  because no market price is currently available for it.\n\n\
+  Please check the market list and select a different market.
+
 muSig.offer.listing.removeOffer.confirmation=Are you sure you want to delete this offer?
 muSig.offer.listing.rateLimitsExceeded.removeOffer.warning=You cannot remove that offer because you have exceeded the rate limit.\n\
   Please try to use a different offer.


### PR DESCRIPTION
fixes #4271

### To Test

1. Temporarily add the following override to `FiatCurrencyRepository.java` for testing. Replace the country code `"DE"` with your local country code. This associates the legacy currency `"BGN"` with that country code:

  common/src/main/java/bisq/common/asset/FiatCurrencyRepository.java#L101
```java
if (countryCode.equals("DE")) {
    return new FiatCurrency("BGN");
}
```

2. Start the application and create a test user.

3. Stop the application and make a copy of the data directory. This copy can be reused for subsequent test runs.

4. Revert the temporary change.

5. Start the application using the copied data directory.

6. Create one or more test offers:
   - Bisq Easy (direct or assisted)
   - MuSig Offerbook
   - MuSig My Offers tab
   - Create a MuSig crypto offer and switch in the wizard from crypto to the fiat offers


**Expected result:** No exception is thrown when no market price is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market selection in the trade wizard, including more reliable default selection.
  * Prevented offer creation when no market is selected or when market pricing is unavailable.
  * Added clear warnings explaining why offer creation cannot continue.
  * Prevented unpriced markets from updating offer details or proceeding to the create-offer screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->