### PR TITLE
chore: sync #4898 to main — Add NETWORK_INFO API feature flag

### DIFF
--- a/api/src/main/java/bisq/api/rest_api/endpoints/config/ApiFeature.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/config/ApiFeature.java
@@ -37,7 +37,8 @@ import lombok.Getter;
  */
 @Getter
 public enum ApiFeature {
-    CLOSED_TRADES("closed-trades");
+    CLOSED_TRADES("closed-trades"),
+    NETWORK_INFO("network-info");
 
     private final String key;
 


### PR DESCRIPTION
Automated sync of #4898 from `for-mobile-based-on-2.1.11` to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `network-info` API feature, enabling network information functionality through feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->