### PR TITLE
chore: sync #4878 to main — Add NETWORK_INFO websocket topic for network state

### DIFF
--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -219,6 +219,7 @@ public class ApiService implements Service {
                     tradeService,
                     userService,
                     bisqEasyService,
+                    networkService,
                     openTradeItemsService));
         } else {
             webSocketService = Optional.empty();

--- a/api/src/main/java/bisq/api/dto/network/ConnectionDto.java
+++ b/api/src/main/java/bisq/api/dto/network/ConnectionDto.java
@@ -15,19 +15,11 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.api.web_socket.subscription;
+package bisq.api.dto.network;
 
-public enum Topic {
-    MARKET_PRICE,
-    NUM_OFFERS,
-    OFFERS,
-    TRADES,
-    TRADE_PROPERTIES,
-    TRADE_CHAT_MESSAGES,
-    CHAT_REACTIONS,
-    REPUTATION,
-    NUM_USER_PROFILES,
-    ALERT_NOTIFICATIONS,
-    TRADE_RESTRICTING_ALERT,
-    NETWORK_INFO,
+public record ConnectionDto(String connectionId,
+                            String address,
+                            boolean outbound,
+                            boolean seed,
+                            long establishedAtMillis) {
 }

--- a/api/src/main/java/bisq/api/dto/network/NetworkInfoDto.java
+++ b/api/src/main/java/bisq/api/dto/network/NetworkInfoDto.java
@@ -15,19 +15,14 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.api.web_socket.subscription;
+package bisq.api.dto.network;
 
-public enum Topic {
-    MARKET_PRICE,
-    NUM_OFFERS,
-    OFFERS,
-    TRADES,
-    TRADE_PROPERTIES,
-    TRADE_CHAT_MESSAGES,
-    CHAT_REACTIONS,
-    REPUTATION,
-    NUM_USER_PROFILES,
-    ALERT_NOTIFICATIONS,
-    TRADE_RESTRICTING_ALERT,
-    NETWORK_INFO,
+import javax.annotation.Nullable;
+import java.util.List;
+
+public record NetworkInfoDto(boolean allDataReceived,
+                             boolean torRunning,
+                             @Nullable String myAddress,
+                             @Nullable String keyId,
+                             List<ConnectionDto> connections) {
 }

--- a/api/src/main/java/bisq/api/web_socket/WebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/WebSocketService.java
@@ -30,6 +30,7 @@ import bisq.common.application.Service;
 import bisq.common.observable.Observable;
 import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.observable.collection.ObservableSet;
+import bisq.network.NetworkService;
 import bisq.trade.TradeService;
 import bisq.user.UserService;
 import lombok.Getter;
@@ -66,6 +67,7 @@ public class WebSocketService implements Service {
                             TradeService tradeService,
                             UserService userService,
                             BisqEasyService bisqEasyService,
+                            NetworkService networkService,
                             OpenTradeItemsService openTradeItemsService) {
         this.apiConfig = apiConfig;
         subscriptionService = new SubscriptionService(bondedRolesService,
@@ -74,6 +76,7 @@ public class WebSocketService implements Service {
                 tradeService,
                 userService,
                 bisqEasyService,
+                networkService,
                 openTradeItemsService);
         webSocketRestApiService = new WebSocketRestApiService(apiConfig, tlsContextService);
         webSocketConnectionHandler = new WebSocketConnectionHandler(subscriptionService, webSocketRestApiService);

--- a/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
@@ -1,0 +1,204 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.domain.network;
+
+import bisq.api.dto.network.ConnectionDto;
+import bisq.api.dto.network.NetworkInfoDto;
+import bisq.api.web_socket.domain.BaseWebSocketService;
+import bisq.api.web_socket.subscription.ModificationType;
+import bisq.api.web_socket.subscription.Subscriber;
+import bisq.api.web_socket.subscription.SubscriberRepository;
+import bisq.api.web_socket.subscription.SubscriptionRequest;
+import bisq.api.web_socket.subscription.Topic;
+import bisq.common.network.Address;
+import bisq.common.network.TransportType;
+import bisq.common.observable.Pin;
+import bisq.common.util.StringUtils;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.ServiceNode;
+import bisq.network.p2p.message.EnvelopePayloadMessage;
+import bisq.network.p2p.node.CloseReason;
+import bisq.network.p2p.node.Connection;
+import bisq.network.p2p.node.Node;
+import bisq.network.p2p.services.data.inventory.InventoryService;
+import bisq.network.p2p.services.peer_group.PeerGroupManager;
+import bisq.network.p2p.services.peer_group.PeerGroupService;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
+
+/**
+ * Pushes the local node's network state (peer count, data-sync flag, tor status, own address, key id and
+ * the active connections) to subscribers. The values are read from {@link Node} / {@link ServiceNode} /
+ * {@link PeerGroupService} / {@link InventoryService}, giving clients that reach the node over the API the
+ * same network view an embedded-core node has.
+ */
+@Slf4j
+public class NetworkInfoWebSocketService extends BaseWebSocketService {
+    // Priority order used to pick the primary node whose address, key id and connections we expose.
+    // We expose a single default node; for a node app this is typically the only supported transport,
+    // so the first match wins.
+    private static final List<TransportType> TRANSPORT_PRIORITY = List.of(TransportType.TOR, TransportType.I2P, TransportType.CLEAR);
+
+    private final NetworkService networkService;
+    private final Node.Listener nodeListener;
+    private final Set<Pin> pins = new CopyOnWriteArraySet<>();
+    @Nullable
+    private volatile ServiceNode observedServiceNode;
+
+    public NetworkInfoWebSocketService(SubscriberRepository subscriberRepository,
+                                       NetworkService networkService) {
+        super(subscriberRepository, Topic.NETWORK_INFO);
+        this.networkService = networkService;
+
+        nodeListener = new Node.Listener() {
+            @Override
+            public void onMessage(EnvelopePayloadMessage envelopePayloadMessage, Connection connection, NetworkId networkId) {
+            }
+
+            @Override
+            public void onConnection(Connection connection) {
+                onChange();
+            }
+
+            @Override
+            public void onDisconnect(Connection connection, CloseReason closeReason) {
+                onChange();
+            }
+
+            @Override
+            public void onStateChange(Node.State state) {
+                onChange();
+            }
+        };
+    }
+
+    @Override
+    public void validate(SubscriptionRequest request) {
+        if (StringUtils.toOptional(request.getParameter()).isPresent()) {
+            throw new IllegalArgumentException("NETWORK_INFO does not support a subscription parameter");
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> initialize() {
+        findPrimaryServiceNode().ifPresent(serviceNode -> {
+            observedServiceNode = serviceNode;
+            serviceNode.getDefaultNode().addListener(nodeListener);
+
+            serviceNode.getInventoryService()
+                    .map(InventoryService::getInitialInventoryRequestsCompleted)
+                    .ifPresent(observable -> pins.add(observable.addObserver(completed -> onChange())));
+        });
+
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> shutdown() {
+        ServiceNode serviceNode = observedServiceNode;
+        if (serviceNode != null) {
+            serviceNode.getDefaultNode().removeListener(nodeListener);
+            observedServiceNode = null;
+        }
+        pins.forEach(Pin::unbind);
+        pins.clear();
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public Optional<String> getJsonPayload() {
+        return toJson(buildNetworkInfoDto());
+    }
+
+    private void onChange() {
+        Set<Subscriber> subscribers = subscriberRepository.findSubscribers(topic).values().stream()
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+        if (subscribers.isEmpty()) {
+            return;
+        }
+        try {
+            send(subscribers, getJsonPayload(), topic, ModificationType.REPLACE);
+        } catch (Exception e) {
+            log.error("Failed to send network info update", e);
+        }
+    }
+
+    private NetworkInfoDto buildNetworkInfoDto() {
+        Optional<ServiceNode> primaryServiceNode = Optional.ofNullable(observedServiceNode);
+        Optional<Node> defaultNode = primaryServiceNode.map(ServiceNode::getDefaultNode);
+        PeerGroupService peerGroupService = primaryServiceNode
+                .flatMap(ServiceNode::getPeerGroupManager)
+                .map(PeerGroupManager::getPeerGroupService)
+                .orElse(null);
+
+        // Snapshot the currently active connections while building the payload.
+        List<ConnectionDto> connections = defaultNode
+                .map(node -> toConnectionDtos(node, peerGroupService))
+                .orElseGet(List::of);
+
+        boolean allDataReceived = primaryServiceNode
+                .flatMap(ServiceNode::getInventoryService)
+                .map(inventoryService -> inventoryService.getInitialInventoryRequestsCompleted().get())
+                .orElse(false);
+
+        boolean torRunning = networkService.findDefaultNode(TransportType.TOR)
+                .map(node -> node.getState().get() == Node.State.RUNNING)
+                .orElse(false);
+
+        String myAddress = defaultNode
+                .flatMap(Node::findMyAddress)
+                .map(Address::getFullAddress)
+                .orElse(null);
+
+        String keyId = defaultNode
+                .map(node -> node.getNetworkId().getKeyId())
+                .orElse(null);
+
+        return new NetworkInfoDto(allDataReceived, torRunning, myAddress, keyId, connections);
+    }
+
+    private List<ConnectionDto> toConnectionDtos(Node node, @Nullable PeerGroupService peerGroupService) {
+        List<ConnectionDto> connections = new ArrayList<>();
+        node.getAllActiveConnections().forEach(connection ->
+                connections.add(new ConnectionDto(
+                        connection.getId(),
+                        connection.getPeerAddress().getFullAddress(),
+                        connection.isOutboundConnection(),
+                        peerGroupService != null && peerGroupService.isSeed(connection),
+                        connection.getCreated())));
+        return connections;
+    }
+
+    private Optional<ServiceNode> findPrimaryServiceNode() {
+        return TRANSPORT_PRIORITY.stream()
+                .filter(networkService.getSupportedTransportTypes()::contains)
+                .map(networkService::findServiceNode)
+                .flatMap(Optional::stream)
+                .findFirst();
+    }
+}

--- a/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
@@ -25,6 +25,9 @@ import bisq.api.web_socket.subscription.Subscriber;
 import bisq.api.web_socket.subscription.SubscriberRepository;
 import bisq.api.web_socket.subscription.SubscriptionRequest;
 import bisq.api.web_socket.subscription.Topic;
+import bisq.bonded_roles.BondedRoleType;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRole;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
 import bisq.common.network.Address;
 import bisq.common.network.TransportType;
 import bisq.common.observable.Pin;
@@ -37,6 +40,7 @@ import bisq.network.p2p.node.CloseReason;
 import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
 import bisq.network.p2p.services.data.inventory.InventoryService;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
 import bisq.network.p2p.services.peer_group.PeerGroupManager;
 import bisq.network.p2p.services.peer_group.PeerGroupService;
 import lombok.extern.slf4j.Slf4j;
@@ -64,15 +68,31 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
     private static final List<TransportType> TRANSPORT_PRIORITY = List.of(TransportType.TOR, TransportType.I2P, TransportType.CLEAR);
 
     private final NetworkService networkService;
+    private final AuthorizedBondedRolesService authorizedBondedRolesService;
     private final Node.Listener nodeListener;
+    private final AuthorizedBondedRolesService.Listener bondedRolesListener;
     private final Set<Pin> pins = new CopyOnWriteArraySet<>();
     @Nullable
     private volatile ServiceNode observedServiceNode;
 
     public NetworkInfoWebSocketService(SubscriberRepository subscriberRepository,
-                                       NetworkService networkService) {
+                                       NetworkService networkService,
+                                       AuthorizedBondedRolesService authorizedBondedRolesService) {
         super(subscriberRepository, Topic.NETWORK_INFO);
         this.networkService = networkService;
+        this.authorizedBondedRolesService = authorizedBondedRolesService;
+
+        bondedRolesListener = new AuthorizedBondedRolesService.Listener() {
+            @Override
+            public void onAuthorizedDataAdded(AuthorizedData authorizedData) {
+                onSeedRoleChanged(authorizedData);
+            }
+
+            @Override
+            public void onAuthorizedDataRemoved(AuthorizedData authorizedData) {
+                onSeedRoleChanged(authorizedData);
+            }
+        };
 
         nodeListener = new Node.Listener() {
             @Override
@@ -105,6 +125,8 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
 
     @Override
     public CompletableFuture<Boolean> initialize() {
+        authorizedBondedRolesService.addListener(bondedRolesListener);
+
         findPrimaryServiceNode().ifPresent(serviceNode -> {
             observedServiceNode = serviceNode;
             serviceNode.getDefaultNode().addListener(nodeListener);
@@ -119,6 +141,8 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
 
     @Override
     public CompletableFuture<Boolean> shutdown() {
+        authorizedBondedRolesService.removeListener(bondedRolesListener);
+
         ServiceNode serviceNode = observedServiceNode;
         if (serviceNode != null) {
             serviceNode.getDefaultNode().removeListener(nodeListener);
@@ -145,6 +169,16 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
             send(subscribers, getJsonPayload(), topic, ModificationType.REPLACE);
         } catch (Exception e) {
             log.error("Failed to send network info update", e);
+        }
+    }
+
+    // Adding or removing a seed node bonded role mutates the seed set of the PeerGroupService, which reclassifies
+    // already established connections. AuthorizedBondedRolesService applies that change to the NetworkService before
+    // it notifies its listeners, so the payload we build here already reflects the new classification.
+    private void onSeedRoleChanged(AuthorizedData authorizedData) {
+        if (authorizedData.getAuthorizedDistributedData() instanceof AuthorizedBondedRole authorizedBondedRole
+                && authorizedBondedRole.getBondedRoleType() == BondedRoleType.SEED_NODE) {
+            onChange();
         }
     }
 

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
@@ -25,6 +25,7 @@ import bisq.api.web_socket.domain.alert_notifications.AlertNotificationsWebSocke
 import bisq.api.web_socket.domain.chat.reactions.ChatReactionsWebSocketService;
 import bisq.api.web_socket.domain.chat.trade.TradeChatMessagesWebSocketService;
 import bisq.api.web_socket.domain.market_price.MarketPriceWebSocketService;
+import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
 import bisq.api.web_socket.domain.offers.NumOffersWebSocketService;
 import bisq.api.web_socket.domain.offers.OffersWebSocketService;
 import bisq.api.web_socket.domain.reputation.ReputationWebSocketService;
@@ -37,6 +38,7 @@ import bisq.bonded_roles.BondedRolesService;
 import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
 import bisq.chat.ChatService;
 import bisq.common.application.Service;
+import bisq.network.NetworkService;
 import bisq.trade.TradeService;
 import bisq.common.util.StringUtils;
 import bisq.user.UserService;
@@ -60,6 +62,7 @@ public class SubscriptionService implements Service {
     private final NumUserProfilesWebSocketService numUserProfilesWebSocketService;
     private final TradeRestrictingAlertWebSocketService tradeRestrictingAlertWebSocketService;
     private final AlertNotificationsWebSocketService alertNotificationsWebSocketService;
+    private final NetworkInfoWebSocketService networkInfoWebSocketService;
 
     public SubscriptionService(BondedRolesService bondedRolesService,
                                AlertNotificationsService alertNotificationsService,
@@ -67,6 +70,7 @@ public class SubscriptionService implements Service {
                                TradeService tradeService,
                                UserService userService,
                                BisqEasyService bisqEasyService,
+                               NetworkService networkService,
                                OpenTradeItemsService openTradeItemsService) {
         subscriberRepository = new SubscriberRepository();
 
@@ -84,6 +88,7 @@ public class SubscriptionService implements Service {
         numUserProfilesWebSocketService = new NumUserProfilesWebSocketService(subscriberRepository, userService);
         tradeRestrictingAlertWebSocketService = new TradeRestrictingAlertWebSocketService(subscriberRepository, bondedRolesService.getAlertService());
         alertNotificationsWebSocketService = new AlertNotificationsWebSocketService(subscriberRepository, alertNotificationsService);
+        networkInfoWebSocketService = new NetworkInfoWebSocketService(subscriberRepository, networkService);
     }
 
     @Override
@@ -98,7 +103,8 @@ public class SubscriptionService implements Service {
                 .thenCompose(e -> reputationWebSocketService.initialize())
                 .thenCompose(e -> numUserProfilesWebSocketService.initialize())
                 .thenCompose(e -> tradeRestrictingAlertWebSocketService.initialize())
-                .thenCompose(e -> alertNotificationsWebSocketService.initialize());
+                .thenCompose(e -> alertNotificationsWebSocketService.initialize())
+                .thenCompose(e -> networkInfoWebSocketService.initialize());
     }
 
     @Override
@@ -113,7 +119,8 @@ public class SubscriptionService implements Service {
                 .thenCompose(e -> reputationWebSocketService.shutdown())
                 .thenCompose(e -> numUserProfilesWebSocketService.shutdown())
                 .thenCompose(e -> tradeRestrictingAlertWebSocketService.shutdown())
-                .thenCompose(e -> alertNotificationsWebSocketService.shutdown());
+                .thenCompose(e -> alertNotificationsWebSocketService.shutdown())
+                .thenCompose(e -> networkInfoWebSocketService.shutdown());
     }
 
     public void onConnectionClosed(WebSocket webSocket) {
@@ -220,6 +227,9 @@ public class SubscriptionService implements Service {
             }
             case ALERT_NOTIFICATIONS -> {
                 return Optional.of(alertNotificationsWebSocketService);
+            }
+            case NETWORK_INFO -> {
+                return Optional.of(networkInfoWebSocketService);
             }
         }
         log.warn("No WebSocketService for topic {} found", topic);

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
@@ -88,7 +88,9 @@ public class SubscriptionService implements Service {
         numUserProfilesWebSocketService = new NumUserProfilesWebSocketService(subscriberRepository, userService);
         tradeRestrictingAlertWebSocketService = new TradeRestrictingAlertWebSocketService(subscriberRepository, bondedRolesService.getAlertService());
         alertNotificationsWebSocketService = new AlertNotificationsWebSocketService(subscriberRepository, alertNotificationsService);
-        networkInfoWebSocketService = new NetworkInfoWebSocketService(subscriberRepository, networkService);
+        networkInfoWebSocketService = new NetworkInfoWebSocketService(subscriberRepository,
+                networkService,
+                bondedRolesService.getAuthorizedBondedRolesService());
     }
 
     @Override

--- a/api/src/test/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,10 +66,11 @@ class NetworkInfoWebSocketServiceTest {
         listener.onAuthorizedDataAdded(authorizedBondedRoleData(BondedRoleType.MEDIATOR));
         verify(webSocket, never()).send(anyString());
 
-        // Adding and removing a seed node role reclassifies existing connections, so both must trigger an update
+        // Adding and removing a seed node role reclassifies existing connections, so both must trigger an update.
+        // Subscriber.send dispatches to its own executor, so we await the sends instead of verifying immediately.
         listener.onAuthorizedDataAdded(authorizedBondedRoleData(BondedRoleType.SEED_NODE));
         listener.onAuthorizedDataRemoved(authorizedBondedRoleData(BondedRoleType.SEED_NODE));
-        verify(webSocket, times(2)).send(anyString());
+        verify(webSocket, timeout(1000).times(2)).send(anyString());
 
         service.shutdown().join();
         verify(authorizedBondedRolesService).removeListener(listener);

--- a/api/src/test/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.domain.network;
+
+import bisq.api.web_socket.subscription.SubscriberRepository;
+import bisq.api.web_socket.subscription.SubscriptionRequest;
+import bisq.bonded_roles.BondedRoleType;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRole;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
+import bisq.common.network.TransportType;
+import bisq.network.NetworkService;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
+import org.glassfish.grizzly.impl.ReadyFutureImpl;
+import org.glassfish.grizzly.websockets.WebSocket;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NetworkInfoWebSocketServiceTest {
+
+    @Test
+    void seedRoleChangeIsPushedToSubscribers() {
+        SubscriberRepository subscriberRepository = new SubscriberRepository();
+        AuthorizedBondedRolesService authorizedBondedRolesService = mock(AuthorizedBondedRolesService.class);
+        NetworkInfoWebSocketService service = new NetworkInfoWebSocketService(subscriberRepository,
+                networkService(),
+                authorizedBondedRolesService);
+
+        service.initialize().join();
+
+        ArgumentCaptor<AuthorizedBondedRolesService.Listener> listenerCaptor =
+                ArgumentCaptor.forClass(AuthorizedBondedRolesService.Listener.class);
+        verify(authorizedBondedRolesService).addListener(listenerCaptor.capture());
+        AuthorizedBondedRolesService.Listener listener = listenerCaptor.getValue();
+
+        WebSocket webSocket = subscribe(subscriberRepository);
+
+        // Authorized data which is not a seed node role must not trigger an update
+        listener.onAuthorizedDataAdded(authorizedBondedRoleData(BondedRoleType.MEDIATOR));
+        verify(webSocket, never()).send(anyString());
+
+        // Adding and removing a seed node role reclassifies existing connections, so both must trigger an update
+        listener.onAuthorizedDataAdded(authorizedBondedRoleData(BondedRoleType.SEED_NODE));
+        listener.onAuthorizedDataRemoved(authorizedBondedRoleData(BondedRoleType.SEED_NODE));
+        verify(webSocket, times(2)).send(anyString());
+
+        service.shutdown().join();
+        verify(authorizedBondedRolesService).removeListener(listener);
+    }
+
+    private NetworkService networkService() {
+        NetworkService networkService = mock(NetworkService.class);
+        when(networkService.getSupportedTransportTypes()).thenReturn(Set.of());
+        when(networkService.findDefaultNode(any(TransportType.class))).thenReturn(Optional.empty());
+        return networkService;
+    }
+
+    private WebSocket subscribe(SubscriberRepository subscriberRepository) {
+        WebSocket webSocket = mock(WebSocket.class, RETURNS_DEEP_STUBS);
+        doAnswer(invocation -> ReadyFutureImpl.create(null)).when(webSocket).send(anyString());
+        String requestJson = "{\"type\":\"SubscriptionRequest\",\"requestId\":\"request-1\",\"topic\":\"NETWORK_INFO\"}";
+        subscriberRepository.add(SubscriptionRequest.fromJson(requestJson).orElseThrow(), Optional.empty(), webSocket);
+        return webSocket;
+    }
+
+    private AuthorizedData authorizedBondedRoleData(BondedRoleType bondedRoleType) {
+        AuthorizedBondedRole authorizedBondedRole = mock(AuthorizedBondedRole.class);
+        when(authorizedBondedRole.getBondedRoleType()).thenReturn(bondedRoleType);
+        AuthorizedData authorizedData = mock(AuthorizedData.class);
+        when(authorizedData.getAuthorizedDistributedData()).thenReturn(authorizedBondedRole);
+        return authorizedData;
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
@@ -26,6 +26,7 @@ import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
 import bisq.chat.ChatService;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
 import bisq.common.observable.collection.ObservableSet;
+import bisq.network.NetworkService;
 import bisq.trade.TradeService;
 import bisq.user.UserService;
 import org.glassfish.grizzly.impl.ReadyFutureImpl;
@@ -66,6 +67,7 @@ class SubscriptionServiceTest {
                 mock(TradeService.class, RETURNS_DEEP_STUBS),
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
                 mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
         );
 
@@ -91,6 +93,7 @@ class SubscriptionServiceTest {
                 mock(TradeService.class, RETURNS_DEEP_STUBS),
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
                 mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
         );
         SubscriberRepository subscriberRepository = getSubscriberRepository(service);
@@ -132,6 +135,7 @@ class SubscriptionServiceTest {
                 mock(TradeService.class, RETURNS_DEEP_STUBS),
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
                 mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
         );
 


### PR DESCRIPTION
Manual sync of #4878 from `for-mobile-based-on-2.1.11` to `main` (with conflict resolution).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `NETWORK_INFO` WebSocket subscription topic.
  * Subscribers can receive real-time network status, including data synchronization, Tor availability, local identity details, and active connections.
  * Connection details include peer address, direction, seed status, and connection time.
  * Updates are delivered automatically as network conditions change.
* **Tests**
  * Added coverage for network information updates, subscription delivery, role changes, and service shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->