### PR TITLE
Explain missing or mismatched mediator to taker

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/open_trades/trade_state/TradeStateController.java
@@ -62,6 +62,7 @@ import bisq.settings.DontShowAgainService;
 import bisq.support.mediation.bisq_easy.BisqEasyMediationRequest;
 import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
 import lombok.Getter;
@@ -190,9 +191,12 @@ public class TradeStateController implements Controller {
                                                 .dontShowAgainId(key)
                                                 .show();
                                     } else {
+                                        String displayMessage = trade.getPeersTradeProtocolFailure() == TradeProtocolFailure.MEDIATORS_NOT_MATCHING
+                                                ? Res.get("bisqEasy.openTrades.failedAtPeer.mediatorsNotMatching")
+                                                : peersErrorMessage;
                                         new Popup().headline(Res.get("bisqEasy.openTrades.atPeer.failure.popup.headline"))
                                                 .failure(Res.get("bisqEasy.openTrades.failure.popup.message.header"),
-                                                        peersErrorMessage,
+                                                        displayMessage,
                                                         Res.get("bisqEasy.openTrades.failure.popup.message.footer"))
                                                 .dontShowAgainId(key)
                                                 .show();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/take_offer/review/TakeOfferReviewController.java
@@ -58,6 +58,7 @@ import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
@@ -179,7 +180,7 @@ public class TakeOfferReviewController implements Controller {
             new Popup().warning(Res.get("bisqEasy.takeOffer.noMediatorAvailable.warning"))
                     .closeButtonText(Res.get("action.cancel"))
                     .onClose(onCancelHandler)
-                    .actionButtonText(Res.get("confirmation.ok"))
+                    .actionButtonText(Res.get("bisqEasy.takeOffer.noMediatorAvailable.proceed"))
                     .onAction(() -> doTakeOffer(bisqEasyOffer, takerIdentity, mediator))
                     .show();
         } else {
@@ -236,16 +237,19 @@ public class TakeOfferReviewController implements Controller {
         peersErrorMessagePin = trade.peersErrorMessageObservable().addObserver(peersErrorMessage -> {
                     if (peersErrorMessage != null) {
                         UIThread.run(() -> {
-                            if (trade.getTradeProtocolFailure() == null || trade.getTradeProtocolFailure().isUnexpected()) {
+                            if (trade.getPeersTradeProtocolFailure() == null || trade.getPeersTradeProtocolFailure().isUnexpected()) {
                                 String errorStackTrace = trade.getPeersErrorStackTrace() != null ? StringUtils.truncate(trade.getPeersErrorStackTrace(), 2000) : "";
                                 new Popup().error(Res.get("bisqEasy.openTrades.failedAtPeer.errorPopup.message",
                                                 peersErrorMessage,
                                                 errorStackTrace))
                                         .show();
                             } else {
+                                String displayMessage = trade.getPeersTradeProtocolFailure() == TradeProtocolFailure.MEDIATORS_NOT_MATCHING
+                                        ? Res.get("bisqEasy.openTrades.failedAtPeer.mediatorsNotMatching")
+                                        : peersErrorMessage;
                                 new Popup().headline(Res.get("bisqEasy.openTrades.atPeer.failure.popup.headline"))
                                         .failure(Res.get("bisqEasy.openTrades.failure.popup.message.header"),
-                                                peersErrorMessage,
+                                                displayMessage,
                                                 Res.get("bisqEasy.openTrades.failure.popup.message.footer"))
                                         .show();
                             }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/review/TradeWizardReviewController.java
@@ -70,6 +70,7 @@ import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
 import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
@@ -454,7 +455,7 @@ public class TradeWizardReviewController implements Controller {
         if (!DevMode.isDevMode() && mediator.isEmpty()) {
             new Popup().warning(Res.get("bisqEasy.takeOffer.noMediatorAvailable.warning"))
                     .closeButtonText(Res.get("action.cancel"))
-                    .actionButtonText(Res.get("confirmation.ok"))
+                    .actionButtonText(Res.get("bisqEasy.takeOffer.noMediatorAvailable.proceed"))
                     .onAction(() -> doTakeOffer(bisqEasyOffer, takerIdentity, mediator))
                     .show();
         } else {
@@ -518,9 +519,12 @@ public class TradeWizardReviewController implements Controller {
                                                 errorStackTrace))
                                         .show();
                             } else {
+                                String displayMessage = trade.getPeersTradeProtocolFailure() == TradeProtocolFailure.MEDIATORS_NOT_MATCHING
+                                        ? Res.get("bisqEasy.openTrades.failedAtPeer.mediatorsNotMatching")
+                                        : peersErrorMessage;
                                 new Popup().headline(Res.get("bisqEasy.openTrades.atPeer.failure.popup.headline"))
                                         .failure(Res.get("bisqEasy.openTrades.failure.popup.message.header"),
-                                                peersErrorMessage,
+                                                displayMessage,
                                                 Res.get("bisqEasy.openTrades.failure.popup.message.footer"))
                                         .show();
                             }

--- a/i18n/src/main/resources/bisq_easy.properties
+++ b/i18n/src/main/resources/bisq_easy.properties
@@ -371,7 +371,11 @@ bisqEasy.takeOffer.review.takeOfferSuccess.subTitle=Please get in touch with the
 bisqEasy.takeOffer.review.takeOfferSuccessButton=Show trade in 'Open Trades'
 bisqEasy.takeOffer.tradeLogMessage={0} has sent a message for taking {1}''s offer
 
-bisqEasy.takeOffer.noMediatorAvailable.warning=There is no mediator available. You have to use the support chat instead.
+bisqEasy.takeOffer.noMediatorAvailable.warning=No mediator is currently available.\n\n\
+  You can try to restart the application to reload the network data. Alternatively you can take the offer without mediation. \
+  The other peer may reject the request if they selected a mediator.\n\n\
+  If any issues arise during the trade, you can get help in the support chat.
+bisqEasy.takeOffer.noMediatorAvailable.proceed=Take offer without mediator
 bisqEasy.takeOffer.makerBanned.warning=The maker of this offer is banned. Please try to use a different offer.
 # suppress inspection "UnusedProperty"
 bisqEasy.takeOffer.bitcoinPaymentData.warning.MAIN_CHAIN=The Bitcoin address that you have entered appears to be invalid.\n\n\
@@ -613,6 +617,8 @@ bisqEasy.openTrades.failed.errorPopup.message=The trade failed: ''{0}''\n\n\
 bisqEasy.openTrades.failedAtPeer.errorMessage=The trade failed at your peer: ''{0}''
 bisqEasy.openTrades.failedAtPeer.errorPopup.message=The trade failed at your peer: ''{0}''\n\n\
   Stack trace: {1}
+bisqEasy.openTrades.failedAtPeer.mediatorsNotMatching=The mediator information for this trade is incomplete or does not match. The offer was therefore not taken.\n\n\
+  This is unusual and may mean that the network data is not fully synchronized. You can restart the application and try again.
 bisqEasy.openTrades.failure.popup.headline=Trade failed
 bisqEasy.openTrades.failure.popup.message.header=An error occurred during trade execution:
 bisqEasy.openTrades.failure.popup.message.footer=This can happen under certain conditions. If you need help, you can request mediation or contact the Bisq support team in the Support chat room.

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandler.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandler.java
@@ -122,6 +122,7 @@ public class BisqEasyTakeOfferRequestHandler extends BisqEasyTradeMessageHandler
             String errorMessage = String.format("Mediators do not match.\n" +
                     "Maker's mediator: %s\n" +
                     "Taker's mediator: %s", mediator, takersContract.getMediator());
+            log.warn(errorMessage);
             throw new TradeProtocolException(errorMessage, TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
         }
 


### PR DESCRIPTION
Fixes #4868

## Problem

The taker selects the mediator from its locally known network data when taking an offer. If that data is missing, the selection comes back empty. The warning popup read like a routine notice and continued with a plain OK, and when the maker then rejected the request because the mediators did not match, the taker's failure popup showed the maker's raw error text including a `UserProfile` dump. The taker had no way to understand what happened or that a restart would fix it (logs and repro in the issue).

## Fix

Deliberately minimal scope, as agreed in review:

- The consent popup states that no mediator is currently available, suggests restarting the application to reload the network data, warns that the peer may reject the request if they selected a mediator, and its action button is labeled "Take offer without mediator" instead of OK.
- When the maker rejects with `MEDIATORS_NOT_MATCHING`, the taker sees a localized explanation (mediator information incomplete or mismatching, likely unsynchronized network data, restart may fix it) instead of the raw error. The maker's error message stays as it was and is additionally logged as a warning.
- The take offer review peer-error observer checked the local trade protocol failure instead of the peer's, which routed expected peer failures into the raw stack trace popup in the take flow; it now checks the peer's failure like the other sites.

The maker-side mediator check is unchanged: matching mediators or both empty proceed (both empty continues as an unmediated trade, which is intentional), anything else keeps getting rejected.

## Manual testing

Verified on a local CLEAR-net setup: 2 seeds, a mediator instance publishing the authorized role data, Alice as maker, Bob as taker. The empty-mediator states were simulated with temporary local hacks forcing the respective client's selection empty, since the dev network caches the mediator data once published.

Taker consent popup, shown before sending when the taker's own mediator selection is empty:

<img width="1115" height="629" alt="Consent popup" src="https://github.com/user-attachments/assets/ebd1f2fd-ab79-4e1f-83c0-d52586b15483" />

Mismatch explanation popup, shown when the maker's rejection arrives:

<img width="1115" height="629" alt="Mismatch popup" src="https://github.com/user-attachments/assets/996044f1-576f-46e8-952b-537a646e52ca" />

All four maker/taker mediator combinations were tested:

1. **Taker empty, maker resolved:** consent popup → proceed → the maker rejects and logs the mediator details, the taker gets the mismatch explanation popup.
2. **Both empty:** consent popup → proceed → unmediated trade created on both sides, the trade details show no mediator.
3. **Both resolve the same mediator:** no popups, normal mediated trade.
4. **Taker resolved, maker empty:** no consent popup (the taker sees nothing unusual before sending), the maker rejects and the mismatch explanation popup is shown directly.

## Remarks

- The taker-empty/maker-resolved case still produces a failed trade on both sides after the taker proceeds; per the review discussion this is accepted, the popups turn it from an unexplained failure into an informed choice with a diagnosable outcome.
- The false "successfully took the offer" overlay that can appear after a failed take, and the related overlay/button restoration issues, are pre-existing and fixed on #4824, so they were deliberately left out here to avoid duplicating that PR.
- Non-English locales show the previous translated consent-popup text until the next automated translation sync picks up the reworded key.
