### PR TITLE
Expose bootstrap trade limits and API capabilities

### DIFF
--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -33,6 +33,7 @@ import bisq.api.rest_api.PairingApiResourceConfig;
 import bisq.api.rest_api.RestApiResourceConfig;
 import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.api.rest_api.endpoints.chat.trade.TradeChatMessagesRestApi;
+import bisq.api.rest_api.endpoints.config.ConfigRestApi;
 import bisq.api.rest_api.endpoints.devices.DevicesRestApi;
 import bisq.api.rest_api.endpoints.explorer.ExplorerRestApi;
 import bisq.api.rest_api.endpoints.market_price.MarketPriceRestApi;
@@ -183,6 +184,7 @@ public class ApiService implements Service {
         ExplorerRestApi explorerRestApi = new ExplorerRestApi(bondedRolesService.getExplorerService());
         ReputationRestApi reputationRestApi = new ReputationRestApi(reputationService, userService);
         DevicesRestApi devicesRestApi = new DevicesRestApi(deviceRegistrationService);
+        ConfigRestApi configRestApi = new ConfigRestApi();
 
         ResourceConfig resourceConfig;
         if (apiConfig.isRestEnabled() || apiConfig.isWebsocketEnabled()) {
@@ -205,7 +207,8 @@ public class ApiService implements Service {
                     userDefinedPaymentAccountsRestApi,
                     reputationRestApi,
                     userProfileRestApi,
-                    devicesRestApi);
+                    devicesRestApi,
+                    configRestApi);
         } else {
             resourceConfig = new PairingApiResourceConfig(accessApi);
         }

--- a/api/src/main/java/bisq/api/dto/config/ApiCapabilitiesDto.java
+++ b/api/src/main/java/bisq/api/dto/config/ApiCapabilitiesDto.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.dto.config;
+
+import java.util.List;
+
+/**
+ * The set of recent API features this node build supports, plus its API version. See {@code ConfigRestApi}
+ * for the contract. {@code features} are stable kebab-case keys; a client that cannot reach the endpoint
+ * (older node) treats every recent feature as unsupported.
+ */
+public record ApiCapabilitiesDto(String apiVersion, List<String> features) {
+}

--- a/api/src/main/java/bisq/api/dto/config/TradeAmountLimitsDto.java
+++ b/api/src/main/java/bisq/api/dto/config/TradeAmountLimitsDto.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.dto.config;
+
+import bisq.api.dto.common.monetary.FiatDto;
+
+/**
+ * Static Bisq Easy trade-amount limits, mirrored from bisq2 core's {@code BisqEasyTradeAmountLimits}.
+ * These are fixed for a given core/api version and identical across the P2P network, so clients can
+ * fetch them once instead of hardcoding them. Served by {@code ConfigRestApi}.
+ */
+public record TradeAmountLimitsDto(FiatDto defaultMinUsdTradeAmount,
+                                   FiatDto maxUsdTradeAmount,
+                                   double tolerance,
+                                   double requiredReputationScorePerUsd) {
+}

--- a/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
@@ -6,6 +6,7 @@ import bisq.api.access.permissions.PermissionService;
 import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.api.rest_api.endpoints.chat.trade.TradeChatMessagesRestApi;
+import bisq.api.rest_api.endpoints.config.ConfigRestApi;
 import bisq.api.rest_api.endpoints.devices.DevicesRestApi;
 import bisq.api.rest_api.endpoints.explorer.ExplorerRestApi;
 import bisq.api.rest_api.endpoints.market_price.MarketPriceRestApi;
@@ -43,7 +44,8 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
                                  UserDefinedPaymentAccountsRestApi userDefinedPaymentAccountsRestApi,
                                  ReputationRestApi reputationRestApi,
                                  UserProfileRestApi userProfileRestApi,
-                                 DevicesRestApi devicesRestApi) {
+                                 DevicesRestApi devicesRestApi,
+                                 ConfigRestApi configRestApi) {
         super(apiConfig, accessApi, permissionService, sessionAuthenticationService);
 
         // Swagger/OpenApi does not work when using instances at register instead of classes.
@@ -64,6 +66,7 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
         register(ReputationRestApi.class);
         register(UserProfileRestApi.class);
         register(DevicesRestApi.class);
+        register(ConfigRestApi.class);
 
         register(new AbstractBinder() {
             @Override
@@ -82,6 +85,7 @@ public class RestApiResourceConfig extends RestApiBaseResourceConfig {
                 bind(reputationRestApi).to(ReputationRestApi.class);
                 bind(userProfileRestApi).to(UserProfileRestApi.class);
                 bind(devicesRestApi).to(DevicesRestApi.class);
+                bind(configRestApi).to(ConfigRestApi.class);
             }
         });
     }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/config/ApiFeature.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/config/ApiFeature.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.Getter;
+
+/**
+ * Registry of the "recent" API features a client may gate its UI on — capabilities that older nodes
+ * (or a Bisq Desktop node) might not have yet. Served as stable kebab-case keys by {@code ConfigRestApi}.
+ * <p>
+ * ONLY list features that are genuinely new enough that some reachable nodes lack them. Long-standing,
+ * universally-available behaviour does not belong here — the list should stay small. Add a key ONLY once
+ * the feature is actually implemented in this build; {@code ConfigRestApiTest} fails otherwise.
+ * <p>
+ * Example — closed trades: a client gates its "Closed trades" screen on {@link #CLOSED_TRADES}. A node
+ * that lists it exposes {@code GET /trades/closed}; a node without the capabilities endpoint returns 404,
+ * so the client reads it as unsupported and hides the screen. New features (e.g. a future
+ * {@code "network-info"} once its subscription topic ships) are added the same way.
+ */
+@Getter
+public enum ApiFeature {
+    CLOSED_TRADES("closed-trades");
+
+    private final String key;
+
+    ApiFeature(String key) {
+        this.key = key;
+    }
+
+    public static List<String> allKeys() {
+        return Arrays.stream(values()).map(ApiFeature::getKey).toList();
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/endpoints/config/ConfigRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/config/ConfigRestApi.java
@@ -18,9 +18,11 @@
 package bisq.api.rest_api.endpoints.config;
 
 import bisq.api.dto.DtoMappings;
+import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.RestApiBase;
 import bisq.bisq_easy.BisqEasyTradeAmountLimits;
+import bisq.common.application.ApplicationVersion;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -76,6 +78,39 @@ public class ConfigRestApi extends RestApiBase {
             return buildOkResponse(dto);
         } catch (Exception e) {
             log.error("Failed to retrieve trade-amount limits", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Returns the recent API features this node supports (see {@link ApiFeature}), so a client can
+     * enable or hide feature UI for the node it is paired with.
+     * <p>
+     * How clients use it: fetch once, cache keyed by {@code apiVersion}, and gate each feature on its
+     * key being present. The crucial property is the ABSENCE case — a node too old to have this
+     * endpoint returns 404, which the client reads as "none of these recent features are supported"
+     * and hides them all. So adding a feature to a client only needs a key here; no client-side
+     * version checks.
+     */
+    @GET
+    @Path("/capabilities")
+    @Operation(
+            summary = "Get supported API features",
+            description = "The recent API features this node supports, as stable kebab-case keys, plus the "
+                    + "node's API version. A node without this endpoint (older node / Bisq Desktop) is treated "
+                    + "by clients as supporting none of them.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Supported features retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = ApiCapabilitiesDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getCapabilities() {
+        try {
+            String apiVersion = ApplicationVersion.getVersion().toString();
+            return buildOkResponse(new ApiCapabilitiesDto(apiVersion, ApiFeature.allKeys()));
+        } catch (Exception e) {
+            log.error("Failed to retrieve API capabilities", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
         }
     }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/config/ConfigRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/config/ConfigRestApi.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.config;
+
+import bisq.api.dto.DtoMappings;
+import bisq.api.dto.config.TradeAmountLimitsDto;
+import bisq.api.rest_api.endpoints.RestApiBase;
+import bisq.bisq_easy.BisqEasyTradeAmountLimits;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Serves static bisq2 configuration that clients would otherwise have to hardcode.
+ * <p>
+ * SCOPE CONTRACT — only expose values here that are ALL of:
+ * <ul>
+ *     <li>static: they change only between bisq2 core/api versions, never per user or at runtime;</li>
+ *     <li>global: identical for every peer on the network;</li>
+ *     <li>small: cheap enough for a client to fetch once and cache.</li>
+ * </ul>
+ * Anything user-specific, runtime-mutable, large, or that belongs to a single feature's flow does
+ * NOT go here — give it its own feature endpoint. Keeping this endpoint honest avoids turning it
+ * into a kitchen-sink blob that couples unrelated features' release cadence and cache invalidation.
+ */
+@Slf4j
+@Path("/config")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Config API", description = "Static, version-global bisq2 configuration for clients")
+public class ConfigRestApi extends RestApiBase {
+
+    @GET
+    @Path("/trade-amount-limits")
+    @Operation(
+            summary = "Get Bisq Easy trade-amount limits",
+            description = "Static min/max USD trade amounts, tolerance and required reputation-per-USD, "
+                    + "mirrored from bisq2 core. Fixed per core/api version.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Trade-amount limits retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = TradeAmountLimitsDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getTradeAmountLimits() {
+        try {
+            TradeAmountLimitsDto dto = new TradeAmountLimitsDto(
+                    DtoMappings.FiatMapping.fromBisq2Model(BisqEasyTradeAmountLimits.DEFAULT_MIN_USD_TRADE_AMOUNT),
+                    DtoMappings.FiatMapping.fromBisq2Model(BisqEasyTradeAmountLimits.MAX_USD_TRADE_AMOUNT),
+                    BisqEasyTradeAmountLimits.TOLERANCE,
+                    BisqEasyTradeAmountLimits.getRequiredReputationScorePerUsd());
+            return buildOkResponse(dto);
+        } catch (Exception e) {
+            log.error("Failed to retrieve trade-amount limits", e);
+            return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/endpoints/config/ConfigRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/config/ConfigRestApi.java
@@ -17,6 +17,7 @@
 
 package bisq.api.rest_api.endpoints.config;
 
+import bisq.api.access.AllowUnauthenticated;
 import bisq.api.dto.DtoMappings;
 import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
@@ -48,12 +49,20 @@ import lombok.extern.slf4j.Slf4j;
  * Anything user-specific, runtime-mutable, large, or that belongs to a single feature's flow does
  * NOT go here — give it its own feature endpoint. Keeping this endpoint honest avoids turning it
  * into a kitchen-sink blob that couples unrelated features' release cadence and cache invalidation.
+ * <p>
+ * {@link AllowUnauthenticated}: this is public, non-sensitive, version-global metadata (no user data),
+ * so it must be readable by ANY client regardless of its granted permission set. Without this, the
+ * authorization filter rejects it with 403 whenever {@code authorizationRequired=true} (the api-app
+ * default), because {@code RestPermissionMapping} has no per-feature rule for {@code /config} — and
+ * we do NOT want to couple public config reads to a feature permission (e.g. SETTINGS), which would
+ * break API clients paired with a narrower permission set.
  */
 @Slf4j
 @Path("/config")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Config API", description = "Static, version-global bisq2 configuration for clients")
+@AllowUnauthenticated
 public class ConfigRestApi extends RestApiBase {
 
     @GET

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.config;
+
+import bisq.api.dto.config.TradeAmountLimitsDto;
+import bisq.bisq_easy.BisqEasyTradeAmountLimits;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigRestApiTest {
+
+    @Test
+    void getTradeAmountLimitsMirrorsCoreConstants() {
+        ConfigRestApi restApi = new ConfigRestApi();
+
+        Response response = restApi.getTradeAmountLimits();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        TradeAmountLimitsDto dto = (TradeAmountLimitsDto) response.getEntity();
+
+        // The DTO must carry exactly what core exposes — this is the single-source-of-truth contract
+        // the mobile client and node both rely on. If a core constant changes, this test fails loudly.
+        assertThat(dto.defaultMinUsdTradeAmount().getValue())
+                .isEqualTo(BisqEasyTradeAmountLimits.DEFAULT_MIN_USD_TRADE_AMOUNT.getValue());
+        assertThat(dto.defaultMinUsdTradeAmount().getCode()).isEqualTo("USD");
+        assertThat(dto.maxUsdTradeAmount().getValue())
+                .isEqualTo(BisqEasyTradeAmountLimits.MAX_USD_TRADE_AMOUNT.getValue());
+        assertThat(dto.maxUsdTradeAmount().getCode()).isEqualTo("USD");
+        assertThat(dto.tolerance()).isEqualTo(BisqEasyTradeAmountLimits.TOLERANCE);
+        assertThat(dto.requiredReputationScorePerUsd())
+                .isEqualTo(BisqEasyTradeAmountLimits.getRequiredReputationScorePerUsd());
+    }
+}

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -17,6 +17,7 @@
 
 package bisq.api.rest_api.endpoints.config;
 
+import bisq.api.access.AllowUnauthenticated;
 import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.trades.TradeRestApi;
@@ -81,6 +82,18 @@ class ConfigRestApiTest {
                         .isTrue();
             }
         }
+    }
+
+    /**
+     * Guards public reachability: config is version-global, non-sensitive metadata and must be
+     * readable by any client. Without {@link AllowUnauthenticated} the authorization filter returns
+     * 403 for /config whenever authorizationRequired=true (RestPermissionMapping has no /config rule).
+     */
+    @Test
+    void configIsPublicSoTheAuthorizationFilterDoesNotReject403() {
+        assertThat(ConfigRestApi.class.isAnnotationPresent(AllowUnauthenticated.class))
+                .as("/config must be @AllowUnauthenticated — it has no RestPermissionMapping rule and would otherwise 403")
+                .isTrue();
     }
 
     private static boolean hasEndpoint(Class<?> resource, String path) {

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -17,10 +17,17 @@
 
 package bisq.api.rest_api.endpoints.config;
 
+import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
+import bisq.api.rest_api.endpoints.trades.TradeRestApi;
 import bisq.bisq_easy.BisqEasyTradeAmountLimits;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,5 +53,43 @@ class ConfigRestApiTest {
         assertThat(dto.tolerance()).isEqualTo(BisqEasyTradeAmountLimits.TOLERANCE);
         assertThat(dto.requiredReputationScorePerUsd())
                 .isEqualTo(BisqEasyTradeAmountLimits.getRequiredReputationScorePerUsd());
+    }
+
+    @Test
+    void getCapabilitiesListsSupportedFeaturesWithVersion() {
+        ConfigRestApi restApi = new ConfigRestApi();
+
+        Response response = restApi.getCapabilities();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        ApiCapabilitiesDto dto = (ApiCapabilitiesDto) response.getEntity();
+        assertThat(dto.apiVersion()).isNotBlank();
+        assertThat(dto.features()).containsExactlyElementsOf(ApiFeature.allKeys());
+        assertThat(dto.features()).contains(ApiFeature.CLOSED_TRADES.getKey());
+    }
+
+    /**
+     * Anti-drift guard: a declared feature must be backed by a real, wired endpoint/topic — never a
+     * key for something not implemented in this build. As features are added here, extend this check.
+     */
+    @Test
+    void everyDeclaredFeatureIsBackedByARealImplementation() {
+        for (ApiFeature feature : ApiFeature.values()) {
+            switch (feature) {
+                case CLOSED_TRADES -> assertThat(hasEndpoint(TradeRestApi.class, "/closed"))
+                        .as("closed-trades must expose GET /trades/closed")
+                        .isTrue();
+            }
+        }
+    }
+
+    private static boolean hasEndpoint(Class<?> resource, String path) {
+        return Arrays.stream(resource.getDeclaredMethods())
+                .anyMatch(m -> m.isAnnotationPresent(GET.class) && isPath(m, path));
+    }
+
+    private static boolean isPath(Method method, String path) {
+        Path annotation = method.getAnnotation(Path.class);
+        return annotation != null && annotation.value().equals(path);
     }
 }

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyTradeAmountLimits.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyTradeAmountLimits.java
@@ -56,6 +56,12 @@ public class BisqEasyTradeAmountLimits {
     public static final long MIN_REPUTATION_SCORE_TO_CREATE_SELL_OFFER = 1200;
     private static final Set<String> SELL_OFFERS_WITH_INSUFFICIENT_REPUTATION = new HashSet<>();
 
+    // Exposes the otherwise-private reputation-per-USD constant so the Connect config API (and any
+    // single-source-of-truth reader) can surface it without duplicating the literal.
+    public static double getRequiredReputationScorePerUsd() {
+        return REQUIRED_REPUTATION_SCORE_PER_USD;
+    }
+
     public static Optional<Monetary> getMinQuoteSideTradeAmount(MarketPriceService marketPriceService, Market market) {
         return marketPriceService.findMarketPriceQuote(MarketRepository.getUSDBitcoinMarket())
                 .map(priceQuote -> priceQuote.toBaseSideMonetary(DEFAULT_MIN_USD_TRADE_AMOUNT))


### PR DESCRIPTION
 - contribs to https://github.com/bisq-network/bisq-mobile/issues/1260
 - network feature currently needs this in as well (new WS TOPIC as per #4878
 - new config and capabilities APIs for bisq-mobile to fetch static data and new-features running node support
 - this allows dynamic check against running node coping with lower release pace of Bisq2 Desktop for both, REST APIs and WS TOPICs dependency
 - added docs and AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public configuration endpoints for trade amount limits and API capabilities.
  - Exposed supported API features and application version metadata.
  - Added unauthenticated access to configuration information.

- **Tests**
  - Added coverage validating configuration responses, feature mappings, endpoint reachability, and trade limit accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->