### PR TITLE
Fix ignored user handling in private chats

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -128,7 +128,8 @@ public class ChatMessagesListController implements Controller {
     private final LeavePrivateChatManager leavePrivateChatManager;
     private final DontShowAgainService dontShowAgainService;
     private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
-    private Pin selectedChannelPin, chatMessagesPin, bisqEasyOfferbookMessageTypeFilterPin, highlightedMessagePin;
+    private Pin selectedChannelPin, chatMessagesPin, bisqEasyOfferbookMessageTypeFilterPin, highlightedMessagePin,
+            ignoredUserProfileIdsPin;
     private Subscription selectedChannelSubscription, focusSubscription, scrollValuePin, scrollBarVisiblePin,
             layoutChildrenDonePin;
     private static final String DONT_SHOW_CHAT_RULES_WARNING_KEY = "privateChatRulesWarning";
@@ -171,6 +172,9 @@ public class ChatMessagesListController implements Controller {
         bisqEasyOfferbookMessageTypeFilterPin = settingsService.getBisqEasyOfferbookMessageTypeFilter()
                 .addObserver(filter -> UIThread.run(this::updatePredicate));
 
+        ignoredUserProfileIdsPin = userProfileService.getIgnoredUserProfileIds()
+                .addObserver(() -> UIThread.run(this::updatePredicate));
+
         if (selectedChannelPin != null) {
             selectedChannelPin.unbind();
         }
@@ -201,6 +205,10 @@ public class ChatMessagesListController implements Controller {
     public void onDeactivate() {
         if (bisqEasyOfferbookMessageTypeFilterPin != null) {
             bisqEasyOfferbookMessageTypeFilterPin.unbind();
+        }
+        if (ignoredUserProfileIdsPin != null) {
+            ignoredUserProfileIdsPin.unbind();
+            ignoredUserProfileIdsPin = null;
         }
         if (selectedChannelPin != null) {
             selectedChannelPin.unbind();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsController.java
@@ -48,7 +48,7 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
     private final ChatNotificationService chatNotificationService;
     private final ReputationService reputationService;
     private final LeavePrivateChatManager leavePrivateChatManager;
-    private Pin channelItemPin, channelsPin, changedChatNotificationPin;
+    private Pin channelItemPin, channelsPin, changedChatNotificationPin, ignoredUserProfileIdsPin;
     private Subscription openPrivateChatsPin;
 
     public PrivateChatsController(ServiceProvider serviceProvider,
@@ -80,6 +80,8 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
         chatNotificationService.getNotConsumedNotifications().forEach(this::handleNotification);
         changedChatNotificationPin = chatNotificationService.getChangedNotification().addObserver(this::handleNotification);
 
+        ignoredUserProfileIdsPin = userProfileService.getIgnoredUserProfileIds().addObserver(this::ignoredUserProfileIdsChanged);
+
         maybeSelectFirst();
     }
 
@@ -93,6 +95,7 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
         resetSelectedChildTarget();
         openPrivateChatsPin.unsubscribe();
         changedChatNotificationPin.unbind();
+        ignoredUserProfileIdsPin.unbind();
     }
 
     @Override
@@ -103,6 +106,7 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
             if (chatChannel == null) {
                 model.getSelectedItem().set(null);
                 model.setPeersReputationScore(null);
+                model.getPeersUserProfileIgnored().set(false);
                 model.getPeersUserProfile().set(null);
                 maybeSelectFirst();
             }
@@ -111,6 +115,7 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
                 // Set reputation score first since observable is userProfile, which updates both user and reputation
                 UserProfile peer = userProfileService.getManagedUserProfile(channel.getPeer());
                 model.setPeersReputationScore(reputationService.getReputationScore(peer));
+                model.getPeersUserProfileIgnored().set(userProfileService.isChatUserIgnored(peer));
                 model.getPeersUserProfile().set(peer);
 
                 model.getListItems().stream()
@@ -144,6 +149,15 @@ public abstract class PrivateChatsController extends ChatController<PrivateChats
                     "Not possible to leave a channel which is not a private chat.");
             leavePrivateChatManager.leaveChannel((PrivateChatChannel<?>) selectedChannel);
         }
+    }
+
+    private void ignoredUserProfileIdsChanged() {
+        UIThread.run(() -> {
+            model.getListItems().forEach(item ->
+                    item.setPeerIgnored(userProfileService.isChatUserIgnored(item.getPeersUserProfile())));
+            UserProfile peer = model.getPeersUserProfile().get();
+            model.getPeersUserProfileIgnored().set(peer != null && userProfileService.isChatUserIgnored(peer));
+        });
     }
 
     private void channelsChanged() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsModel.java
@@ -42,6 +42,7 @@ public abstract class PrivateChatsModel extends ChatModel {
     private final SortedList<PrivateChatsView.ListItem> sortedList = new SortedList<>(filteredList);
     private final ObjectProperty<PrivateChatsView.ListItem> selectedItem = new SimpleObjectProperty<>();
     private final ObjectProperty<UserProfile> peersUserProfile = new SimpleObjectProperty<>();
+    private final BooleanProperty peersUserProfileIgnored = new SimpleBooleanProperty();
     @Setter
     private ReputationScore peersReputationScore;
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/priv/PrivateChatsView.java
@@ -22,6 +22,7 @@ import bisq.desktop.common.Layout;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.containers.Spacer;
 import bisq.desktop.components.controls.Badge;
+import bisq.desktop.components.controls.BisqTooltip;
 import bisq.desktop.components.controls.DropdownBisqMenuItem;
 import bisq.desktop.components.table.BisqTableColumn;
 import bisq.desktop.components.table.BisqTableView;
@@ -33,6 +34,8 @@ import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
@@ -40,6 +43,7 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -60,9 +64,11 @@ import java.util.Optional;
 public abstract class PrivateChatsView extends ChatView<PrivateChatsView, PrivateChatsModel> {
     private BisqTableView<ListItem> tableView;
     private VBox openChatsSelectionList, chatHeaderVBox;
-    private Subscription noOpenChatsPin, tableViewSelectionPin, selectedModelItemPin, peersUserProfilePin;
+    private Subscription noOpenChatsPin, tableViewSelectionPin, selectedModelItemPin, peersUserProfilePin,
+            peersUserProfileIgnoredPin;
     private UserProfileDisplay chatPeerUserProfileDisplay;
     private DropdownBisqMenuItem leaveChatButton;
+    private final Tooltip headerIgnoredPeerTooltip = new BisqTooltip(Res.get("chat.private.ignoredPeer.tooltip"));
 
     public PrivateChatsView(PrivateChatsModel model,
                             PrivateChatsController controller,
@@ -114,6 +120,12 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             }
         });
 
+        peersUserProfileIgnoredPin = EasyBind.subscribe(model.getPeersUserProfileIgnored(), ignored -> {
+            if (chatPeerUserProfileDisplay != null) {
+                applyPeerIgnoredState(chatPeerUserProfileDisplay, headerIgnoredPeerTooltip, ignored);
+            }
+        });
+
         leaveChatButton.setOnAction(e -> getController().onLeaveChat());
 
         ellipsisMenu.visibleProperty().bind(model.getNoOpenChats().not());
@@ -133,6 +145,7 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
         tableViewSelectionPin.unsubscribe();
         noOpenChatsPin.unsubscribe();
         peersUserProfilePin.unsubscribe();
+        peersUserProfileIgnoredPin.unsubscribe();
 
         leaveChatButton.setOnAction(null);
         ellipsisMenu.visibleProperty().unbind();
@@ -141,7 +154,12 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
         tableView.visibleProperty().unbind();
         tableView.managedProperty().unbind();
 
+        disposeChatPeerUserProfileDisplay();
+    }
+
+    private void disposeChatPeerUserProfileDisplay() {
         if (chatPeerUserProfileDisplay != null) {
+            Tooltip.uninstall(chatPeerUserProfileDisplay, headerIgnoredPeerTooltip);
             chatPeerUserProfileDisplay.dispose();
             chatPeerUserProfileDisplay = null;
         }
@@ -212,6 +230,8 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             private final UserProfileDisplay userProfileDisplay = new UserProfileDisplay();
             private final HBox hBox = new HBox(5);
             private final Badge badge = new Badge(Pos.CENTER_RIGHT);
+            private final Tooltip ignoredPeerTooltip = new BisqTooltip(Res.get("chat.private.ignoredPeer.tooltip"));
+            private Subscription peerIgnoredPin;
 
             {
                 getStyleClass().add("user-profile-table-cell");
@@ -222,19 +242,36 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             protected void updateItem(ListItem item, boolean empty) {
                 super.updateItem(item, empty);
 
+                if (peerIgnoredPin != null) {
+                    peerIgnoredPin.unsubscribe();
+                    peerIgnoredPin = null;
+                }
+
                 if (item != null && !empty) {
                     userProfileDisplay.setUserProfile(item.getPeersUserProfile(), false);
                     userProfileDisplay.setReputationScore(item.getReputationScore());
                     badge.textProperty().bind(item.getNumNotificationsString());
+                    peerIgnoredPin = EasyBind.subscribe(item.getPeerIgnored(), ignored ->
+                            applyPeerIgnoredState(userProfileDisplay, ignoredPeerTooltip, ignored));
 
                     setGraphic(hBox);
                 } else {
                     badge.textProperty().unbind();
+                    Tooltip.uninstall(userProfileDisplay, ignoredPeerTooltip);
                     userProfileDisplay.dispose();
                     setGraphic(null);
                 }
             }
         };
+    }
+
+    private static void applyPeerIgnoredState(UserProfileDisplay userProfileDisplay, Tooltip tooltip, boolean ignored) {
+        userProfileDisplay.setOpacity(ignored ? 0.4 : 1);
+        if (ignored) {
+            Tooltip.install(userProfileDisplay, tooltip);
+        } else {
+            Tooltip.uninstall(userProfileDisplay, tooltip);
+        }
     }
 
     protected PrivateChatsModel getModel() {
@@ -246,9 +283,12 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
     }
 
     private void createHeaderVBox(boolean hasPeerToDisplay) {
+        disposeChatPeerUserProfileDisplay();
         chatHeaderVBox.getChildren().clear();
         if (hasPeerToDisplay) {
             chatPeerUserProfileDisplay = new UserProfileDisplay(34);
+            applyPeerIgnoredState(chatPeerUserProfileDisplay, headerIgnoredPeerTooltip,
+                    getModel().getPeersUserProfileIgnored().get());
             chatHeaderVBox.getChildren().add(chatPeerUserProfileDisplay);
             chatHeaderVBox.setAlignment(Pos.CENTER_LEFT);
         } else {
@@ -278,6 +318,7 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
         private final String totalReputationScoreString, profileAgeString;
         private final ReputationScore reputationScore;
         private final StringProperty numNotificationsString = new SimpleStringProperty();
+        private final BooleanProperty peerIgnored = new SimpleBooleanProperty();
 
         public ListItem(TwoPartyPrivateChatChannel channel,
                         ReputationService reputationService,
@@ -285,6 +326,7 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
             this.channel = channel;
 
             peersUserProfile = userProfileService.getManagedUserProfile(channel.getPeer());
+            peerIgnored.set(userProfileService.isChatUserIgnored(peersUserProfile));
 
             peersUserName = peersUserProfile.getUserName();
             myUserName = channel.getMyUserIdentity().getUserName();
@@ -302,6 +344,10 @@ public abstract class PrivateChatsView extends ChatView<PrivateChatsView, Privat
 
         public void setNumNotifications(long numNotifications) {
             numNotificationsString.set(numNotifications == 0 ? "" : String.valueOf(numNotifications));
+        }
+
+        public void setPeerIgnored(boolean ignored) {
+            peerIgnored.set(ignored);
         }
     }
 }

--- a/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
+++ b/chat/src/main/java/bisq/chat/notifications/ChatNotificationService.java
@@ -55,8 +55,11 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -96,7 +99,7 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
     private boolean isApplicationFocussed;
     private final Set<String> prunedAndExpiredChatMessageIds = new HashSet<>();
     @Nullable
-    private Pin bisqEasyOpenTradeChannelServicePin, bisqEasyOfferbookChannelServicePin;
+    private Pin bisqEasyOpenTradeChannelServicePin, bisqEasyOfferbookChannelServicePin, ignoredUserProfileIdsPin;
     private final Set<Pin> commonPublicChatChannelServicePins = new HashSet<>();
     private final Set<Pin> twoPartyPrivateChatChannelServicePins = new HashSet<>();
     private final Set<Pin> prunedAndExpiredDataRequestPins = new HashSet<>();
@@ -165,6 +168,9 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
         prunedAndExpiredChatMessageIds.forEach(this::removeNotification);
         prunedAndExpiredChatMessageIds.clear();
 
+        ignoredUserProfileIdsPin = userProfileService.getIgnoredUserProfileIds()
+                .addObserver(this::consumeNotificationsFromIgnoredUsers);
+
         BisqEasyOpenTradeChannelService bisqEasyOpenTradeChannelService = chatService.getBisqEasyOpenTradeChannelService();
         bisqEasyOpenTradeChannelServicePin = bisqEasyOpenTradeChannelService.getChannels().addObserver(() ->
                 onChannelsChanged(bisqEasyOpenTradeChannelService.getChannels()));
@@ -190,6 +196,10 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
 
     @Override
     public CompletableFuture<Boolean> shutdown() {
+        if (ignoredUserProfileIdsPin != null) {
+            ignoredUserProfileIdsPin.unbind();
+            ignoredUserProfileIdsPin = null;
+        }
         if (bisqEasyOpenTradeChannelServicePin != null) {
             bisqEasyOpenTradeChannelServicePin.unbind();
             bisqEasyOpenTradeChannelServicePin = null;
@@ -347,6 +357,16 @@ public class ChatNotificationService extends RateLimitedPersistenceClient<ChatNo
         if (wasRemoved) {
             persist();
         }
+    }
+
+    @VisibleForTesting
+    void consumeNotificationsFromIgnoredUsers() {
+        List<ChatNotification> notificationsFromIgnoredUsers = getNotConsumedNotifications()
+                .filter(notification -> notification.getSenderUserProfile()
+                        .map(sender -> userProfileService.isChatUserIgnored(sender.getId()))
+                        .orElse(false))
+                .toList();
+        notificationsFromIgnoredUsers.forEach(this::consumeNotification);
     }
 
     private void consumeNotification(ChatNotification notification) {

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
@@ -196,6 +196,11 @@ public class TwoPartyPrivateChatChannelService extends PrivateChatChannelService
 
     @Override
     protected Optional<TwoPartyPrivateChatChannel> createNewChannelFromReceivedMessage(TwoPartyPrivateChatMessage message) {
+        if (userProfileService.isChatUserIgnored(message.getSenderUserProfile())) {
+            log.info("We received a private chat message from ignored user {} and do not have a channel with them. " +
+                    "We do not create a new channel.", message.getAuthorUserProfileId());
+            return Optional.empty();
+        }
         return createAndAddChannel(message.getSenderUserProfile(), message.getReceiverUserProfileId());
     }
 

--- a/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
+++ b/chat/src/main/java/bisq/chat/two_party/TwoPartyPrivateChatChannelService.java
@@ -197,7 +197,7 @@ public class TwoPartyPrivateChatChannelService extends PrivateChatChannelService
     @Override
     protected Optional<TwoPartyPrivateChatChannel> createNewChannelFromReceivedMessage(TwoPartyPrivateChatMessage message) {
         if (userProfileService.isChatUserIgnored(message.getSenderUserProfile())) {
-            log.info("We received a private chat message from ignored user {} and do not have a channel with them. " +
+            log.debug("We received a private chat message from ignored user {} and do not have a channel with them. " +
                     "We do not create a new channel.", message.getAuthorUserProfileId());
             return Optional.empty();
         }

--- a/chat/src/test/java/bisq/chat/notifications/ChatNotificationServiceIgnoredUsersTest.java
+++ b/chat/src/test/java/bisq/chat/notifications/ChatNotificationServiceIgnoredUsersTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.chat.notifications;
+
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatChannelDomain;
+import bisq.chat.ChatMessage;
+import bisq.chat.ChatService;
+import bisq.network.NetworkService;
+import bisq.notifications.NotificationService;
+import bisq.persistence.Persistence;
+import bisq.persistence.PersistenceService;
+import bisq.settings.SettingsService;
+import bisq.user.identity.UserIdentityService;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ChatNotificationServiceIgnoredUsersTest {
+    private static final String IGNORED_PROFILE_ID = "ignored-user-profile-id";
+    private static final String OTHER_PROFILE_ID = "other-user-profile-id";
+
+    private ChatNotificationService chatNotificationService;
+    private UserProfileService userProfileService;
+
+    @BeforeEach
+    void setUp() {
+        PersistenceService persistenceService = mock(PersistenceService.class);
+        @SuppressWarnings("unchecked")
+        Persistence<ChatNotificationsStore> persistence = mock(Persistence.class);
+        when(persistenceService.<ChatNotificationsStore>getOrCreatePersistence(any(), any(), any()))
+                .thenReturn(persistence);
+        when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        NetworkService networkService = mock(NetworkService.class);
+        when(networkService.getDataService()).thenReturn(Optional.empty());
+
+        userProfileService = mock(UserProfileService.class);
+        when(userProfileService.isChatUserIgnored(IGNORED_PROFILE_ID)).thenReturn(true);
+        when(userProfileService.isChatUserIgnored(OTHER_PROFILE_ID)).thenReturn(false);
+
+        chatNotificationService = new ChatNotificationService(persistenceService,
+                networkService,
+                mock(ChatService.class),
+                mock(NotificationService.class),
+                mock(SettingsService.class),
+                mock(UserIdentityService.class),
+                userProfileService);
+    }
+
+    @Test
+    void notificationFromIgnoredUserGetsConsumed() {
+        ChatNotification notification = addNotification("a", IGNORED_PROFILE_ID);
+
+        chatNotificationService.consumeNotificationsFromIgnoredUsers();
+
+        assertTrue(notification.getIsConsumed().get());
+    }
+
+    @Test
+    void notificationFromOtherUserStaysUnconsumed() {
+        ChatNotification notification = addNotification("b", OTHER_PROFILE_ID);
+
+        chatNotificationService.consumeNotificationsFromIgnoredUsers();
+
+        assertFalse(notification.getIsConsumed().get());
+    }
+
+    @Test
+    void notificationWithoutSenderStaysUnconsumed() {
+        ChatNotification notification = addNotification("c", null);
+
+        chatNotificationService.consumeNotificationsFromIgnoredUsers();
+
+        assertFalse(notification.getIsConsumed().get());
+    }
+
+    @Test
+    void onlyIgnoredSendersNotificationsAreConsumedInMixedSet() {
+        ChatNotification fromIgnored = addNotification("d", IGNORED_PROFILE_ID);
+        ChatNotification fromOther = addNotification("e", OTHER_PROFILE_ID);
+
+        chatNotificationService.consumeNotificationsFromIgnoredUsers();
+
+        assertTrue(fromIgnored.getIsConsumed().get());
+        assertFalse(fromOther.getIsConsumed().get());
+    }
+
+    private ChatNotification addNotification(String id, String senderProfileId) {
+        ChatChannel<?> chatChannel = mock(ChatChannel.class);
+        when(chatChannel.getId()).thenReturn("channel-" + id);
+        when(chatChannel.getChatChannelDomain()).thenReturn(ChatChannelDomain.DISCUSSION);
+
+        ChatMessage chatMessage = mock(ChatMessage.class);
+        when(chatMessage.getId()).thenReturn("message-" + id);
+        when(chatMessage.getDate()).thenReturn(System.currentTimeMillis());
+
+        Optional<UserProfile> sender = Optional.ofNullable(senderProfileId)
+                .map(profileId -> {
+                    UserProfile userProfile = mock(UserProfile.class);
+                    when(userProfile.getId()).thenReturn(profileId);
+                    return userProfile;
+                });
+
+        ChatNotification notification = new ChatNotification("notification-" + id,
+                "title",
+                "message",
+                chatChannel,
+                chatMessage,
+                sender);
+        chatNotificationService.getPersistableStore().getNotifications().add(notification);
+        return notification;
+    }
+}

--- a/chat/src/test/java/bisq/chat/two_party/TwoPartyPrivateChatChannelServiceTest.java
+++ b/chat/src/test/java/bisq/chat/two_party/TwoPartyPrivateChatChannelServiceTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.chat.two_party;
+
+import bisq.chat.ChatChannelDomain;
+import bisq.chat.ChatMessageType;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.persistence.DbSubDirectory;
+import bisq.persistence.Persistence;
+import bisq.persistence.PersistenceService;
+import bisq.settings.SettingsService;
+import bisq.user.UserService;
+import bisq.user.banned.BannedUserService;
+import bisq.user.contact_list.ContactListService;
+import bisq.user.identity.UserIdentity;
+import bisq.user.identity.UserIdentityService;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class TwoPartyPrivateChatChannelServiceTest {
+    private static final String PEER_PROFILE_ID = "1111111111111111111111111111111111111111";
+    private static final String MY_PROFILE_ID = "2222222222222222222222222222222222222222";
+
+    private TwoPartyPrivateChatChannelService service;
+    private UserProfileService userProfileService;
+    private UserIdentityService userIdentityService;
+    private SettingsService settingsService;
+    private ContactListService contactListService;
+    private UserIdentity myUserIdentity;
+    private UserProfile peer;
+
+    @BeforeEach
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void setUp() {
+        PersistenceService persistenceService = mock(PersistenceService.class);
+        Persistence persistence = mock(Persistence.class);
+        when(persistenceService.getOrCreatePersistence(any(), any(DbSubDirectory.class), anyString(), any()))
+                .thenReturn(persistence);
+        when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        userIdentityService = mock(UserIdentityService.class);
+        userProfileService = mock(UserProfileService.class);
+        contactListService = mock(ContactListService.class);
+        settingsService = mock(SettingsService.class);
+        UserService userService = mock(UserService.class);
+        when(userService.getUserIdentityService()).thenReturn(userIdentityService);
+        when(userService.getUserProfileService()).thenReturn(userProfileService);
+        when(userService.getBannedUserService()).thenReturn(mock(BannedUserService.class));
+        when(userService.getContactListService()).thenReturn(contactListService);
+
+        myUserIdentity = mock(UserIdentity.class);
+        when(myUserIdentity.getId()).thenReturn(MY_PROFILE_ID);
+        when(userIdentityService.findUserIdentity(MY_PROFILE_ID)).thenReturn(Optional.of(myUserIdentity));
+
+        peer = mock(UserProfile.class);
+        when(peer.getId()).thenReturn(PEER_PROFILE_ID);
+
+        service = new TwoPartyPrivateChatChannelService(persistenceService,
+                mock(NetworkService.class),
+                userService,
+                settingsService,
+                ChatChannelDomain.DISCUSSION);
+    }
+
+    @Test
+    void receivedMessageFromIgnoredUserDoesNotCreateChannel() {
+        when(userProfileService.isChatUserIgnored(peer)).thenReturn(true);
+
+        service.onMessage(textMessageFromPeer());
+
+        assertTrue(service.getChannels().isEmpty());
+    }
+
+    @Test
+    void receivedMessageFromNotIgnoredUserCreatesChannelAndDeliversMessage() {
+        when(userProfileService.isChatUserIgnored(peer)).thenReturn(false);
+        TwoPartyPrivateChatMessage message = textMessageFromPeer();
+
+        service.onMessage(message);
+
+        assertEquals(1, service.getChannels().size());
+        TwoPartyPrivateChatChannel channel = service.getChannels().stream().findFirst().orElseThrow();
+        assertTrue(channel.getChatMessages().contains(message));
+    }
+
+    @Test
+    void receivedMessageFromIgnoredUserDoesNotAddThemToContactList() {
+        when(userProfileService.isChatUserIgnored(peer)).thenReturn(true);
+        when(settingsService.getDoAutoAddToContactList()).thenReturn(true);
+
+        service.onMessage(textMessageFromPeer());
+
+        verifyNoInteractions(contactListService);
+    }
+
+    @Test
+    void receivedMessageFromIgnoredUserIsStillAddedToExistingChannel() {
+        when(userProfileService.isChatUserIgnored(peer)).thenReturn(true);
+        when(userIdentityService.getSelectedUserIdentity()).thenReturn(myUserIdentity);
+        TwoPartyPrivateChatChannel channel = service.findOrCreateChannel(ChatChannelDomain.DISCUSSION, peer).orElseThrow();
+
+        service.onMessage(textMessageFromPeer());
+
+        assertEquals(1, channel.getChatMessages().size());
+    }
+
+    private TwoPartyPrivateChatMessage textMessageFromPeer() {
+        return new TwoPartyPrivateChatMessage("messageId",
+                ChatChannelDomain.DISCUSSION,
+                TwoPartyPrivateChatChannel.createId(ChatChannelDomain.DISCUSSION, PEER_PROFILE_ID, MY_PROFILE_ID),
+                peer,
+                MY_PROFILE_ID,
+                mock(NetworkId.class),
+                "hi",
+                Optional.empty(),
+                System.currentTimeMillis(),
+                false,
+                ChatMessageType.TEXT,
+                new HashSet<>());
+    }
+}

--- a/i18n/src/main/resources/chat.properties
+++ b/i18n/src/main/resources/chat.properties
@@ -98,8 +98,8 @@ chat.leave.confirmLeaveChat=Leave chat
 chat.messagebox.placeholder.title.noMessages=Start the conversation!
 chat.messagebox.placeholder.description.noMessages=Join {0} to share your thoughts and ask questions.
 chat.ignoreUser.warn=Selecting 'Ignore user' will effectively hide all messages from this user.\n\n\
-  This action will take effect the next time you enter the chat.\n\n\
-  To reverse this, go to the more options menu > Channel Info > Participants and select 'Undo ignore' next to the user.
+  To reverse this, open the user's profile card and select 'Undo ignore', or in public channels go to the \
+  more options menu > Channel Info > Participants and select 'Undo ignore' next to the user.
 chat.ignoreUser.confirm=Ignore user
 
 
@@ -113,6 +113,7 @@ chat.private.messagebox.noChats.placeholder.title=You don't have any ongoing con
 chat.private.messagebox.noChats.placeholder.description=To chat with a peer privately, hover over their message in a\n\
   public chat and click 'Send private message'.
 chat.private.openChatsList.headline=Chat peers
+chat.private.ignoredPeer.tooltip=You have ignored this user
 chat.private.leaveChat.confirmation=Are you sure you want to leave this chat?\n\
   You will lose access to the chat and all the chat information.
 chat.private.chatRulesWarningMessage.headline=Warning


### PR DESCRIPTION
Fixes #2079

## Problem

When a user is ignored, their messages are hidden in private chat, but:

1. If the ignoring user has closed (left) the private channel, a new message from the ignored user recreates the channel in the "Chat peers" list. With the auto-add-to-contact-list setting enabled, this also re-adds the ignored user to the contact list.
2. There was no indication in the private chat itself that the peer is ignored - the channel and header looked completely normal, just with invisible messages. The only marker was the participants sidebar, which is not reachable from private chats (the ellipsis menu there has no Channel info entry).
3. Ignoring or un-ignoring a user only took effect on the message list after re-entering the chat (the filter predicate was only applied on channel activation).

## Fix

- `TwoPartyPrivateChatChannelService.createNewChannelFromReceivedMessage` does not create a channel when the sender is ignored (mirrors the existing guard against creating channels from leave messages). Messages into an existing channel are still stored but hidden, so nothing is lost if the user later un-ignores the peer. Trade chat channels are not affected.
- The ignored peer is now dimmed with a "You have ignored this user" tooltip in the Chat peers list and in the chat header, updating live when the ignore state changes (same 40% dimming as the participants sidebar uses).

 
<img width="455" height="237" alt="Screenshot from 2026-07-20 14-31-34" src="https://github.com/user-attachments/assets/fd06d69e-5f07-49ac-ada7-053ae40680d7" />


- The message list re-applies its filter when the ignored-users set changes, so ignoring/un-ignoring takes effect immediately in all chat lists. The ignore warning popup text no longer claims the change takes effect "the next time you enter the chat", and now also mentions the profile card as the undo path (private chats have no Channel info menu).

## Testing

- New `TwoPartyPrivateChatChannelServiceTest` (4 cases): ignored sender does not create a channel and does not get added to the contact list; non-ignored sender still creates the channel and the message is delivered; ignored sender's message into an existing channel is still stored.
- Manually verified with two local clients: dimming and tooltip appear in list and header when ignoring; un-ignore via profile card un-dims live; message hiding/unhiding applies immediately; after leaving the channel, a new message from the ignored peer does not recreate it; after un-ignoring, messaging works normally again.

## Remarks

- Messages from ignored users arriving into an existing open channel are deliberately still persisted (hidden), to keep ignore reversible. Dropping them entirely (like banned users) would lose history on un-ignore.
- The updated `chat.ignoreUser.warn` text only changes the English source; translations will lag until the next translation sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added “ignored peer” indicator styling, tooltips, and header/table updates in private chats.
  * Added tooltip text and improved ignore/undo guidance in chat messaging.

* **Bug Fixes**
  * Prevents creating new private chat channels from ignored senders; messages only append to existing chats.
  * Automatically consumes queued notifications from newly ignored senders.

* **Tests**
  * Added unit tests for ignored-user private chat behavior and ignored-user notification consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->