### PR TITLE
Guard Transifex workflow_run uploads

### DIFF
--- a/.github/workflows/sync_transifex.yml
+++ b/.github/workflows/sync_transifex.yml
@@ -9,6 +9,8 @@ on:
   workflow_run:
     workflows: [ Build Bisq 2 ]
     types: [ completed ]
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -16,7 +18,15 @@ permissions:
 jobs:
   verify:
     name: Verify Transifex configuration
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
@@ -52,7 +62,12 @@ jobs:
 
   calculate_and_push_sources:
     name: Calculate pushes and push source files
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     needs: verify
     runs-on: ubuntu-24.04
     outputs:


### PR DESCRIPTION
## Summary

- Limit the `workflow_run` Transifex trigger to `Build Bisq 2` runs on `main`.
- Add job-level guards so the privileged upload path only follows successful `push` builds from the base repository's default branch.
- Keep the existing `pull_request` verification path for `.tx/config` and i18n property changes.

## Why

`actions/checkout@v7` now refuses to check out fork pull request code from a trusted `workflow_run` context. That surfaced a latent issue in this workflow: after a successful PR build, the `workflow_run` payload points at the PR head SHA, and the Transifex workflow tried to check that SHA out before checking whether the commit belongs to `main`.

The failure happens before any Transifex command runs. It is not caused by missing GitHub Actions minutes or a missing `TX_TOKEN`.

Using `allow-unsafe-pr-checkout: true` would silence the checkout error, but it would be the wrong fix here because later jobs can use `secrets.TX_TOKEN`. The safe behavior is to skip the privileged upload path for PR/fork-triggered `workflow_run` events and only upload after trusted `main` push builds.

## Verification

- Parsed `.github/workflows/sync_transifex.yml` as YAML locally.
- Ran `git diff --check`.
- Confirmed the failed run's triggering `Build Bisq 2` run was `event=pull_request`, `head_repository=hiciefte/bisq2`.
- Confirmed a trusted merge build is `event=push`, `head_branch=main`, `head_repository=bisq-network/bisq2`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited synchronization workflow pull request triggers to the `main` branch.
  * Strengthened workflow validation so source synchronization runs only after successful, eligible builds from the repository’s default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->