### PR TITLE
Add connection metrics to NETWORK_INFO payload

### DIFF
--- a/api/src/main/java/bisq/api/dto/mappings/network/ConnectionMetricsDtoMapping.java
+++ b/api/src/main/java/bisq/api/dto/mappings/network/ConnectionMetricsDtoMapping.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.dto.mappings.network;
+
+import bisq.api.dto.network.ConnectionMetricsDto;
+import bisq.network.p2p.node.network_load.ConnectionMetrics;
+
+public class ConnectionMetricsDtoMapping {
+    public static ConnectionMetricsDto fromBisq2Model(ConnectionMetrics value) {
+        // averageRtt is 0 until a round-trip is measured (handshake / request-response); treat that as "unmeasured".
+        // Null-check the raw average, not the rounded value: a measured sub-millisecond rtt still rounds to 0.
+        double rttRaw = value.getAverageRtt();
+        return new ConnectionMetricsDto(
+                rttRaw > 0 ? Math.round(rttRaw) : null,
+                value.getSentBytes(),
+                value.getNumMessagesSent(),
+                value.getReceivedBytes(),
+                value.getNumMessagesReceived()
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/dto/network/ConnectionMetricsDto.java
+++ b/api/src/main/java/bisq/api/dto/network/ConnectionMetricsDto.java
@@ -17,10 +17,16 @@
 
 package bisq.api.dto.network;
 
-public record ConnectionDto(String connectionId,
-                            String address,
-                            boolean outbound,
-                            boolean seed,
-                            long establishedAtMillis,
-                            ConnectionMetricsDto metrics) {
+import javax.annotation.Nullable;
+
+/**
+ * Per-peer traffic metrics for one connection, read off {@code Connection.getConnectionMetrics()}.
+ * {@code rttMillis} is {@code null} until a round-trip has actually been measured (handshake /
+ * request-response); byte and message counts are lifetime totals for the connection.
+ */
+public record ConnectionMetricsDto(@Nullable Long rttMillis,
+                                   long sentBytes,
+                                   long sentMessageCount,
+                                   long receivedBytes,
+                                   long receivedMessageCount) {
 }

--- a/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
@@ -17,8 +17,8 @@
 
 package bisq.api.web_socket.domain.network;
 
+import bisq.api.dto.mappings.network.ConnectionMetricsDtoMapping;
 import bisq.api.dto.network.ConnectionDto;
-import bisq.api.dto.network.ConnectionMetricsDto;
 import bisq.api.dto.network.NetworkInfoDto;
 import bisq.api.web_socket.domain.BaseWebSocketService;
 import bisq.api.web_socket.subscription.ModificationType;
@@ -37,7 +37,6 @@ import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.node.CloseReason;
 import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
-import bisq.network.p2p.node.network_load.ConnectionMetrics;
 import bisq.network.p2p.services.data.inventory.InventoryService;
 import bisq.network.p2p.services.peer_group.PeerGroupManager;
 import bisq.network.p2p.services.peer_group.PeerGroupService;
@@ -193,21 +192,9 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
                         connection.isOutboundConnection(),
                         peerGroupService != null && peerGroupService.isSeed(connection),
                         connection.getCreated(),
-                        toConnectionMetricsDto(connection.getConnectionMetrics()))));
+                        ConnectionMetricsDtoMapping.fromBisq2Model(connection.getConnectionMetrics()))));
         return connections;
-    }
-
-    private ConnectionMetricsDto toConnectionMetricsDto(ConnectionMetrics metrics) {
-        // averageRtt is 0 until a round-trip is measured (handshake / request-response); treat that as "unmeasured".
-        // Null-check the raw average, not the rounded value: a measured sub-millisecond rtt still rounds to 0.
-        double rttRaw = metrics.getAverageRtt();
-        return new ConnectionMetricsDto(
-                rttRaw > 0 ? Math.round(rttRaw) : null,
-                metrics.getSentBytes(),
-                metrics.getNumMessagesSent(),
-                metrics.getReceivedBytes(),
-                metrics.getNumMessagesReceived());
-    }
+}
 
     private Optional<ServiceNode> findPrimaryServiceNode() {
         return TRANSPORT_PRIORITY.stream()

--- a/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
@@ -18,6 +18,7 @@
 package bisq.api.web_socket.domain.network;
 
 import bisq.api.dto.network.ConnectionDto;
+import bisq.api.dto.network.ConnectionMetricsDto;
 import bisq.api.dto.network.NetworkInfoDto;
 import bisq.api.web_socket.domain.BaseWebSocketService;
 import bisq.api.web_socket.subscription.ModificationType;
@@ -36,6 +37,7 @@ import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.node.CloseReason;
 import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
+import bisq.network.p2p.node.network_load.ConnectionMetrics;
 import bisq.network.p2p.services.data.inventory.InventoryService;
 import bisq.network.p2p.services.peer_group.PeerGroupManager;
 import bisq.network.p2p.services.peer_group.PeerGroupService;
@@ -190,8 +192,21 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
                         connection.getPeerAddress().getFullAddress(),
                         connection.isOutboundConnection(),
                         peerGroupService != null && peerGroupService.isSeed(connection),
-                        connection.getCreated())));
+                        connection.getCreated(),
+                        toConnectionMetricsDto(connection.getConnectionMetrics()))));
         return connections;
+    }
+
+    private ConnectionMetricsDto toConnectionMetricsDto(ConnectionMetrics metrics) {
+        // averageRtt is 0 until a round-trip is measured (handshake / request-response); treat that as "unmeasured".
+        // Null-check the raw average, not the rounded value: a measured sub-millisecond rtt still rounds to 0.
+        double rttRaw = metrics.getAverageRtt();
+        return new ConnectionMetricsDto(
+                rttRaw > 0 ? Math.round(rttRaw) : null,
+                metrics.getSentBytes(),
+                metrics.getNumMessagesSent(),
+                metrics.getReceivedBytes(),
+                metrics.getNumMessagesReceived());
     }
 
     private Optional<ServiceNode> findPrimaryServiceNode() {

--- a/network/network/src/main/java/bisq/network/p2p/node/network_load/ConnectionMetrics.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/network_load/ConnectionMetrics.java
@@ -27,6 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -36,18 +38,22 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ConnectionMetrics {
     private final long created;
     private final AtomicLong lastUpdate = new AtomicLong();
-    private final TreeMap<Integer, AtomicLong> numMessagesSentPerMinute = new TreeMap<>();
-    private final TreeMap<Integer, AtomicLong> sentBytesPerMinute = new TreeMap<>();
-    private final TreeMap<Integer, AtomicLong> spentSendMessageTimePerMinute = new TreeMap<>();
-    private final TreeMap<Integer, AtomicLong> deserializeTimePerMinute = new TreeMap<>();
-    private final TreeMap<Integer, AtomicLong> numMessagesReceivedPerMinute = new TreeMap<>();
-    private final TreeMap<Integer, AtomicLong> receivedBytesPerMinute = new TreeMap<>();
+    // onSent is called from the connection's send thread pool (which grows to several threads), onReceived
+    // from its read thread and clear from whichever thread triggers the shutdown, while readers
+    // (NetworkLoadService, the desktop UI, the api services and toString) traverse the maps concurrently.
+    // ConcurrentSkipListMap makes computeIfAbsent atomic and gives weakly consistent iterators, and it keeps
+    // the ascending key order sumOfLastMinute relies on.
+    private final ConcurrentNavigableMap<Integer, AtomicLong> numMessagesSentPerMinute = new ConcurrentSkipListMap<>();
+    private final ConcurrentNavigableMap<Integer, AtomicLong> sentBytesPerMinute = new ConcurrentSkipListMap<>();
+    private final ConcurrentNavigableMap<Integer, AtomicLong> spentSendMessageTimePerMinute = new ConcurrentSkipListMap<>();
+    private final ConcurrentNavigableMap<Integer, AtomicLong> deserializeTimePerMinute = new ConcurrentSkipListMap<>();
+    private final ConcurrentNavigableMap<Integer, AtomicLong> numMessagesReceivedPerMinute = new ConcurrentSkipListMap<>();
+    private final ConcurrentNavigableMap<Integer, AtomicLong> receivedBytesPerMinute = new ConcurrentSkipListMap<>();
     private final Map<String, AtomicLong> numSentMessagesByClassName = new ConcurrentHashMap<>();
     private final Map<String, AtomicLong> numReceivedMessagesByClassName = new ConcurrentHashMap<>();
     private final Map<String, AtomicLong> numSentDistributedDataByClassName = new ConcurrentHashMap<>();
     private final Map<String, AtomicLong> numReceivedDistributedDataByClassName = new ConcurrentHashMap<>();
 
-    private final AtomicLong numMessagesReceived = new AtomicLong();
     private final List<Long> rrtList = new CopyOnWriteArrayList<>();
 
     public ConnectionMetrics() {
@@ -234,18 +240,21 @@ public class ConnectionMetrics {
         rrtList.clear();
     }
 
-    private long sumOf(TreeMap<Integer, AtomicLong> treeMap) {
-        return treeMap.values().stream().mapToLong(AtomicLong::get).sum();
+    private long sumOf(ConcurrentNavigableMap<Integer, AtomicLong> map) {
+        return map.values().stream().mapToLong(AtomicLong::get).sum();
     }
 
-    private long sumOfLastMinute(TreeMap<Integer, AtomicLong> treeMap, int lastMinutes) {
-        // The Treemap returns the values in ascending order of the corresponding keys.
-        int from = Math.max(0, treeMap.size() - lastMinutes);
-        List<AtomicLong> list = new ArrayList<>(treeMap.values()).subList(from, treeMap.size());
-        return list.stream().mapToLong(AtomicLong::get).sum();
+    private long sumOfLastMinute(ConcurrentNavigableMap<Integer, AtomicLong> map, int lastMinutes) {
+        // The buckets are keyed by the age in minutes, so the descending map returns the most recent ones first.
+        return map.descendingMap().values().stream()
+                .limit(lastMinutes)
+                .mapToLong(AtomicLong::get)
+                .sum();
     }
 
     private int getAgeInMinutes(long now) {
-        return (int) (now - created) / 60000;
+        // The cast has to be applied after the division, otherwise the millisecond delta gets truncated to int
+        // and wraps after about 25 days, which would make the bucket keys negative.
+        return (int) ((now - created) / 60000);
     }
 }

--- a/network/network/src/test/java/bisq/network/p2p/node/network_load/ConnectionMetricsTest.java
+++ b/network/network/src/test/java/bisq/network/p2p/node/network_load/ConnectionMetricsTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.network.p2p.node.network_load;
+
+import bisq.common.util.ClassUtils;
+import bisq.network.p2p.message.NetworkEnvelope;
+import bisq.network.p2p.node.authorization.token.hash_cash_v2.HashCashV2Token;
+import bisq.network.p2p.services.peer_group.keep_alive.Ping;
+import bisq.security.pow.ProofOfWork;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the aggregation over the per-minute buckets. All events of a test land in the same bucket, as the bucket
+ * key is the age of the ConnectionMetrics in minutes, so the selection across several buckets in sumOfLastMinute
+ * is not covered here. That would require the creation time to be injectable.
+ */
+public class ConnectionMetricsTest {
+    private static final String PING_CLASS_NAME = ClassUtils.getClassName(Ping.class);
+
+    @Test
+    public void testSentMetrics() {
+        ConnectionMetrics connectionMetrics = new ConnectionMetrics();
+        NetworkEnvelope networkEnvelope = createNetworkEnvelope();
+        long serializedSize = networkEnvelope.getSerializedSize();
+
+        connectionMetrics.onSent(networkEnvelope, 10);
+        connectionMetrics.onSent(networkEnvelope, 20);
+
+        assertThat(connectionMetrics.getNumMessagesSent()).isEqualTo(2);
+        assertThat(connectionMetrics.getSentBytes()).isEqualTo(2 * serializedSize);
+        assertThat(connectionMetrics.getSpentSendMessageTimePerMinute()).isEqualTo(30);
+        assertThat(connectionMetrics.getNumSentMessagesByClassName().get(PING_CLASS_NAME).get()).isEqualTo(2);
+
+        // Nothing was received, so the received maps stay empty.
+        assertThat(connectionMetrics.getNumMessagesReceived()).isZero();
+        assertThat(connectionMetrics.getReceivedBytes()).isZero();
+    }
+
+    @Test
+    public void testReceivedMetrics() {
+        ConnectionMetrics connectionMetrics = new ConnectionMetrics();
+        NetworkEnvelope networkEnvelope = createNetworkEnvelope();
+        long serializedSize = networkEnvelope.getSerializedSize();
+
+        connectionMetrics.onReceived(networkEnvelope, 5);
+        connectionMetrics.onReceived(networkEnvelope, 7);
+
+        assertThat(connectionMetrics.getNumMessagesReceived()).isEqualTo(2);
+        assertThat(connectionMetrics.getReceivedBytes()).isEqualTo(2 * serializedSize);
+        assertThat(connectionMetrics.getDeserializeTimePerMinute()).isEqualTo(12);
+        assertThat(connectionMetrics.getNumReceivedMessagesByClassName().get(PING_CLASS_NAME).get()).isEqualTo(2);
+
+        assertThat(connectionMetrics.getNumMessagesSent()).isZero();
+        assertThat(connectionMetrics.getSentBytes()).isZero();
+    }
+
+    @Test
+    public void testSumOfLastMinutesWithSingleBucket() {
+        ConnectionMetrics connectionMetrics = new ConnectionMetrics();
+        NetworkEnvelope networkEnvelope = createNetworkEnvelope();
+        long serializedSize = networkEnvelope.getSerializedSize();
+
+        connectionMetrics.onSent(networkEnvelope, 10);
+        connectionMetrics.onSent(networkEnvelope, 20);
+        connectionMetrics.onReceived(networkEnvelope, 5);
+
+        // All events are in the bucket of the current minute, so the windowed sums match the totals.
+        assertThat(connectionMetrics.getNumMessagesSentOfLast5Minutes()).isEqualTo(2);
+        assertThat(connectionMetrics.getSentBytesOfLast5Minutes()).isEqualTo(2 * serializedSize);
+        assertThat(connectionMetrics.getSpentSendMessageTimeOfLast5Minutes()).isEqualTo(30);
+        assertThat(connectionMetrics.getNumMessagesReceivedOfLast5Minutes()).isEqualTo(1);
+        assertThat(connectionMetrics.getReceivedBytesOfLast5Minutes()).isEqualTo(serializedSize);
+        assertThat(connectionMetrics.getDeserializeTimeOfLast5Minutes()).isEqualTo(5);
+
+        assertThat(connectionMetrics.getNumMessagesSentOfLastHour()).isEqualTo(2);
+        assertThat(connectionMetrics.getSentBytesOfLastHour()).isEqualTo(2 * serializedSize);
+    }
+
+    @Test
+    public void testSumOfLastMinutesWithoutData() {
+        ConnectionMetrics connectionMetrics = new ConnectionMetrics();
+
+        assertThat(connectionMetrics.getSentBytesOfLast5Minutes()).isZero();
+        assertThat(connectionMetrics.getNumMessagesReceivedOfLastHour()).isZero();
+        assertThat(connectionMetrics.getSentBytes()).isZero();
+        assertThat(connectionMetrics.getAverageRtt()).isZero();
+    }
+
+    @Test
+    public void testAverageRtt() {
+        ConnectionMetrics connectionMetrics = new ConnectionMetrics();
+
+        assertThat(connectionMetrics.getAverageRtt()).isZero();
+
+        connectionMetrics.addRtt(10);
+        connectionMetrics.addRtt(20);
+
+        assertThat(connectionMetrics.getAverageRtt()).isEqualTo(15d);
+    }
+
+    @Test
+    public void testClear() {
+        ConnectionMetrics connectionMetrics = new ConnectionMetrics();
+        NetworkEnvelope networkEnvelope = createNetworkEnvelope();
+
+        connectionMetrics.onSent(networkEnvelope, 10);
+        connectionMetrics.onReceived(networkEnvelope, 5);
+        connectionMetrics.addRtt(10);
+
+        connectionMetrics.clear();
+
+        assertThat(connectionMetrics.getNumMessagesSent()).isZero();
+        assertThat(connectionMetrics.getSentBytes()).isZero();
+        assertThat(connectionMetrics.getSpentSendMessageTimePerMinute()).isZero();
+        assertThat(connectionMetrics.getNumMessagesReceived()).isZero();
+        assertThat(connectionMetrics.getReceivedBytes()).isZero();
+        assertThat(connectionMetrics.getDeserializeTimePerMinute()).isZero();
+        assertThat(connectionMetrics.getSentBytesOfLast5Minutes()).isZero();
+        assertThat(connectionMetrics.getAverageRtt()).isZero();
+        assertThat(connectionMetrics.getNumSentMessagesByClassName()).isEmpty();
+        assertThat(connectionMetrics.getNumReceivedMessagesByClassName()).isEmpty();
+    }
+
+    private static NetworkEnvelope createNetworkEnvelope() {
+        // The token is never verified here, we only need a serializable envelope, so dummy arrays are sufficient.
+        // Creating a real token would run the proof of work mining and take seconds.
+        ProofOfWork proofOfWork = new ProofOfWork(new byte[20], 0, null, 0, new byte[72], 0);
+        return new NetworkEnvelope(new HashCashV2Token(proofOfWork, 0), new Ping(1));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network information now includes per-connection performance metrics for active connections.
  * When available, round-trip time (RTT) is shown; otherwise it’s omitted until measured.
  * Connection totals are added, including sent/received bytes and sent/received message counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->