### PR TITLE
Add tests for NETWORK_INFO API capability

### DIFF
--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -22,10 +22,18 @@ import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.trades.TradeRestApi;
 import bisq.api.web_socket.domain.BaseWebSocketService;
+import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
 import bisq.api.web_socket.subscription.SubscriptionService;
 import bisq.api.web_socket.subscription.Topic;
+import bisq.bisq_easy.BisqEasyService;
 import bisq.bisq_easy.BisqEasyTradeAmountLimits;
+import bisq.bonded_roles.BondedRolesService;
+import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
+import bisq.chat.ChatService;
+import bisq.network.NetworkService;
+import bisq.trade.TradeService;
+import bisq.user.UserService;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
@@ -34,8 +42,11 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
 
 class ConfigRestApiTest {
 
@@ -97,12 +108,13 @@ class ConfigRestApiTest {
                         .as("closed-trades must expose GET /trades/closed")
                         .isTrue();
                 case NETWORK_INFO -> {
-                    assertThat(topicOf(new NetworkInfoWebSocketService(null, null)))
+                    BaseWebSocketService service = routeTopic(Topic.NETWORK_INFO);
+                    assertThat(service)
+                            .as("SubscriptionService must route NETWORK_INFO to a live NetworkInfoWebSocketService")
+                            .isInstanceOf(NetworkInfoWebSocketService.class);
+                    assertThat(topicOf(service))
                             .as("network-info must be backed by a service bound to Topic.NETWORK_INFO")
                             .isEqualTo(Topic.NETWORK_INFO);
-                    assertThat(hasFieldOfType(SubscriptionService.class, NetworkInfoWebSocketService.class))
-                            .as("SubscriptionService must hold the NetworkInfoWebSocketService so NETWORK_INFO subscriptions resolve")
-                            .isTrue();
                 }
             }
         }
@@ -130,8 +142,30 @@ class ConfigRestApiTest {
         }
     }
 
-    private static boolean hasFieldOfType(Class<?> owner, Class<?> fieldType) {
-        return Arrays.stream(owner.getDeclaredFields()).anyMatch(f -> f.getType().equals(fieldType));
+    /**
+     * Resolves the topic through a real {@link SubscriptionService} so the check covers the constructor
+     * wiring and the routing switch, not just a field declaration.
+     */
+    @SuppressWarnings("unchecked")
+    private static BaseWebSocketService routeTopic(Topic topic) {
+        SubscriptionService subscriptionService = new SubscriptionService(
+                mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
+                mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
+                mock(ChatService.class, RETURNS_DEEP_STUBS),
+                mock(TradeService.class, RETURNS_DEEP_STUBS),
+                mock(UserService.class, RETURNS_DEEP_STUBS),
+                mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS));
+        try {
+            Method method = SubscriptionService.class.getDeclaredMethod("findWebSocketService", Topic.class);
+            method.setAccessible(true);
+            Optional<BaseWebSocketService> routed =
+                    (Optional<BaseWebSocketService>) method.invoke(subscriptionService, topic);
+            return routed.orElseThrow(() -> new AssertionError("SubscriptionService does not route " + topic));
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not resolve the WebSocketService for " + topic, e);
+        }
     }
 
     private static boolean hasEndpoint(Class<?> resource, String path) {

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -21,12 +21,17 @@ import bisq.api.access.AllowUnauthenticated;
 import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.trades.TradeRestApi;
+import bisq.api.web_socket.domain.BaseWebSocketService;
+import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
+import bisq.api.web_socket.subscription.SubscriptionService;
+import bisq.api.web_socket.subscription.Topic;
 import bisq.bisq_easy.BisqEasyTradeAmountLimits;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
@@ -67,6 +72,17 @@ class ConfigRestApiTest {
         assertThat(dto.apiVersion()).isNotBlank();
         assertThat(dto.features()).containsExactlyElementsOf(ApiFeature.allKeys());
         assertThat(dto.features()).contains(ApiFeature.CLOSED_TRADES.getKey());
+        assertThat(dto.features()).contains(ApiFeature.NETWORK_INFO.getKey());
+    }
+
+    /**
+     * The keys are the wire contract capability-gated clients match on, so they must stay stable even
+     * if the enum constants get renamed.
+     */
+    @Test
+    void featureKeysAreStableWireIdentifiers() {
+        assertThat(ApiFeature.CLOSED_TRADES.getKey()).isEqualTo("closed-trades");
+        assertThat(ApiFeature.NETWORK_INFO.getKey()).isEqualTo("network-info");
     }
 
     /**
@@ -80,6 +96,14 @@ class ConfigRestApiTest {
                 case CLOSED_TRADES -> assertThat(hasEndpoint(TradeRestApi.class, "/closed"))
                         .as("closed-trades must expose GET /trades/closed")
                         .isTrue();
+                case NETWORK_INFO -> {
+                    assertThat(topicOf(new NetworkInfoWebSocketService(null, null)))
+                            .as("network-info must be backed by a service bound to Topic.NETWORK_INFO")
+                            .isEqualTo(Topic.NETWORK_INFO);
+                    assertThat(hasFieldOfType(SubscriptionService.class, NetworkInfoWebSocketService.class))
+                            .as("SubscriptionService must hold the NetworkInfoWebSocketService so NETWORK_INFO subscriptions resolve")
+                            .isTrue();
+                }
             }
         }
     }
@@ -94,6 +118,20 @@ class ConfigRestApiTest {
         assertThat(ConfigRestApi.class.isAnnotationPresent(AllowUnauthenticated.class))
                 .as("/config must be @AllowUnauthenticated — it has no RestPermissionMapping rule and would otherwise 403")
                 .isTrue();
+    }
+
+    private static Topic topicOf(BaseWebSocketService service) {
+        try {
+            Field field = BaseWebSocketService.class.getDeclaredField("topic");
+            field.setAccessible(true);
+            return (Topic) field.get(service);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not read the topic of " + service.getClass().getSimpleName(), e);
+        }
+    }
+
+    private static boolean hasFieldOfType(Class<?> owner, Class<?> fieldType) {
+        return Arrays.stream(owner.getDeclaredFields()).anyMatch(f -> f.getType().equals(fieldType));
     }
 
     private static boolean hasEndpoint(Class<?> resource, String path) {

--- a/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
@@ -25,10 +25,12 @@ import bisq.bonded_roles.release.AppType;
 import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
 import bisq.chat.ChatService;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
+import bisq.common.json.JsonMapperProvider;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.network.NetworkService;
 import bisq.trade.TradeService;
 import bisq.user.UserService;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.glassfish.grizzly.impl.ReadyFutureImpl;
 import org.glassfish.grizzly.websockets.WebSocket;
 import org.junit.jupiter.api.Test;
@@ -147,6 +149,46 @@ class SubscriptionServiceTest {
         assertThat(groups).hasSize(1);
         assertThat(groups.keySet().iterator().next().parameter()).isEqualTo(Optional.of("EUR"));
         assertThat(groups.values().iterator().next()).hasSize(2);
+    }
+
+    /**
+     * Anti-drift guard for the {@code network-info} API capability: a dropped constructor assignment or a
+     * missing routing branch would leave the topic unreachable, which a field-declaration check cannot see.
+     */
+    @Test
+    void networkInfoSubscriptionResolvesToTheInitializedServiceAndIsAnswered() throws Exception {
+        SubscriptionService service = new SubscriptionService(
+                mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
+                mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
+                mock(ChatService.class, RETURNS_DEEP_STUBS),
+                mock(TradeService.class, RETURNS_DEEP_STUBS),
+                mock(UserService.class, RETURNS_DEEP_STUBS),
+                mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
+        );
+
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = mock(WebSocket.class, RETURNS_DEEP_STUBS);
+        doAnswer(invocation -> {
+            sentMessages.add(invocation.getArgument(0));
+            return ReadyFutureImpl.create(null);
+        }).when(webSocket).send(anyString());
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        assertThat(sentMessages).hasSize(1);
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.get("type").asText()).isEqualTo("SubscriptionResponse");
+        assertThat(response.hasNonNull("errorMessage"))
+                .as("a valid NETWORK_INFO subscription must not produce an error response")
+                .isFalse();
+        assertThat(response.hasNonNull("payload")).isTrue();
+        assertThat(response.get("payload").asText())
+                .as("payload must be a NetworkInfoDto")
+                .contains("allDataReceived")
+                .contains("connections");
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isNotEmpty();
     }
 
     private static String subscriptionJson(String requestId, String topic, String parameter) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming the network information capability uses its stable identifier.
  * Verified network information subscriptions are routed to the correct real-time topic and service.
  * Added regression checks confirming subscriptions return valid network information and register successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->