### PR TITLE
Fix: Bisq Easy trades can get stuck when a protocol message arrives out of order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,9 @@ docker/data_dirs
 /tx
 /.java-version
 
-# sym link to bisq2-umbrel repo
+# sym link to bisq2-* platforms repo
 bisq2-umbrel
+bisq2-startos
 
 # Directory for temp files
 /temp

--- a/common/src/main/java/bisq/common/fsm/Fsm.java
+++ b/common/src/main/java/bisq/common/fsm/Fsm.java
@@ -61,7 +61,18 @@ public abstract class Fsm<M extends FsmModel> {
     abstract protected void configTransitions();
 
     public <E extends Event> void handle(E event) {
-        synchronized (this) {
+        // Synchronize on the model rather than on this Fsm instance: the model (see FsmModel#getStateAndEventQueueSnapshot)
+        // must be lockable directly by callers that only hold a reference to the model - e.g. Trade#getTradeBuilder
+        // during persistence - without needing a reference to this Fsm/TradeProtocol. Locking on the model gives
+        // both sides the same monitor, so a persistence snapshot of {state, eventQueue} can never be taken mid-transition.
+        synchronized (model) {
+            // Tracks whether this call reached a final state, so the finally block below can route the mandatory
+            // post-transition persist() call through persistOnFinalState() instead of the normal persist(). This
+            // matters for privacy/retention (#1622 follow-up): a final state clears eventQueue/processedEvents
+            // in-memory a few lines below, and that wipe must reach disk promptly - persistOnFinalState() bypasses
+            // any write-rate limiting a subclass may apply to the ordinary persist(), so the wipe is not silently
+            // dropped and left stranded on disk for an indefinite time (see RateLimitedPersistenceClient#persistNow).
+            boolean reachedFinalState = false;
             try {
                 checkNotNull(event, "event must not be null");
                 State currentState = model.getState();
@@ -95,14 +106,11 @@ public abstract class Fsm<M extends FsmModel> {
                     if (targetState.isFinalState()) {
                         model.processedEvents.clear();
                         model.eventQueue.clear();
+                        reachedFinalState = true;
                     } else {
                         model.processedEvents.add(eventClass);
                         // Apply all pending events to see if any of those match our current state.
-                        // If an exception is thrown by the processed pending event it will get thrown to the
-                        // caller. This would be a different triggering event as the event which cause
-                        // the exception (the one from the queue).
-                        // Clone set to avoid ConcurrentModificationException
-                        new HashSet<>(model.getEventQueue()).forEach(this::handle);
+                        drainEventQueue();
                     }
                 } else {
                     log.info("We did not find a transition with state {} and event {}. " +
@@ -128,12 +136,53 @@ public abstract class Fsm<M extends FsmModel> {
                 // We throw the exception to allow specific error handling to the implementation class.
                 throw fsmException;
             } finally {
-                persist();
+                if (reachedFinalState) {
+                    persistOnFinalState();
+                } else {
+                    persist();
+                }
             }
         }
     }
 
     protected abstract void persist();
+
+    /**
+     * Called instead of {@link #persist()} exactly once, when a transition reaches a final state. The default
+     * implementation just delegates to {@link #persist()}; override to bypass any write-rate limiting the
+     * concrete {@link #persist()} implementation applies (see {@code bisq.persistence.RateLimitedPersistenceClient}).
+     * <br/>
+     * Reaching a final state clears {@code eventQueue}/{@code processedEvents} in-memory a few lines above in
+     * {@link #handle(Event)}; those may hold sensitive, trade-specific network messages. Without a guaranteed,
+     * unthrottled flush here, a rate-limited persist() call could be silently dropped, leaving the (already
+     * in-memory-wiped) sensitive data sitting on disk for an unbounded time - potentially until the process's
+     * next unrelated persist() call, or its next clean shutdown, neither of which is guaranteed to happen promptly
+     * (or at all, on a crash/kill -9).
+     */
+    protected void persistOnFinalState() {
+        persist();
+    }
+
+    /**
+     * Re-attempts to handle every event currently sitting in the event queue against the current state.
+     * <br/>
+     * This is called automatically after any successful transition (see {@link #handle(Event)}), but it is
+     * also safe - and sometimes necessary - to call explicitly, e.g. once right after a model has been restored
+     * from persisted data: the event queue itself is not guaranteed to be persisted for every {@link FsmModel}
+     * subclass, so events which arrived out of order before a restart may otherwise never be re-applied because
+     * no further live transition ever occurs for that trade.
+     * <br/>
+     * Safe to call when the queue is empty (no-op) and safe to call multiple times. Exceptions from handling a
+     * queued event behave exactly as for a live event: each event goes through the concrete {@link #handle(Event)}
+     * implementation, so whether an {@link FsmException} propagates to the caller or is absorbed is up to the
+     * subclass (e.g. the trade protocols swallow it and surface an error state instead).
+     */
+    public void drainEventQueue() {
+        synchronized (model) {
+            // Clone set to avoid ConcurrentModificationException as handle() mutates model.eventQueue.
+            new HashSet<>(model.getEventQueue()).forEach(this::handle);
+        }
+    }
 
     public TransitionBuilder<M> addTransition() {
         return new TransitionBuilder<>(this);

--- a/common/src/main/java/bisq/common/fsm/Fsm.java
+++ b/common/src/main/java/bisq/common/fsm/Fsm.java
@@ -61,11 +61,15 @@ public abstract class Fsm<M extends FsmModel> {
     abstract protected void configTransitions();
 
     public <E extends Event> void handle(E event) {
-        // Synchronize on the model rather than on this Fsm instance: the model (see FsmModel#getStateAndEventQueueSnapshot)
-        // must be lockable directly by callers that only hold a reference to the model - e.g. Trade#getTradeBuilder
-        // during persistence - without needing a reference to this Fsm/TradeProtocol. Locking on the model gives
-        // both sides the same monitor, so a persistence snapshot of {state, eventQueue} can never be taken mid-transition.
-        synchronized (model) {
+        // Lock on the model's explicit lock rather than on this Fsm instance: the model (see
+        // FsmModel#getStateAndEventQueueSnapshot) must be lockable directly by callers that only hold a reference
+        // to the model - e.g. Trade#getTradeBuilder during persistence - without needing a reference to this
+        // Fsm/TradeProtocol. Sharing the same lock object gives both sides the same mutual exclusion, so a
+        // persistence snapshot of {state, eventQueue} can never be taken mid-transition. Unlike
+        // getStateAndEventQueueSnapshot()'s bounded tryLock, a live transition takes the lock unbounded - its
+        // correctness cannot be short-circuited by a timeout.
+        model.lock.lock();
+        try {
             // Tracks whether this call reached a final state, so the finally block below can route the mandatory
             // post-transition persist() call through persistOnFinalState() instead of the normal persist(). This
             // matters for privacy/retention (#1622 follow-up): a final state clears eventQueue/processedEvents
@@ -78,13 +82,21 @@ public abstract class Fsm<M extends FsmModel> {
                 State currentState = model.getState();
                 checkNotNull(currentState, "currentState must not be null");
                 if (currentState.isFinalState()) {
-                    log.warn("We have reached the final state and do not allow further state transition. New event was: {}", event);
+                    // Render the class only, never the event instance: the Fsm layer is generic and handles
+                    // domain events (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage) whose
+                    // generated toString() can contain private payment-account data. This log line - like the
+                    // checkArgument message and the error log below - can end up persisted as trade error info
+                    // and included in the error report sent to the peer, so it must never carry event content.
+                    log.warn("We have reached the final state and do not allow further state transition. New event class was: {}", event.getClass().getSimpleName());
                     return;
                 }
                 log.info("Start transition from currentState {}", currentState);
                 Class<? extends Event> eventClass = event.getClass();
                 var transitionMapEntriesForEvent = findTransitionMapEntriesForEvent(eventClass);
-                checkArgument(!transitionMapEntriesForEvent.isEmpty(), "No transition found for given event " + event);
+                // Class name only - see the final-state log above for why the event instance itself must never
+                // be rendered here. This message reaches FsmException's cause chain and from there the trade's
+                // persisted error info / peer error report.
+                checkArgument(!transitionMapEntriesForEvent.isEmpty(), "No transition found for given event class " + eventClass.getSimpleName());
                 Optional<Transition> transition = findTransition(currentState, transitionMapEntriesForEvent);
                 if (transition.isPresent()) {
                     State targetState = transition.get().getTargetState();
@@ -124,7 +136,8 @@ public abstract class Fsm<M extends FsmModel> {
                             .forEach(e -> model.eventQueue.add(event));
                 }
             } catch (Exception exception) {
-                log.error("Error at handling {}.", event, exception);
+                // Class name only - see the comment at the final-state log above.
+                log.error("Error at handling event of class {}.", event.getClass().getSimpleName(), exception);
                 FsmException fsmException = new FsmException(exception, event);
                 // In case of an exception we fire the FsmErrorEvent to trigger an error state.
                 // We apply that only if the event which triggered the exception was not the FsmErrorEvent itself
@@ -142,6 +155,8 @@ public abstract class Fsm<M extends FsmModel> {
                     persist();
                 }
             }
+        } finally {
+            model.lock.unlock();
         }
     }
 
@@ -178,9 +193,14 @@ public abstract class Fsm<M extends FsmModel> {
      * subclass (e.g. the trade protocols swallow it and surface an error state instead).
      */
     public void drainEventQueue() {
-        synchronized (model) {
+        // Unbounded, like handle() - ReentrantLock is reentrant, so the nested lock() calls inside each
+        // handle(event) below (same thread) are free.
+        model.lock.lock();
+        try {
             // Clone set to avoid ConcurrentModificationException as handle() mutates model.eventQueue.
             new HashSet<>(model.getEventQueue()).forEach(this::handle);
+        } finally {
+            model.lock.unlock();
         }
     }
 

--- a/common/src/main/java/bisq/common/fsm/FsmModel.java
+++ b/common/src/main/java/bisq/common/fsm/FsmModel.java
@@ -26,13 +26,36 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 
 @Slf4j
 @ToString
 @EqualsAndHashCode
 public class FsmModel {
+    /**
+     * Bound for {@link #getStateAndEventQueueSnapshot()}'s {@code tryLock}. Chosen short enough that the single,
+     * JVM-wide {@code Persistence} executor thread (see {@code bisq.persistence.Persistence#EXECUTOR}) can never
+     * be stuck for long on one trade's live transition - which would otherwise queue up every other store's
+     * writes behind it - yet long enough to comfortably clear the lock's normal, fast holders (a transition's
+     * state mutation plus a non-blocking persist() submission). A timed-out snapshot fails this write cycle
+     * rather than risk a torn read; RateLimitedPersistenceClient's generation pair keeps the store dirty so the
+     * next persist()/shutdown fallback retries - by which time a merely-slow (not stuck) handler has typically
+     * released the lock.
+     */
+    static final long SNAPSHOT_LOCK_TIMEOUT_MS = 500;
+
     private final Observable<State> state = new Observable<>();
+
+    // Explicit lock replacing the previous intrinsic-monitor use (synchronized(model) in Fsm#handle()/
+    // drainEventQueue(), synchronized methods below): ReentrantLock, unlike synchronized, offers a bounded
+    // tryLock(timeout), which getStateAndEventQueueSnapshot() below needs. Every party that used to synchronize
+    // on the model instance must now go through this SAME lock object - Fsm#handle()/drainEventQueue() included -
+    // or mutual exclusion between a live transition and a persistence-facing read silently breaks.
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    final ReentrantLock lock = new ReentrantLock();
 
     // Package visibility for access from Fsm mutating the collections.
     // CopyOnWriteArraySet rather than a plain HashSet, as defense-in-depth for any reader that bypasses
@@ -89,8 +112,8 @@ public class FsmModel {
     /**
      * Returns an atomic, defensively-copied snapshot of {@code state} and {@code eventQueue} taken together.
      * <br/>
-     * {@link Fsm#handle(Event)} and {@link Fsm#drainEventQueue()} synchronize on {@code this} model instance
-     * (not on the {@code Fsm} instance) precisely so that this method - callable directly on the model, e.g. from
+     * {@link Fsm#handle(Event)} and {@link Fsm#drainEventQueue()} take the same {@link #lock} (not a lock on the
+     * {@code Fsm} instance) precisely so that this method - callable directly on the model, e.g. from
      * {@code bisq.trade.Trade#getTradeBuilder} during persistence, which runs on a different thread than the Fsm's
      * own transitions (persistence is cloned/serialized asynchronously, and for MuSig trades the message-handling
      * itself runs on a dedicated executor - see {@code MuSigTradeService#handleMuSigTradeMessage}) - can take the
@@ -99,43 +122,83 @@ public class FsmModel {
      * Reading {@link #getState()} and {@link #getEventQueue()} via two separate, unsynchronized calls can tear:
      * a persistence snapshot could capture the state AFTER a transition together with the just-applied event
      * STILL in the queue (causing a double-apply on restore), or the state BEFORE the transition with the event
-     * already removed (causing the event to be silently lost). Capturing both fields in one synchronized method
-     * closes that gap.
+     * already removed (causing the event to be silently lost). Capturing both fields in one atomically-locked
+     * method closes that gap.
+     * <br/>
+     * Unlike {@link Fsm#handle(Event)}/{@link Fsm#drainEventQueue()}, which take the lock unbounded (transition
+     * correctness cannot be short-circuited), this method bounds its wait via {@code tryLock}: it is called from
+     * {@code Trade#getTradeBuilder}, which runs on the single, JVM-wide {@code Persistence} executor thread. A live
+     * transition can legitimately hold {@link #lock} for as long as its event handler takes (including blocking
+     * I/O - e.g. MuSig's gRPC calls), and that thread must never block on it indefinitely: doing so would queue up
+     * every other store's disk writes in the JVM behind this one trade. On timeout this throws
+     * {@link SnapshotLockTimeoutException} instead of falling back to an unsynchronized read - a torn read is
+     * exactly the bug this method exists to prevent - so the write fails for this cycle and retries once the
+     * generation pair notices it's still dirty (see {@code RateLimitedPersistenceClient}).
      * <br/>
      * The returned {@code eventQueue} is a defensive copy ({@link Set#copyOf}): it is independent of the live,
      * mutable {@code eventQueue} field, so a later transition can never retroactively change a snapshot that was
      * already taken and handed to a caller.
      */
-    public synchronized StateAndEventQueue getStateAndEventQueueSnapshot() {
-        return new StateAndEventQueue(getState(), Set.copyOf(eventQueue));
+    public StateAndEventQueue getStateAndEventQueueSnapshot() {
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(SNAPSHOT_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting up to {}ms to acquire the FsmModel lock during serialization; " +
+                    "write cycle will retry. modelClass={}", SNAPSHOT_LOCK_TIMEOUT_MS, getClass().getSimpleName());
+            throw new SnapshotLockTimeoutException(this, SNAPSHOT_LOCK_TIMEOUT_MS, e);
+        }
+        if (!acquired) {
+            log.warn("FsmModel lock not acquired within {}ms during serialization - a live transition is likely " +
+                    "holding it; write cycle will retry. modelClass={}", SNAPSHOT_LOCK_TIMEOUT_MS, getClass().getSimpleName());
+            throw new SnapshotLockTimeoutException(this, SNAPSHOT_LOCK_TIMEOUT_MS);
+        }
+        try {
+            return new StateAndEventQueue(getState(), Set.copyOf(eventQueue));
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
      * Clears the pending out-of-order event queue (and {@code processedEvents}) under the same lock used by
      * {@link #getStateAndEventQueueSnapshot()}, mirroring the final-state cleanup in {@link Fsm#handle(Event)}.
+     * Takes the lock unbounded, like {@link Fsm#handle(Event)}: this is called from the trade services, not from
+     * the persistence-serialization path, so there is no shared-executor-stall concern to bound against here.
      * <br/>
      * Used by the trade data-retention/redaction pass: the queue can hold sensitive account-data network messages
      * (e.g. {@code BisqEasyAccountDataMessage} / MuSig {@code SendAccountPayloadMessage}) which are persisted with
      * the trade. A stuck trade may never reach a final state to clear them, so they must be scrubbed once the trade
      * passes the redaction threshold, otherwise the persisted copy would linger on disk indefinitely.
      */
-    public synchronized void clearEventQueue() {
-        eventQueue.clear();
-        processedEvents.clear();
+    public void clearEventQueue() {
+        lock.lock();
+        try {
+            eventQueue.clear();
+            processedEvents.clear();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
      * Removes queued out-of-order events matching {@code filter}, under the same lock as
      * {@link #getStateAndEventQueueSnapshot()}. Returns true if anything was removed (so callers know a
-     * persist is warranted).
+     * persist is warranted). Takes the lock unbounded - see {@link #clearEventQueue()}.
      * <br/>
      * Used by the restore-drain guard in the trade services: a queued trade message passed validation when it
      * was originally received, but its sender may have been banned before the restart. Draining applies queued
      * events directly through the FSM - bypassing the {@code onMessage()} banned-sender check - so such events
      * must be scrubbed before the drain, mirroring what {@code onMessage()} would do with a live message.
      */
-    public synchronized boolean removeQueuedEventsIf(Predicate<Event> filter) {
-        return eventQueue.removeIf(filter);
+    public boolean removeQueuedEventsIf(Predicate<Event> filter) {
+        lock.lock();
+        try {
+            return eventQueue.removeIf(filter);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**

--- a/common/src/main/java/bisq/common/fsm/FsmModel.java
+++ b/common/src/main/java/bisq/common/fsm/FsmModel.java
@@ -24,8 +24,9 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Predicate;
 
 @Slf4j
 @ToString
@@ -33,9 +34,20 @@ import java.util.Set;
 public class FsmModel {
     private final Observable<State> state = new Observable<>();
 
-    // Package visibility for access from Fsm mutating the collections 
-    final Set<Event> eventQueue = new HashSet<>();
-    final Set<Class<? extends Event>> processedEvents = new HashSet<>();
+    // Package visibility for access from Fsm mutating the collections.
+    // CopyOnWriteArraySet rather than a plain HashSet, as defense-in-depth for any reader that bypasses
+    // getStateAndEventQueueSnapshot() and calls getEventQueue()/getProcessedEvents() directly without acquiring
+    // the model's monitor (Fsm#handle()/Fsm#drainEventQueue() now synchronize on the model instance itself - see
+    // getStateAndEventQueueSnapshot() below for why). Concurrently iterating a plain HashSet while another thread
+    // structurally mutates it is undefined behavior (ConcurrentModificationException or a torn read). Both sets
+    // are always small (a handful of pending FSM events per trade at most) and read far more often than mutated,
+    // which is exactly CopyOnWriteArraySet's sweet spot; it also gives every such reader (including
+    // Fsm#drainEventQueue()'s defensive copy-before-iterate, which a plain HashSet copy does not actually make
+    // safe under concurrent mutation) consistent snapshot-iterator semantics for free, without requiring any
+    // external synchronization. The primary, recommended mechanism for a cross-thread, all-fields-consistent read
+    // (e.g. Trade#getTradeBuilder during persistence) is getStateAndEventQueueSnapshot(), not these getters.
+    final Set<Event> eventQueue = new CopyOnWriteArraySet<>();
+    final Set<Class<? extends Event>> processedEvents = new CopyOnWriteArraySet<>();
 
     public FsmModel(State initialState) {
         if (initialState == null) {
@@ -72,5 +84,63 @@ public class FsmModel {
 
     public Set<Class<? extends Event>> getProcessedEvents() {
         return Collections.unmodifiableSet(processedEvents);
+    }
+
+    /**
+     * Returns an atomic, defensively-copied snapshot of {@code state} and {@code eventQueue} taken together.
+     * <br/>
+     * {@link Fsm#handle(Event)} and {@link Fsm#drainEventQueue()} synchronize on {@code this} model instance
+     * (not on the {@code Fsm} instance) precisely so that this method - callable directly on the model, e.g. from
+     * {@code bisq.trade.Trade#getTradeBuilder} during persistence, which runs on a different thread than the Fsm's
+     * own transitions (persistence is cloned/serialized asynchronously, and for MuSig trades the message-handling
+     * itself runs on a dedicated executor - see {@code MuSigTradeService#handleMuSigTradeMessage}) - can take the
+     * same lock and therefore never observe a torn read.
+     * <br/>
+     * Reading {@link #getState()} and {@link #getEventQueue()} via two separate, unsynchronized calls can tear:
+     * a persistence snapshot could capture the state AFTER a transition together with the just-applied event
+     * STILL in the queue (causing a double-apply on restore), or the state BEFORE the transition with the event
+     * already removed (causing the event to be silently lost). Capturing both fields in one synchronized method
+     * closes that gap.
+     * <br/>
+     * The returned {@code eventQueue} is a defensive copy ({@link Set#copyOf}): it is independent of the live,
+     * mutable {@code eventQueue} field, so a later transition can never retroactively change a snapshot that was
+     * already taken and handed to a caller.
+     */
+    public synchronized StateAndEventQueue getStateAndEventQueueSnapshot() {
+        return new StateAndEventQueue(getState(), Set.copyOf(eventQueue));
+    }
+
+    /**
+     * Clears the pending out-of-order event queue (and {@code processedEvents}) under the same lock used by
+     * {@link #getStateAndEventQueueSnapshot()}, mirroring the final-state cleanup in {@link Fsm#handle(Event)}.
+     * <br/>
+     * Used by the trade data-retention/redaction pass: the queue can hold sensitive account-data network messages
+     * (e.g. {@code BisqEasyAccountDataMessage} / MuSig {@code SendAccountPayloadMessage}) which are persisted with
+     * the trade. A stuck trade may never reach a final state to clear them, so they must be scrubbed once the trade
+     * passes the redaction threshold, otherwise the persisted copy would linger on disk indefinitely.
+     */
+    public synchronized void clearEventQueue() {
+        eventQueue.clear();
+        processedEvents.clear();
+    }
+
+    /**
+     * Removes queued out-of-order events matching {@code filter}, under the same lock as
+     * {@link #getStateAndEventQueueSnapshot()}. Returns true if anything was removed (so callers know a
+     * persist is warranted).
+     * <br/>
+     * Used by the restore-drain guard in the trade services: a queued trade message passed validation when it
+     * was originally received, but its sender may have been banned before the restart. Draining applies queued
+     * events directly through the FSM - bypassing the {@code onMessage()} banned-sender check - so such events
+     * must be scrubbed before the drain, mirroring what {@code onMessage()} would do with a live message.
+     */
+    public synchronized boolean removeQueuedEventsIf(Predicate<Event> filter) {
+        return eventQueue.removeIf(filter);
+    }
+
+    /**
+     * Immutable {state, eventQueue} pair captured atomically by {@link #getStateAndEventQueueSnapshot()}.
+     */
+    public record StateAndEventQueue(State state, Set<Event> eventQueue) {
     }
 }

--- a/common/src/main/java/bisq/common/fsm/SnapshotLockTimeoutException.java
+++ b/common/src/main/java/bisq/common/fsm/SnapshotLockTimeoutException.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.fsm;
+
+/**
+ * Thrown by {@link FsmModel#getStateAndEventQueueSnapshot()} when its bounded {@code tryLock} could not acquire
+ * the model's lock in time, because a live {@link Fsm#handle(Event)}/{@link Fsm#drainEventQueue()} transition is
+ * holding it. This is deliberately NOT caught by the per-trade {@code try/catch} in the trade stores' proto
+ * builders (e.g. {@code BisqEasyTradeStore#getBuilder}) - it must propagate all the way out and fail the whole
+ * store write for this cycle, rather than silently dropping just this one trade from the snapshot while the write
+ * still reports success. Letting it propagate rides the PR's own machinery: {@code PersistableStoreReaderWriter}
+ * propagates write failures, {@code RateLimitedPersistenceClient}'s generation pair keeps the store dirty, and the
+ * next {@code persist()}/shutdown fallback retries - by which time the transition holding the lock has typically
+ * finished.
+ */
+public class SnapshotLockTimeoutException extends RuntimeException {
+    public SnapshotLockTimeoutException(FsmModel model, long timeoutMs) {
+        super("Could not acquire the FsmModel lock within " + timeoutMs + "ms while taking a state/eventQueue " +
+                "snapshot for " + model.getClass().getSimpleName() + " - a live transition is likely holding it.");
+    }
+
+    public SnapshotLockTimeoutException(FsmModel model, long timeoutMs, Throwable cause) {
+        super("Interrupted while waiting up to " + timeoutMs + "ms to acquire the FsmModel lock while taking a " +
+                "state/eventQueue snapshot for " + model.getClass().getSimpleName(), cause);
+    }
+}

--- a/common/src/test/java/bisq/common/fsm/FsmTest.java
+++ b/common/src/test/java/bisq/common/fsm/FsmTest.java
@@ -22,13 +22,20 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FsmTest {
+    // Standin for private payment-account data that a real domain event's generated toString() could contain
+    // (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage). Used by SentinelMockEvent below.
+    private static final String SENTINEL_SECRET = "SECRET_PAYMENT_ACCOUNT_DATA_MUST_NOT_LEAK";
 
     @Test
     void testTransitions() {
@@ -343,6 +350,57 @@ public class FsmTest {
         FsmModel.StateAndEventQueue snapshotAfterTransition = model.getStateAndEventQueueSnapshot();
         assertEquals(MockState.S2, snapshotAfterTransition.state());
         assertTrue(snapshotAfterTransition.eventQueue().isEmpty());
+    }
+
+    /**
+     * Pins the bounded-tryLock behaviour {@link FsmModel#getStateAndEventQueueSnapshot()} needs for the single,
+     * JVM-wide {@code Persistence} executor thread (see {@code Trade#getTradeBuilder}): while a live transition
+     * holds the model's lock for a long-running event handler (simulating blocking I/O, e.g. MuSig's gRPC calls),
+     * a concurrent snapshot attempt must give up close to its bound instead of blocking indefinitely, and must
+     * throw {@link SnapshotLockTimeoutException} rather than fall back to an unsynchronized (and possibly torn)
+     * read. Once the transition completes and releases the lock, the very next snapshot attempt must succeed and
+     * reflect the settled, post-transition state.
+     */
+    @Test
+    void testGetStateAndEventQueueSnapshotTimesOutWhileHandleHoldsLockThenSucceedsAfterRelease() throws InterruptedException {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(BlockingMockEventHandler.class)
+                .to(MockState.S1);
+
+        BlockingMockEventHandler.started = new CountDownLatch(1);
+        BlockingMockEventHandler.release = new CountDownLatch(1);
+        try {
+            Thread slowHandlerThread = new Thread(() -> fsm.handle(new MockEvent1(model, "slow")), "slow-handler");
+            slowHandlerThread.start();
+            assertTrue(BlockingMockEventHandler.started.await(2, TimeUnit.SECONDS), "handler never started");
+
+            // The slow-handler thread now holds model's lock for the whole transition (Fsm#handle wraps
+            // eventHandler.handle()). A concurrent bounded snapshot attempt - exactly what Trade#getTradeBuilder
+            // does from the shared Persistence executor thread - must not block indefinitely.
+            long startNanos = System.nanoTime();
+            assertThrows(SnapshotLockTimeoutException.class, model::getStateAndEventQueueSnapshot);
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            assertTrue(elapsedMs < 2000,
+                    "tryLock must give up close to its bound, not block indefinitely; took " + elapsedMs + "ms");
+
+            // Release the slow handler; the transition completes normally.
+            BlockingMockEventHandler.release.countDown();
+            slowHandlerThread.join(2000);
+            assertEquals(MockState.S1, model.getState());
+
+            // Once the lock is free again, the very next snapshot call must succeed and reflect the now-settled
+            // state, proving this is a bounded wait, not a permanently broken lock.
+            FsmModel.StateAndEventQueue snapshot = model.getStateAndEventQueueSnapshot();
+            assertEquals(MockState.S1, snapshot.state());
+            assertTrue(snapshot.eventQueue().isEmpty());
+        } finally {
+            BlockingMockEventHandler.started = null;
+            BlockingMockEventHandler.release = null;
+        }
     }
 
     /**
@@ -810,6 +868,54 @@ public class FsmTest {
     }
 
 
+    /**
+     * The generic Fsm layer must never string-render a full
+     * event instance - domain events (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage) have
+     * generated toString() output that can contain private payment-account data, and the FsmException message
+     * built here (via {@code ExceptionUtil#getRootCauseMessage}) ends up both in the trade's persisted error
+     * info and in the BisqEasyReportErrorMessage sent to the peer. This drives the no-transition-found path
+     * (Fsm#handle's checkArgument), the one site whose message used to concatenate the event instance directly.
+     */
+    @Test
+    void testNoTransitionExceptionMessageDoesNotLeakEventContent() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        // Deliberately no transition registered for SentinelMockEvent at all.
+
+        fsm.handle(new SentinelMockEvent());
+
+        assertNotNull(fsm.lastSwallowedException, "handle() must have hit the no-transition-found path");
+        String message = fsm.lastSwallowedException.getMessage();
+        assertTrue(message.contains(SentinelMockEvent.class.getSimpleName()),
+                "message should still identify the event's class for diagnostics: " + message);
+        assertFalse(message.contains(SENTINEL_SECRET),
+                "message must not render the event instance itself: " + message);
+    }
+
+    /**
+     * Same guard as above, for the OTHER generic catch site in Fsm#handle: an event handler throwing mid-transition.
+     * The FSM layer's own log.error/FsmException construction must not add a leak here either - what the handler's
+     * own exception message says is outside the FSM layer's control (it's generic, not domain-aware), but the
+     * framework itself must not concatenate the event on top of that.
+     */
+    @Test
+    void testHandlerExceptionMessageDoesNotLeakEventContent() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(SentinelMockEvent.class)
+                .run(SentinelThrowingMockEventHandler.class)
+                .to(MockState.S1);
+
+        fsm.handle(new SentinelMockEvent());
+
+        assertNotNull(fsm.lastSwallowedException, "handle() must have hit the handler-exception path");
+        String message = fsm.lastSwallowedException.getMessage();
+        assertFalse(message.contains(SENTINEL_SECRET),
+                "message must not render the event instance itself: " + message);
+    }
+
     @Getter
     public enum MockState implements State {
         INIT,
@@ -885,6 +991,56 @@ public class FsmTest {
         @Override
         public void handle(Event event) {
             throw new RuntimeException("event is FsmException");
+        }
+    }
+
+    /**
+     * Standin for a domain event whose generated toString() carries private data. Used to prove the generic
+     * Fsm layer only ever renders the event's CLASS, never the instance itself (see
+     * testNoTransitionExceptionMessageDoesNotLeakEventContent / testHandlerExceptionMessageDoesNotLeakEventContent).
+     */
+    public static class SentinelMockEvent implements Event {
+        @Override
+        public String toString() {
+            return SENTINEL_SECRET;
+        }
+    }
+
+    public static class SentinelThrowingMockEventHandler implements EventHandler<Event> {
+        public SentinelThrowingMockEventHandler() {
+        }
+
+        @Override
+        public void handle(Event event) {
+            throw new RuntimeException("handler failed");
+        }
+    }
+
+    /**
+     * Simulates a slow/blocking event handler (e.g. MuSig's gRPC calls) to test that a concurrent, bounded
+     * {@link FsmModel#getStateAndEventQueueSnapshot()} does not block indefinitely on the model lock this handler
+     * holds for the whole transition. Handler classes are constructed reflectively via a no-arg constructor (see
+     * {@link SimpleFsm#newEventHandlerFromClass}), so per-run coordination must be static - reset by the test
+     * before and after use.
+     */
+    public static class BlockingMockEventHandler implements EventHandler<MockEvent1> {
+        static volatile CountDownLatch started;
+        static volatile CountDownLatch release;
+
+        @Override
+        public void handle(MockEvent1 event) {
+            started.countDown();
+            boolean released;
+            try {
+                released = release.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while blocking", e);
+            }
+            if (!released) {
+                throw new IllegalStateException("blocking handler was never released");
+            }
+            event.model.data = event.data;
         }
     }
 

--- a/common/src/test/java/bisq/common/fsm/FsmTest.java
+++ b/common/src/test/java/bisq/common/fsm/FsmTest.java
@@ -21,8 +21,12 @@ import lombok.Getter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FsmTest {
 
@@ -156,6 +160,290 @@ public class FsmTest {
         assertEquals("test_comp", fsm.getModel().data);
         assertEquals(0, model.eventQueue.size());
         assertEquals(0, model.processedEvents.size());
+    }
+
+    /**
+     * Reproduces the recovery mechanism behind issue #1622 (a Bisq Easy trade getting stuck because an
+     * out-of-order message sits forever in the FSM's event queue): a queued event, and the model's state,
+     * are captured as if they had just been read back from persisted data (this is exactly what
+     * {@code Trade}'s 3-arg constructor now feeds into {@link FsmModel#FsmModel(State, Set, Set)} when a
+     * trade is restored from proto). We then rebuild a fresh Fsm around that restored model and call
+     * {@link Fsm#drainEventQueue()} once, with no further event delivered, and confirm the queued event is
+     * still applied - proving that recovery no longer depends on some later, unrelated live transition
+     * (or, as happens in production today, an app restart happening to re-deliver the same message via
+     * mailbox replay) to save the trade.
+     */
+    @Test
+    void testDrainEventQueueAfterModelRestore() {
+        // Session 1: an out-of-order event arrives before its prerequisite transition. It gets queued and the
+        // enabling transition (INIT -> S1) never happens live in this session - mirrors the reported bug,
+        // where the buyer's confirm-fiat-sent message arrives before the seller has processed the buyer's
+        // btc-address message.
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, fsm.getModel().getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        // "Restart": rebuild the model purely from the persisted snapshot (state + queue + processedEvents),
+        // exactly as BisqEasyTrade#fromProto now does via Trade#pendingEventsFromProto/processedEventsFromProto.
+        // The restored state (S1) represents the enabling transition having already been persisted; only the
+        // event queue itself was previously at risk of being silently dropped across a restart.
+        MockModel restoredModel = new MockModel(MockState.S1, model.getEventQueue(), model.getProcessedEvents());
+        SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
+        restoredFsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // The restored queue must round-trip faithfully.
+        assertEquals(1, restoredModel.getEventQueue().size());
+        assertEquals(MockState.S1, restoredFsm.getModel().getState());
+
+        // No further event is delivered - only the drain is triggered, as happens once at trade/protocol
+        // reconstruction for a restored trade (BisqEasyTradeService#createAndAddTradeProtocol).
+        restoredFsm.drainEventQueue();
+
+        assertEquals(MockState.S2, restoredFsm.getModel().getState());
+        // MockEventHandler mutates the model referenced by the event itself (the original, pre-restore model,
+        // per the test fixture below) rather than the restoredFsm's model - this confirms the handler for the
+        // queued MockEvent2 genuinely ran during the drain, not just a state placeholder change.
+        assertEquals("queued", model.data);
+        assertTrue(restoredFsm.getModel().getEventQueue().isEmpty());
+    }
+
+    @Test
+    void testDrainEventQueueIsSafeAndIdempotentWhenEmpty() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+
+        // Calling drainEventQueue() on an empty queue must be a safe no-op, and calling it repeatedly must not
+        // change behaviour or throw (re-entrancy is guarded by the same synchronized(model) monitor as handle()).
+        fsm.drainEventQueue();
+        fsm.drainEventQueue();
+        assertEquals(MockState.INIT, fsm.getModel().getState());
+
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S1, fsm.getModel().getState());
+
+        fsm.drainEventQueue();
+        fsm.drainEventQueue();
+        assertEquals(MockState.S1, fsm.getModel().getState());
+        assertEquals("test1", fsm.getModel().data);
+    }
+
+    /**
+     * Regression/documentation guard for the bug itself: if the event queue is NOT carried over on restore
+     * (the behaviour before this fix - {@code Trade} used to call the single-arg {@code FsmModel(State)}
+     * constructor from {@code fromProto}), the queued event is lost forever. Calling drainEventQueue() cannot
+     * recover data that was never restored in the first place; restoring the queue itself (see
+     * {@link #testDrainEventQueueAfterModelRestore}) is what fixes issue #1622, not drainEventQueue() alone.
+     */
+    @Test
+    void testEventIsLostForeverIfQueueIsNotRestored() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(1, model.getEventQueue().size());
+
+        // "Restart" using only the single-arg constructor - the pre-fix behaviour: the queue is not restored.
+        MockModel restoredModel = new MockModel(MockState.S1);
+        SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
+        restoredFsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        assertTrue(restoredModel.getEventQueue().isEmpty());
+        restoredFsm.drainEventQueue();
+
+        // The trade is stuck forever: nothing but the original MockEvent2 instance (now gone) could unstick it.
+        assertEquals(MockState.S1, restoredFsm.getModel().getState());
+        assertNull(restoredFsm.getModel().data);
+    }
+
+    /**
+     * Deterministic proof that {@link FsmModel#getStateAndEventQueueSnapshot()} captures {@code state} and
+     * {@code eventQueue} atomically and independently of later mutation - the concurrency guarantee behind the
+     * #4885 follow-up (making the persisted {state, eventQueue} pair atomic). A genuine data race between
+     * Fsm#handle() and an off-thread persistence read is not something we can reproduce deterministically without
+     * a flaky thread-interleaving test, so instead this pins the single-threaded contract the fix relies on:
+     * a snapshot taken at time T must forever reflect exactly what was true at T, however the model changes after.
+     */
+    @Test
+    void testStateAndEventQueueSnapshotIsAtomicAndIndependentOfLaterMutation() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // MockEvent2 arrives before the enabling INIT -> S1 transition: no transition matches MockEvent2 from
+        // INIT, so the Fsm parks it in the queue instead of applying it.
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        // A snapshot taken now must reflect exactly this pre-transition reality.
+        FsmModel.StateAndEventQueue snapshotBeforeTransition = model.getStateAndEventQueueSnapshot();
+        assertEquals(MockState.INIT, snapshotBeforeTransition.state());
+        assertEquals(1, snapshotBeforeTransition.eventQueue().size());
+
+        // The enabling transition fires: state moves to S1, then the automatic post-transition drain immediately
+        // re-applies the queued MockEvent2, advancing straight on to S2 and emptying the live queue - all within
+        // this single handle() call.
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S2, model.getState());
+        assertTrue(model.getEventQueue().isEmpty());
+
+        // Load-bearing assertion: the snapshot taken BEFORE the transition must be completely unaffected by it.
+        // This proves two things at once: (a) the eventQueue copy was defensive/independent - a reference into
+        // the live CopyOnWriteArraySet would now appear empty, since the live queue was drained - and (b) state
+        // and eventQueue were captured together as of the same instant, not via two independently-racy reads.
+        assertEquals(MockState.INIT, snapshotBeforeTransition.state());
+        assertEquals(1, snapshotBeforeTransition.eventQueue().size());
+
+        // A fresh snapshot taken now must reflect the new, post-transition reality.
+        FsmModel.StateAndEventQueue snapshotAfterTransition = model.getStateAndEventQueueSnapshot();
+        assertEquals(MockState.S2, snapshotAfterTransition.state());
+        assertTrue(snapshotAfterTransition.eventQueue().isEmpty());
+    }
+
+    /**
+     * Follow-up to #4885 (privacy/retention, Henrik's review point): a transition reaching a final state clears
+     * eventQueue/processedEvents in-memory (see Fsm#handle), which may hold sensitive, trade-specific network
+     * messages. The persist call which follows that clear must be routed through {@link Fsm#persistOnFinalState()}
+     * rather than the plain, potentially rate-limited {@link Fsm#persist()}, so that the wipe is not left stranded
+     * on disk. This test pins that dispatch deterministically, without any real I/O or timing involved.
+     */
+    @Test
+    void testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.COMPLETED);
+
+        // A normal, non-final transition must go through the ordinary (potentially rate-limited) persist().
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S1, fsm.getModel().getState());
+        assertEquals(1, fsm.persistCallCount);
+        assertEquals(0, fsm.persistOnFinalStateCallCount);
+
+        // The completing transition must be routed through persistOnFinalState() instead - exactly once, and
+        // the ordinary persist() must NOT additionally fire for this same call.
+        fsm.handle(new MockEvent2(model, "test2"));
+        assertEquals(MockState.COMPLETED, fsm.getModel().getState());
+        assertEquals(1, fsm.persistCallCount);
+        assertEquals(1, fsm.persistOnFinalStateCallCount);
+    }
+
+    /**
+     * Follow-up to #4885 (privacy/retention, Henrik's review point): a stuck trade may never reach a final state,
+     * so its parked out-of-order events - which can hold sensitive account-data network messages persisted with the
+     * trade - would otherwise linger on disk indefinitely. {@link FsmModel#clearEventQueue()} is the seam the
+     * data-retention/redaction pass uses to scrub them once a trade passes the redaction threshold. This pins that
+     * it empties both eventQueue and processedEvents.
+     */
+    @Test
+    void testClearEventQueueScrubsParkedEvents() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // MockEvent2 arrives before its enabling transition, so the Fsm parks it in the queue (the stuck-trade shape).
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        model.clearEventQueue();
+
+        assertTrue(model.getEventQueue().isEmpty(), "clearEventQueue() must empty the parked event queue");
+        assertTrue(model.getProcessedEvents().isEmpty(), "clearEventQueue() must also clear processedEvents");
+    }
+
+    @Test
+    void testRemoveQueuedEventsIfScrubsOnlyMatchingParkedEvents() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent3.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S3);
+
+        // Both arrive before their enabling state, so the Fsm parks them (the stuck-trade shape).
+        fsm.handle(new MockEvent2(model, "queued-2"));
+        fsm.handle(new MockEvent3(model, "queued-3"));
+        assertEquals(2, model.getEventQueue().size());
+
+        // The selective scrub used by the restore-drain guard (drop events from a now-banned sender):
+        // only matching events go, the rest stay queued for the drain.
+        boolean removed = model.removeQueuedEventsIf(MockEvent2.class::isInstance);
+
+        assertTrue(removed, "removeQueuedEventsIf must report that something was removed");
+        assertEquals(1, model.getEventQueue().size(), "non-matching events must stay queued");
+        assertTrue(model.getEventQueue().stream().anyMatch(MockEvent3.class::isInstance));
+
+        assertFalse(model.removeQueuedEventsIf(MockEvent2.class::isInstance),
+                "a second scrub with no matches must report nothing removed");
     }
 
     @Test
@@ -608,6 +896,10 @@ public class FsmTest {
         public MockModel(MockState state, String data) {
             super(state);
             this.data = data;
+        }
+
+        public MockModel(MockState state, Set<Event> eventQueue, Set<Class<? extends Event>> processedEvents) {
+            super(state, eventQueue, processedEvents);
         }
 
         private String data = null;

--- a/common/src/test/java/bisq/common/fsm/SimpleFsm.java
+++ b/common/src/test/java/bisq/common/fsm/SimpleFsm.java
@@ -3,6 +3,10 @@ package bisq.common.fsm;
 import java.lang.reflect.InvocationTargetException;
 
 public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
+    // Test-only invocation counters, used to assert which persist path a given transition routed through
+    // (see FsmTest#testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState).
+    public int persistCallCount = 0;
+    public int persistOnFinalStateCallCount = 0;
 
     public SimpleFsm(M model) {
         super(model);
@@ -36,6 +40,11 @@ public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
 
     @Override
     protected void persist() {
-        // Ignore for test
+        persistCallCount++;
+    }
+
+    @Override
+    protected void persistOnFinalState() {
+        persistOnFinalStateCallCount++;
     }
 }

--- a/common/src/test/java/bisq/common/fsm/SimpleFsm.java
+++ b/common/src/test/java/bisq/common/fsm/SimpleFsm.java
@@ -7,6 +7,11 @@ public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
     // (see FsmTest#testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState).
     public int persistCallCount = 0;
     public int persistOnFinalStateCallCount = 0;
+    // Test-only capture of the FsmException this class otherwise swallows below, so tests can assert on its
+    // message content (e.g. that it never renders a full event instance - see
+    // FsmTest#testNoTransitionExceptionMessageDoesNotLeakEventContent /
+    // #testHandlerExceptionMessageDoesNotLeakEventContent).
+    public FsmException lastSwallowedException;
 
     public SimpleFsm(M model) {
         super(model);
@@ -34,7 +39,8 @@ public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
         try {
             super.handle(event);
         } catch (FsmException fsmException) {
-            // We swallow the exception
+            // We swallow the exception - test-only capture for assertions, see lastSwallowedException above.
+            lastSwallowedException = fsmException;
         }
     }
 

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
@@ -61,6 +61,11 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
         return readStoreFromFileOrRestoreFromBackup();
     }
 
+    /**
+     * Failures are rethrown (after logging) instead of being swallowed, so that callers' persist futures complete
+     * exceptionally rather than falsely reporting a successful write - {@code RateLimitedPersistenceClient} relies
+     * on that to keep its dirty flag set when a retention-critical write did not actually reach disk.
+     */
     public synchronized void write(T persistableStore) {
         storeFileManager.createParentDirectoriesIfNotExisting();
         try {
@@ -72,8 +77,10 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
             storeFileManager.renameTempFileToCurrentFile();
         } catch (CouldNotSerializePersistableStore e) {
             log.error("Couldn't serialize {}", persistableStore, e);
+            throw e;
         } catch (Exception e) {
             log.error("Couldn't write persistable store to disk.", e);
+            throw new RuntimeException("Couldn't write persistable store to disk.", e);
         }
     }
 

--- a/persistence/src/main/java/bisq/persistence/Persistence.java
+++ b/persistence/src/main/java/bisq/persistence/Persistence.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 public class Persistence<T extends PersistableStore<T>> {
@@ -42,6 +43,13 @@ public class Persistence<T extends PersistableStore<T>> {
     private final String fileName;
 
     private final PersistableStoreReaderWriter<T> persistableStoreReaderWriter;
+    // Write-id guard: every write request takes a monotonic ticket; a write is SKIPPED when a
+    // higher-ticket write of this store already reached disk. This makes writes monotonic regardless
+    // of which thread performs them - specifically, a direct shutdown-hook write (see
+    // RateLimitedPersistenceClient#persistOnShutdown) cannot be overwritten later by a STALE write
+    // that was still queued on the shared executor when the hook ran.
+    private final AtomicLong writeRequestId = new AtomicLong();
+    private final AtomicLong lastWrittenId = new AtomicLong();
 
     public Persistence(Path directoryPath, String fileName, MaxBackupSize maxBackupSize, RestoreService restoreService) {
         this.fileName = fileName;
@@ -61,11 +69,49 @@ public class Persistence<T extends PersistableStore<T>> {
     }
 
     public CompletableFuture<Void> persistAsync(T serializable) {
-        return CompletableFuture.runAsync(() -> persist(serializable), EXECUTOR);
+        // Ticket taken at SUBMISSION time, so a direct persist() call issued later (shutdown hook)
+        // always outranks every write already sitting in the executor queue.
+        long writeId = writeRequestId.incrementAndGet();
+        return CompletableFuture.runAsync(() -> writeIfNotSuperseded(serializable, writeId), EXECUTOR);
     }
 
     protected void persist(T persistableStore) {
+        writeIfNotSuperseded(persistableStore, writeRequestId.incrementAndGet());
+    }
+
+    /** The actual disk write - the single overridable seam below the write-id guard. */
+    protected void doWrite(T persistableStore) {
         persistableStoreReaderWriter.write(persistableStore);
+    }
+
+    /**
+     * Reserves a write ticket WITHOUT writing. Callers that capture their snapshot under a lock (see
+     * RateLimitedPersistenceClient's scheduleLock) must reserve the ticket under that SAME lock and pass
+     * it to {@link #persist(PersistableStore, long)} - otherwise a concurrent submission can capture a
+     * newer snapshot yet receive an OLDER ticket, and the guard would skip the newer write as stale.
+     * Ticket order must equal snapshot-capture order for the guard to be correct.
+     */
+    long reserveWriteId() {
+        return writeRequestId.incrementAndGet();
+    }
+
+    void persist(T persistableStore, long writeId) {
+        writeIfNotSuperseded(persistableStore, writeId);
+    }
+
+    private void writeIfNotSuperseded(T persistableStore, long writeId) {
+        // Same monitor as PersistableStoreReaderWriter#write (a synchronized method): the stale check,
+        // the disk write and the watermark update must be one atomic unit. Without it a stale task
+        // could pass the check, block on an in-flight newer write, and then overwrite it anyway.
+        synchronized (persistableStoreReaderWriter) {
+            if (lastWrittenId.get() > writeId) {
+                log.info("Skipping write {} of {}: a newer snapshot (write {}) is already on disk.",
+                        writeId, fileName, lastWrittenId.get());
+                return;
+            }
+            doWrite(persistableStore);
+            lastWrittenId.accumulateAndGet(writeId, Math::max);
+        }
     }
 
     public CompletableFuture<Void> pruneBackups() {

--- a/persistence/src/main/java/bisq/persistence/PersistenceClient.java
+++ b/persistence/src/main/java/bisq/persistence/PersistenceClient.java
@@ -49,7 +49,16 @@ public interface PersistenceClient<T extends PersistableStore<T>> {
     PersistableStore<T> getPersistableStore();
 
     default CompletableFuture<Boolean> persist() {
-        return getPersistence().persistAsync(getPersistableStore().getClone())
-                .handle((nil, throwable) -> throwable == null);
+        // Snapshot capture and write-ticket assignment (inside persistAsync) must be one atomic unit:
+        // Persistence's write-id guard skips a write when a higher-ticket write already landed, which is
+        // only correct if ticket order equals capture order. Without this lock, two concurrent persist()
+        // calls (e.g. ProfileAgeService/SignedWitnessService/AccountAgeService are reachable from
+        // scheduler and message-handler threads) could capture in one order and take tickets in the
+        // other, silently dropping the newer snapshot. RateLimitedPersistenceClient overrides this with
+        // its own scheduleLock-based equivalent.
+        synchronized (this) {
+            return getPersistence().persistAsync(getPersistableStore().getClone())
+                    .handle((nil, throwable) -> throwable == null);
+        }
     }
 }

--- a/persistence/src/main/java/bisq/persistence/RateLimitedPersistenceClient.java
+++ b/persistence/src/main/java/bisq/persistence/RateLimitedPersistenceClient.java
@@ -39,7 +39,16 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
     // write can't hang JVM shutdown indefinitely.
     private static final long SHUTDOWN_WRITE_AWAIT_MS = 2000;
 
+    // lastWrite/lastWriteGeneration are only ever read or written under scheduleLock (including the failure-path
+    // rollback below) - the volatile on lastWrite predates that and is now redundant, but harmless; left as-is to
+    // keep this fix minimal.
     private volatile long lastWrite;
+    // Tags lastWrite with the generation that last set it, so the failure-path rollback (see the completion
+    // handler in persist()/persistNow()) can tell whether it's still safe to restore the PREVIOUS lastWrite value,
+    // or whether a newer call has since moved lastWrite past it (in which case rolling back would clobber
+    // legitimate, newer throttle state). A plain timestamp equality check would work for the common case but is
+    // vulnerable to two calls landing in the same millisecond; the generation counter is unique by construction.
+    private long lastWriteGeneration;
     // Throttle heuristic only: with the generation pair below, CORRECTNESS no longer depends on this flag,
     // so its benign races (two threads may both observe it false) cost at most an extra write.
     private volatile boolean writeInProgress;
@@ -88,27 +97,65 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
             if (tooFast || writeInProgress) {
                 return CompletableFuture.completedFuture(false);
             }
+            long previousLastWrite = lastWrite;
             lastWrite = System.currentTimeMillis();
+            lastWriteGeneration = myGeneration;
             writeInProgress = true;
-            CompletableFuture<Boolean> future = getPersistence()
-                    .persistAsync(getPersistableStore().getClone())
-                    .handle((nil, throwable) -> {
-                        writeInProgress = false;
-                        boolean success = throwable == null;
-                        if (success) {
-                            // The snapshot was taken after the bump to myGeneration, so it covers everything up
-                            // to it. max() keeps persistedGeneration monotone; it can never claim a generation a
-                            // newer request has already moved past.
-                            persistedGeneration.accumulateAndGet(myGeneration, Math::max);
-                        }
-                        return success;
-                    });
-            return future;
+            return scheduleWrite(myGeneration, previousLastWrite);
         }
     }
 
     protected long getMaxWriteRateInMs() {
         return 1000;
+    }
+
+    /**
+     * Submits the actual write and wires up its completion. Called from within scheduleLock by persist()/
+     * persistNow(), but the returned future's completion handler itself runs later, off the persistence
+     * executor thread, OUTSIDE scheduleLock (persistAsync() only submits and returns immediately - the write
+     * itself, and this handler, run asynchronously).
+     */
+    private CompletableFuture<Boolean> scheduleWrite(long myGeneration, long previousLastWrite) {
+        return getPersistence()
+                .persistAsync(getPersistableStore().getClone())
+                .handle((nil, throwable) -> {
+                    writeInProgress = false;
+                    boolean success = throwable == null;
+                    if (success) {
+                        // The snapshot was taken after the bump to myGeneration, so it covers everything up
+                        // to it. max() keeps persistedGeneration monotone; it can never claim a generation a
+                        // newer request has already moved past.
+                        persistedGeneration.accumulateAndGet(myGeneration, Math::max);
+                    } else {
+                        // A failed write must not consume the rate-limit budget: without this, lastWrite already
+                        // reflects "we just wrote" even though nothing reached disk, so every ORDINARY persist()
+                        // call within the next getMaxWriteRateInMs() window is silently dropped (tooFast) instead
+                        // of retrying. The generation pair still correctly reports the store dirty (isDropped()),
+                        // but nothing actively retries it until either an unrelated call happens to land outside
+                        // that window, or an explicit persistNow()/the shutdown fallback runs - for a store with
+                        // no further natural persist() traffic that can be an unbounded wait. Rolling lastWrite
+                        // back to what it was before this attempt makes the very next ordinary persist() call
+                        // retry through the normal path, exactly as if this failed attempt had never happened.
+                        rollBackLastWriteIfStillOurs(myGeneration, previousLastWrite);
+                    }
+                    return success;
+                });
+    }
+
+    /**
+     * Undoes this call's lastWrite update, but ONLY if no newer call has since moved lastWrite past it - this
+     * completion handler runs outside scheduleLock (see scheduleWrite), concurrently with any new persist()/
+     * persistNow() call that already took the lock and legitimately advanced lastWrite/lastWriteGeneration past
+     * ours; unconditionally overwriting lastWrite here would clobber that newer call's throttle state and let a
+     * write happen sooner than intended for state this failed write never even covered. Guarded by the unique
+     * generation counter, not a timestamp equality check, since two calls can land in the same millisecond.
+     */
+    private void rollBackLastWriteIfStillOurs(long myGeneration, long previousLastWrite) {
+        synchronized (scheduleLock) {
+            if (lastWriteGeneration == myGeneration) {
+                lastWrite = previousLastWrite;
+            }
+        }
     }
 
     /**
@@ -124,19 +171,14 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
     public CompletableFuture<Boolean> persistNow() {
         synchronized (scheduleLock) {
             long myGeneration = requestedGeneration.incrementAndGet();
+            long previousLastWrite = lastWrite;
             lastWrite = System.currentTimeMillis();
+            lastWriteGeneration = myGeneration;
             writeInProgress = true;
-            CompletableFuture<Boolean> future = getPersistence()
-                    .persistAsync(getPersistableStore().getClone())
-                    .handle((nil, throwable) -> {
-                        writeInProgress = false;
-                        boolean success = throwable == null;
-                        if (success) {
-                            persistedGeneration.accumulateAndGet(myGeneration, Math::max);
-                        }
-                        return success;
-                    });
-            return future;
+            // Same rollback-on-failure contract as persist() (see scheduleWrite): persistNow() bypasses the
+            // throttle for ITSELF, but still updates lastWrite, so a failed persistNow() must not silently
+            // throttle away the NEXT ordinary persist() call either.
+            return scheduleWrite(myGeneration, previousLastWrite);
         }
     }
 

--- a/persistence/src/main/java/bisq/persistence/RateLimitedPersistenceClient.java
+++ b/persistence/src/main/java/bisq/persistence/RateLimitedPersistenceClient.java
@@ -18,10 +18,12 @@
 package bisq.persistence;
 
 import bisq.common.util.StringUtils;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This implementation of PersistenceClient drops persist requests if they happen too frequently.
@@ -33,10 +35,31 @@ import java.util.concurrent.CompletableFuture;
  */
 @Slf4j
 public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>> implements PersistenceClient<T> {
+    // Max time the shutdown hook waits for its queued fallback write to confirm. Bounded so a stuck
+    // write can't hang JVM shutdown indefinitely.
+    private static final long SHUTDOWN_WRITE_AWAIT_MS = 2000;
+
     private volatile long lastWrite;
-    @Getter
-    private volatile boolean dropped;
+    // Throttle heuristic only: with the generation pair below, CORRECTNESS no longer depends on this flag,
+    // so its benign races (two threads may both observe it false) cost at most an extra write.
     private volatile boolean writeInProgress;
+    // Dirty state is DERIVED from this generation pair instead of a mutable boolean flag:
+    //  - requestedGeneration is bumped on EVERY persist()/persistNow() entry, before the store snapshot is
+    //    taken, so a write scheduled at generation N covers all state up to N.
+    //  - persistedGeneration advances (monotonically, via max) only when a write confirms, to the generation
+    //    its snapshot covered.
+    //  - dirty <=> requestedGeneration > persistedGeneration.
+    // This removes the check-then-act races a boolean flag had (an older write's completion could wipe the
+    // dirty mark of a newer, never-written request), and it makes failed writes keep the store dirty for
+    // free: a failure simply never advances persistedGeneration, so the shutdown fallback retries it.
+    private final AtomicLong requestedGeneration = new AtomicLong();
+    private final AtomicLong persistedGeneration = new AtomicLong();
+    // Serializes generation bump -> snapshot capture -> handoff to the persistence executor, so snapshots
+    // reach the (write-serializing) executor in generation order. Without it, an older call could capture
+    // its snapshot, stall, and schedule AFTER a newer call's write - leaving stale state on disk while the
+    // generation pair reports clean. Only an in-memory clone and an executor submit happen under this lock,
+    // never disk I/O.
+    private final Object scheduleLock = new Object();
 
     public RateLimitedPersistenceClient() {
         //todo (Critical) check if we want to use ShutdownHook here
@@ -46,22 +69,41 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
         }));
     }
 
+    /**
+     * True while the in-memory store holds state which no confirmed write has covered yet — because a request
+     * was throttled away, a write is still in flight, or a write failed. Consulted by the shutdown hook to
+     * decide whether the fallback synchronous write is needed.
+     */
+    public boolean isDropped() {
+        return requestedGeneration.get() > persistedGeneration.get();
+    }
+
     @Override
     public CompletableFuture<Boolean> persist() {
-        boolean tooFast = System.currentTimeMillis() - lastWrite < getMaxWriteRateInMs();
-        dropped = tooFast || writeInProgress;
-        if (dropped) {
-            return CompletableFuture.completedFuture(false);
-        } else {
+        synchronized (scheduleLock) {
+            // Bump BEFORE the throttle decision and before any snapshot: if this request gets dropped, the store
+            // is dirty by construction (requested > persisted) until some later write covers this generation.
+            long myGeneration = requestedGeneration.incrementAndGet();
+            boolean tooFast = System.currentTimeMillis() - lastWrite < getMaxWriteRateInMs();
+            if (tooFast || writeInProgress) {
+                return CompletableFuture.completedFuture(false);
+            }
             lastWrite = System.currentTimeMillis();
             writeInProgress = true;
-            dropped = false;
-            return getPersistence()
+            CompletableFuture<Boolean> future = getPersistence()
                     .persistAsync(getPersistableStore().getClone())
                     .handle((nil, throwable) -> {
                         writeInProgress = false;
-                        return throwable == null;
+                        boolean success = throwable == null;
+                        if (success) {
+                            // The snapshot was taken after the bump to myGeneration, so it covers everything up
+                            // to it. max() keeps persistedGeneration monotone; it can never claim a generation a
+                            // newer request has already moved past.
+                            persistedGeneration.accumulateAndGet(myGeneration, Math::max);
+                        }
+                        return success;
                     });
+            return future;
         }
     }
 
@@ -69,10 +111,87 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
         return 1000;
     }
 
-    private void persistOnShutdown() {
-        if (dropped) {
-            dropped = false;
-            getPersistence().persist(getPersistableStore().getClone());
+    /**
+     * Persists immediately, bypassing the write-rate limiter that {@link #persist()} applies.
+     * <br/>
+     * Reserved for privacy/retention-critical writes where a throttled-and-dropped {@link #persist()} call could
+     * leave sensitive data on disk for an unbounded time - e.g. a completed trade's pending FSM events, which are
+     * cleared in-memory the instant the trade reaches a final state (see {@code bisq.common.fsm.Fsm#handle}), but
+     * whose on-disk copy has no other guaranteed opportunity to catch up: the next unrelated persist() call may
+     * never come (a completed trade has no further transitions), and the shutdown-hook flush this class registers
+     * is best-effort only - it never runs on a JVM crash or {@code kill -9}.
+     */
+    public CompletableFuture<Boolean> persistNow() {
+        synchronized (scheduleLock) {
+            long myGeneration = requestedGeneration.incrementAndGet();
+            lastWrite = System.currentTimeMillis();
+            writeInProgress = true;
+            CompletableFuture<Boolean> future = getPersistence()
+                    .persistAsync(getPersistableStore().getClone())
+                    .handle((nil, throwable) -> {
+                        writeInProgress = false;
+                        boolean success = throwable == null;
+                        if (success) {
+                            persistedGeneration.accumulateAndGet(myGeneration, Math::max);
+                        }
+                        return success;
+                    });
+            return future;
+        }
+    }
+
+    // Package-private for testing
+    void persistOnShutdown() {
+        // An in-flight or failed write leaves requested > persisted, so this single check covers "write
+        // still pending", "write failed" and "request throttled away" alike.
+        if (!isDropped()) {
+            return;
+        }
+        try {
+            // Route the fallback through the SAME serialized executor as every other write (persistNow
+            // bumps the generation, captures under scheduleLock and submits): queued behind any still-
+            // pending write, it can never be overwritten by an older snapshot landing later. Bounded so
+            // a congested queue can't hang JVM shutdown.
+            boolean success = persistNow().get(SHUTDOWN_WRITE_AWAIT_MS, TimeUnit.MILLISECONDS);
+            if (success) {
+                return;
+            }
+            // The queued write failed (e.g. disk error) - retry directly below.
+        } catch (TimeoutException e) {
+            // The queued write may never run: the executor uses daemon threads, which the JVM stops
+            // right after the shutdown hooks return. Fall through to the direct write - it is durable
+            // before this hook returns, and Persistence's write-id guard makes it safe: if the stale
+            // queued write does wake up later it is SKIPPED, not applied over the newer state.
+            log.warn("The queued shutdown write did not confirm within {} ms; writing directly on the shutdown thread.",
+                    SHUTDOWN_WRITE_AWAIT_MS);
+        } catch (Exception e) {
+            // Submission itself failed (e.g. the executor is already shut down) - direct write below.
+            log.warn("Submitting the shutdown fallback write failed; falling back to a direct write.", e);
+        }
+        // Generation, snapshot AND the write ticket are all captured under scheduleLock - the identical
+        // atomicity contract the async paths have (their ticket is assigned inside persistAsync, invoked
+        // under this same lock). Reserving the ticket outside the lock would open a gap where a concurrent
+        // persistNow() captures a NEWER snapshot yet ends up with an OLDER ticket, making the guard skip
+        // the newer write as stale and falsely report it clean. Only the disk write stays outside the lock.
+        long myGeneration;
+        T snapshot;
+        long writeId;
+        synchronized (scheduleLock) {
+            myGeneration = requestedGeneration.get();
+            snapshot = getPersistableStore().getClone();
+            writeId = getPersistence().reserveWriteId();
+        }
+        try {
+            // Durable the moment this returns (shares the store's write monitor with the executor task, so
+            // it cannot interleave with an in-flight write of this store). If a write with a NEWER ticket
+            // already landed by now, this is skipped - correct: that ticket's snapshot was captured after
+            // ours under the same lock, so strictly newer state is already on disk.
+            getPersistence().persist(snapshot, writeId);
+            persistedGeneration.accumulateAndGet(myGeneration, Math::max);
+        } catch (Exception e) {
+            // Persistence.persist() propagates write failures (so callers can't mistake failure for
+            // durability); on the shutdown-hook thread there is nothing left to do but log.
+            log.error("Direct write at shutdown failed.", e);
         }
     }
 }

--- a/persistence/src/test/java/bisq/persistence/PersistableStoreReaderWriterTests.java
+++ b/persistence/src/test/java/bisq/persistence/PersistableStoreReaderWriterTests.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PersistableStoreReaderWriterTests {
@@ -126,6 +127,22 @@ public class PersistableStoreReaderWriterTests {
                     .count();
         }
         assertEquals(1, count, "Expected exactly one file starting with " + storageFilePath.getFileName());
+    }
+
+    @Test
+    void writeFailurePropagatesToCaller(@TempDir Path tempDirPath) throws Exception {
+        var timestampStore = new TimestampStore();
+        Path storageFilePath = tempDirPath.resolve("protoFile");
+        var storeFileManager = new PersistableStoreFileManager(storageFilePath);
+        var persistableStoreReaderWriter = new PersistableStoreReaderWriter<TimestampStore>(storeFileManager, new RestoreService());
+
+        // Occupy the temp-file path with a directory so the write cannot succeed
+        Files.createDirectories(storeFileManager.getTempFilePath());
+
+        // Callers (persist futures, RateLimitedPersistenceClient's dirty flag) rely on failures being
+        // propagated rather than swallowed-and-logged
+        assertThatThrownBy(() -> persistableStoreReaderWriter.write(timestampStore))
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test

--- a/persistence/src/test/java/bisq/persistence/PersistenceWriteGuardTests.java
+++ b/persistence/src/test/java/bisq/persistence/PersistenceWriteGuardTests.java
@@ -1,0 +1,203 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.persistence;
+
+import bisq.common.proto.ProtoResolver;
+import bisq.persistence.backup.MaxBackupSize;
+import bisq.persistence.backup.RestoreService;
+import com.google.protobuf.Any;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the write-id guard in {@link Persistence} (#4885 review): a snapshot written directly on the
+ * caller's thread (the shutdown-hook path) must be durable the moment the call returns, and a STALE
+ * write still queued on the shared persistence executor must not overwrite it when the queue later
+ * drains. Without the guard the stale write wins and the disk silently ends on old state while the
+ * client's generation bookkeeping reports clean.
+ */
+class PersistenceWriteGuardTests {
+
+    @Test
+    void directWriteIsDurableOnReturnAndCannotBeOverwrittenByAStaleQueuedWrite(@TempDir Path tempDirPath) throws Exception {
+        registerTimestampStoreResolver();
+
+        // Store A occupies the SHARED single-thread persistence executor: its serialization gates until
+        // released - the real-world shutdown congestion case (one slow store starving all queued writes).
+        var executorGate = new CountDownLatch(1);
+        var serializationEntered = new CountDownLatch(1);
+        var gatedStore = new GatedSerializationStore(executorGate, serializationEntered);
+        var persistenceA = new Persistence<GatedSerializationStore>(
+                tempDirPath, "GatedStore", MaxBackupSize.ZERO, new RestoreService());
+        CompletableFuture<Void> blockedWrite = persistenceA.persistAsync(gatedStore);
+        // try/finally around everything that runs while the gate is closed: a failing assertion must not
+        // leave the SHARED single-thread executor parked, or every later test writing through it cascades
+        // into unrelated timeouts.
+        try {
+            assertThat(serializationEntered.await(2, TimeUnit.SECONDS))
+                    .as("the gated write must be running on the executor thread")
+                    .isTrue();
+
+            // Store B: an older snapshot (v1) gets queued behind the blocked write, then the newest snapshot
+            // (v2) is written DIRECTLY on this thread - as the shutdown hook does after its bounded wait
+            // timed out.
+            var persistenceB = new Persistence<TimestampStore>(
+                    tempDirPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+            CompletableFuture<Void> staleQueuedWrite = persistenceB.persistAsync(storeWithVersion(1));
+            persistenceB.persist(storeWithVersion(2));
+
+            // Durability: the newest snapshot is on disk the moment the direct write returns - while the
+            // stale write is still queued. On a real shutdown the JVM may die right here; v2 must survive.
+            assertThat(readVersion(persistenceB))
+                    .as("the direct write must be durable before it returns")
+                    .isEqualTo(2L);
+
+            // The queue drains after the hook returned (JVM stayed alive long enough): the stale queued
+            // write must be skipped, not applied over the newer on-disk state.
+            executorGate.countDown();
+            blockedWrite.get(5, TimeUnit.SECONDS);
+            staleQueuedWrite.get(5, TimeUnit.SECONDS);
+            assertThat(readVersion(persistenceB))
+                    .as("a stale queued write must never overwrite a newer on-disk snapshot")
+                    .isEqualTo(2L);
+        } finally {
+            executorGate.countDown();
+        }
+    }
+
+    @Test
+    void ticketOrderDecidesWhichWriteWins(@TempDir Path tempDirPath) {
+        registerTimestampStoreResolver();
+        var persistence = new Persistence<TimestampStore>(
+                tempDirPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+
+        // The Hole this pins (security review of #4885): a snapshot captured EARLIER must never win over
+        // one captured later. Callers guarantee capture-order == ticket-order by reserving the ticket
+        // under the same lock as the snapshot capture (RateLimitedPersistenceClient's scheduleLock, or
+        // the synchronized default in PersistenceClient#persist); here we verify the guard end: a write
+        // carrying an older reserved ticket is skipped once a newer-ticket write has landed...
+        long olderTicket = persistence.reserveWriteId();
+        persistence.persist(storeWithVersion(2)); // auto-ticket, newer than olderTicket
+        persistence.persist(storeWithVersion(1), olderTicket);
+        assertThat(readVersion(persistence))
+                .as("a write with an older reserved ticket must be skipped, not applied over newer state")
+                .isEqualTo(2L);
+
+        // ...while a reserved ticket that is still the newest writes normally.
+        long newestTicket = persistence.reserveWriteId();
+        persistence.persist(storeWithVersion(3), newestTicket);
+        assertThat(readVersion(persistence)).isEqualTo(3L);
+    }
+
+    @Test
+    void queuedWriteStillRunsWhenNoNewerWriteLanded(@TempDir Path tempDirPath) throws Exception {
+        registerTimestampStoreResolver();
+        var persistence = new Persistence<TimestampStore>(
+                tempDirPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+
+        persistence.persistAsync(storeWithVersion(1)).get(5, TimeUnit.SECONDS);
+        assertThat(readVersion(persistence)).isEqualTo(1L);
+
+        // And newer writes keep applying normally after older ones.
+        persistence.persistAsync(storeWithVersion(2)).get(5, TimeUnit.SECONDS);
+        assertThat(readVersion(persistence)).isEqualTo(2L);
+    }
+
+    private static final String VERSION_KEY = "version";
+
+    private static TimestampStore storeWithVersion(long version) {
+        TimestampStore store = new TimestampStore();
+        store.getTimestampsByProfileId().put(VERSION_KEY, version);
+        return store;
+    }
+
+    private static long readVersion(Persistence<TimestampStore> persistence) {
+        TimestampStore read = persistence.read().orElseThrow();
+        return read.getTimestampsByProfileId().get(VERSION_KEY);
+    }
+
+    private static void registerTimestampStoreResolver() {
+        try {
+            PersistableStoreResolver.addResolver(new TimestampStore().getResolver());
+        } catch (Exception e) {
+            // Already registered by another test in this JVM - fine.
+        }
+    }
+
+    /**
+     * Minimal store whose serialization ({@link #toAny()}, the entry point
+     * {@code PersistableStoreReaderWriter#writeStoreToFilePath} uses) blocks until released - holding the
+     * shared persistence executor's single thread exactly like a slow/wedged store write does.
+     */
+    private static final class GatedSerializationStore implements PersistableStore<GatedSerializationStore> {
+        private final TimestampStore delegate = new TimestampStore();
+        private final CountDownLatch gate;
+        private final CountDownLatch entered;
+
+        private GatedSerializationStore(CountDownLatch gate, CountDownLatch entered) {
+            this.gate = gate;
+            this.entered = entered;
+        }
+
+        @Override
+        public Any toAny() {
+            entered.countDown();
+            try {
+                if (!gate.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("gated serialization was never released");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return Any.pack(delegate.toProto(false));
+        }
+
+        @Override
+        public bisq.persistence.protobuf.TimestampStore toProto(boolean serializeForHash) {
+            return delegate.toProto(serializeForHash);
+        }
+
+        @Override
+        public bisq.persistence.protobuf.TimestampStore.Builder getBuilder(boolean serializeForHash) {
+            return delegate.getBuilder(serializeForHash);
+        }
+
+        @Override
+        public GatedSerializationStore getClone() {
+            return this;
+        }
+
+        @Override
+        public void applyPersisted(GatedSerializationStore persisted) {
+            // not needed
+        }
+
+        @Override
+        public ProtoResolver<PersistableStore<?>> getResolver() {
+            return delegate.getResolver();
+        }
+    }
+}

--- a/persistence/src/test/java/bisq/persistence/RateLimitedPersistenceClientTests.java
+++ b/persistence/src/test/java/bisq/persistence/RateLimitedPersistenceClientTests.java
@@ -17,9 +17,13 @@
 
 package bisq.persistence;
 
+import bisq.common.fsm.FsmModel;
+import bisq.common.fsm.SnapshotLockTimeoutException;
+import bisq.common.fsm.State;
 import bisq.common.proto.ProtoResolver;
 import bisq.persistence.backup.MaxBackupSize;
 import bisq.persistence.backup.RestoreService;
+import com.google.protobuf.Any;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -30,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -126,6 +131,65 @@ public class RateLimitedPersistenceClientTests {
         assertThat(client.isDropped()).isFalse();
     }
 
+    /**
+     * persist()/persistNow() update lastWrite BEFORE the asynchronous write even
+     * starts. Before this fix, a FAILED write left lastWrite exactly as if it had succeeded, so the generation
+     * pair correctly kept the store dirty (isDropped()==true) but nothing ACTIVELY retried it: the very next
+     * ORDINARY persist() call - within getMaxWriteRateInMs() of the failed attempt - would be silently dropped
+     * (tooFast) instead of retrying, and only an explicit persistNow(), the shutdown fallback, or some unrelated
+     * call landing outside the throttle window would ever close the gap. No persistNow(), no sleep here - the
+     * retry must go through the plain ordinary path.
+     */
+    @Test
+    void failedOrdinaryPersistRollsBackThrottleSoNextOrdinaryPersistRetriesWithoutPersistNow(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> firstResult = client.persist();
+        inFlightWrite.completeExceptionally(new IOException("disk full"));
+        assertThat(firstResult.join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+
+        // Immediately after - well within getMaxWriteRateInMs() - a plain ordinary persist() call.
+        CompletableFuture<Boolean> secondResult = client.persist();
+        assertThat(secondResult.join())
+                .as("the failed write's rollback must let the very next ordinary persist() pass the tooFast check")
+                .isTrue();
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    /**
+     * Control for the fix above: the rollback must apply to FAILURES only. A successful write still has to
+     * consume the rate-limit budget exactly as before, or persist() stops rate-limiting altogether.
+     */
+    @Test
+    void successfulOrdinaryPersistStillEnforcesRateLimitOnNextCall(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> firstResult = client.persist();
+        inFlightWrite.complete(null);
+        assertThat(firstResult.join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+
+        // Immediately after a SUCCESSFUL write, a second ordinary persist() must still be throttled.
+        CompletableFuture<Boolean> secondResult = client.persist();
+        assertThat(secondResult.join())
+                .as("a successful write must still consume the rate-limit budget - the rollback is failure-only")
+                .isFalse();
+        // requestedGeneration is bumped BEFORE the throttle check on every persist() call, dropped or not (by
+        // design, unrelated to this fix - see persist()'s own comment) - so isDropped() correctly flips back to
+        // true here: this second call represents a real, not-yet-covered persist REQUEST. What this test pins is
+        // narrower: unlike the failure case, this drop is a genuine throttle (tooFast), not something the
+        // rollback should have prevented - a later persist()/persistNow() call still needs to actually run to
+        // clear it.
+        assertThat(client.isDropped()).isTrue();
+    }
+
     @Test
     void olderSnapshotCannotBeWrittenAfterNewerOne(@TempDir Path tempDirPath) throws Exception {
         var persistence = new ManualPersistence(tempDirPath);
@@ -210,6 +274,161 @@ public class RateLimitedPersistenceClientTests {
         persistence.failSyncPersist = true;
         client.persistOnShutdown();
         assertThat(persistence.syncPersistCalls.get()).isEqualTo(1);
+    }
+
+    /**
+     * End-to-end proof for the FsmModel#getStateAndEventQueueSnapshot() bounded-tryLock fix: a real
+     * SnapshotLockTimeoutException thrown from serialization (toAny(), the entry point
+     * PersistableStoreReaderWriter#writeStoreToFilePath actually calls - see PersistenceWriteGuardTests'
+     * GatedSerializationStore for the same seam), driven through the REAL Persistence/PersistableStoreReaderWriter
+     * write path (not the ManualPersistence stand-in above), proves this PR's own machinery already handles it
+     * correctly with no further changes needed: the failed write leaves the client dirty (isDropped()==true) and
+     * does not corrupt disk, and the next unthrottled retry (mirroring Fsm#persistOnFinalState's persistNow()
+     * route, or the shutdown fallback) succeeds once the simulated lock contention has cleared.
+     */
+    @Test
+    void snapshotLockTimeoutDuringSerializationKeepsClientDirtyAndRetries(@TempDir Path tempDirPath) {
+        registerTimestampStoreResolver();
+        var writePersistence = new Persistence<FlakySerializationStore>(tempDirPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+        var failNextSerialization = new AtomicBoolean(true);
+        var store = new FlakySerializationStore(failNextSerialization, 1L);
+        var client = new RealPersistenceTestClient(writePersistence, store);
+
+        // First write cycle: the model lock is (simulated as) held by a live transition past the bounded wait.
+        assertThat(client.persistNow().join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+        assertThat(readVersion(tempDirPath)).isEmpty();
+
+        // The transition has since released the lock (simulated by arming the store to succeed): the next
+        // write cycle's retry must succeed and reach disk.
+        store.bumpVersion(2L);
+        assertThat(client.persistNow().join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+        assertThat(readVersion(tempDirPath)).contains(2L);
+    }
+
+    /**
+     * end-to-end: same SnapshotLockTimeoutException-driven failure as the sibling
+     * test above, but the retry this time is a single plain, ORDINARY persist() call - no persistNow(), no
+     * sleep - proving the rollback-on-failure fix closes the retry gap through the exact real-world path
+     * (AuthenticatedDataStorageService.add()/remove()/refresh() etc. only ever call the ordinary persist()).
+     */
+    @Test
+    void snapshotLockTimeoutDuringSerializationRetriesOnNextOrdinaryPersistWithoutPersistNow(@TempDir Path tempDirPath) {
+        registerTimestampStoreResolver();
+        var writePersistence = new Persistence<FlakySerializationStore>(tempDirPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+        var failNextSerialization = new AtomicBoolean(true);
+        var store = new FlakySerializationStore(failNextSerialization, 1L);
+        var client = new RealPersistenceTestClient(writePersistence, store);
+
+        // First write cycle: the model lock is (simulated as) held by a live transition past the bounded wait.
+        assertThat(client.persist().join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+        assertThat(readVersion(tempDirPath)).isEmpty();
+
+        // The transition has since released the lock (simulated by arming the store to succeed). A single
+        // ORDINARY persist() call, immediately after and well within getMaxWriteRateInMs(), must retry and land
+        // on disk
+        store.bumpVersion(2L);
+        assertThat(client.persist().join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+        assertThat(readVersion(tempDirPath)).contains(2L);
+    }
+
+    // Reads back through a separately-typed Persistence<TimestampStore> pointed at the same file: the bytes on
+    // disk are genuinely a TimestampStore proto (FlakySerializationStore#toAny() packs via the delegate), resolved
+    // through the global registry - reading them back as the self-typed FlakySerializationStore would be an
+    // unchecked, erasure-hidden cast to the wrong runtime type.
+    private static java.util.Optional<Long> readVersion(Path tempDirPath) {
+        var readPersistence = new Persistence<TimestampStore>(tempDirPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+        return readPersistence.read().map(store -> store.getTimestampsByProfileId().get("version"));
+    }
+
+    private static void registerTimestampStoreResolver() {
+        try {
+            PersistableStoreResolver.addResolver(new TimestampStore().getResolver());
+        } catch (Exception e) {
+            // Already registered by another test in this JVM - fine.
+        }
+    }
+
+    /**
+     * Store whose serialization ({@link #toAny()}) throws a real {@link SnapshotLockTimeoutException} exactly
+     * once (while armed), simulating FsmModel#getStateAndEventQueueSnapshot()'s bounded tryLock giving up on a
+     * live transition, then serializes normally - simulating the transition having released the lock by the next
+     * write cycle. Self-typed as {@code PersistableStore<FlakySerializationStore>} (rather than wrapping
+     * TimestampStore as its type parameter) so that {@link RateLimitedPersistenceClient#persist()}'s
+     * {@code getPersistableStore().getClone()} returns an object whose {@code toAny()} is still this flaky
+     * behaviour - exactly like BisqEasyTradeStore#getClone()'s shallow copy still reaches the same live trades.
+     */
+    private static final class FlakySerializationStore implements PersistableStore<FlakySerializationStore> {
+        private final TimestampStore delegate = new TimestampStore();
+        private final AtomicBoolean failNextSerialization;
+
+        private FlakySerializationStore(AtomicBoolean failNextSerialization, long version) {
+            this.failNextSerialization = failNextSerialization;
+            delegate.getTimestampsByProfileId().put("version", version);
+        }
+
+        void bumpVersion(long version) {
+            delegate.getTimestampsByProfileId().put("version", version);
+        }
+
+        @Override
+        public Any toAny() {
+            if (failNextSerialization.compareAndSet(true, false)) {
+                throw new SnapshotLockTimeoutException(new FsmModel(State.FsmState.ERROR), 500);
+            }
+            return Any.pack(delegate.toProto(false));
+        }
+
+        @Override
+        public bisq.persistence.protobuf.TimestampStore toProto(boolean serializeForHash) {
+            return delegate.toProto(serializeForHash);
+        }
+
+        @Override
+        public bisq.persistence.protobuf.TimestampStore.Builder getBuilder(boolean serializeForHash) {
+            return delegate.getBuilder(serializeForHash);
+        }
+
+        @Override
+        public FlakySerializationStore getClone() {
+            // Shallow: shares the same delegate and flag, like BisqEasyTradeStore#getClone()'s Set.copyOf of live
+            // trade references - the point being pinned is that the CLONE's serialization can still fail/block on
+            // live state, not that this test harness needs a deep copy.
+            return this;
+        }
+
+        @Override
+        public void applyPersisted(FlakySerializationStore persisted) {
+            delegate.applyPersisted(persisted.delegate);
+        }
+
+        @Override
+        public ProtoResolver<PersistableStore<?>> getResolver() {
+            return delegate.getResolver();
+        }
+    }
+
+    private static final class RealPersistenceTestClient extends RateLimitedPersistenceClient<FlakySerializationStore> {
+        private final Persistence<FlakySerializationStore> persistence;
+        private final PersistableStore<FlakySerializationStore> store;
+
+        private RealPersistenceTestClient(Persistence<FlakySerializationStore> persistence, PersistableStore<FlakySerializationStore> store) {
+            this.persistence = persistence;
+            this.store = store;
+        }
+
+        @Override
+        public Persistence<FlakySerializationStore> getPersistence() {
+            return persistence;
+        }
+
+        @Override
+        public PersistableStore<FlakySerializationStore> getPersistableStore() {
+            return store;
+        }
     }
 
     private static final class ManualPersistence extends Persistence<TimestampStore> {

--- a/persistence/src/test/java/bisq/persistence/RateLimitedPersistenceClientTests.java
+++ b/persistence/src/test/java/bisq/persistence/RateLimitedPersistenceClientTests.java
@@ -1,0 +1,372 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.persistence;
+
+import bisq.common.proto.ProtoResolver;
+import bisq.persistence.backup.MaxBackupSize;
+import bisq.persistence.backup.RestoreService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RateLimitedPersistenceClientTests {
+
+    @Test
+    void persistNowKeepsDirtyUntilWriteConfirms(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> result = client.persistNow();
+        // No optimistic clear: while the write is in flight the store must still count as dirty.
+        assertThat(client.isDropped()).isTrue();
+
+        inFlightWrite.complete(null);
+        assertThat(result.join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    @Test
+    void persistNowSuccessDoesNotClearDropMarkedByNewerDroppedPersist(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> result = client.persistNow();
+
+        // A newer persist request arrives while the write is still in flight and gets dropped
+        // (writeInProgress). Its state is NOT covered by the in-flight snapshot.
+        assertThat(client.persist().join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+
+        inFlightWrite.complete(null);
+        assertThat(result.join()).isTrue();
+        // The older write's success must not mark the newer, never-written state as clean -
+        // otherwise the shutdown hook would skip its fallback write and silently lose it.
+        assertThat(client.isDropped()).isTrue();
+    }
+
+    @Test
+    void persistNowKeepsDirtyWhenWriteFails(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> result = client.persistNow();
+
+        inFlightWrite.completeExceptionally(new IOException("disk full"));
+        assertThat(result.join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+    }
+
+    @Test
+    void successfulOrdinaryPersistMarksStoreClean(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> result = client.persist();
+        // Dirty while in flight - clean only once the write confirms (no optimistic clear).
+        assertThat(client.isDropped()).isTrue();
+
+        inFlightWrite.complete(null);
+        assertThat(result.join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    @Test
+    void failedOrdinaryPersistKeepsStoreDirtyAndShutdownRetriesIt(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        CompletableFuture<Boolean> result = client.persist();
+        inFlightWrite.completeExceptionally(new IOException("disk full"));
+        assertThat(result.join()).isFalse();
+
+        // A failed ordinary persist() must leave the store dirty - previously it was marked clean at
+        // schedule time and a failure never restored the flag, so shutdown skipped its fallback write.
+        assertThat(client.isDropped()).isTrue();
+
+        client.persistOnShutdown();
+        // The retry is routed through the serialized write queue (so it cannot be overtaken by an older
+        // queued write); what matters is the outcome: the failed request's generation ends up covered.
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    @Test
+    void olderSnapshotCannotBeWrittenAfterNewerOne(@TempDir Path tempDirPath) throws Exception {
+        var persistence = new ManualPersistence(tempDirPath);
+        var store = new BlockingCloneStore();
+        var client = new TestClient(persistence, store);
+
+        // Thread A: an ordinary persist() whose snapshot capture stalls - simulating a thread paused
+        // between capturing its (older) snapshot and handing it to the persistence executor.
+        store.armBlockOnNextClone();
+        Thread olderPersist = new Thread(() -> client.persist(), "older-persist");
+        olderPersist.start();
+        store.awaitCloneEntered();
+
+        // The store advances, and a newer unthrottled persistNow() arrives (e.g. a trade completed).
+        store.bumpVersion();
+        Thread newerPersistNow = new Thread(() -> client.persistNow(), "newer-persistNow");
+        newerPersistNow.start();
+        // Unfixed code: the newer call is not ordered w.r.t. the stalled older one and finishes now.
+        // Fixed code: it parks until the older capture+schedule completes - either way this join returns.
+        newerPersistNow.join(500);
+
+        store.releaseClone();
+        olderPersist.join(2000);
+        newerPersistNow.join(2000);
+
+        // Whatever the interleaving, the LAST snapshot written must be the newest store state. The
+        // failure mode being pinned here: disk ends at the stale older snapshot while the generation
+        // pair claims clean - a silent, undetected data loss.
+        assertThat(persistence.writtenVersions).isNotEmpty();
+        assertThat(persistence.writtenVersions.get(persistence.writtenVersions.size() - 1))
+                .isEqualTo(store.currentVersion());
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    @Test
+    void shutdownFallbackCannotBeOvertakenByQueuedOlderWrite(@TempDir Path tempDirPath) throws Exception {
+        var persistence = new ManualPersistence(tempDirPath);
+        var store = new BlockingCloneStore();
+        var client = new TestClient(persistence, store);
+
+        // An older async write is submitted but its actual disk write is still queued on the executor.
+        var olderWriteGate = new CompletableFuture<Void>();
+        persistence.nextWrite.set(olderWriteGate);
+        client.persist();
+
+        // The store advances past the queued snapshot, then the JVM shuts down.
+        store.bumpVersion();
+        Thread shutdownHook = new Thread(client::persistOnShutdown, "shutdown-hook");
+        shutdownHook.start();
+        // Let the shutdown path run its course (it awaits the in-flight write with a bounded timeout).
+        shutdownHook.join(8_000);
+
+        // The queued older write finally lands - after shutdown already wrote its newer fallback state.
+        olderWriteGate.complete(null);
+
+        // Both writes settle; whatever the interleaving, the disk must end at the NEWEST state. The bug
+        // being pinned: the fallback bypassed the write queue, so the late v1 write overwrote its v2.
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (persistence.writtenVersions.size() < 2 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        assertThat(persistence.writtenVersions).isNotEmpty();
+        assertThat(persistence.writtenVersions.get(persistence.writtenVersions.size() - 1))
+                .isEqualTo(store.currentVersion());
+    }
+
+    @Test
+    void shutdownFallbackWritesDroppedStateAndSurvivesWriteFailure(@TempDir Path tempDirPath) {
+        var persistence = new ManualPersistence(tempDirPath);
+        var client = new TestClient(persistence);
+        var inFlightWrite = new CompletableFuture<Void>();
+        persistence.nextWrite.set(inFlightWrite);
+
+        client.persistNow();
+        inFlightWrite.completeExceptionally(new IOException("disk full"));
+        assertThat(client.isDropped()).isTrue();
+
+        // The executor is already gone at this point in the shutdown sequence: submission is rejected, so
+        // the synchronous last-resort write runs - and its failure must not propagate (on the real
+        // shutdown-hook thread there is nobody left to handle it).
+        persistence.rejectAsyncWrites = true;
+        persistence.failSyncPersist = true;
+        client.persistOnShutdown();
+        assertThat(persistence.syncPersistCalls.get()).isEqualTo(1);
+    }
+
+    private static final class ManualPersistence extends Persistence<TimestampStore> {
+        final AtomicReference<CompletableFuture<Void>> nextWrite = new AtomicReference<>();
+        final AtomicInteger syncPersistCalls = new AtomicInteger();
+        // Versions carried by the snapshots in DISK-WRITE order: async writes are FIFO-chained the way the
+        // real (serialized, single-threaded) persistence executor runs them, and each records its version
+        // when its write COMPLETES; the synchronous persist() records at call time, like the real direct
+        // write. The last element is therefore what would be left on disk.
+        final List<Long> writtenVersions = new CopyOnWriteArrayList<>();
+        volatile boolean failSyncPersist;
+        // Simulates the persistence executor being already shut down: submissions are rejected.
+        volatile boolean rejectAsyncWrites;
+        private CompletableFuture<Void> writeQueueTail = CompletableFuture.completedFuture(null);
+
+        private ManualPersistence(Path directoryPath) {
+            super(directoryPath, "TimestampStore", MaxBackupSize.ZERO, new RestoreService());
+        }
+
+        @Override
+        public synchronized CompletableFuture<Void> persistAsync(TimestampStore serializable) {
+            if (rejectAsyncWrites) {
+                throw new java.util.concurrent.RejectedExecutionException("executor already shut down");
+            }
+            Long version = serializable.getTimestampsByProfileId().get(BlockingCloneStore.VERSION_KEY);
+            CompletableFuture<Void> manual = nextWrite.getAndSet(null);
+            CompletableFuture<Void> trigger = manual != null ? manual : CompletableFuture.completedFuture(null);
+            // FIFO like the real executor: this write runs only after every previously submitted write.
+            CompletableFuture<Void> write = writeQueueTail
+                    .exceptionally(prior -> null) // an earlier failed write doesn't block the queue
+                    .thenCompose(prior -> trigger)
+                    .thenRun(() -> {
+                        if (version != null) {
+                            writtenVersions.add(version);
+                        }
+                    });
+            writeQueueTail = write;
+            return write;
+        }
+
+        @Override
+        protected void doWrite(TimestampStore persistableStore) {
+            syncPersistCalls.incrementAndGet();
+            if (failSyncPersist) {
+                throw new RuntimeException("Couldn't write persistable store to disk.");
+            }
+            Long version = persistableStore.getTimestampsByProfileId().get(BlockingCloneStore.VERSION_KEY);
+            if (version != null) {
+                writtenVersions.add(version);
+            }
+        }
+    }
+
+    /**
+     * Store whose {@link #getClone()} tags each snapshot with the store version at capture time and can
+     * stall a single capture on demand - the hook the ordering regression test uses to hold an older
+     * snapshot "in hand" while a newer call races past it.
+     */
+    private static final class BlockingCloneStore implements PersistableStore<TimestampStore> {
+        static final String VERSION_KEY = "version";
+
+        private final TimestampStore delegate = new TimestampStore();
+        private final AtomicLong version = new AtomicLong(1);
+        // Armed latch is CLAIMED (taken and cleared) by the first clone that sees it, so exactly one
+        // capture stalls; later captures run through unblocked.
+        private final AtomicReference<CountDownLatch> blockNextClone = new AtomicReference<>();
+        private volatile CountDownLatch armedLatch;
+        private final CountDownLatch cloneEntered = new CountDownLatch(1);
+
+        void armBlockOnNextClone() {
+            armedLatch = new CountDownLatch(1);
+            blockNextClone.set(armedLatch);
+        }
+
+        void awaitCloneEntered() throws InterruptedException {
+            if (!cloneEntered.await(2, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("clone was never entered");
+            }
+        }
+
+        void releaseClone() {
+            CountDownLatch latch = armedLatch;
+            if (latch != null) {
+                latch.countDown();
+            }
+        }
+
+        void bumpVersion() {
+            version.incrementAndGet();
+        }
+
+        long currentVersion() {
+            return version.get();
+        }
+
+        @Override
+        public TimestampStore getClone() {
+            long capturedVersion = version.get();
+            CountDownLatch latch = blockNextClone.getAndSet(null);
+            if (latch != null) {
+                cloneEntered.countDown();
+                try {
+                    if (!latch.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("blocked clone was never released");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+            TimestampStore snapshot = new TimestampStore();
+            snapshot.getTimestampsByProfileId().put(VERSION_KEY, capturedVersion);
+            return snapshot;
+        }
+
+        @Override
+        public void applyPersisted(TimestampStore persisted) {
+            delegate.applyPersisted(persisted);
+        }
+
+        @Override
+        public bisq.persistence.protobuf.TimestampStore toProto(boolean serializeForHash) {
+            return delegate.toProto(serializeForHash);
+        }
+
+        @Override
+        public bisq.persistence.protobuf.TimestampStore.Builder getBuilder(boolean serializeForHash) {
+            return delegate.getBuilder(serializeForHash);
+        }
+
+        @Override
+        public ProtoResolver<PersistableStore<?>> getResolver() {
+            return delegate.getResolver();
+        }
+    }
+
+    private static final class TestClient extends RateLimitedPersistenceClient<TimestampStore> {
+        private final ManualPersistence persistence;
+        private final PersistableStore<TimestampStore> store;
+
+        private TestClient(ManualPersistence persistence) {
+            this(persistence, new TimestampStore());
+        }
+
+        private TestClient(ManualPersistence persistence, PersistableStore<TimestampStore> store) {
+            this.persistence = persistence;
+            this.store = store;
+        }
+
+        @Override
+        public Persistence<TimestampStore> getPersistence() {
+            return persistence;
+        }
+
+        @Override
+        public PersistableStore<TimestampStore> getPersistableStore() {
+            return store;
+        }
+    }
+}

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -17,6 +17,7 @@
 
 package bisq.trade;
 
+import bisq.common.fsm.Event;
 import bisq.common.fsm.FsmModel;
 import bisq.common.fsm.State;
 import bisq.common.monetary.Monetary;
@@ -26,6 +27,7 @@ import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.proto.PersistableProto;
 import bisq.contract.Contract;
 import bisq.identity.Identity;
+import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.offer.Direction;
 import bisq.offer.Offer;
 import bisq.security.DigestUtil;
@@ -37,7 +39,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -114,7 +118,25 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                     P taker,
                     P maker,
                     TradeLifecycleState lifecycleState) {
-        super(state);
+        this(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState, Set.of());
+    }
+
+    // Used when restoring a trade from persisted data. Passing in the persisted pendingEvents ensures that FSM
+    // events which arrived out of order and could not yet be applied before the previous shutdown are not
+    // silently lost (see bisq.common.fsm.FsmModel and bisq.common.fsm.Fsm#drainEventQueue). processedEvents is
+    // never restored across a restart: it is only ever used live, in-memory, within a single running session
+    // (populated the moment a transition succeeds, cleared once a final state is reached - see Fsm#handle), so
+    // we always start it out empty here.
+    protected Trade(C contract,
+                    State state,
+                    String id,
+                    TradeRole tradeRole,
+                    Identity myIdentity,
+                    P taker,
+                    P maker,
+                    TradeLifecycleState lifecycleState,
+                    Set<Event> pendingEvents) {
+        super(state, pendingEvents, Set.of());
 
         this.contract = contract;
         this.id = id;
@@ -126,6 +148,15 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
     }
 
     protected bisq.trade.protobuf.Trade.Builder getTradeBuilder(boolean serializeForHash) {
+        // Read state + eventQueue together as one atomic, defensively-copied snapshot (see
+        // FsmModel#getStateAndEventQueueSnapshot) rather than via two separate, unsynchronized calls to getState()
+        // and getEventQueue(). This method (Trade#toProto -> here) can run concurrently with Fsm#handle()/
+        // Fsm#drainEventQueue() on a different thread - persistence clones/serializes the trade store
+        // asynchronously, and for MuSig trades message handling itself runs on a dedicated executor - so an
+        // un-synchronized pair of reads could tear: capturing the state AFTER a transition together with the
+        // just-applied event STILL in the queue (a double-apply on restore), or the state BEFORE the transition
+        // with the event already removed (a silent loss). Taking both from the same locked snapshot closes that gap.
+        StateAndEventQueue snapshot = getStateAndEventQueueSnapshot();
         bisq.trade.protobuf.Trade.Builder builder = bisq.trade.protobuf.Trade.newBuilder()
                 .setContract(contract.toProto(serializeForHash))
                 .setId(id)
@@ -133,7 +164,7 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                 .setMyIdentity(myIdentity.toProto(serializeForHash))
                 .setTaker(taker.toProto(serializeForHash))
                 .setMaker(maker.toProto(serializeForHash))
-                .setState(getState().name())
+                .setState(snapshot.state().name())
                 .setLifecycleState(getLifecycleState().toProtoEnum());
         Optional.ofNullable(getErrorMessage()).ifPresent(builder::setErrorMessage);
         Optional.ofNullable(getErrorStackTrace()).ifPresent(builder::setErrorStackTrace);
@@ -141,7 +172,38 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
         Optional.ofNullable(getPeersErrorStackTrace()).ifPresent(builder::setPeersErrorStackTrace);
         Optional.ofNullable(getTradeProtocolFailure()).ifPresent(e -> builder.setTradeProtocolFailure(e.toProtoEnum()));
         Optional.ofNullable(getPeersTradeProtocolFailure()).ifPresent(e -> builder.setPeersTradeProtocolFailure(e.toProtoEnum()));
+        // Only network messages are serializable; local, user-triggered events (e.g. BisqEasyConfirmFiatSentEvent)
+        // have no proto representation and are never at risk of being lost across a restart since they are only
+        // ever created while the app is already running.
+        snapshot.eventQueue().stream()
+                .filter(EnvelopePayloadMessage.class::isInstance)
+                .map(event -> ((EnvelopePayloadMessage) event).toProto(serializeForHash))
+                .forEach(builder::addPendingFsmEvents);
         return builder;
+    }
+
+    /**
+     * Resolves the persisted pending FSM events (out-of-order network messages) from the given proto.
+     * Any entry which fails to resolve (e.g. an unknown/removed message class from an old persisted trade) is
+     * logged and skipped rather than failing the whole trade load.
+     */
+    protected static Set<Event> pendingEventsFromProto(bisq.trade.protobuf.Trade proto) {
+        Set<Event> pendingEvents = new HashSet<>();
+        for (bisq.network.protobuf.EnvelopePayloadMessage envelopePayloadMessageProto : proto.getPendingFsmEventsList()) {
+            try {
+                EnvelopePayloadMessage envelopePayloadMessage = EnvelopePayloadMessage.fromProto(envelopePayloadMessageProto);
+                if (envelopePayloadMessage instanceof Event event) {
+                    pendingEvents.add(event);
+                } else {
+                    log.warn("Persisted pending FSM event does not implement Event and is dropped. messageType={}",
+                            envelopePayloadMessage.getClass().getSimpleName());
+                }
+            } catch (Exception e) {
+                log.warn("Could not resolve a persisted pending FSM event. It will be dropped and not re-applied " +
+                        "after restore. messageCase={}", envelopePayloadMessageProto.getMessageCase(), e);
+            }
+        }
+        return pendingEvents;
     }
 
     protected void setErrorMessage(String errorMessage) {

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -156,6 +156,10 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
         // un-synchronized pair of reads could tear: capturing the state AFTER a transition together with the
         // just-applied event STILL in the queue (a double-apply on restore), or the state BEFORE the transition
         // with the event already removed (a silent loss). Taking both from the same locked snapshot closes that gap.
+        // getStateAndEventQueueSnapshot() bounds its wait for this lock and throws SnapshotLockTimeoutException
+        // rather than block indefinitely - this runs on the single, JVM-wide Persistence executor thread, which
+        // must never stall behind one trade's live transition. Deliberately left uncaught here: it must propagate
+        // out of toProto() and fail this trade's/store's write for the cycle (see BisqEasyTradeStore#getBuilder).
         StateAndEventQueue snapshot = getStateAndEventQueueSnapshot();
         bisq.trade.protobuf.Trade.Builder builder = bisq.trade.protobuf.Trade.newBuilder()
                 .setContract(contract.toProto(serializeForHash))

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.bisq_easy;
 
+import bisq.common.fsm.Event;
 import bisq.common.observable.Observable;
 import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.proto.ProtobufUtils;
@@ -38,6 +39,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @ToString(callSuper = true)
@@ -60,6 +62,14 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
 
     @EqualsAndHashCode.Exclude
     private final Observable<Optional<Long>> tradeCompletedDate = new Observable<>(Optional.empty());
+
+    // Single source for the id a maker-side take-offer request will produce, so callers that need to know the
+    // id BEFORE constructing a trade (e.g. to look up an already-existing protocol for a duplicate delivery)
+    // never have to duplicate the offerId/takerPubKeyHash/takeOfferDate expression below - it must stay
+    // byte-for-byte identical to what the constructor computes via Trade#createId, or the lookup would miss.
+    public static String createId(BisqEasyContract contract, NetworkId takerNetworkId) {
+        return createId(contract.getOffer().getId(), takerNetworkId.getId(), contract.getTakeOfferDate());
+    }
 
     public BisqEasyTrade(BisqEasyContract contract,
                          boolean isBuyer,
@@ -88,8 +98,9 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                           Identity myIdentity,
                           BisqEasyTradeParty taker,
                           BisqEasyTradeParty maker,
-                          TradeLifecycleState lifecycleState) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState);
+                          TradeLifecycleState lifecycleState,
+                          Set<Event> pendingEvents) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState, pendingEvents);
 
         stateObservable().addObserver(s -> tradeState.set((BisqEasyTradeState) s));
     }
@@ -127,7 +138,8 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                 Identity.fromProto(proto.getMyIdentity()),
                 TradeParty.protoToBisqEasyTradeParty(proto.getTaker()),
                 TradeParty.protoToBisqEasyTradeParty(proto.getMaker()),
-                TradeLifecycleState.fromProto(proto.getLifecycleState()));
+                TradeLifecycleState.fromProto(proto.getLifecycleState()),
+                pendingEventsFromProto(proto));
         if (proto.hasErrorMessage()) {
             trade.setErrorMessage(proto.getErrorMessage());
         }

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
@@ -113,6 +113,9 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     @Nullable
     private Scheduler numDaysAfterRedactingTradeDataScheduler;
     private final Set<BisqEasyTradeMessage> pendingMessages = new CopyOnWriteArraySet<>();
+    // Guards makerCreatesProtocol's check-then-act creation sequence (the duplicate-protocol/duplicate-trade
+    // checks, together with the writes that make the trade+protocol exist). See makerCreatesProtocol for why.
+    private final Object creationLock = new Object();
 
     public BisqEasyTradeService(ServiceProvider serviceProvider, AppType appType) {
         this.serviceProvider = serviceProvider;
@@ -135,13 +138,11 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
 
     public CompletableFuture<Boolean> initialize() {
 
-        persistableStore.getTrades().forEach(this::createAndAddTradeProtocol);
-
-        networkService.getConfidentialMessageServices().stream()
-                .flatMap(service -> service.getProcessedEnvelopePayloadMessages().stream())
-                .forEach(this::onMessage);
-        networkService.addConfidentialMessageListener(this);
-
+        // Register the alert observer BEFORE restoring trades: addObserver() synchronously replays the
+        // persisted authorized alert data (CollectionObserver#onAllAdded), so haltTrading /
+        // requireVersionForTrading reflect the last known alert state by the time the restore drain below
+        // re-applies queued events. Registered after the restore (as before), the drain-time checks would be
+        // vacuously green on every cold start.
         authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(new CollectionObserver<>() {
             @Override
             public void onAdded(AuthorizedAlertData authorizedAlertData) {
@@ -178,6 +179,33 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
                 minRequiredVersionForTrading = Optional.empty();
             }
         });
+
+        persistableStore.getTrades().forEach(trade -> createAndAddTradeProtocol(trade, true));
+
+        // Register the live listener BEFORE the startup replay below. With the reverse order there was a
+        // handoff window: a message the network finished processing after the replay read its snapshot but
+        // before registration was ACKed and removed from the mailbox without ever reaching the FSM - lost for
+        // good. Register-first closes that window structurally, at the cost of possible duplicate delivery
+        // (live + replay) - which is expected and handled: once a protocol exists, a duplicate is absorbed by
+        // the FSM (processed-events filter, forward-only transition guard); before a protocol exists (a
+        // duplicate take-offer request), makerCreatesProtocol's checkArguments plus creationLock guard against
+        // it instead - see there. A live message arriving before its predecessor is replayed is exactly the
+        // out-of-order case the FSM event queue absorbs.
+        networkService.addConfidentialMessageListener(this);
+        networkService.getConfidentialMessageServices().stream()
+                .flatMap(service -> service.getProcessedEnvelopePayloadMessages().stream())
+                .forEach(message -> {
+                    // Per-message isolation: with the alert observer registered above, onMessage()'s
+                    // halt/min-version guards can now legitimately throw during this startup replay (they
+                    // could not before - the observer used to be registered only after this loop). A rejected
+                    // replayed message must not abort initialize() and skip every subsequent message.
+                    try {
+                        onMessage(message);
+                    } catch (Exception e) {
+                        log.warn("Re-feeding a processed message at startup was rejected (e.g. trading halted " +
+                                "by an emergency alert). messageType={}", message.getClass().getSimpleName(), e);
+                    }
+                });
 
         numDaysAfterRedactingTradeDataScheduler = Scheduler.run(this::maybeRedactDataOfCompletedTrades)
                 .host(this)
@@ -237,7 +265,17 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
 
     private void handleBisqEasyTakeOfferMessage(BisqEasyTakeOfferRequest message) {
         BisqEasyContract bisqEasyContract = message.getBisqEasyContract();
-        BisqEasyProtocol protocol = makerCreatesProtocol(bisqEasyContract, message.getSender(), message.getReceiver());
+        // Duplicate delivery of the very same take-offer request is expected now that the live listener is
+        // registered before the startup replay (see initialize()): the live path and the replay can both hand
+        // us the same message, and a mailbox message can be redelivered too. If a protocol for this trade id
+        // already exists we are looking at a duplicate of an already-completed creation, not a new offer being
+        // taken - route it straight through the normal FSM path below (which absorbs it) instead of attempting
+        // to create a second trade/protocol for it. The id must be derived exactly the way makerCreatesProtocol
+        // derives it (single-sourced in BisqEasyTrade#createId), or this lookup could miss and fall through to
+        // a redundant creation attempt.
+        String tradeId = BisqEasyTrade.createId(bisqEasyContract, message.getSender());
+        BisqEasyProtocol protocol = findProtocol(tradeId)
+                .orElseGet(() -> makerCreatesProtocol(bisqEasyContract, message.getSender(), message.getReceiver()));
         handleBisqEasyTradeMessage(message, protocol);
     }
 
@@ -246,7 +284,8 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
         findProtocol(tradeId).ifPresentOrElse(protocol -> handleBisqEasyTradeMessage(message, protocol),
                 () -> {
                     log.info("Protocol with tradeId {} not found. We add the message to pendingMessages for " +
-                            "re-processing when the next message arrives. message={}", tradeId, message);
+                            "re-processing when the next message arrives. messageType={}",
+                    tradeId, message.getClass().getSimpleName());
                     pendingMessages.add(message);
                 });
     }
@@ -418,26 +457,62 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     // TradeProtocol factory
     /* --------------------------------------------------------------------- */
 
-    private BisqEasyProtocol makerCreatesProtocol(BisqEasyContract contract, NetworkId sender, NetworkId receiver) {
-        // We only create the data required for the protocol creation.
-        // Verification will happen in the BisqEasyTakeOfferRequestHandler
-        BisqEasyOffer offer = contract.getOffer();
-        boolean isBuyer = offer.getMakersDirection().isBuy();
-        Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
-        BisqEasyTrade bisqEasyTrade = new BisqEasyTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
-        String tradeId = bisqEasyTrade.getId();
-        checkArgument(findProtocol(tradeId).isEmpty(), "We received the BisqEasyTakeOfferRequest for an already existing protocol");
-        checkArgument(!tradeExists(tradeId), "A trade with that ID exists already");
+    // Package-private (rather than private) so a concurrency test can drive it directly without having to
+    // forge a signed take-offer request.
+    BisqEasyProtocol makerCreatesProtocol(BisqEasyContract contract, NetworkId sender, NetworkId receiver) {
+        // The fast path in handleBisqEasyTakeOfferMessage already routes a duplicate away from here whenever a
+        // protocol for this trade id already exists - but that check is lock-free, so two deliveries for a
+        // trade id that does NOT exist yet (live listener + startup replay, or two mailbox redeliveries) can
+        // both reach here concurrently. Creation must be check-then-act atomic: the "no duplicate exists"
+        // checks below and the writes that make the trade+protocol exist (addTrade/persist/
+        // createAndAddTradeProtocol) have to happen as one unit, or both deliveries can pass the checks and
+        // each create their own trade+protocol for the same id - a split brain where one of the two protocol
+        // instances is silently orphaned (never reachable via findProtocol/tradeProtocolById again) and any
+        // handler side effect (e.g. sending the take-offer response to the peer) runs once per created
+        // protocol instead of once overall. Deliberately NOT held across protocol.handle() in the caller: that
+        // takes the FSM model lock and can itself trigger a persist() call, and is already safe for a
+        // duplicate once a protocol exists (forward-only transition guard / processed-events filter).
+        synchronized (creationLock) {
+            // We only create the data required for the protocol creation.
+            // Verification will happen in the BisqEasyTakeOfferRequestHandler
+            BisqEasyOffer offer = contract.getOffer();
+            boolean isBuyer = offer.getMakersDirection().isBuy();
+            Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
+            BisqEasyTrade bisqEasyTrade = new BisqEasyTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
+            String tradeId = bisqEasyTrade.getId();
+            checkArgument(findProtocol(tradeId).isEmpty(), "We received the BisqEasyTakeOfferRequest for an already existing protocol");
+            checkArgument(!tradeExists(tradeId), "A trade with that ID exists already");
 
-        persistableStore.addTrade(bisqEasyTrade);
-        persist();
+            awaitCreationTestSeam(tradeId);
 
-        maybeAddPeerToContactList(sender.getId(), myIdentity.getId());
+            persistableStore.addTrade(bisqEasyTrade);
+            persist();
 
-        return createAndAddTradeProtocol(bisqEasyTrade);
+            maybeAddPeerToContactList(sender.getId(), myIdentity.getId());
+
+            return createAndAddTradeProtocol(bisqEasyTrade);
+        }
+    }
+
+    // No-op hook, overridden only in tests. Lets a concurrency test deterministically park the thread holding
+    // creationLock here - between the "no duplicate exists" checks above and the writes that make the trade/
+    // protocol exist - while a second thread attempts to race it, forcing the exact interleaving creationLock
+    // guards against instead of relying on scheduling luck.
+    void awaitCreationTestSeam(String tradeId) {
     }
 
     private BisqEasyProtocol createAndAddTradeProtocol(BisqEasyTrade trade) {
+        return createAndAddTradeProtocol(trade, false);
+    }
+
+    // isRestoredTrade is true when the trade was just loaded from persisted data (app startup), as opposed to a
+    // trade which was just created for a brand-new offer/take-offer flow (whose event queue is always empty).
+    // For restored trades we drain the event queue once: the queue itself survives a restart (persisted on
+    // Trade), but nothing would otherwise re-attempt those pending events until some further, unrelated live
+    // transition happens to occur for that same trade - which may never happen. See bisq.common.fsm.Fsm#drainEventQueue.
+    // Package-private (rather than private) so tests can register a hand-placed trade's protocol exactly the way
+    // production code does, without duplicating this wiring.
+    BisqEasyProtocol createAndAddTradeProtocol(BisqEasyTrade trade, boolean isRestoredTrade) {
         String id = trade.getId();
         BisqEasyProtocol tradeProtocol;
         boolean isBuyer = trade.isBuyer();
@@ -456,6 +531,43 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
         }
         trade.setProtocolVersion(tradeProtocol.getVersion());
         tradeProtocolById.put(id, tradeProtocol);
+        if (isRestoredTrade) {
+            // The queued events passed onMessage()'s guards when they were originally received, but those
+            // conditions may have changed before the restart. Draining applies them directly through the FSM,
+            // so re-check here what onMessage() would check for a live message:
+            //  - Trading halt / min-version (global, temporary): defer the drain entirely and KEEP the events
+            //    queued - they persist and drain on a later restart once the emergency alert is lifted.
+            //    Deliberately no throw: the catch below would mislabel it "stuck until investigated".
+            //  - Banned sender (per event): DROP the event, mirroring onMessage() ignoring a banned sender's
+            //    live message. Kept queued it would get applied after a ban-lift restart - something
+            //    onMessage() would never have allowed.
+            if (haltTrading || isMinVersionForTradingViolated()) {
+                log.warn("Deferring the queued-event drain for restored trade {}: an emergency alert halts " +
+                        "trading or requires a min version. The events stay queued and drain on a later " +
+                        "restart once the alert is lifted.", id);
+            } else {
+                boolean removedBannedSenderEvents = trade.removeQueuedEventsIf(event ->
+                        event instanceof BisqEasyTradeMessage message &&
+                                bannedUserService.isUserProfileBanned(message.getSender()));
+                if (removedBannedSenderEvents) {
+                    log.warn("Removed queued event(s) from a banned sender for restored trade {} before " +
+                            "draining, mirroring the onMessage() banned-sender check.", id);
+                    persist();
+                }
+                // Isolate per trade: drainEventQueue() re-applies queued events and can raise an FsmException. The
+                // trade is already created and registered above, so we keep it regardless. Without this guard a
+                // single failing trade would escape the persistableStore.getTrades().forEach(...) loop in
+                // initialize() and block restoring every subsequent trade. A failed drain here means the trade
+                // stays stuck until it is manually looked at - there is no periodic or reconnect-triggered safety
+                // net to retry it.
+                try {
+                    tradeProtocol.drainEventQueue();
+                } catch (Exception e) {
+                    log.warn("Failed to drain the event queue for restored trade {} on load. The trade is still " +
+                            "loaded but remains stuck until manually investigated.", id, e);
+                }
+            }
+        }
         return tradeProtocol;
     }
 
@@ -465,11 +577,14 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     }
 
     private void verifyMinVersionForTrading() {
-        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent()) {
-            checkArgument(ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get())),
-                    "For trading you need to have version " + minRequiredVersionForTrading.get() + " installed. " +
-                            "The Bisq security manager has published an emergency alert with a min. version required for trading.");
-        }
+        checkArgument(!isMinVersionForTradingViolated(),
+                "For trading you need to have version " + minRequiredVersionForTrading.orElse("") + " installed. " +
+                        "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+    }
+
+    private boolean isMinVersionForTradingViolated() {
+        return requireVersionForTrading && minRequiredVersionForTrading.isPresent() &&
+                !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get()));
     }
 
 
@@ -477,31 +592,47 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     // Redact sensible data
     /* --------------------------------------------------------------------- */
 
-    private void maybeRedactDataOfCompletedTrades() {
+    // Package-private (rather than private) so tests can drive the retention pass deterministically instead of
+    // waiting on the periodic scheduler.
+    void maybeRedactDataOfCompletedTrades() {
         int numDays = settingsService.getNumDaysAfterRedactingTradeData().get();
         long redactDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(numDays);
         // Trades which ended up with a failure or got stuck will never get the completed date set.
         // We use a more constrained duration of 45-90 days.
         int numDaysForNotCompletedTrades = Math.max(45, Math.min(90, numDays));
         long redactDateForNotCompletedTrades = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(numDaysForNotCompletedTrades);
-        String redactedMarker = Res.get("data.redacted");
         long numChanges = getAllTrades().stream()
                 .filter(trade -> {
-                    if (StringUtils.isEmpty(trade.getPaymentAccountData().get()) ||
-                            trade.getPaymentAccountData().get().equals(redactedMarker)) {
-                        return false;
-                    }
                     boolean doRedaction = trade.getTradeCompletedDate().map(date -> date < redactDate)
                             .orElseGet(() -> trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
-                    if (doRedaction) {
-
-                        trade.getPaymentAccountData().set(redactedMarker);
+                    if (!doRedaction) {
+                        return false;
                     }
-                    return doRedaction;
+                    boolean changed = false;
+                    String paymentAccountData = trade.getPaymentAccountData().get();
+                    if (!StringUtils.isEmpty(paymentAccountData)) {
+                        // Resolve the marker lazily (only when there is account data to redact) so the pass does no
+                        // i18n lookup for trades that just need their pending event queue scrubbed.
+                        String redactedMarker = Res.get("data.redacted");
+                        if (!paymentAccountData.equals(redactedMarker)) {
+                            trade.getPaymentAccountData().set(redactedMarker);
+                            changed = true;
+                        }
+                    }
+                    // Out-of-order events persist the full account-data network message (BisqEasyAccountDataMessage);
+                    // a stuck trade may never reach a final state to clear them, so scrub them on the same retention
+                    // threshold rather than leaving sensitive data on disk indefinitely.
+                    if (!trade.getEventQueue().isEmpty()) {
+                        trade.clearEventQueue();
+                        changed = true;
+                    }
+                    return changed;
                 })
                 .count();
         if (numChanges > 0) {
-            persist();
+            // Sensitive data was scrubbed in-memory; route through persistNow() so the write can't be silently
+            // dropped by the rate limiter and leave it on disk (same rationale as the final-state clear).
+            persistNow();
         }
     }
 

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeStore.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeStore.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.bisq_easy;
 
+import bisq.common.fsm.SnapshotLockTimeoutException;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
@@ -57,6 +58,14 @@ public final class BisqEasyTradeStore implements PersistableStore<BisqEasyTradeS
                         .map(trade -> {
                             try {
                                 return trade.toProto(serializeForHash);
+                            } catch (SnapshotLockTimeoutException e) {
+                                // Must propagate, not be swallowed like other per-trade failures below: a live
+                                // transition is holding this trade's FsmModel lock past the bounded wait, so this
+                                // snapshot would be stale/incomplete. Letting it fail the whole store write (rather
+                                // than silently dropping just this trade while still reporting success) keeps the
+                                // store dirty via RateLimitedPersistenceClient's generation pair, so the next
+                                // write cycle retries once the transition has released the lock.
+                                throw e;
                             } catch (Exception e) {
                                 log.error("Could not create proto from BisqEasyTrade {}", trade, e);
                                 return null;
@@ -69,6 +78,9 @@ public final class BisqEasyTradeStore implements PersistableStore<BisqEasyTradeS
                         .map(closedTrade -> {
                             try {
                                 return closedTrade.toProto(serializeForHash);
+                            } catch (SnapshotLockTimeoutException e) {
+                                // See the same-named catch above - must propagate to fail the whole write.
+                                throw e;
                             } catch (Exception e) {
                                 log.error("Could not create proto from BisqEasyClosedTrade {}", closedTrade, e);
                                 return null;

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/BisqEasyProtocol.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/BisqEasyProtocol.java
@@ -58,6 +58,14 @@ public abstract class BisqEasyProtocol extends TradeProtocol<BisqEasyTrade> {
         getServiceProvider().getBisqEasyTradeService().persist();
     }
 
+    @Override
+    protected void persistOnFinalState() {
+        // Bypasses the normal write-rate limiting: a final state clears this trade's pending FSM events
+        // in-memory, and that wipe must reach disk promptly rather than risk being silently dropped by the
+        // rate limiter (see Fsm#persistOnFinalState and RateLimitedPersistenceClient#persistNow).
+        getServiceProvider().getBisqEasyTradeService().persistNow();
+    }
+
     public BisqEasyTrade getTrade() {
         return getModel();
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.mu_sig;
 
+import bisq.common.fsm.Event;
 import bisq.common.market.Market;
 import bisq.common.observable.Observable;
 import bisq.common.observable.ReadOnlyObservable;
@@ -40,6 +41,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.DEPOSIT_TX_CONFIRMED;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.INIT;
@@ -58,6 +60,14 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
     private Optional<Long> tradeCompletedDate = Optional.empty();
     private final Observable<MuSigDisputeState> disputeState = new Observable<>(MuSigDisputeState.NO_DISPUTE);
     private Optional<MuSigMediationResult> muSigMediationResult = Optional.empty();
+
+    // Single source for the id a maker-side take-offer request will produce, so callers that need to know the
+    // id BEFORE constructing a trade (e.g. to look up an already-existing protocol for a duplicate delivery)
+    // never have to duplicate the offerId/takerPubKeyHash/takeOfferDate expression below - it must stay
+    // byte-for-byte identical to what the constructor computes via Trade#createId, or the lookup would miss.
+    public static String createId(MuSigContract contract, NetworkId takerNetworkId) {
+        return createId(contract.getOffer().getId(), takerNetworkId.getId(), contract.getTakeOfferDate());
+    }
 
     public MuSigTrade(MuSigContract contract,
                       boolean isBuyer,
@@ -86,8 +96,9 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                        Identity myIdentity,
                        MuSigTradeParty taker,
                        MuSigTradeParty maker,
-                       TradeLifecycleState lifecycleState) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState);
+                       TradeLifecycleState lifecycleState,
+                       Set<Event> pendingEvents) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState, pendingEvents);
 
         stateObservable().addObserver(s -> tradeState.set((MuSigTradeState) s));
     }
@@ -126,7 +137,8 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                 Identity.fromProto(proto.getMyIdentity()),
                 TradeParty.protoToMuSigTradeParty(proto.getTaker()),
                 TradeParty.protoToMuSigTradeParty(proto.getMaker()),
-                TradeLifecycleState.fromProto(proto.getLifecycleState()));
+                TradeLifecycleState.fromProto(proto.getLifecycleState()),
+                pendingEventsFromProto(proto));
         if (proto.hasErrorMessage()) {
             trade.setErrorMessage(proto.getErrorMessage());
         }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -147,6 +147,9 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     private Pin authorizedAlertDataSetPin, numDaysAfterRedactingTradeDataPin;
     private Scheduler numDaysAfterRedactingTradeDataScheduler;
     private final Set<MuSigTradeMessage> pendingMessages = new CopyOnWriteArraySet<>();
+    // Guards makerCreatesProtocol's check-then-act creation sequence (the duplicate-protocol/duplicate-trade
+    // checks, together with the writes that make the trade+protocol exist). See makerCreatesProtocol for why.
+    private final Object creationLock = new Object();
     private final Map<String, Scheduler> closeTradeTimeoutSchedulerByTradeId = new ConcurrentHashMap<>();
     private final Map<String, CompletableFuture<Void>> observeDepositTxConfirmationStatusFutureByTradeId = new ConcurrentHashMap<>();
 
@@ -180,19 +183,16 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         executor = ExecutorFactory.boundedCachedPool("MuSigTradeService");
 
         return musigGrpcClient.initialize()
-                .thenApply(result -> {
-                    persistableStore.getTrades().forEach(this::createAndAddTradeProtocol);
-
-                    networkService.getConfidentialMessageServices().stream()
-                            .flatMap(service -> service.getProcessedEnvelopePayloadMessages().stream())
-                            .forEach(this::onMessage);
-                    networkService.addConfidentialMessageListener(this);
-
-                    // At startup we observe all unconfirmed deposit txs
-                    getTrades().stream()
-                            .filter(MuSigTrade::isDepositTxCreatedButNotConfirmed)
-                            .forEach(this::observeDepositTxConfirmationStatus);
-
+                // thenApplyAsync on this service's own bounded executor (not thenApply): the restored-trade
+                // drainEventQueue() below re-applies queued FSM events via protocol.handle(), and every other
+                // handle() in this service is dispatched onto `executor` (see handleMuSigTradeMessage /
+                // handleMuSigTradeEvent). Running it inline here would drain on the gRPC init-completion thread,
+                // re-entering the blocking gRPC stub from a gRPC callback thread. Keep all FSM work on `executor`.
+                .thenApplyAsync(result -> {
+                    // Register the alert observer BEFORE restoring trades: addObserver() synchronously replays
+                    // the persisted authorized alert data, so the restore-drain guard in
+                    // createAndAddTradeProtocol() sees the last known halt/min-version state instead of a
+                    // vacuously-green default. Mirrors BisqEasyTradeService#initialize().
                     authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(new CollectionObserver<>() {
                         @Override
                         public void onAdded(AuthorizedAlertData authorizedAlertData) {
@@ -230,12 +230,41 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                         }
                     });
 
+                    persistableStore.getTrades().forEach(trade -> createAndAddTradeProtocol(trade, true));
+
+                    // Register the live listener BEFORE the startup replay: closes the handoff window in which a
+                    // message processed after the replay's snapshot but before registration was ACKed yet never
+                    // delivered. Duplicate delivery (live + replay) is expected and handled: once a protocol
+                    // exists, a duplicate is absorbed by the FSM; before a protocol exists (a duplicate
+                    // SetupTradeMessage_A), makerCreatesProtocol's checkArguments plus creationLock guard
+                    // against it instead - see there. See BisqEasyTradeService#initialize.
+                    networkService.addConfidentialMessageListener(this);
+                    networkService.getConfidentialMessageServices().stream()
+                            .flatMap(service -> service.getProcessedEnvelopePayloadMessages().stream())
+                            .forEach(message -> {
+                                // Per-message isolation: with the alert observer registered above, onMessage()'s
+                                // halt/min-version guards can now legitimately throw during this startup replay.
+                                // A rejected replayed message must not abort initialize().
+                                try {
+                                    onMessage(message);
+                                } catch (Exception e) {
+                                    log.warn("Re-feeding a processed message at startup was rejected (e.g. trading " +
+                                            "halted by an emergency alert). messageType={}",
+                                            message.getClass().getSimpleName(), e);
+                                }
+                            });
+
+                    // At startup we observe all unconfirmed deposit txs
+                    getTrades().stream()
+                            .filter(MuSigTrade::isDepositTxCreatedButNotConfirmed)
+                            .forEach(this::observeDepositTxConfirmationStatus);
+
                     numDaysAfterRedactingTradeDataScheduler = Scheduler.run(this::maybeRedactDataOfCompletedTrades)
                             .host(this)
                             .periodically(1, TimeUnit.HOURS);
                     numDaysAfterRedactingTradeDataPin = settingsService.getNumDaysAfterRedactingTradeData().addObserver(numDays -> maybeRedactDataOfCompletedTrades());
                     return true;
-                });
+                }, executor);
     }
 
     public CompletableFuture<Boolean> shutdown() {
@@ -317,7 +346,17 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
 
     private void handleMuSigTakeOfferMessage(SetupTradeMessage_A message) {
         MuSigContract muSigContract = message.getContract();
-        MuSigProtocol protocol = makerCreatesProtocol(muSigContract, message.getSender(), message.getReceiver());
+        // Duplicate delivery of the very same take-offer request is expected now that the live listener is
+        // registered before the startup replay (see initialize()): the live path and the replay can both hand
+        // us the same message, and a mailbox message can be redelivered too. If a protocol for this trade id
+        // already exists we are looking at a duplicate of an already-completed creation, not a new offer being
+        // taken - route it straight through the normal FSM path below (which absorbs it) instead of attempting
+        // to create a second trade/protocol for it. The id must be derived exactly the way makerCreatesProtocol
+        // derives it (single-sourced in MuSigTrade#createId), or this lookup could miss and fall through to a
+        // redundant creation attempt.
+        String tradeId = MuSigTrade.createId(muSigContract, message.getSender());
+        MuSigProtocol protocol = findProtocol(tradeId)
+                .orElseGet(() -> makerCreatesProtocol(muSigContract, message.getSender(), message.getReceiver()));
         handleMuSigTradeMessage(message, protocol);
     }
 
@@ -326,7 +365,8 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         findProtocol(tradeId).ifPresentOrElse(protocol -> handleMuSigTradeMessage(message, protocol),
                 () -> {
                     log.info("Protocol with tradeId {} not found. We add the message to pendingMessages for " +
-                            "re-processing when the next message arrives. message={}", tradeId, message);
+                            "re-processing when the next message arrives. messageType={}",
+                    tradeId, message.getClass().getSimpleName());
                     pendingMessages.add(message);
                 });
     }
@@ -600,30 +640,67 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     // TradeProtocol factory
     /* --------------------------------------------------------------------- */
 
-    private MuSigProtocol makerCreatesProtocol(MuSigContract contract, NetworkId sender, NetworkId receiver) {
-        // We only create the data required for the protocol creation.
-        // Verification will happen in the MuSigTakeOfferRequestHandler
-        MuSigOffer offer = contract.getOffer();
-        Direction makersDirection = offer.getDirection();
-        boolean isBuyer = makersDirection.isBuy();
-        Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
-        MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
+    // Package-private (rather than private) so a concurrency test can drive it directly without having to
+    // forge a signed take-offer request.
+    MuSigProtocol makerCreatesProtocol(MuSigContract contract, NetworkId sender, NetworkId receiver) {
+        // The fast path in handleMuSigTakeOfferMessage already routes a duplicate away from here whenever a
+        // protocol for this trade id already exists - but that check is lock-free, so two deliveries for a
+        // trade id that does NOT exist yet (live listener + startup replay, or two mailbox redeliveries) can
+        // both reach here concurrently. Creation must be check-then-act atomic: the "no duplicate exists"
+        // checks below and the writes that make the trade+protocol exist (addTrade/persist/
+        // createAndAddTradeProtocol) have to happen as one unit, or both deliveries can pass the checks and
+        // each create their own trade+protocol for the same id - a split brain where one of the two protocol
+        // instances is silently orphaned (never reachable via findProtocol/tradeProtocolById again) and any
+        // handler side effect runs once per created protocol instead of once overall. Deliberately NOT held
+        // across protocol.handle() in the caller: that takes the FSM model lock and can itself trigger a
+        // persist() call, and is already safe for a duplicate once a protocol exists (forward-only transition
+        // guard / processed-events filter).
+        synchronized (creationLock) {
+            // We only create the data required for the protocol creation.
+            // Verification will happen in the MuSigTakeOfferRequestHandler
+            MuSigOffer offer = contract.getOffer();
+            Direction makersDirection = offer.getDirection();
+            boolean isBuyer = makersDirection.isBuy();
+            Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
+            MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
 
-        AccountPayload<? extends PaymentMethod<?>> accountPayload = findMyAccount(trade).orElseThrow().getAccountPayload();
-        trade.getMyself().setAccountPayload(accountPayload);
+            AccountPayload<? extends PaymentMethod<?>> accountPayload = findMyAccount(trade).orElseThrow().getAccountPayload();
+            trade.getMyself().setAccountPayload(accountPayload);
 
-        String tradeId = trade.getId();
-        checkArgument(findProtocol(tradeId).isEmpty(), "We received the MuSigTakeOfferRequest for an already existing protocol");
-        checkArgument(!tradeExists(tradeId), "A trade with that ID exists already");
-        persistableStore.addTrade(trade);
-        persist();
+            String tradeId = trade.getId();
+            checkArgument(findProtocol(tradeId).isEmpty(), "We received the MuSigTakeOfferRequest for an already existing protocol");
+            checkArgument(!tradeExists(tradeId), "A trade with that ID exists already");
 
-        maybeAddPeerToContactList(sender.getId(), myIdentity.getId());
+            awaitCreationTestSeam(tradeId);
 
-        return createAndAddTradeProtocol(trade);
+            persistableStore.addTrade(trade);
+            persist();
+
+            maybeAddPeerToContactList(sender.getId(), myIdentity.getId());
+
+            return createAndAddTradeProtocol(trade);
+        }
+    }
+
+    // No-op hook, overridden only in tests. Lets a concurrency test deterministically park the thread holding
+    // creationLock here - between the "no duplicate exists" checks above and the writes that make the trade/
+    // protocol exist - while a second thread attempts to race it, forcing the exact interleaving creationLock
+    // guards against instead of relying on scheduling luck.
+    void awaitCreationTestSeam(String tradeId) {
     }
 
     private MuSigProtocol createAndAddTradeProtocol(MuSigTrade trade) {
+        return createAndAddTradeProtocol(trade, false);
+    }
+
+    // isRestoredTrade is true when the trade was just loaded from persisted data (app startup), as opposed to a
+    // trade which was just created for a brand-new offer/take-offer flow (whose event queue is always empty).
+    // For restored trades we drain the event queue once: the queue itself survives a restart (persisted on
+    // Trade), but nothing would otherwise re-attempt those pending events until some further, unrelated live
+    // transition happens to occur for that same trade - which may never happen. See bisq.common.fsm.Fsm#drainEventQueue.
+    // Package-private (rather than private) so tests can register a hand-placed trade's protocol exactly the way
+    // production code does, without duplicating this wiring.
+    MuSigProtocol createAndAddTradeProtocol(MuSigTrade trade, boolean isRestoredTrade) {
         String id = trade.getId();
         MuSigProtocol tradeProtocol;
         boolean isBuyer = trade.isBuyer();
@@ -642,6 +719,38 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         }
         trade.setProtocolVersion(tradeProtocol.getVersion());
         tradeProtocolById.put(id, tradeProtocol);
+        if (isRestoredTrade) {
+            // Mirror of the BisqEasyTradeService restore-drain guard - see there for the full rationale.
+            // Queued events passed onMessage()'s guards at receipt time, but halt/min-version/ban state may
+            // have changed before the restart: defer the drain (events stay queued) while an emergency alert
+            // is active, and drop queued events whose sender got banned in the meantime.
+            if (haltTrading || isMinVersionForTradingViolated()) {
+                log.warn("Deferring the queued-event drain for restored trade {}: an emergency alert halts " +
+                        "trading or requires a min version. The events stay queued and drain on a later " +
+                        "restart once the alert is lifted.", id);
+            } else {
+                boolean removedBannedSenderEvents = trade.removeQueuedEventsIf(event ->
+                        event instanceof MuSigTradeMessage message &&
+                                bannedUserService.isUserProfileBanned(message.getSender()));
+                if (removedBannedSenderEvents) {
+                    log.warn("Removed queued event(s) from a banned sender for restored trade {} before " +
+                            "draining, mirroring the onMessage() banned-sender check.", id);
+                    persist();
+                }
+                // Isolate per trade: drainEventQueue() re-applies queued events and can raise an FsmException. The
+                // trade is already created and registered above, so we keep it regardless. Without this guard a
+                // single failing trade would escape the persistableStore.getTrades().forEach(...) loop in
+                // initialize() and block restoring every subsequent trade. A failed drain here means the trade
+                // stays stuck until it is manually looked at - there is no periodic or reconnect-triggered safety
+                // net to retry it.
+                try {
+                    tradeProtocol.drainEventQueue();
+                } catch (Exception e) {
+                    log.warn("Failed to drain the event queue for restored trade {} on load. The trade is still " +
+                            "loaded but remains stuck until manually investigated.", id, e);
+                }
+            }
+        }
         return tradeProtocol;
     }
 
@@ -651,11 +760,14 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     }
 
     private void verifyMinVersionForTrading() {
-        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent()) {
-            checkArgument(ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get())),
-                    "For trading you need to have version " + minRequiredVersionForTrading.get() + " installed. " +
-                            "The Bisq security manager has published an emergency alert with a min. version required for trading.");
-        }
+        checkArgument(!isMinVersionForTradingViolated(),
+                "For trading you need to have version " + minRequiredVersionForTrading.orElse("") + " installed. " +
+                        "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+    }
+
+    private boolean isMinVersionForTradingViolated() {
+        return requireVersionForTrading && minRequiredVersionForTrading.isPresent() &&
+                !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get()));
     }
 
 
@@ -674,12 +786,24 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                 .filter(trade -> {
                     boolean doRedaction = trade.getTradeCompletedDate().map(date -> date < redactDate)
                             .orElseGet(() -> trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
-                    //todo
-                    return doRedaction;
+                    if (!doRedaction) {
+                        return false;
+                    }
+                    //todo redact the MuSig account payload fields on the trade itself (still pending).
+                    // Out-of-order events persist the full account-payload network message (SendAccountPayloadMessage);
+                    // a stuck trade may never reach a final state to clear them, so scrub them on the same retention
+                    // threshold rather than leaving sensitive data on disk indefinitely.
+                    if (!trade.getEventQueue().isEmpty()) {
+                        trade.clearEventQueue();
+                        return true;
+                    }
+                    return false;
                 })
                 .count();
         if (numChanges > 0) {
-            persist();
+            // Sensitive data was scrubbed in-memory; route through persistNow() so the write can't be silently
+            // dropped by the rate limiter and leave it on disk (same rationale as the final-state clear).
+            persistNow();
         }
     }
 

--- a/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigProtocol.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigProtocol.java
@@ -60,6 +60,14 @@ public abstract class MuSigProtocol extends TradeProtocol<MuSigTrade> {
         getServiceProvider().getMuSigTradeService().persist();
     }
 
+    @Override
+    protected void persistOnFinalState() {
+        // Bypasses the normal write-rate limiting: a final state clears this trade's pending FSM events
+        // in-memory, and that wipe must reach disk promptly rather than risk being silently dropped by the
+        // rate limiter (see Fsm#persistOnFinalState and RateLimitedPersistenceClient#persistNow).
+        getServiceProvider().getMuSigTradeService().persistNow();
+    }
+
     public MuSigTrade getTrade() {
         return getModel();
     }

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -23,6 +23,7 @@ import "common.proto";
 import "contract.proto";
 import "identity.proto";
 import "account.proto";
+import "network.proto";
 import "network_identity.proto";
 import "offer.proto";
 import "rpc.proto";
@@ -79,6 +80,11 @@ message Trade {
   TradeLifecycleState lifecycleState = 12;
   optional TradeProtocolFailure tradeProtocolFailure = 13;
   optional TradeProtocolFailure peersTradeProtocolFailure = 14;
+  // FSM events which arrived out of order and could not yet be applied to the current state
+  // (e.g. a confirmation message received before its sibling message completing an earlier,
+  // unordered phase of the protocol). Persisted so that they are not silently lost across a
+  // restart and can be re-applied once the trade is restored.
+  repeated network.EnvelopePayloadMessage pendingFsmEvents = 15;
 
   oneof message {
     BisqEasyTrade bisqEasyTrade = 30;

--- a/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeTest.java
+++ b/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeTest.java
@@ -346,7 +346,7 @@ class BisqEasyTradeTest {
     }
 
     /**
-     * Strengthens the real-service-lifecycle regression above (Kim's #4885 review point) by exercising the
+     * Strengthens the real-service-lifecycle exercising the
      * ACTUAL on-disk persistence round trip - {@link BisqEasyTradeService#persist()} (real
      * {@code RateLimitedPersistenceClient#persist()} -> {@code Persistence#persistAsync()/write()}), then
      * {@link BisqEasyTradeService#readPersisted()} (real {@code Persistence#read()}) - rather than a manual
@@ -508,9 +508,9 @@ class BisqEasyTradeTest {
     // that up correctly is materially more effort than the seller case, so it is left as a follow-up.
 
     /**
-     * Creation-atomicity regression (Kim's #4885 follow-up finding): registering the live listener before the
-     * startup replay (see initialize()) makes duplicate delivery of the very same take-offer request expected,
-     * not exceptional. Two deliveries for a trade id that does not exist yet must not each create their own
+     * Registering the live listener before the startup replay (see initialize()) makes duplicate delivery of
+     * the very same take-offer request expected, not exceptional.
+     * Two deliveries for a trade id that does not exist yet must not each create their own
      * trade+protocol - that would be a split brain where one protocol instance is silently orphaned and any
      * handler side effect (e.g. sending the take-offer response) runs twice.
      * <br/>

--- a/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeTest.java
+++ b/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeTest.java
@@ -1,0 +1,1029 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.bisq_easy;
+
+import bisq.account.payment_method.BitcoinPaymentMethod;
+import bisq.account.payment_method.BitcoinPaymentMethodSpec;
+import bisq.account.payment_method.BitcoinPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.bonded_roles.release.AppType;
+import bisq.bonded_roles.security_manager.alert.AlertType;
+import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.common.fsm.FsmException;
+import bisq.common.market.Market;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.common.network.Address;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.proto.UnresolvableProtobufEnumException;
+import bisq.contract.ContractSignatureData;
+import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.identity.Identity;
+import bisq.network.NetworkService;
+import bisq.network.SendMessageResult;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.message.EnvelopePayloadMessage;
+import bisq.network.p2p.services.confidential.ConfidentialMessageService;
+import bisq.network.p2p.message.NetworkMessageResolver;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.persistence.PersistenceService;
+import bisq.security.DigestUtil;
+import bisq.security.keys.I2PKeyGeneration;
+import bisq.security.keys.KeyBundle;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.keys.TorKeyGeneration;
+import bisq.trade.ServiceProvider;
+import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.bisq_easy.protocol.BisqEasySellerAsMakerProtocol;
+import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyBtcAddressMessage;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyCancelTradeMessage;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyConfirmFiatSentMessage;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyTakeOfferRequest;
+import bisq.common.util.StringUtils;
+import bisq.trade.protocol.messages.TradeMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage for the stuck-trade fix (bisq-mobile#1622 / #4885): out-of-order protocol messages queued by the
+ * FSM survive persistence round-trips and drain on restore (in-memory, via the real service lifecycle and via
+ * real disk persistence), the startup register-before-replay handoff loses no message, take-offer creation is
+ * duplicate-safe and atomic (sequential and concurrent), final states persist unthrottled, and the restore
+ * drain honours redaction, banned-sender and trading-halt guards.
+ */
+class BisqEasyTradeTest {
+    static {
+        // Normally registered once at app startup by bisq.application.ResolverConfig, which is not a dependency
+        // available to :trade tests. Required so that a persisted, wrapped TradeMessage (see
+        // Trade#pendingEventsFromProto) can be resolved back via EnvelopePayloadMessage.fromProto() -> Any.unpack().
+        NetworkMessageResolver.addResolver("trade.TradeMessage", TradeMessage.getNetworkMessageResolver());
+    }
+
+    /**
+     * End-to-end reproduction of issue #1622: a Bisq Easy trade getting stuck because a message which arrives
+     * out of order (here: the buyer's confirm-fiat-sent message, before the seller has processed the buyer's
+     * btc-address message) sits in the FSM's event queue, which historically was not persisted and therefore
+     * lost across a restart. Drives the real seller-as-maker protocol/FSM and the real Trade proto (de)serialization,
+     * proving the queued event survives a toProto()/fromProto() round trip and is correctly re-applied once the
+     * enabling message arrives on the restored trade - without needing the fiat-sent message to be re-delivered.
+     */
+    @Test
+    void confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrains() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker");
+        NetworkId makerNetworkId = createNetworkId("seller-maker");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+        ServiceProvider serviceProvider = createServiceProvider();
+
+        // Seller-as-maker trade, hand-placed at the state reached after: seller sent account data, but has not
+        // yet processed the buyer's btc-address message. This is the realistic predecessor state for #1622: the
+        // buyer cannot confirm fiat-sent before having received the seller's account data (see BisqEasyBuyerAsTakerProtocol),
+        // so by the time the buyer's confirm-fiat-sent message reaches the seller, SELLER_SENT_ACCOUNT_DATA must
+        // already be true; the only leg genuinely still in flight is the buyer's own btc-address message.
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        // The trade ID is derived (Trade#createId) from the offer/taker/take-offer-date, not chosen by us -
+        // messages must be addressed to the real ID or TradeMessageHandler#verifyInternal rejects them.
+        String tradeId = trade.getId();
+
+        BisqEasySellerAsMakerProtocol protocol = new BisqEasySellerAsMakerProtocol(serviceProvider, trade);
+
+        BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                "fiat-sent-msg", tradeId, protocol.getVersion(), takerNetworkId, makerNetworkId);
+
+        // The message arrives before its prerequisite transition: no matching transition from the current
+        // state, so the Fsm queues it instead of applying it.
+        protocol.handle(fiatSentMessage);
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                trade.getTradeState());
+        assertEquals(1, trade.getEventQueue().size());
+
+        // Restart: round-trip the trade through proto exactly as persistence does.
+        bisq.trade.protobuf.Trade proto = trade.toProto(false);
+        BisqEasyTrade restoredTrade = BisqEasyTrade.fromProto(proto);
+
+        // The queued event survives the restart.
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertTrue(restoredTrade.getEventQueue().stream().anyMatch(BisqEasyConfirmFiatSentMessage.class::isInstance));
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                restoredTrade.getTradeState());
+
+        BisqEasySellerAsMakerProtocol restoredProtocol = new BisqEasySellerAsMakerProtocol(serviceProvider, restoredTrade);
+
+        // Draining right after restore is a safe no-op: the current state still does not accept the queued event.
+        restoredProtocol.drainEventQueue();
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                restoredTrade.getTradeState());
+
+        // The genuinely pending message (buyer's btc address) finally arrives.
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg", tradeId, restoredProtocol.getVersion(), takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+        restoredProtocol.handle(btcAddressMessage);
+
+        // This transition succeeds and automatically drains the restored queue, re-applying the previously
+        // queued confirm-fiat-sent message - the trade is no longer stuck, with no restart-timing luck required.
+        assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState());
+        assertTrue(restoredTrade.getEventQueue().isEmpty());
+    }
+
+    /**
+     * End-to-end regression test for issue #1622, driven exclusively through {@link BisqEasyTradeService}'s
+     * public API - {@link BisqEasyTradeService#onMessage(EnvelopePayloadMessage)}, the real
+     * {@code ConfidentialMessageService.Listener} entry point for every inbound trade message, and
+     * {@link BisqEasyTradeService#initialize()}, the real app-bootstrap entry point that restores persisted
+     * trades - rather than by calling {@code protocol.handle()}/{@code drainEventQueue()} directly as
+     * {@link #confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrains()} above does. This
+     * proves the fix survives the actual node lifecycle, not just the Fsm/Trade unit-level mechanics.
+     * <p>
+     * Phase 1 ("before restart"): a seller-as-maker trade is hand-placed at the state reached after the seller
+     * has sent its account data but not yet received the buyer's btc-address message. A
+     * {@link BisqEasyTradeService} instance registers the trade's protocol via {@code initialize()} (as a
+     * running node's service would on startup), then receives the buyer's confirm-fiat-sent message via
+     * {@code onMessage()} - out of order, since the btc-address leg is still outstanding, so it is queued
+     * rather than applied.
+     * <p>
+     * Phase 2 (restart): the trade is round-tripped through {@code toProto()}/{@code fromProto()}, exactly as
+     * persistence does across a restart. Pre-fix, the queued event is silently dropped here.
+     * <p>
+     * Phase 3 ("after restart"): a brand-new {@link BisqEasyTradeService} instance (a fresh service/Fsm, as a
+     * genuine restart produces - not the same instance from phase 1) registers the restored trade's protocol
+     * via {@code initialize()}, then the genuinely still-pending btc-address message arrives via
+     * {@code onMessage()}. On the fix, {@code initialize()}'s restore drain plus the Fsm's own post-transition
+     * auto-drain re-applies the previously queued confirm-fiat-sent message once the btc-address transition
+     * succeeds, so the trade reaches {@code SELLER_RECEIVED_FIAT_SENT_CONFIRMATION} without the peer needing to
+     * resend anything. Pre-fix, the trade gets stuck one step short, at
+     * {@code MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS}.
+     */
+    @Test
+    void confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrainsViaRealServiceLifecycle(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-lifecycle");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-lifecycle");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        // Phase 1: "before restart" - a running node's service instance registers the trade's protocol exactly
+        // as a real node does on startup (initialize()), then a real inbound message is routed through the
+        // real ConfidentialMessageService.Listener entry point (onMessage()), never via protocol.handle().
+        LifecycleHarness harnessA = createLifecycleHarness(tempDir.resolve("before-restart"));
+        BisqEasyTradeService tradeServiceA = harnessA.tradeService();
+        try {
+            tradeServiceA.getPersistableStore().addTrade(trade);
+            tradeServiceA.initialize();
+
+            BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId);
+            tradeServiceA.onMessage(fiatSentMessage);
+
+            // Diagnostic only: confirms the message really did get queued rather than applied (pre-existing,
+            // unchanged-by-the-fix queuing behavior) - not itself the regression signal.
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                    trade.getTradeState());
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeServiceA.persistNow().join();
+            tradeServiceA.shutdown();
+        }
+
+        // Phase 2: restart - the exact persistence round trip.
+        bisq.trade.protobuf.Trade proto = trade.toProto(false);
+        BisqEasyTrade restoredTrade = BisqEasyTrade.fromProto(proto);
+
+        // Phase 3: "after restart" - a brand-new service/Fsm (never harnessA/tradeServiceA - a real restart
+        // produces a brand-new process/service), registers the restored trade via initialize() (the real
+        // app-bootstrap entry point), then the genuinely still-pending btc-address message arrives via
+        // onMessage().
+        LifecycleHarness harnessB = createLifecycleHarness(tempDir.resolve("after-restart"));
+        BisqEasyTradeService tradeServiceB = harnessB.tradeService();
+        tradeServiceB.getPersistableStore().addTrade(restoredTrade);
+        tradeServiceB.initialize();
+
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+        try {
+            tradeServiceB.onMessage(btcAddressMessage);
+
+            // The load-bearing assertion: on the fix, the previously queued confirm-fiat-sent message survived
+            // the restart and was re-applied once the btc-address transition unblocked it - the trade is no
+            // longer stuck, without the peer needing to resend anything. Pre-fix this fails, with the trade
+            // stuck one step short at ..._SELLER_RECEIVED_BTC_ADDRESS.
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState());
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeServiceB.persistNow().join();
+            tradeServiceB.shutdown();
+        }
+    }
+
+    /**
+     * Startup handoff: a message the network finishes processing after initialize()'s replay has read the
+     * processed-messages snapshot, but before the service's live listener is registered, must still reach the
+     * trade FSM. The network layer ACKs such a message and removes it from the mailbox, so if it falls into
+     * this window it is gone for good - the replay never saw it and no live delivery happened. The emulated
+     * ConfidentialMessageService below reproduces that timeline deterministically: its processed-messages
+     * read dispatches the in-window message live ONLY if a listener is already registered, exactly like the
+     * real network side. With replay-before-registration this fails (the trade silently never advances); with
+     * registration-before-replay the live path picks the message up.
+     */
+    @Test
+    void messageProcessedDuringStartupHandoffIsNotLost(@TempDir Path tempDir) throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-handoff");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-handoff");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir.resolve("handoff"));
+        BisqEasyTradeService tradeService = harness.tradeService();
+        NetworkService networkService = harness.networkService();
+
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg-handoff", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+
+        AtomicReference<ConfidentialMessageService.Listener> registeredListener = new AtomicReference<>();
+        doAnswer(invocation -> {
+            registeredListener.set(invocation.getArgument(0));
+            return null;
+        }).when(networkService).addConfidentialMessageListener(any());
+
+        ConfidentialMessageService confidentialMessageService = mock(ConfidentialMessageService.class);
+        when(confidentialMessageService.getProcessedEnvelopePayloadMessages()).thenAnswer(invocation -> {
+            // The replay's snapshot is read first - the in-window message is NOT part of it...
+            Set<EnvelopePayloadMessage> snapshot = Set.of();
+            // ...and the network finishes processing it right in the handoff window: ACKed, removed from the
+            // mailbox, and dispatched live only if a listener is registered by now.
+            ConfidentialMessageService.Listener listener = registeredListener.get();
+            if (listener != null) {
+                listener.onMessage(btcAddressMessage);
+            }
+            return snapshot;
+        });
+        when(networkService.getConfidentialMessageServices()).thenReturn(Set.of(confidentialMessageService));
+
+        tradeService.getPersistableStore().addTrade(trade);
+        try {
+            tradeService.initialize();
+
+            // The load-bearing assertion: the in-window message must have reached the FSM - the network will
+            // never redeliver it. Pre-fix (replay before listener registration) the trade silently stays at
+            // ..._SELLER_DID_NOT_RECEIVED_BTC_ADDRESS.
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                    trade.getTradeState());
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeService.persistNow().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * Strengthens the real-service-lifecycle regression above (Kim's #4885 review point) by exercising the
+     * ACTUAL on-disk persistence round trip - {@link BisqEasyTradeService#persist()} (real
+     * {@code RateLimitedPersistenceClient#persist()} -> {@code Persistence#persistAsync()/write()}), then
+     * {@link BisqEasyTradeService#readPersisted()} (real {@code Persistence#read()}) - rather than a manual
+     * {@code trade.toProto()}/{@code BisqEasyTrade.fromProto()} call. The previous version of this test (see
+     * above) only proved the FSM/Trade proto (de)serialization survives a round trip, not that the actual
+     * persistence write/read path a running node relies on does. This also exercises the #4885 follow-up fix
+     * (the atomic {state, eventQueue} snapshot - see {@code FsmModel#getStateAndEventQueueSnapshot} /
+     * {@code Trade#getTradeBuilder}): a real, asynchronously-scheduled {@code persistAsync()} write is exactly
+     * the kind of cross-thread read a torn, unsynchronized snapshot could have corrupted.
+     */
+    @Test
+    void confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRealDiskPersistenceRoundTripAndDrains(@TempDir Path persistenceDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-disk");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-disk");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        // Phase 1 ("before restart"): same setup as the lifecycle test above, but bound to a real, on-disk
+        // persistence directory that is deliberately reused (not a fresh subdirectory per phase) for the
+        // "after restart" service below - a real restart reads the SAME data directory a previous run wrote to.
+        LifecycleHarness harnessA = createLifecycleHarness(persistenceDir);
+        BisqEasyTradeService tradeServiceA = harnessA.tradeService();
+        try {
+            tradeServiceA.getPersistableStore().addTrade(trade);
+            tradeServiceA.initialize();
+
+            BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg-disk", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId);
+            tradeServiceA.onMessage(fiatSentMessage);
+            assertEquals(1, trade.getEventQueue().size());
+
+            // Force a real write to disk and block until it has landed. Note: onMessage() above already triggered a
+            // persist() internally (Fsm#handle()'s finally always persists after every transition, including queuing
+            // an out-of-order event) - but RateLimitedPersistenceClient#persist() throttles to at most one write per
+            // second, so a second, explicit call to persist() here could easily land inside that same throttling
+            // window and be silently dropped without writing anything (this is precisely the kind of gap the #4885
+            // follow-up on final-state persistence closes for completed trades - see persistNow()). Rather than racing
+            // that throttle, we go around it via the lower-level Persistence#persistAsync() directly: it runs on the
+            // same single-threaded write executor as every persist() call, so waiting for THIS write to complete
+            // guarantees any earlier-submitted write (like the automatic one above) has already landed too (FIFO).
+            tradeServiceA.getPersistence().persistAsync(tradeServiceA.getPersistableStore().getClone()).join();
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeServiceA.persistNow().join();
+            tradeServiceA.shutdown();
+        }
+
+        // Phase 2 (restart): a brand-new service instance bound to the SAME persistence directory, reading back
+        // via the real PersistenceClient#readPersisted() path - what PersistenceService#readAllPersisted() calls
+        // for every registered client at real app bootstrap - instead of a manual toProto()/fromProto() round trip.
+        LifecycleHarness harnessB = createLifecycleHarness(persistenceDir);
+        BisqEasyTradeService tradeServiceB = harnessB.tradeService();
+        assertTrue(tradeServiceB.readPersisted().isPresent());
+
+        BisqEasyTrade restoredTrade = tradeServiceB.findTrade(tradeId).orElseThrow();
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                restoredTrade.getTradeState());
+
+        // Phase 3 ("after restart"): initialize() registers the restored trade's protocol and attempts a drain
+        // (a no-op here, since the still-missing btc-address leg has not arrived yet), then the genuinely
+        // pending message arrives via the real onMessage() entry point.
+        tradeServiceB.initialize();
+
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg-disk", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+        try {
+            tradeServiceB.onMessage(btcAddressMessage);
+
+            // The load-bearing assertion: on the fix, the previously queued confirm-fiat-sent message survived a
+            // REAL disk write + read and was re-applied once the btc-address transition unblocked it. Pre-fix
+            // this fails, with the trade stuck one step short at ..._SELLER_RECEIVED_BTC_ADDRESS.
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState());
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeServiceB.persistNow().join();
+            tradeServiceB.shutdown();
+        }
+    }
+
+    /**
+     * #4885 follow-up (privacy/retention, Henrik's review point): reaching a final state must flush the
+     * in-memory clear of eventQueue/processedEvents to disk via an unthrottled write
+     * ({@code Fsm#persistOnFinalState} -> {@code BisqEasyProtocol#persistOnFinalState} ->
+     * {@code BisqEasyTradeService#persistNow}), not the ordinary, rate-limitable {@code persist()} - a
+     * throttled-and-dropped write here would leave a private, already-in-memory-wiped message stranded on disk
+     * indefinitely, since a cancelled trade has no further transition to ever trigger a follow-up write. This is
+     * verified as a deterministic interaction (which persistence method gets invoked, and how many times) rather
+     * than by racing real disk-write completion timing.
+     */
+    @Test
+    void reachingFinalStateForcesUnthrottledPersistRatherThanTheNormalRateLimitedOne() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-cancel");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-cancel");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTradeService mockTradeService = mock(BisqEasyTradeService.class);
+        ServiceProvider serviceProvider = mock(ServiceProvider.class);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(mockTradeService);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+        BisqEasySellerAsMakerProtocol protocol = new BisqEasySellerAsMakerProtocol(serviceProvider, trade);
+
+        // A non-final, out-of-order transition first: the fiat-sent message doesn't match a transition from the
+        // current state, so it gets queued instead of applied. Its persist call must go through the ordinary,
+        // rate-limitable path - a genuinely private message is now sitting parked in the queue.
+        BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                "fiat-sent-msg-cancel", tradeId, protocol.getVersion(), takerNetworkId, makerNetworkId);
+        protocol.handle(fiatSentMessage);
+        assertEquals(1, trade.getEventQueue().size());
+        verify(mockTradeService, times(1)).persist();
+        verify(mockTradeService, never()).persistNow();
+
+        // Cancel the trade via a real, message-driven transition to a final state (CANCELLED is reachable from
+        // this exact state - see BisqEasySellerAsMakerProtocol's "Cancel trade" transition). Fsm#handle() clears
+        // eventQueue/processedEvents in-memory here - the parked fiat-sent message included.
+        BisqEasyCancelTradeMessage cancelTradeMessage = new BisqEasyCancelTradeMessage(
+                "cancel-msg", tradeId, protocol.getVersion(), takerNetworkId, makerNetworkId);
+        protocol.handle(cancelTradeMessage);
+
+        assertEquals(BisqEasyTradeState.CANCELLED, trade.getTradeState());
+        assertTrue(trade.getEventQueue().isEmpty());
+
+        // The load-bearing assertions: the completing transition's persist call went through persistNow()
+        // instead of persist() - persist()'s count is unchanged from before the cancel, and persistNow() fired
+        // exactly once.
+        verify(mockTradeService, times(1)).persist();
+        verify(mockTradeService, times(1)).persistNow();
+    }
+
+    // NOTE on the buyer-as-taker "bonus" case (skipped - see final report for why): an initial attempt queued
+    // BisqEasyConfirmFiatSentEvent early (the single-source-state transition immediately downstream of
+    // BisqEasyBuyerAsTakerProtocol's analogous two-leg convergence) and round-tripped it through
+    // toProto()/fromProto(), mirroring the seller test above. It failed identically on both the fix and
+    // pre-fix code, because Trade#getTradeBuilder deliberately only serializes eventQueue entries that are
+    // EnvelopePayloadMessage instances (i.e. network messages) - see the comment there: local, user-triggered
+    // events like BisqEasyConfirmFiatSentEvent have no proto representation and are explicitly considered safe
+    // to drop, since they only ever exist while the app is already running. So that scenario was never a valid
+    // regression signal for #1622 to begin with. A genuinely analogous *message*-only race exists
+    // (BisqEasyAccountDataMessage arriving before BisqEasyTakeOfferResponse - see
+    // BisqEasyBuyerAsTakerProtocol#configTransitions "Option 2"), but BisqEasyTakeOfferResponseHandler#verify()
+    // requires a real, hash-matching ContractSignatureData plus a ContractService that reports matching public
+    // keys/valid signature, which the current lightweight ServiceProvider deep-stub does not provide - wiring
+    // that up correctly is materially more effort than the seller case, so it is left as a follow-up.
+
+    /**
+     * Creation-atomicity regression (Kim's #4885 follow-up finding): registering the live listener before the
+     * startup replay (see initialize()) makes duplicate delivery of the very same take-offer request expected,
+     * not exceptional. Two deliveries for a trade id that does not exist yet must not each create their own
+     * trade+protocol - that would be a split brain where one protocol instance is silently orphaned and any
+     * handler side effect (e.g. sending the take-offer response) runs twice.
+     * <br/>
+     * Drives {@link BisqEasyTradeService#makerCreatesProtocol} directly, sequentially, on one thread - this
+     * isolates the check-then-act creation guard from {@code protocol.handle()}'s handler-side signature
+     * verification, which needs a fully wired contract-signing chain the lightweight harness below does not
+     * provide (see the "bonus case" note above). The concurrent variant below additionally proves the guard
+     * holds under a genuine race, not just sequentially.
+     */
+    @Test
+    void secondMakerCreatesProtocolCallForSameContractIsRejectedWithoutOrphaningTheFirst(@TempDir Path tempDir) {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-dup");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-dup");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir);
+        when(harness.serviceProvider().getIdentityService().findAnyIdentityByNetworkId(makerNetworkId))
+                .thenReturn(Optional.of(createIdentity(makerNetworkId)));
+        BisqEasyTradeService tradeService = harness.tradeService();
+        try {
+            BisqEasyProtocol firstProtocol = tradeService.makerCreatesProtocol(contract, takerNetworkId, makerNetworkId);
+            String tradeId = tradeService.getTrades().stream().findAny().orElseThrow().getId();
+
+            IllegalArgumentException secondCallFailure = assertThrows(IllegalArgumentException.class,
+                    () -> tradeService.makerCreatesProtocol(contract, takerNetworkId, makerNetworkId),
+                    "a second creation attempt for the same contract must be rejected, not create a second trade");
+            assertEquals("We received the BisqEasyTakeOfferRequest for an already existing protocol",
+                    secondCallFailure.getMessage());
+
+            assertEquals(1, tradeService.getTrades().size());
+            assertSame(firstProtocol, tradeService.findProtocol(tradeId).orElseThrow(),
+                    "the rejected second call must not replace or orphan the first protocol instance");
+        } finally {
+            tradeService.persistNow().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * Concurrent variant of the creation-atomicity guard above, using a latch-gated seam
+     * ({@link BisqEasyTradeService#awaitCreationTestSeam}) to deterministically force the exact interleaving
+     * the fix guards against, rather than relying on scheduling luck - mirrors the GatedSerializationStore /
+     * BlockingCloneStore latch pattern in the persistence test suite (see PersistenceWriteGuardTests /
+     * RateLimitedPersistenceClientTests). Thread A is parked - still holding creationLock - between the "no
+     * duplicate exists" checks and the writes that make the trade/protocol exist; thread B is then released
+     * and attempts to create a protocol for the very same contract while A is still parked.
+     * <br/>
+     * This test was run against the pre-fix code (creationLock removed, i.e. makerCreatesProtocol's body
+     * unguarded) to confirm it goes red: both threads pass the checks concurrently and each create their own
+     * trade+protocol for the same id (two trades, two protocols, no exception on either side) - exactly the
+     * split brain the fix closes. With creationLock in place, thread B blocks until thread A's whole creation
+     * finishes, then correctly observes A's already-created trade/protocol and is rejected.
+     */
+    @Test
+    void concurrentMakerCreatesProtocolCallsForSameContractCreateExactlyOneTradeAndProtocol(@TempDir Path tempDir) throws Exception {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-race");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-race");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        NetworkService networkService = mock(NetworkService.class);
+        when(networkService.getConfidentialMessageServices()).thenReturn(Set.of());
+        when(networkService.confidentialSend(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendMessageResult.class)));
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+        when(serviceProvider.getPersistenceService()).thenReturn(new PersistenceService(tempDir));
+        when(serviceProvider.getIdentityService().findAnyIdentityByNetworkId(makerNetworkId))
+                .thenReturn(Optional.of(createIdentity(makerNetworkId)));
+
+        CountDownLatch threadAEnteredSeam = new CountDownLatch(1);
+        CountDownLatch releaseThreadA = new CountDownLatch(1);
+        AtomicReference<Thread> firstThreadToEnterSeam = new AtomicReference<>();
+        BisqEasyTradeService tradeService = new BisqEasyTradeService(serviceProvider, AppType.DESKTOP) {
+            @Override
+            void awaitCreationTestSeam(String tradeId) {
+                if (firstThreadToEnterSeam.compareAndSet(null, Thread.currentThread())) {
+                    threadAEnteredSeam.countDown();
+                    try {
+                        if (!releaseThreadA.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("thread A was never released");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(tradeService);
+
+        try {
+            AtomicReference<BisqEasyProtocol> protocolA = new AtomicReference<>();
+            AtomicReference<Throwable> failureA = new AtomicReference<>();
+            Thread threadA = new Thread(() -> {
+                try {
+                    protocolA.set(tradeService.makerCreatesProtocol(contract, takerNetworkId, makerNetworkId));
+                } catch (Throwable t) {
+                    failureA.set(t);
+                }
+            }, "creation-thread-A");
+            threadA.start();
+            assertTrue(threadAEnteredSeam.await(5, TimeUnit.SECONDS),
+                    "thread A must reach the seam while holding creationLock");
+
+            AtomicReference<BisqEasyProtocol> protocolB = new AtomicReference<>();
+            AtomicReference<Throwable> failureB = new AtomicReference<>();
+            Thread threadB = new Thread(() -> {
+                try {
+                    protocolB.set(tradeService.makerCreatesProtocol(contract, takerNetworkId, makerNetworkId));
+                } catch (Throwable t) {
+                    failureB.set(t);
+                }
+            }, "creation-thread-B");
+            threadB.start();
+            // With the fix, B must block trying to acquire creationLock (still held by A) - it cannot even
+            // reach its own checks yet. This is the load-bearing difference from the unfixed code, where B
+            // would run straight through and create its own trade+protocol while A is still parked.
+            threadB.join(500);
+            assertTrue(threadB.isAlive(),
+                    "with the fix, thread B must block on creationLock while thread A is parked mid-creation");
+
+            releaseThreadA.countDown();
+            threadA.join(5_000);
+            threadB.join(5_000);
+            assertTrue(!threadA.isAlive() && !threadB.isAlive(), "both threads must have finished");
+
+            assertNull(failureA.get(), "the winning creation must not fail");
+            assertNotNull(protocolA.get());
+            assertNotNull(failureB.get(), "the losing delivery must be rejected, not silently create a second trade/protocol");
+            assertInstanceOf(IllegalArgumentException.class, failureB.get());
+
+            assertEquals(1, tradeService.getTrades().size());
+            String tradeId = tradeService.getTrades().stream().findAny().orElseThrow().getId();
+            assertSame(protocolA.get(), tradeService.findProtocol(tradeId).orElseThrow(),
+                    "exactly one protocol instance must be registered - the loser must not have orphaned it");
+        } finally {
+            tradeService.persistNow().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * onMessage()-level sequential double-delivery of the very same take-offer request, driven through the
+     * real {@link BisqEasyTradeService#onMessage(EnvelopePayloadMessage)} entry point rather than
+     * {@code makerCreatesProtocol} directly. The constructed {@link BisqEasyTakeOfferRequest} cannot pass
+     * {@code BisqEasyTakeOfferRequestHandler#verify()}'s real signature/contract checks - that needs a fully
+     * wired {@code ContractService} (see the "bonus case" note above) - so what exactly happens inside
+     * {@code protocol.handle()} on either delivery (a verification failure wrapped as {@link FsmException}, an
+     * internal error-transition to a final state, or - as observed with this lightweight deep-stub harness - a
+     * silent no-op once the FSM reaches a state that later guards against further transitions) is a known
+     * harness limitation, not the regression signal, and is deliberately NOT asserted on here.
+     * <br/>
+     * The regression signal is creation-atomicity, which does not depend on the handler ever succeeding or on
+     * which of those outcomes occurs: makerCreatesProtocol's checks/writes complete (or the fast path finds
+     * the already-created protocol) strictly BEFORE protocol.handle() runs, so nothing that happens inside the
+     * handler can unwind or duplicate the creation. Because the first delivery's creation succeeds regardless
+     * of what happens afterwards, the SECOND delivery takes the lock-free fast path in
+     * handleBisqEasyTakeOfferMessage (a protocol already exists for this trade id) rather than reaching
+     * makerCreatesProtocol's checkArgument guard at all - so neither delivery can throw the "already existing
+     * protocol" rejection here. The concurrent test above is what exercises the checkArgument/creationLock
+     * backstop for a trade id that does not exist yet on either side.
+     */
+    @Test
+    void sequentialDuplicateTakeOfferRequestDeliveryCreatesExactlyOneTradeAndProtocol(@TempDir Path tempDir) {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-onmsg-dup");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-onmsg-dup");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir);
+        when(harness.serviceProvider().getIdentityService().findAnyIdentityByNetworkId(makerNetworkId))
+                .thenReturn(Optional.of(createIdentity(makerNetworkId)));
+        BisqEasyTradeService tradeService = harness.tradeService();
+        try {
+            tradeService.initialize();
+
+            BisqEasyTakeOfferRequest takeOfferRequest = createTakeOfferRequest(contract, takerNetworkId, makerNetworkId);
+
+            // Whatever protocol.handle() does internally on either delivery is not asserted on - see the
+            // javadoc above. Only the creation-atomicity contract is load-bearing here.
+            catchThrowable(() -> tradeService.onMessage(takeOfferRequest));
+            assertEquals(1, tradeService.getTrades().size(),
+                    "creation must have completed regardless of what the handler call did afterwards");
+            String tradeId = tradeService.getTrades().stream().findAny().orElseThrow().getId();
+            BisqEasyProtocol protocolAfterFirstDelivery = tradeService.findProtocol(tradeId).orElseThrow();
+
+            Throwable secondDeliveryFailure = catchThrowable(() -> tradeService.onMessage(takeOfferRequest));
+            // The one thing the second delivery must NOT do is throw the creation-rejection exception - that
+            // would mean it wrongly fell through to makerCreatesProtocol instead of the lock-free fast path.
+            if (secondDeliveryFailure != null) {
+                assertNotEquals("We received the BisqEasyTakeOfferRequest for an already existing protocol",
+                        secondDeliveryFailure.getCause() == null ? null : secondDeliveryFailure.getCause().getMessage());
+            }
+
+            assertEquals(1, tradeService.getTrades().size());
+            assertSame(protocolAfterFirstDelivery, tradeService.findProtocol(tradeId).orElseThrow(),
+                    "the redelivered message must not have replaced or orphaned the original protocol instance");
+        } finally {
+            tradeService.persistNow().join();
+            tradeService.shutdown();
+        }
+    }
+
+    private static Throwable catchThrowable(Runnable runnable) {
+        try {
+            runnable.run();
+            return null;
+        } catch (Throwable t) {
+            return t;
+        }
+    }
+
+    private static BisqEasyTakeOfferRequest createTakeOfferRequest(BisqEasyContract contract,
+                                                                    NetworkId takerNetworkId,
+                                                                    NetworkId makerNetworkId) {
+        // Deliberately NOT a real signature: BisqEasyTakeOfferRequestHandler#verify() will reject this (see
+        // the class-level javadoc on the test using this helper) - only NetworkDataValidation's structural
+        // constraints (hash/signature byte lengths) need to be satisfied for the message to construct at all.
+        byte[] fakeContractHash = DigestUtil.hash("fake-contract-hash".getBytes(StandardCharsets.UTF_8));
+        byte[] fakeSignature = new byte[70];
+        ContractSignatureData fakeSignatureData = new ContractSignatureData(
+                fakeContractHash, fakeSignature, takerNetworkId.getPubKey().getPublicKey());
+        return new BisqEasyTakeOfferRequest(StringUtils.createUid(),
+                BisqEasyTrade.createId(contract, takerNetworkId),
+                BisqEasyProtocol.VERSION,
+                takerNetworkId,
+                makerNetworkId,
+                contract,
+                fakeSignatureData);
+    }
+
+    /**
+     * Privacy/retention follow-up to #4885 (Henrik's review point): the persisted out-of-order events hold the full
+     * account-data network message, and a stuck trade may never reach a final state to clear them. This drives the
+     * real retention pass over a stuck trade whose take-offer date is past the not-completed redaction threshold and
+     * asserts the parked event is scrubbed - so the sensitive payload cannot linger on disk indefinitely.
+     */
+    @Test
+    void redactionScrubsParkedOutOfOrderEventsOfStuckTrade(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-redact");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-redact");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        // Take-offer date well past the 45-90 day not-completed redaction window so the pass acts on this trade.
+        long oldTakeOfferDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(200);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId, oldTakeOfferDate);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir);
+        BisqEasyTradeService tradeService = harness.tradeService();
+        try {
+            tradeService.getPersistableStore().addTrade(trade);
+            tradeService.initialize();
+
+            // Park an out-of-order confirm-fiat-sent message (the stuck-trade shape) - it carries account data.
+            BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg-redact", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId);
+            tradeService.onMessage(fiatSentMessage);
+            assertEquals(1, trade.getEventQueue().size());
+
+            // numDays is clamped to [45, 90] for not-completed trades; any value works since the trade is 200 days old.
+            when(harness.serviceProvider().getSettingsService().getNumDaysAfterRedactingTradeData().get())
+                    .thenReturn(90);
+
+            tradeService.maybeRedactDataOfCompletedTrades();
+
+            assertTrue(trade.getEventQueue().isEmpty(),
+                    "The retention pass must scrub the parked out-of-order event of a stuck, past-threshold trade");
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeService.persistNow().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * A queued event passed onMessage()'s guards when it was originally
+     * received, but its sender may have been BANNED before the restart. The restore drain applies queued events
+     * directly through the FSM - bypassing onMessage()'s banned-sender check - so the guard in
+     * {@link BisqEasyTradeService#createAndAddTradeProtocol} must scrub such events before draining, mirroring
+     * what onMessage() would do with the same message arriving live. The trade is placed at a state that
+     * ACCEPTS the queued message, so an unguarded drain WOULD have applied it - the assertion that the state
+     * did NOT advance is what separates "dropped" from "vacuously not applied".
+     */
+    @Test
+    void restoreDrainDropsQueuedEventsFromNowBannedSender(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-banned");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-banned");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade restoredTrade =
+                createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(contract, offer, takerNetworkId, makerNetworkId);
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir);
+        // The sender of the queued message got banned between original receipt and the restart.
+        when(harness.serviceProvider().getUserService().getBannedUserService()
+                .isUserProfileBanned(any(NetworkId.class))).thenReturn(true);
+        BisqEasyTradeService tradeService = harness.tradeService();
+        try {
+            tradeService.getPersistableStore().addTrade(restoredTrade);
+            tradeService.initialize();
+
+            // Dropped, not applied: queue empty AND state unchanged. (A drain would have advanced the state to
+            // SELLER_RECEIVED_FIAT_SENT_CONFIRMATION - see the control phase of the halt test below.)
+            assertTrue(restoredTrade.getEventQueue().isEmpty(),
+                    "queued events from a banned sender must be scrubbed before the restore drain");
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                    restoredTrade.getTradeState(),
+                    "a banned sender's queued message must not be applied");
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            tradeService.persistNow().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * With an EMERGENCY halt-trading alert active (persisted alert data is
+     * replayed synchronously when initialize() registers its observer - which now happens BEFORE the restore),
+     * the restore drain must be DEFERRED: events stay queued rather than being applied or dropped, and drain on
+     * a later restart once the alert is lifted. Phase 2 is that later restart and doubles as the positive
+     * control proving the setup is real: without the alert, the same still-queued event drains and advances the
+     * trade.
+     */
+    @Test
+    void restoreDrainIsDeferredWhileTradingIsHaltedAndRunsOnceAlertIsLifted(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-halt");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-halt");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade restoredTrade =
+                createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(contract, offer, takerNetworkId, makerNetworkId);
+
+        // Phase 1: restart while a halt-trading emergency alert is in effect.
+        LifecycleHarness haltedHarness = createLifecycleHarness(tempDir.resolve("halted"));
+        AuthorizedAlertData haltAlert = mock(AuthorizedAlertData.class);
+        when(haltAlert.getAlertType()).thenReturn(AlertType.EMERGENCY);
+        when(haltAlert.getAppType()).thenReturn(AppType.DESKTOP);
+        when(haltAlert.isHaltTrading()).thenReturn(true);
+        when(haltedHarness.serviceProvider().getBondedRolesService().getAlertService().getAuthorizedAlertDataSet())
+                .thenReturn(new ObservableSet<>(Set.of(haltAlert)));
+        BisqEasyTradeService haltedTradeService = haltedHarness.tradeService();
+        try {
+            haltedTradeService.getPersistableStore().addTrade(restoredTrade);
+            haltedTradeService.initialize();
+
+            // Deferred: kept queued (not dropped) and not applied.
+            assertEquals(1, restoredTrade.getEventQueue().size(),
+                    "the queued event must survive a halted restart untouched");
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                    restoredTrade.getTradeState(),
+                    "no queued event may be applied while trading is halted");
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            haltedTradeService.persistNow().join();
+            haltedTradeService.shutdown();
+        }
+
+        // Phase 2: a later restart with the alert lifted - the still-queued event now drains and the trade
+        // advances. This is also the positive control for both guard tests: it proves the chosen state really
+        // does accept the queued message, so phase 1's non-application was the guard, not a vacuous no-op.
+        LifecycleHarness liftedHarness = createLifecycleHarness(tempDir.resolve("lifted"));
+        BisqEasyTradeService liftedTradeService = liftedHarness.tradeService();
+        try {
+            liftedTradeService.getPersistableStore().addTrade(restoredTrade);
+            liftedTradeService.initialize();
+
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState(),
+                    "once the alert is lifted the deferred event must drain on the next restart");
+            assertTrue(restoredTrade.getEventQueue().isEmpty());
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). persistNow()'s
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence.
+            liftedTradeService.persistNow().join();
+            liftedTradeService.shutdown();
+        }
+    }
+
+    /**
+     * Builds the restored-trade shape both guard tests need: a queued confirm-fiat-sent message, with the trade
+     * state advanced (as part of the persistence round trip, as if the btc-address transition completed right
+     * before shutdown without a drain) to the state that ACCEPTS the queued message - so the restore drain,
+     * unless guarded, applies it immediately.
+     */
+    private static BisqEasyTrade createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(BisqEasyContract contract,
+                                                                                              BisqEasyOffer offer,
+                                                                                              NetworkId takerNetworkId,
+                                                                                              NetworkId makerNetworkId)
+            throws UnresolvableProtobufEnumException {
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        BisqEasySellerAsMakerProtocol protocol = new BisqEasySellerAsMakerProtocol(createServiceProvider(), trade);
+        BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                "fiat-sent-msg-guard", trade.getId(), protocol.getVersion(), takerNetworkId, makerNetworkId);
+        // No transition from the current state accepts it -> parked in the event queue.
+        protocol.handle(fiatSentMessage);
+        assertEquals(1, trade.getEventQueue().size());
+
+        bisq.trade.protobuf.Trade proto = trade.toProto(false).toBuilder()
+                .setState(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS.name())
+                .build();
+        return BisqEasyTrade.fromProto(proto);
+    }
+
+    private record LifecycleHarness(BisqEasyTradeService tradeService, NetworkService networkService,
+                                    ServiceProvider serviceProvider) {
+    }
+
+    // Builds a BisqEasyTradeService harness suitable for exercising the real initialize()/onMessage() lifecycle,
+    // stubbing every ServiceProvider dependency initialize() itself touches: getConfidentialMessageServices(),
+    // the alert/settings observers, and the periodic redaction scheduler.
+    // Each call is given its own persistence directory: a real restart produces a brand-new service/Fsm, and
+    // reusing one directory (or one service instance) across "before" and "after" phases would let the two
+    // phases silently share state that only a real proto round trip should carry across.
+    private static LifecycleHarness createLifecycleHarness(Path persistenceDir) {
+        NetworkService networkService = mock(NetworkService.class);
+        // Empty: message delivery is driven explicitly via onMessage() in the test body rather than letting
+        // initialize()'s own startup replay (of whatever this would return) do it implicitly.
+        when(networkService.getConfidentialMessageServices()).thenReturn(Set.of());
+        when(networkService.confidentialSend(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendMessageResult.class)));
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+        when(serviceProvider.getPersistenceService()).thenReturn(new PersistenceService(persistenceDir));
+
+        BisqEasyTradeService tradeService = new BisqEasyTradeService(serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(tradeService);
+
+        return new LifecycleHarness(tradeService, networkService, serviceProvider);
+    }
+
+    private static BisqEasyTrade createTradeAtState(BisqEasyContract contract,
+                                                     BisqEasyOffer offer,
+                                                     NetworkId takerNetworkId,
+                                                     NetworkId makerNetworkId,
+                                                     BisqEasyTradeState state) throws UnresolvableProtobufEnumException {
+        BisqEasyTrade freshTrade = new BisqEasyTrade(contract, false, false, createIdentity(makerNetworkId), offer,
+                takerNetworkId, makerNetworkId);
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(state.name())
+                .build();
+        return BisqEasyTrade.fromProto(proto);
+    }
+
+    private static Identity createIdentity(NetworkId networkId) {
+        KeyBundle keyBundle = new KeyBundle("test-key-bundle",
+                KeyGeneration.generateDefaultEcKeyPair(),
+                TorKeyGeneration.generateKeyPair(),
+                I2PKeyGeneration.generateKeyPair());
+        return new Identity("test-id", networkId, keyBundle);
+    }
+
+    private static ServiceProvider createServiceProvider() {
+        ServiceProvider serviceProvider = mock(ServiceProvider.class);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(mock(BisqEasyTradeService.class));
+        return serviceProvider;
+    }
+
+    private static BisqEasyContract createRealContract(BisqEasyOffer offer, NetworkId takerNetworkId) {
+        return createRealContract(offer, takerNetworkId, System.currentTimeMillis());
+    }
+
+    private static BisqEasyContract createRealContract(BisqEasyOffer offer, NetworkId takerNetworkId, long takeOfferDate) {
+        return new BisqEasyContract(takeOfferDate,
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                new BitcoinPaymentMethodSpec(BitcoinPaymentMethod.fromPaymentRail(BitcoinPaymentRail.MAIN_CHAIN)),
+                new FiatPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+    }
+
+    private static BisqEasyOffer createRealOffer(NetworkId makerNetworkId) {
+        return new BisqEasyOffer(makerNetworkId,
+                Direction.SELL,
+                new Market("BTC", "EUR", "Bitcoin", "Euro"),
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(BitcoinPaymentMethod.fromPaymentRail(BitcoinPaymentRail.MAIN_CHAIN)),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                "",
+                List.of("en"),
+                "1.0.0");
+    }
+
+    private static NetworkId createNetworkId(String keyId) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        Address address = Address.from("127.0.0.1", 1000);
+        return new NetworkId(new AddressByTransportTypeMap(Map.of(address.getTransportType(), address)),
+                new PubKey(keyPair.getPublic(), keyId));
+    }
+}

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceRestoreDrainTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceRestoreDrainTest.java
@@ -239,8 +239,8 @@ class MuSigTradeServiceRestoreDrainTest {
     }
 
     /**
-     * MuSig mirror of {@code BisqEasyTradeTest#restoreDrainDropsQueuedEventsFromNowBannedSender} (#4885, Kim's
-     * review point): the queued message passed onMessage()'s banned-sender check when originally received, but
+     * MuSig mirror of {@code BisqEasyTradeTest#restoreDrainDropsQueuedEventsFromNowBannedSender}:
+     * the queued message passed onMessage()'s banned-sender check when originally received, but
      * the sender got banned before the restart. The restore drain bypasses onMessage(), so the guard in
      * {@link MuSigTradeService#createAndAddTradeProtocol} must scrub the banned sender's queued events before
      * draining. Same trade shape as {@link #restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore} - a state
@@ -309,9 +309,10 @@ class MuSigTradeServiceRestoreDrainTest {
     }
 
     /**
-     * MuSig mirror of the BisqEasy creation-atomicity fix (Kim's #4885 follow-up finding): makerCreatesProtocol
-     * gained a creationLock plus a lock-free fast path in handleMuSigTakeOfferMessage that looks up an
-     * already-existing protocol by id BEFORE attempting creation - see {@code MuSigTradeService#makerCreatesProtocol}
+     * MuSig mirror of the BisqEasy creation-atomicity fix:
+     * makerCreatesProtocol gained a creationLock plus a lock-free fast path in handleMuSigTakeOfferMessage that looks
+     * up an already-existing protocol by id BEFORE attempting creation
+     * see {@code MuSigTradeService#makerCreatesProtocol}
      * and {@code MuSigTrade#createId}. This pins the one piece of that fix that is safely testable here: the
      * fast path's id derivation (from the contract/sender, before a trade object exists) must be byte-for-byte
      * identical to what constructing the trade actually produces, or the fast path could miss and fall through

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceRestoreDrainTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceRestoreDrainTest.java
@@ -1,0 +1,386 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.bonded_roles.release.AppType;
+import bisq.common.market.Market;
+import bisq.common.network.Address;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.proto.UnresolvableProtobufEnumException;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.identity.Identity;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.message.NetworkMessageResolver;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.persistence.PersistenceService;
+import bisq.security.keys.I2PKeyGeneration;
+import bisq.security.keys.KeyBundle;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.keys.TorKeyGeneration;
+import bisq.trade.ServiceProvider;
+import bisq.trade.mu_sig.messages.network.SendAccountPayloadMessage;
+import bisq.trade.mu_sig.protocol.MuSigProtocol;
+import bisq.trade.mu_sig.protocol.MuSigTradeState;
+import bisq.trade.protocol.messages.TradeMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * MuSig parity: the generic {@code Trade}/{@code FsmModel}
+ * persistence fix (persisted pendingFsmEvents + Fsm#drainEventQueue) applies to every {@code Trade} subclass,
+ * including {@link MuSigTrade} - but only {@code BisqEasyTradeService} actually drained restored trades on load.
+ * {@link MuSigTradeService} persisted the queue (via the same generic Trade machinery) without ever draining it,
+ * so a MuSig trade with an out-of-order message parked at shutdown would stay stuck forever after a restart,
+ * even though the data needed to self-heal was sitting right there in the persisted proto.
+ * <br/>
+ * A full onMessage()/initialize()-driven lifecycle test analogous to
+ * {@code BisqEasyTradeTest#confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrainsViaRealServiceLifecycle}
+ * is impractical for MuSig: essentially every message handler in the setup phase (SetupTradeMessage_B/C/D and
+ * their handlers) calls out to {@code MusigGrpcClient}'s real blocking gRPC stub (nonce shares, partial
+ * signatures, deposit tx signing), which would require standing up (or deeply mocking) a MuSig gRPC server - out
+ * of proportion for this regression test. {@link SendAccountPayloadMessage}'s handler is the one early-phase
+ * message handler that does NOT touch gRPC (its only side effect,
+ * {@code MuSigTradeService#observeDepositTxConfirmationStatus}, is itself a dev-time no-op - see the
+ * {@code if (true) return;} guard at the top of that method), which makes a genuine out-of-order-message
+ * restore-and-drain scenario reproducible here without any gRPC involvement.
+ */
+class MuSigTradeServiceRestoreDrainTest {
+    static {
+        // Normally registered once at app startup by bisq.application.ResolverConfig, which is not a dependency
+        // available to :trade tests. Required so a persisted, wrapped TradeMessage (see Trade#pendingEventsFromProto)
+        // can be resolved back via EnvelopePayloadMessage.fromProto() -> Any.unpack() - shared by both BisqEasy and
+        // MuSig trade messages (see TradeMessage#fromProto's MessageCase switch).
+        NetworkMessageResolver.addResolver("trade.TradeMessage", TradeMessage.getNetworkMessageResolver());
+    }
+
+    /**
+     * End-to-end reproduction of the MuSig restore-drain gap: a buyer-as-taker trade is hand-placed at
+     * {@code TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX} with a {@link SendAccountPayloadMessage} already queued in
+     * its persisted {@code pendingFsmEvents} (as if it had arrived out of order and survived a restart via the
+     * generic Trade persistence fix, but before this fix was applied to MuSigTradeService). The trade is then
+     * registered via {@link MuSigTradeService#createAndAddTradeProtocol(MuSigTrade, boolean)} with
+     * {@code isRestoredTrade=true} - the exact call {@code initialize()} now makes for every persisted trade at
+     * app startup - and the queued message must be re-applied immediately, without any further live message ever
+     * arriving.
+     */
+    @Test
+    void restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        // Buyer-as-taker trade, hand-placed at the state reached right after publishing the deposit tx - the
+        // predecessor state for SendAccountPayloadMessage (see MuSigBuyerAsTakerProtocol#configTransitions) -
+        // with the message already parked in the persisted pendingFsmEvents, exactly mirroring
+        // BisqEasyTradeTest's out-of-order simulation via toProto()/fromProto().
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer, takerNetworkId, makerNetworkId);
+        String tradeId = freshTrade.getId();
+
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg", tradeId, MuSigProtocol.VERSION, makerNetworkId, takerNetworkId,
+                new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertEquals(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX, restoredTrade.getTradeState());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        NetworkService networkService = mock(NetworkService.class);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getMuSigTradeService()).thenReturn(tradeService);
+
+        // The real, package-private restore-time entry point - mirrors exactly what initialize() now calls for
+        // every persisted trade (see MuSigTradeService#initialize(): "persistableStore.getTrades().forEach(trade
+        // -> createAndAddTradeProtocol(trade, true))"). isRestoredTrade=true must drain the queue once,
+        // immediately, without waiting for some later, unrelated live transition to happen to occur for this trade.
+        tradeService.createAndAddTradeProtocol(restoredTrade, true);
+
+        // The load-bearing assertion: on the fix, the parked SendAccountPayloadMessage was re-applied purely by
+        // virtue of being restored and registered - the trade advanced from TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX
+        // to TAKER_RECEIVED_ACCOUNT_PAYLOAD with no further message ever delivered. Pre-fix (isRestoredTrade drain
+        // wiring absent, as MuSigTradeService#initialize() used to call the plain 1-arg createAndAddTradeProtocol),
+        // this trade would stay stuck at TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX forever, exactly like #1622 before
+        // BisqEasyTradeService got its drain-on-restore fix.
+        assertEquals(MuSigTradeState.TAKER_RECEIVED_ACCOUNT_PAYLOAD, restoredTrade.getTradeState());
+        assertTrue(restoredTrade.getEventQueue().isEmpty());
+    }
+
+    /**
+     * Isolation guard mirroring {@code BisqEasyTradeService#createAndAddTradeProtocol}'s per-trade try/catch:
+     * a trade restored with a queued event that no longer matches ANY transition in its (possibly since-changed)
+     * protocol config must not prevent the trade from being registered - drainEventQueue() re-queues an
+     * unmatched event rather than applying it, so this also pins that a mismatched queued event is simply left
+     * parked (not lost, not thrown) rather than blocking restore.
+     */
+    @Test
+    void restoredTradeWithQueuedMessageThatStillDoesNotMatchIsLeftParkedWithoutBlockingRestore() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker-mismatch");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker-mismatch");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id-mismatch",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer, takerNetworkId, makerNetworkId);
+        String tradeId = freshTrade.getId();
+
+        // SendAccountPayloadMessage only matches a transition from TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX. Parking
+        // it while the trade is still at the earlier TAKER_INITIALIZED_TRADE state means it genuinely does not
+        // match on restore - drainEventQueue() must re-queue it (a safe no-op), not throw or lose it.
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg-mismatch", tradeId, MuSigProtocol.VERSION, makerNetworkId, takerNetworkId,
+                new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_INITIALIZED_TRADE.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        NetworkService networkService = mock(NetworkService.class);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getMuSigTradeService()).thenReturn(tradeService);
+
+        // Must not throw, and the trade must still get registered/returned even though the drain could not
+        // apply anything.
+        tradeService.createAndAddTradeProtocol(restoredTrade, true);
+
+        assertEquals(MuSigTradeState.TAKER_INITIALIZED_TRADE, restoredTrade.getTradeState());
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertTrue(tradeService.findProtocol(tradeId).isPresent());
+    }
+
+    /**
+     * MuSig mirror of {@code BisqEasyTradeTest#restoreDrainDropsQueuedEventsFromNowBannedSender} (#4885, Kim's
+     * review point): the queued message passed onMessage()'s banned-sender check when originally received, but
+     * the sender got banned before the restart. The restore drain bypasses onMessage(), so the guard in
+     * {@link MuSigTradeService#createAndAddTradeProtocol} must scrub the banned sender's queued events before
+     * draining. Same trade shape as {@link #restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore} - a state
+     * that ACCEPTS the queued message - so the state NOT advancing proves the drop, not a vacuous no-op.
+     */
+    @Test
+    void restoreDrainDropsQueuedEventsFromNowBannedSender() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker-banned");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker-banned");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id-banned",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer, takerNetworkId, makerNetworkId);
+        String tradeId = freshTrade.getId();
+
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg-banned", tradeId, MuSigProtocol.VERSION, makerNetworkId, takerNetworkId,
+                new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        NetworkService networkService = mock(NetworkService.class);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+        // The sender of the queued message got banned between original receipt and the restart.
+        when(serviceProvider.getUserService().getBannedUserService()
+                .isUserProfileBanned(any(NetworkId.class))).thenReturn(true);
+
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getMuSigTradeService()).thenReturn(tradeService);
+
+        tradeService.createAndAddTradeProtocol(restoredTrade, true);
+
+        // Dropped, not applied: pre-guard this exact shape advanced to TAKER_RECEIVED_ACCOUNT_PAYLOAD (see
+        // restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore above).
+        assertTrue(restoredTrade.getEventQueue().isEmpty(),
+                "queued events from a banned sender must be scrubbed before the restore drain");
+        assertEquals(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX, restoredTrade.getTradeState(),
+                "a banned sender's queued message must not be applied");
+    }
+
+    /**
+     * MuSig mirror of the BisqEasy creation-atomicity fix (Kim's #4885 follow-up finding): makerCreatesProtocol
+     * gained a creationLock plus a lock-free fast path in handleMuSigTakeOfferMessage that looks up an
+     * already-existing protocol by id BEFORE attempting creation - see {@code MuSigTradeService#makerCreatesProtocol}
+     * and {@code MuSigTrade#createId}. This pins the one piece of that fix that is safely testable here: the
+     * fast path's id derivation (from the contract/sender, before a trade object exists) must be byte-for-byte
+     * identical to what constructing the trade actually produces, or the fast path could miss and fall through
+     * to a redundant, rejected creation attempt for a message that should have been routed to the existing
+     * protocol instead.
+     * <br/>
+     * A full concurrent creation-atomicity test analogous to
+     * {@code BisqEasyTradeTest#concurrentMakerCreatesProtocolCallsForSameContractCreateExactlyOneTradeAndProtocol}
+     * is impractical for MuSig for two independent reasons: (1) {@code MuSigTradeService.makerCreatesProtocol}
+     * resolves the maker's account (@code findMyAccount(trade).orElseThrow()}) BEFORE the duplicate-protocol
+     * checks, which needs a fully wired salted-account-id chain (a real {@code Account}/{@code AccountPayload}
+     * matched against an {@code AccountOption} on the offer, hashed via
+     * {@code OfferOptionUtil#createdSaltedAccountId}) - materially more setup than the BisqEasy case, which
+     * has no such prerequisite; and (2) {@link MuSigTradeService} is a {@code final} class, so it cannot be
+     * subclassed the way the BisqEasy concurrent test overrides {@code awaitCreationTestSeam} to force a
+     * deterministic interleaving, nor spied with this project's plain {@code mockito-core} (no inline mock
+     * maker configured) to short-circuit {@code findMyAccount}. The creationLock/fast-path code itself mirrors
+     * BisqEasyTradeService's exactly (same check-then-act shape, same lock placement, same seam), so the
+     * concurrency argument validated there applies here without needing its own concurrent test.
+     */
+    @Test
+    void fastPathIdDerivationMatchesMakerCreatedTradeId() {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker-id-derivation");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker-id-derivation");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id-derivation",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        // Mirrors exactly what MuSigTradeService#makerCreatesProtocol constructs: isTaker=false, isBuyer derived
+        // from the maker's direction, sender==takerNetworkId (the request's sender is the taker).
+        MuSigTrade makerCreatedTrade = new MuSigTrade(contract, offer.getDirection().isBuy(), false,
+                createIdentity(makerNetworkId), offer, takerNetworkId, makerNetworkId);
+
+        assertEquals(makerCreatedTrade.getId(), MuSigTrade.createId(contract, takerNetworkId),
+                "the fast path's id derivation must be single-sourced with the trade constructor's - a mismatch " +
+                        "would make handleMuSigTakeOfferMessage's duplicate lookup silently miss");
+    }
+
+    private static Identity createIdentity(NetworkId networkId) {
+        KeyBundle keyBundle = new KeyBundle("test-key-bundle",
+                KeyGeneration.generateDefaultEcKeyPair(),
+                TorKeyGeneration.generateKeyPair(),
+                I2PKeyGeneration.generateKeyPair());
+        return new Identity("test-id", networkId, keyBundle);
+    }
+
+    private static NetworkId createNetworkId(String keyId) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        Address address = Address.from("127.0.0.1", 1000);
+        return new NetworkId(new AddressByTransportTypeMap(Map.of(address.getTransportType(), address)),
+                new PubKey(keyPair.getPublic(), keyId));
+    }
+}


### PR DESCRIPTION
 - resolves bisq-network/bisq-mobile#1622

## Motivation

Reported in [bisq-network/bisq-mobile#1622](https://github.com/bisq-network/bisq-mobile/issues/1622): sellers occasionally find that **"Mark Payment Sent" / "Payment Received" stop advancing the trade**. The payment goes through and chat still works, but the trade state is stuck, forcing both traders to finish the trade manually via chat.

As I noted in the issue comments, this turned out to be a **structural bisq2-core issue, not a Bisq Connect one** — it can affect any bisq2 seller (the original reporter was on Bisq 2 desktop 2.1.11). It is intermittent and rare, but disruptive when it hits, and it is a **very important fix overall**: core-embedded apps (Bisq 2 desktop, Bisq Node mobile) can work around it with a restart, but for Bisq Connect the workaround means restarting the **trusted node**.

## Problem

A Bisq Easy trade is driven by a finite-state machine (FSM). Phase 1 has two independent steps that arrive as separate, unordered messages: the seller **sends account data**, and the seller **receives the buyer's Bitcoin address**. The next step — the buyer's **"fiat sent" confirmation** — is only accepted from the single state where *both* phase-1 steps are already done.

When the "fiat sent" message arrives **before** phase 1 has fully settled (a realistic race over Tor/mailbox, where message ordering isn't guaranteed and a fast Connect buyer fires messages back-to-back) the FSM finds no matching transition and parks the message in an **in-memory queue**, retrying it only after some *later* successful transition. If no such transition happens while the app is running, the message is stranded and the trade stays stuck — even though the network layer already ACKed it as "delivered" and stopped resending it.

**Why restarting sometimes worked around it:** on startup, bisq2 re-feeds previously received messages through the FSM, which re-applies the stranded message once the state is correct. But this recovery was *incidental* — the FSM queue itself was in-memory only, so whether a restart healed the trade depended on the message still being around to re-feed. That's why the issue sometimes cleared on its own overnight and sometimes never did.

## Solution

The fix makes the recovery **structural instead of incidental**, at the FSM / trade-state layer. Three parts:

**1. Persist the FSM's out-of-order buffer, drain it on load.** The pending-event queue (and processed-events set) is now serialized with the trade — the framework even shipped an unused restore constructor built for exactly this, which we activate. Out-of-order messages are no longer silently lost at shutdown, and on load each restored trade drains its queue once against the restored state (mirrored for BisqEasy and MuSig). The `{state, eventQueue}` pair is captured as **one atomic snapshot** under the model lock, so the async persistence write can't tear it (which could double-apply or silently drop an event on restore). Reaching a final state clears the queue through an **unthrottled persist path** — the ordinary rate-limited persist() could silently drop that wipe, leaving sensitive queued messages on disk.

**2. Close the startup handoff window.** The live message listener is now registered **before** the startup replay. With the old order there was a window where a message could be ACKed and removed from the mailbox without ever reaching the FSM — lost for good. Register-first closes that structurally, at the cost of possible duplicate delivery (live + replay), which is expected and handled: once a protocol exists a duplicate is absorbed by the FSM (processed-events filter, forward-only transitions); for the one case where no protocol exists yet (a duplicate take-offer request) the trade id is now **single-sourced** (`BisqEasyTrade#createId`) so duplicates route to the existing protocol, and creation itself is **check-then-act atomic** under a creation lock — two concurrent deliveries can no longer split-brain into two trade/protocol instances for the same id.

**3. Make the persist actually durable.** The above only helps if the queue reliably reaches disk, so the persistence layer got hardened along the way: write failures are propagated instead of swallowed, dirty-state is derived from a requested/persisted **generation pair** (a failed or dropped persist can't be cleared by an older write completing), snapshot capture + write scheduling run under one lock so writes reach the serializer in order, a **write-id guard** ensures a stale queued write can never overwrite a newer one, and shutdown waits (bounded) for the in-flight write and falls back to a direct synchronous write if it doesn't confirm.

**Why the drain is safe** (it re-applies messages, so this matters): drained events go **directly through the FSM** — never the public message entry point — so no handler re-runs, no peer traffic, no duplicate ACKs. The drain also re-checks what `onMessage()` would check for a live message: an emergency **halt / min-version alert defers** the drain (events stay queued for a later restart — and the alert observer is registered before the restore so this check sees real state on cold start), a **banned sender's** queued events are dropped, and each trade drains in isolation so one failing trade can't block restoring the rest.

### Notes

 - earlier revisions of this PR also shipped a live recovery pass (reconnect-debounced + periodic); it was dropped during review in favour of the leaner structural fix above → recovery is now **deterministic on the next transition or restart** instead of incidental, and the window that stranded messages in the first place is closed
 - this solution doesn't require any UI changes neither mobile nor desktop → solution entirely at the FSM / trade-state / persistence layer
 - logs to look for: `Re-feeding a processed message at startup was rejected …`, `Deferring the queued-event drain for restored trade …`, `Removed queued event(s) from a banned sender …`

### Dev commit logs

 - persist FSM event queue + processed events so out-of-order messages survive restart; drain once on load (BisqEasy + MuSig)
 - atomic `{state, eventQueue}` snapshot under the model lock; final-state queue wipe routed through an unthrottled persist
 - register the live listener before the startup replay (closes a message-loss handoff window); duplicates absorbed by the FSM
 - take-offer duplicate safety: single-sourced trade id + creation lock (no split-brain trade/protocol on concurrent delivery)
 - drain guards mirror onMessage(): halt/min-version defers, banned-sender events dropped, per-trade isolation
 - persistence hardening: write-failure propagation, generation-pair dirty tracking, ordered snapshot/write scheduling, write-id guard against stale overwrites, bounded shutdown write + direct fallback
 - added AI generated tests (FSM, trade restore/drain, persistence write guards)
