### PR TITLE
chore: sync #4903 to main — Add permessage-deflate to the WebSocket API, and harden the WebSocket-REST proxy

### DIFF
--- a/api/src/main/java/bisq/api/ApiConfig.java
+++ b/api/src/main/java/bisq/api/ApiConfig.java
@@ -35,6 +35,7 @@ public final class ApiConfig {
     // api.server.*
     private final boolean restEnabled;
     private final boolean websocketEnabled;
+    private final boolean websocketCompressionEnabled;
 
     // api.server.bind.*
     private final String bindHost;
@@ -65,6 +66,7 @@ public final class ApiConfig {
             boolean writePairingQrCodeToDisk,
             boolean restEnabled,
             boolean websocketEnabled,
+            boolean websocketCompressionEnabled,
             String bindHost,
             int bindPort,
             int onionServicePort,
@@ -81,6 +83,7 @@ public final class ApiConfig {
         this.writePairingQrCodeToDisk = writePairingQrCodeToDisk;
         this.restEnabled = restEnabled;
         this.websocketEnabled = websocketEnabled;
+        this.websocketCompressionEnabled = websocketCompressionEnabled;
         this.bindHost = bindHost;
         this.bindPort = bindPort;
         this.onionServicePort = onionServicePort;
@@ -117,6 +120,7 @@ public final class ApiConfig {
 
                 serverConfig.getBoolean("restEnabled"),
                 serverConfig.getBoolean("websocketEnabled"),
+                serverConfig.getBoolean("websocketCompressionEnabled"),
 
                 bindConfig.getString("host"),
                 bindConfig.getInt("port"),

--- a/api/src/main/java/bisq/api/HttpServerBootstrapService.java
+++ b/api/src/main/java/bisq/api/HttpServerBootstrapService.java
@@ -25,6 +25,7 @@ import bisq.api.access.transport.TlsContext;
 import bisq.api.access.transport.TlsContextService;
 import bisq.api.rest_api.util.StaticFileHandler;
 import bisq.api.web_socket.WebSocketService;
+import bisq.api.web_socket.compression.PerMessageDeflateAddOn;
 import bisq.api.web_socket.util.GrizzlySwaggerHttpHandler;
 import bisq.common.application.Service;
 import bisq.common.observable.Observable;
@@ -139,6 +140,10 @@ public class HttpServerBootstrapService implements Service {
                         checkArgument(webSocketService.isPresent(), "If websocketEnabled is true we expect that webSocketService is present");
                         networkListener.registerAddOn(new WebSocketAddOn());
                         networkListener.registerAddOn(new WebSocketFilterAddOn(apiConfig, sessionAuthenticationService));
+                        if (apiConfig.isWebsocketCompressionEnabled()) {
+                            // Registered last so the filter ends up directly below the WebSocketFilter
+                            networkListener.registerAddOn(new PerMessageDeflateAddOn());
+                        }
                         WebSocketEngine.getEngine().register("", "/websocket", webSocketService.get().getWebSocketConnectionHandler());
                     }
 

--- a/api/src/main/java/bisq/api/web_socket/WebSocketConnectionHandler.java
+++ b/api/src/main/java/bisq/api/web_socket/WebSocketConnectionHandler.java
@@ -21,6 +21,7 @@ package bisq.api.web_socket;
 import bisq.api.access.filter.Headers;
 import bisq.api.web_socket.rest_api_proxy.WebSocketRestApiService;
 import bisq.api.web_socket.subscription.SubscriptionService;
+import bisq.api.web_socket.util.JsonUtil;
 import bisq.common.application.Service;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.threading.ExecutorFactory;
@@ -85,14 +86,19 @@ public class WebSocketConnectionHandler extends WebSocketApplication implements 
 
     @Override
     public void onMessage(WebSocket webSocket, String message) {
-        log.info("Received message {}", message);
+        // Debug rather than info: this is one full message plus a redaction pass per message, which
+        // production should not pay for. Redacted because a client released before the node took the
+        // identity from the handshake puts its session id into the payload.
+        if (log.isDebugEnabled()) {
+            log.debug("Received message {}", JsonUtil.redactCredentials(message));
+        }
         CompletableFuture.runAsync(() -> {
             if (subscriptionService.canHandle(message)) {
                 subscriptionService.onMessage(message, webSocket);
             } else if (webSocketRestApiService.canHandle(message)) {
                 webSocketRestApiService.onMessage(message, webSocket);
             } else {
-                log.error("No service found for handling message: {}", message);
+                log.error("No service found for handling message: {}", JsonUtil.redactCredentials(message));
             }
         }, executor);
     }

--- a/api/src/main/java/bisq/api/web_socket/compression/PerMessageDeflateAddOn.java
+++ b/api/src/main/java/bisq/api/web_socket/compression/PerMessageDeflateAddOn.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.compression;
+
+import org.glassfish.grizzly.filterchain.FilterChainBuilder;
+import org.glassfish.grizzly.http.server.AddOn;
+import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.websockets.WebSocketFilter;
+
+public class PerMessageDeflateAddOn implements AddOn {
+    @Override
+    public void setup(NetworkListener listener, FilterChainBuilder builder) {
+        int index = builder.indexOfType(WebSocketFilter.class);
+
+        if (index < 0) {
+            throw new IllegalStateException("WebSocketFilter not found. WebSocket compression cannot be installed.");
+        }
+
+        // The filter must sit directly below the WebSocketFilter so that no other filter ever observes
+        // compressed frames. Registering this add-on last puts it there.
+        builder.add(index, new PerMessageDeflateFilter());
+    }
+}

--- a/api/src/main/java/bisq/api/web_socket/compression/PerMessageDeflateFilter.java
+++ b/api/src/main/java/bisq/api/web_socket/compression/PerMessageDeflateFilter.java
@@ -1,0 +1,715 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.compression;
+
+import bisq.api.access.filter.HttpRequestFilterUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.glassfish.grizzly.Buffer;
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.EmptyCompletionHandler;
+import org.glassfish.grizzly.Grizzly;
+import org.glassfish.grizzly.WriteResult;
+import org.glassfish.grizzly.attributes.Attribute;
+import org.glassfish.grizzly.filterchain.BaseFilter;
+import org.glassfish.grizzly.filterchain.FilterChainContext;
+import org.glassfish.grizzly.filterchain.NextAction;
+import org.glassfish.grizzly.http.HttpContent;
+import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.http.HttpResponsePacket;
+import org.glassfish.grizzly.http.util.HttpStatus;
+import org.glassfish.grizzly.memory.Buffers;
+import org.glassfish.grizzly.memory.MemoryManager;
+import org.glassfish.grizzly.websockets.ProtocolError;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+/**
+ * Adds RFC 7692 {@code permessage-deflate} support to the Grizzly WebSocket stack, which does not
+ * implement it on its own (and in fact rejects any frame with a reserved bit set).
+ *
+ * <p>The filter is installed directly below the {@code WebSocketFilter} and works purely on the wire
+ * bytes: inbound it inflates compressed messages and hands plain, complete frames upwards, outbound it
+ * deflates the frames the {@code WebSocketFilter} has just serialized. Everything above it therefore
+ * sees an uncompressed connection.
+ *
+ * <p>Outbound, only an unfragmented message is ever compressed: a fragment is forwarded as it is. Several
+ * client stacks fail to inflate a compressed message that arrives split over multiple frames, so a
+ * fragment that we cannot send as a single compressed frame is sent uncompressed instead. Inbound the
+ * opposite holds, as we have to accept whatever a peer sends: fragments are reassembled and inflated.
+ *
+ * <p>Compression is always negotiated with {@code client_no_context_takeover} and
+ * {@code server_no_context_takeover}. Keeping the deflate window across messages would let an attacker
+ * who can influence any later message probe secrets sent in an earlier one by observing frame sizes
+ * (the CRIME/BREACH attack); resetting per message limits that to data within a single message.
+ */
+@Slf4j
+public class PerMessageDeflateFilter extends BaseFilter {
+    public static final String EXTENSION_NAME = "permessage-deflate";
+
+    private static final String SEC_WEBSOCKET_EXTENSIONS = "Sec-WebSocket-Extensions";
+    private static final String NEGOTIATED_EXTENSION =
+            EXTENSION_NAME + "; client_no_context_takeover; server_no_context_takeover";
+
+    private static final byte OPCODE_CONTINUATION = 0x0;
+    private static final byte OPCODE_TEXT = 0x1;
+    private static final byte OPCODE_BINARY = 0x2;
+    private static final byte OPCODE_CLOSE = 0x8;
+    private static final int MASK_SIZE = 4;
+    private static final byte RSV1 = 0x40;
+
+    // RFC 6455 close codes. We handle the frames below the WebSocketFilter, which therefore never learns
+    // about the error and cannot close on our behalf, so we state the reason ourselves.
+    private static final int CLOSE_PROTOCOL_ERROR = 1002;
+    private static final int CLOSE_TOO_BIG = 1009;
+
+    // Inflating attacker-controlled data is a zip-bomb vector, so both the compressed input and the
+    // inflated output are bounded. The limits apply to inbound data only: they exist to cap how much
+    // heap a peer can make us allocate, not to restrict what we are willing to send.
+    private static final int MAX_FRAME_PAYLOAD_SIZE = 10 * 1024 * 1024;
+    private static final int MAX_MESSAGE_SIZE = 10 * 1024 * 1024;
+    // Below this size deflate reliably makes the payload larger, so we do not even try.
+    private static final int MIN_SIZE_TO_COMPRESS = 64;
+    // The empty deflate block a SYNC_FLUSH emits; RFC 7692 requires it to be stripped before sending.
+    private static final byte[] DEFLATE_TAIL = {0x00, 0x00, (byte) 0xFF, (byte) 0xFF};
+
+    private static final Attribute<ConnectionState> STATE =
+            Grizzly.DEFAULT_ATTRIBUTE_BUILDER.createAttribute("bisq.web_socket.permessage_deflate");
+
+    @Override
+    public NextAction handleRead(FilterChainContext ctx) {
+        Object message = ctx.getMessage();
+        if (!(message instanceof HttpContent httpContent)) {
+            return ctx.getInvokeAction();
+        }
+
+        Connection<?> connection = ctx.getConnection();
+        Optional<ConnectionState> state = findState(connection);
+        if (state.filter(ConnectionState::isEnabled).isEmpty()) {
+            HttpRequestFilterUtils.resolveAsHttpRequest(message)
+                    .filter(HttpRequestFilterUtils::isWebsocketHandshakeRequest)
+                    .ifPresent(request -> onHandshakeRequest(connection, request));
+            return ctx.getInvokeAction();
+        }
+
+        Inbound inbound;
+        try {
+            inbound = processInbound(ctx.getMemoryManager(),
+                    Optional.ofNullable(httpContent.getContent()),
+                    state.get());
+        } catch (ProtocolError e) {
+            log.warn("Closing WebSocket connection: {}", e.getMessage());
+            closeWithStatus(ctx, e instanceof MessageTooLarge ? CLOSE_TOO_BIG : CLOSE_PROTOCOL_ERROR);
+            return ctx.getStopAction();
+        }
+
+        if (inbound.passThrough()) {
+            return ctx.getInvokeAction();
+        }
+        return inbound.content()
+                .map(content -> {
+                    ctx.setMessage(HttpContent.builder(httpContent.getHttpHeader()).content(content).build());
+                    return ctx.getInvokeAction();
+                })
+                .orElseGet(ctx::getStopAction);
+    }
+
+    @Override
+    public NextAction handleWrite(FilterChainContext ctx) {
+        Optional<ConnectionState> found = findState(ctx.getConnection());
+        if (found.isEmpty()) {
+            return ctx.getInvokeAction();
+        }
+        ConnectionState state = found.get();
+
+        Object message = ctx.getMessage();
+        if (message instanceof HttpContent httpContent) {
+            // The handshake response is the only point where we know the upgrade actually succeeded,
+            // so compression is switched on exactly when we confirm the extension to the client.
+            if (!state.enabled
+                    && httpContent.getHttpHeader() instanceof HttpResponsePacket response
+                    && response.getStatus() != HttpStatus.SWITCHING_PROTOCOLS_101.getStatusCode()) {
+                // The upgrade this offer belonged to failed. Were the state left attached, a retry on
+                // the same connection that does not offer the extension would still be answered with
+                // it, and we would compress frames the client never agreed to decompress.
+                STATE.remove(ctx.getConnection());
+                return ctx.getInvokeAction();
+            }
+            if (!state.enabled
+                    && httpContent.getHttpHeader() instanceof HttpResponsePacket response
+                    && response.getStatus() == HttpStatus.SWITCHING_PROTOCOLS_101.getStatusCode()) {
+                // Replaces rather than appends: Grizzly may have written the extensions a
+                // WebSocketApplication declares, but it only echoes their names and cannot apply any of
+                // them, so permessage-deflate is the only one this response can honestly confirm.
+                response.setHeader(SEC_WEBSOCKET_EXTENSIONS, NEGOTIATED_EXTENSION);
+                state.enabled = true;
+            }
+            return ctx.getInvokeAction();
+        }
+
+        if (state.enabled && message instanceof Buffer frame) {
+            ctx.setMessage(deflateFrame(ctx.getMemoryManager(), frame));
+        }
+        return ctx.getInvokeAction();
+    }
+
+    /**
+     * Sends a close frame before dropping the connection, so that the peer learns why it was closed
+     * instead of only seeing the socket go away. The connection is closed once the frame is out.
+     */
+    private static void closeWithStatus(FilterChainContext ctx, int closeCode) {
+        Connection<?> connection = ctx.getConnection();
+        try {
+            byte[] payload = {(byte) (closeCode >>> 8), (byte) closeCode};
+            Buffer closeFrame = Buffers.wrap(ctx.getMemoryManager(), buildFrame(OPCODE_CLOSE, payload));
+            ctx.write(closeFrame, new EmptyCompletionHandler<WriteResult>() {
+                @Override
+                public void completed(WriteResult result) {
+                    connection.closeSilently();
+                }
+
+                @Override
+                public void failed(Throwable throwable) {
+                    connection.closeSilently();
+                }
+            });
+        } catch (Exception e) {
+            log.debug("Could not send the close frame", e);
+            connection.closeSilently();
+        }
+    }
+
+    private static Optional<ConnectionState> findState(Connection<?> connection) {
+        return Optional.ofNullable(STATE.get(connection));
+    }
+
+    // Negotiation
+
+    private void onHandshakeRequest(Connection<?> connection, HttpRequestPacket request) {
+        if (findState(connection).isPresent()) {
+            // The upgrade request may be re-delivered before the protocol switch completes
+            return;
+        }
+        // A client may spread its offers over several header lines, so all of them have to be looked at
+        for (String header : request.getHeaders().values(SEC_WEBSOCKET_EXTENSIONS)) {
+            if (Optional.ofNullable(header).filter(PerMessageDeflateFilter::acceptsOffer).isPresent()) {
+                STATE.set(connection, new ConnectionState());
+                return;
+            }
+        }
+    }
+
+    static boolean acceptsOffer(String header) {
+        for (String offer : header.split(",")) {
+            String[] parts = offer.trim().split(";");
+            if (EXTENSION_NAME.equalsIgnoreCase(parts[0].trim()) && canHonour(parts)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean canHonour(String[] offerParts) {
+        for (int i = 1; i < offerParts.length; i++) {
+            String parameter = offerParts[i].trim();
+            int separator = parameter.indexOf('=');
+            String name = (separator < 0 ? parameter : parameter.substring(0, separator))
+                    .trim().toLowerCase(Locale.ROOT);
+            Optional<String> value = separator < 0
+                    ? Optional.empty()
+                    : Optional.of(unquote(parameter.substring(separator + 1).trim()));
+            switch (name) {
+                case "client_no_context_takeover", "server_no_context_takeover" -> {
+                    // We apply both unconditionally
+                }
+                case "client_max_window_bits" -> {
+                    // Limits the window the CLIENT compresses with, and RFC 7692 lets us ignore the
+                    // value: our Inflater always uses the largest window, which decodes a stream
+                    // produced with any smaller one. Only a value outside the range is refused, as an
+                    // offer we cannot make sense of.
+                    if (value.filter(bits -> !isWindowBits(bits)).isPresent()) {
+                        return false;
+                    }
+                }
+                case "server_max_window_bits" -> {
+                    // Limits the window WE compress with, which java.util.zip cannot restrict, so only
+                    // the largest can be honoured and RFC 7692 has us decline anything else. The offer
+                    // has to carry a value, so one without is refused too.
+                    if (!value.filter("15"::equals).isPresent()) {
+                        return false;
+                    }
+                }
+                // RFC 7692: an offer carrying an unknown parameter must not be accepted
+                default -> {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return true for a window size RFC 7692 allows, which is 8 to 15 without leading zeroes.
+     */
+    private static boolean isWindowBits(String value) {
+        if (value.isEmpty() || value.startsWith("0")) {
+            return false;
+        }
+        try {
+            int bits = Integer.parseInt(value);
+            return bits >= 8 && bits <= 15;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static String unquote(String value) {
+        return value.length() > 1 && value.startsWith("\"") && value.endsWith("\"")
+                ? value.substring(1, value.length() - 1)
+                : value;
+    }
+
+    // Inbound
+
+    /**
+     * Inflates all complete messages held by {@code input}, retaining any trailing partial frame on
+     * {@code state} so that nothing above this filter ever sees an incomplete frame.
+     */
+    static Inbound processInbound(MemoryManager<?> memoryManager, Optional<Buffer> content, ConnectionState state) {
+        Optional<Buffer> remaining = content.filter(Buffer::hasRemaining);
+        if (remaining.isEmpty()) {
+            return Inbound.nothing();
+        }
+        Buffer input = remaining.get();
+
+        Optional<ByteArrayOutputStream> pending = state.leftover;
+        boolean pristine = pending.isEmpty();
+        if (!pristine) {
+            ByteArrayOutputStream leftover = pending.get();
+            // Appending is amortized constant time, whereas merging and re-parsing the accumulated
+            // prefix on every read would be quadratic in the number of reads a peer splits a frame
+            // into, which a peer dribbling out a large frame byte by byte can drive on its own.
+            leftover.writeBytes(copyBytes(input, input.position(), input.limit()));
+            if (leftover.size() < state.leftoverRequiredSize) {
+                return Inbound.nothing();
+            }
+            input = Buffers.wrap(memoryManager, leftover.toByteArray());
+            state.leftover = Optional.empty();
+            state.leftoverRequiredSize = 0;
+        }
+
+        int limit = input.limit();
+        int position = input.position();
+        List<Buffer> output = new ArrayList<>();
+        boolean inflated = false;
+        int requiredSize = 0;
+
+        while (position < limit) {
+            Frame frame = parseFrame(input, position, limit);
+            if (!frame.complete()) {
+                requiredSize = frame.end() - position;
+                break;
+            }
+            if (frame.isControl()) {
+                output.add(input.slice(position, frame.end()));
+            } else {
+                // We consume the frames of a compressed message rather than forwarding them, so the
+                // WebSocketFilter above never sees them and cannot validate the fragmentation of such
+                // a message. Whatever it would have rejected has to be rejected here instead.
+                if (frame.opcode() == OPCODE_CONTINUATION) {
+                    if (!state.messageOpen) {
+                        throw new ProtocolError("Continuation frame without a message to continue");
+                    }
+                    if (frame.rsv1()) {
+                        throw new ProtocolError("RSV1 must not be set on a continuation frame");
+                    }
+                } else {
+                    if (state.messageOpen) {
+                        throw new ProtocolError("New data frame while a fragmented message is still open");
+                    }
+                    state.messageCompressed = frame.rsv1();
+                    state.messageOpcode = frame.opcode();
+                }
+                state.messageOpen = !frame.fin();
+                if (state.messageCompressed) {
+                    inflated = true;
+                    appendPayload(state, input, frame);
+                    if (frame.fin()) {
+                        output.add(inflateMessage(memoryManager, state));
+                    }
+                } else {
+                    output.add(input.slice(position, frame.end()));
+                }
+            }
+            position = frame.end();
+        }
+
+        if (position < limit) {
+            // Incomplete frame: copy it out, the underlying buffer does not survive this read
+            ByteArrayOutputStream incomplete = new ByteArrayOutputStream();
+            incomplete.writeBytes(copyBytes(input, position, limit));
+            state.leftover = Optional.of(incomplete);
+            state.leftoverRequiredSize = requiredSize;
+        } else if (pristine && !inflated) {
+            return Inbound.unchanged();
+        }
+
+        if (output.isEmpty()) {
+            return Inbound.nothing();
+        }
+
+        Buffer merged = output.get(0);
+        for (int i = 1; i < output.size(); i++) {
+            merged = Buffers.appendBuffers(memoryManager, merged, output.get(i));
+        }
+        return Inbound.of(merged);
+    }
+
+    private static void appendPayload(ConnectionState state, Buffer input, Frame frame) {
+        if (frame.maskStart() < 0) {
+            // RFC 6455 requires a client to mask, and for a compressed frame we are the only parser
+            // that sees it, so an unmasked one has to be refused here.
+            throw new ProtocolError("Client frames must be masked");
+        }
+        if (state.messagePayload.isEmpty()) {
+            state.messagePayload = Optional.of(new ByteArrayOutputStream());
+        }
+        if (state.messagePayload.get().size() + frame.payloadLength() > MAX_MESSAGE_SIZE) {
+            throw new MessageTooLarge("Compressed message exceeds " + MAX_MESSAGE_SIZE + " bytes");
+        }
+        byte[] payload = copyBytes(input, frame.payloadStart(), frame.payloadStart() + frame.payloadLength());
+        byte[] mask = copyBytes(input, frame.maskStart(), frame.maskStart() + MASK_SIZE);
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] ^= mask[i % MASK_SIZE];
+        }
+        state.messagePayload.get().writeBytes(payload);
+    }
+
+    private static Buffer inflateMessage(MemoryManager<?> memoryManager, ConnectionState state) {
+        byte[] compressed = state.messagePayload.map(ByteArrayOutputStream::toByteArray).orElse(new byte[0]);
+        state.messagePayload = Optional.empty();
+        return Buffers.wrap(memoryManager, buildFrame(state.messageOpcode, inflate(compressed)));
+    }
+
+    /**
+     * A truncated payload cannot be told apart from a complete one here, so it yields a short message
+     * rather than a protocol error. Every permessage-deflate message ends mid-stream by design — the
+     * sender strips the {@link #DEFLATE_TAIL} and never emits a final block — so {@code finished()} is
+     * false for valid and truncated input alike, and both end with the inflater having consumed all
+     * input and asking for more. Requiring {@code finished()} would reject all legitimate traffic.
+     * A peer can therefore only corrupt its own message, which then fails to parse a level up.
+     */
+    static byte[] inflate(byte[] compressed) {
+        Inflater inflater = new Inflater(true);
+        try {
+            inflater.setInput(compressed);
+            // Sized for the common case and grown on demand: deriving the initial capacity from the
+            // compressed size would let a peer dictate a large allocation before a single byte is
+            // inflated, which is the very thing MAX_MESSAGE_SIZE is there to prevent.
+            ByteArrayOutputStream out = new ByteArrayOutputStream(8192);
+            byte[] chunk = new byte[8192];
+            boolean tailAdded = false;
+            while (true) {
+                int count = inflater.inflate(chunk);
+                if (count > 0) {
+                    if (out.size() + count > MAX_MESSAGE_SIZE) {
+                        throw new MessageTooLarge("Inflated message exceeds " + MAX_MESSAGE_SIZE + " bytes");
+                    }
+                    out.write(chunk, 0, count);
+                    continue;
+                }
+                if (inflater.needsDictionary()) {
+                    throw new ProtocolError("Compressed message requires a preset dictionary");
+                }
+                if (inflater.finished() || !inflater.needsInput() || tailAdded) {
+                    break;
+                }
+                inflater.setInput(DEFLATE_TAIL);
+                tailAdded = true;
+            }
+            return out.toByteArray();
+        } catch (DataFormatException e) {
+            throw new ProtocolError("Could not inflate message: " + e.getMessage());
+        } finally {
+            inflater.end();
+        }
+    }
+
+    // Outbound
+
+    static Buffer deflateFrame(MemoryManager<?> memoryManager, Buffer buffer) {
+        int position = buffer.position();
+        int limit = buffer.limit();
+        Frame frame;
+        try {
+            frame = parseFrame(buffer, position, limit);
+        } catch (ProtocolError e) {
+            // The inbound validation rules do not apply to what we send: a frame the WebSocketFilter
+            // serialized is well-formed by construction and may legitimately exceed the inbound size
+            // limit. Anything we cannot parse is simply forwarded uncompressed rather than failing
+            // the write, so enabling compression can never make a send fail that would have succeeded.
+            log.debug("Sending frame uncompressed, it could not be parsed: {}", e.getMessage());
+            return buffer;
+        }
+        if (!frame.complete()
+                || frame.end() != limit
+                || frame.isControl()
+                || frame.rsv1()
+                // A compressed message split over several frames is what a number of client stacks get
+                // wrong, so a fragment is sent uncompressed rather than as one fragment of a compressed
+                // message. Nothing here fragments today, this keeps it safe if something ever does.
+                || !frame.fin()
+                // We rebuild the frame unmasked, so a masked one would have to be unmasked first.
+                // The server never masks, hence we leave such a frame alone instead.
+                || frame.maskStart() >= 0
+                || frame.opcode() != OPCODE_TEXT && frame.opcode() != OPCODE_BINARY
+                || frame.payloadLength() < MIN_SIZE_TO_COMPRESS) {
+            return buffer;
+        }
+
+        byte[] payload = copyBytes(buffer, frame.payloadStart(), frame.payloadStart() + frame.payloadLength());
+        byte[] compressed = deflate(payload);
+        if (compressed.length >= payload.length) {
+            return buffer;
+        }
+
+        byte[] compressedFrame = buildFrame(frame.opcode(), compressed);
+        compressedFrame[0] |= RSV1;
+        return Buffers.wrap(memoryManager, compressedFrame);
+    }
+
+    static byte[] deflate(byte[] payload) {
+        Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        try {
+            deflater.setInput(payload);
+            ByteArrayOutputStream out = new ByteArrayOutputStream(payload.length);
+            byte[] chunk = new byte[8192];
+            int count;
+            do {
+                count = deflater.deflate(chunk, 0, chunk.length, Deflater.SYNC_FLUSH);
+                out.write(chunk, 0, count);
+            } while (count == chunk.length);
+
+            byte[] compressed = out.toByteArray();
+            return endsWithDeflateTail(compressed)
+                    ? Arrays.copyOf(compressed, compressed.length - DEFLATE_TAIL.length)
+                    : compressed;
+        } finally {
+            deflater.end();
+        }
+    }
+
+    private static boolean endsWithDeflateTail(byte[] compressed) {
+        int offset = compressed.length - DEFLATE_TAIL.length;
+        if (offset < 0) {
+            return false;
+        }
+        for (int i = 0; i < DEFLATE_TAIL.length; i++) {
+            if (compressed[offset + i] != DEFLATE_TAIL[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Framing
+
+    /**
+     * @return the parsed frame, or an incomplete frame whose {@code end} tells the caller how far
+     * {@code buffer} has to be filled before parsing can be attempted again.
+     */
+    static Frame parseFrame(Buffer buffer, int start, int limit) {
+        if (limit - start < 2) {
+            return incomplete(start + 2);
+        }
+        byte firstByte = buffer.get(start);
+        byte secondByte = buffer.get(start + 1);
+        if ((firstByte & 0x30) != 0) {
+            throw new ProtocolError("RSV2 and RSV3 bits must not be set");
+        }
+        boolean fin = (firstByte & 0x80) != 0;
+        boolean rsv1 = (firstByte & RSV1) != 0;
+        byte opcode = (byte) (firstByte & 0x0F);
+        boolean masked = (secondByte & 0x80) != 0;
+        int lengthCode = secondByte & 0x7F;
+        boolean control = (opcode & 0x08) != 0;
+        if (control && rsv1) {
+            throw new ProtocolError("Control frames must not be compressed");
+        }
+
+        int cursor = start + 2;
+        long payloadLength;
+        if (lengthCode <= 125) {
+            payloadLength = lengthCode;
+        } else if (lengthCode == 126) {
+            if (limit - cursor < 2) {
+                return incomplete(cursor + 2);
+            }
+            payloadLength = (buffer.get(cursor) & 0xFFL) << 8 | buffer.get(cursor + 1) & 0xFFL;
+            cursor += 2;
+            if (payloadLength <= 125) {
+                throw new ProtocolError("Payload length is not minimally encoded");
+            }
+        } else {
+            if (limit - cursor < 8) {
+                return incomplete(cursor + 8);
+            }
+            payloadLength = 0;
+            for (int i = 0; i < 8; i++) {
+                payloadLength = payloadLength << 8 | buffer.get(cursor + i) & 0xFFL;
+            }
+            cursor += 8;
+            if (payloadLength >= 0 && payloadLength <= 0xFFFF) {
+                throw new ProtocolError("Payload length is not minimally encoded");
+            }
+        }
+        if (payloadLength < 0) {
+            // RFC 6455: the most significant bit of a 64 bit length must be 0, so this is a malformed
+            // frame rather than one that is merely too big, and it gets the close code to match.
+            throw new ProtocolError("Payload length must not have the most significant bit set");
+        }
+        if (payloadLength > MAX_FRAME_PAYLOAD_SIZE) {
+            throw new MessageTooLarge("Frame payload exceeds " + MAX_FRAME_PAYLOAD_SIZE + " bytes");
+        }
+
+        int maskStart = -1;
+        if (masked) {
+            if (limit - cursor < MASK_SIZE) {
+                return incomplete(cursor + MASK_SIZE);
+            }
+            maskStart = cursor;
+            cursor += MASK_SIZE;
+        }
+        if (limit - cursor < payloadLength) {
+            return incomplete(cursor + (int) payloadLength);
+        }
+        return new Frame(opcode, fin, rsv1, control, maskStart, cursor, (int) payloadLength,
+                cursor + (int) payloadLength, true);
+    }
+
+    private static Frame incomplete(int requiredEnd) {
+        return new Frame((byte) 0, false, false, false, -1, -1, 0, requiredEnd, false);
+    }
+
+    /**
+     * Builds an unfragmented, unmasked frame. Inbound this replaces the fragments of an inflated
+     * message, outbound it replaces the frame the WebSocketFilter serialized.
+     */
+    static byte[] buildFrame(byte opcode, byte[] payload) {
+        byte[] header;
+        int length = payload.length;
+        if (length <= 125) {
+            header = new byte[]{(byte) (0x80 | opcode), (byte) length};
+        } else if (length <= 0xFFFF) {
+            header = new byte[]{(byte) (0x80 | opcode), 126, (byte) (length >>> 8), (byte) length};
+        } else {
+            header = new byte[]{(byte) (0x80 | opcode), 127, 0, 0, 0, 0,
+                    (byte) (length >>> 24), (byte) (length >>> 16), (byte) (length >>> 8), (byte) length};
+        }
+        byte[] frame = new byte[header.length + length];
+        System.arraycopy(header, 0, frame, 0, header.length);
+        System.arraycopy(payload, 0, frame, header.length, length);
+        return frame;
+    }
+
+    private static byte[] copyBytes(Buffer buffer, int start, int end) {
+        byte[] bytes = new byte[end - start];
+        buffer.slice(start, end).get(bytes);
+        return bytes;
+    }
+
+    /**
+     * An inbound size limit was exceeded, which RFC 6455 has a close code of its own for.
+     */
+    static final class MessageTooLarge extends ProtocolError {
+        MessageTooLarge(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * @param content     the frames to forward upwards, empty if the read produced none
+     * @param passThrough true if the input needs no rewriting and can be forwarded as it is
+     */
+    record Inbound(Optional<Buffer> content, boolean passThrough) {
+        static Inbound nothing() {
+            return new Inbound(Optional.empty(), false);
+        }
+
+        static Inbound unchanged() {
+            return new Inbound(Optional.empty(), true);
+        }
+
+        static Inbound of(Buffer content) {
+            return new Inbound(Optional.of(content), false);
+        }
+    }
+
+    /**
+     * @param end      for a complete frame the offset just past it, otherwise the offset the buffer
+     *                 has to reach before the frame can be parsed
+     * @param complete false if the buffer does not hold the frame yet, in which case only
+     *                 {@code end} carries a meaning
+     */
+    record Frame(byte opcode,
+                 boolean fin,
+                 boolean rsv1,
+                 boolean isControl,
+                 int maskStart,
+                 int payloadStart,
+                 int payloadLength,
+                 int end,
+                 boolean complete) {
+    }
+
+    /**
+     * Reads for one connection are serialized but not pinned to a single worker thread, and
+     * {@code enabled} is additionally set from the write path, so the fields are volatile for the same
+     * reason Grizzly's own {@code WebSocketHolder} makes its state volatile.
+     *
+     * <p>Note what carries the safety here: {@code volatile} publishes the reference, not the later
+     * content of the {@link ByteArrayOutputStream} each one points at, and those buffers are mutated in
+     * place. Correctness rests solely on Grizzly serializing the reads of one connection, which puts a
+     * happens-before edge between consecutive read events. A refactor that moves this work off that
+     * thread has to add real synchronization; keeping the fields volatile would not be enough.
+     *
+     * <p>The outbound path needs no state at all: {@code server_no_context_takeover} means every message
+     * is deflated with its own {@link Deflater}, so concurrent sends cannot interfere.
+     */
+    static final class ConnectionState {
+        private volatile boolean enabled;
+        private volatile Optional<ByteArrayOutputStream> leftover = Optional.empty();
+
+        private boolean isEnabled() {
+            return enabled;
+        }
+
+        private volatile int leftoverRequiredSize;
+        private volatile boolean messageOpen;
+        private volatile boolean messageCompressed;
+        private volatile byte messageOpcode;
+        private volatile Optional<ByteArrayOutputStream> messagePayload = Optional.empty();
+    }
+}

--- a/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiRequest.java
+++ b/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiRequest.java
@@ -18,6 +18,7 @@
 package bisq.api.web_socket.rest_api_proxy;
 
 import bisq.api.web_socket.WebSocketMessage;
+import bisq.api.web_socket.util.JsonUtil;
 import bisq.common.json.JsonMapperProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.EqualsAndHashCode;
@@ -39,24 +40,32 @@ public class WebSocketRestApiRequest implements WebSocketMessage {
     private String path;
     private String method;
     private String body;
+    // Accepted but ignored. Clients used to supply the session and client id here and we forwarded
+    // them to the REST API server, which let a client act under an identity it never authenticated
+    // with. The identity is now taken from the authenticated upgrade request instead. Both fields
+    // are kept so that already released clients, which still send them, keep working until they
+    // have rolled out a version that no longer does.
     private Map<String, String> headers;
     private String clientId;
-
-    public static boolean isExpectedJson(String message) {
-        return message.contains("requestId") &&
-                message.contains("path") &&
-                message.contains("method") &&
-                message.contains("body") &&
-                message.contains("headers") &&
-                message.contains("clientId");
-    }
 
     public static Optional<WebSocketRestApiRequest> fromJson(String json) {
         try {
             return Optional.of(JsonMapperProvider.get().readValue(json, WebSocketRestApiRequest.class));
         } catch (JsonProcessingException e) {
-            log.error("Json deserialization failed. Message={}", json, e);
+            log.error("Json deserialization failed. Message={}", JsonUtil.redactCredentials(json), e);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Removes the client supplied headers, so that from here on the request cannot carry them any
+     * further — not into a forwarded request, and not into a log line via {@link #toString()}. The node
+     * takes the identity of the call from the authenticated upgrade request instead, so what the
+     * message carries is discarded. Called once, right after deserialization.
+     */
+    void clearHeaders() {
+        // Jackson deserializes into the field, so emptying it is what actually removes them. Emptied
+        // rather than nulled: the generated getter stays safe to call for anything added later.
+        headers = Map.of();
     }
 }

--- a/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiService.java
+++ b/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiService.java
@@ -18,15 +18,21 @@
 package bisq.api.web_socket.rest_api_proxy;
 
 import bisq.api.ApiConfig;
+import bisq.api.access.filter.Headers;
+import bisq.api.access.filter.authz.AuthorizationException;
+import bisq.api.access.filter.authz.UriValidator;
 import bisq.api.access.transport.TlsContextService;
 import bisq.api.web_socket.util.JsonUtil;
 import bisq.common.application.Service;
+import bisq.common.util.StringUtils;
 import bisq.security.tls.TlsException;
 import bisq.security.tls.TlsTrustManager;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.glassfish.grizzly.websockets.DefaultWebSocket;
 import org.glassfish.grizzly.websockets.WebSocket;
 
 import javax.net.ssl.SSLContext;
@@ -41,8 +47,8 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 
 @Slf4j
@@ -50,16 +56,28 @@ import static java.net.http.HttpClient.Version.HTTP_1_1;
 @EqualsAndHashCode
 @ToString
 public class WebSocketRestApiService implements Service {
+    private static final UriValidator URI_VALIDATOR = new UriValidator();
+
     private final ApiConfig apiConfig;
     private final String restServerUrl;
     private final TlsContextService tlsContextService;
     private Optional<HttpClient> httpClient = Optional.empty();
+
     private final Object httpClientLock = new Object();
 
     public WebSocketRestApiService(ApiConfig apiConfig, TlsContextService tlsContextService) {
         this.apiConfig = apiConfig;
-        this.restServerUrl = apiConfig.getRestProtocol() + "://" + apiConfig.getBindHost() + ":" + apiConfig.getBindPort();
+        this.restServerUrl = apiConfig.getRestProtocol() + "://" + toUriHost(apiConfig.getBindHost())
+                + ":" + apiConfig.getBindPort();
         this.tlsContextService = tlsContextService;
+    }
+
+    /**
+     * An IPv6 literal is only a valid URI host in brackets. Without them the authority does not parse
+     * and every forwarded request would fail on the host comparison in {@link #resolveRestApiUri}.
+     */
+    static String toUriHost(String bindHost) {
+        return bindHost.contains(":") && !bindHost.startsWith("[") ? "[" + bindHost + "]" : bindHost;
     }
 
     @Override
@@ -81,17 +99,18 @@ public class WebSocketRestApiService implements Service {
 
     public void onMessage(String json, WebSocket webSocket) {
         Optional<WebSocketRestApiRequest> webSocketRestApiRequest = WebSocketRestApiRequest.fromJson(json);
+        webSocketRestApiRequest.ifPresent(WebSocketRestApiRequest::clearHeaders);
         webSocketRestApiRequest
-                .map(this::sendToRestApiServer)
+                .map(request -> sendToRestApiServer(request, webSocket))
                 .ifPresent(future -> {
                     future.whenComplete((response, throwable) -> {
                         if (throwable == null) {
                             response.toJson()
                                     .ifPresentOrElse(webSocket::send,
                                             () -> log.warn("Message was not sent to websocket." +
-                                                    "\nJson={}", json));
+                                                    "\nJson={}", JsonUtil.redactCredentials(json)));
                         } else {
-                            log.warn("REST API call failed for request: {}", json, throwable);
+                            log.warn("REST API call failed for request: {}", JsonUtil.redactCredentials(json), throwable);
                             String requestId = webSocketRestApiRequest.get().getRequestId();
                             new WebSocketRestApiResponse(requestId, 500, throwable.getMessage()).toJson()
                                     .ifPresent(webSocket::send);
@@ -100,27 +119,35 @@ public class WebSocketRestApiService implements Service {
                 });
     }
 
-    private CompletableFuture<WebSocketRestApiResponse> sendToRestApiServer(WebSocketRestApiRequest request) {
+    private CompletableFuture<WebSocketRestApiResponse> sendToRestApiServer(WebSocketRestApiRequest request,
+                                                                           WebSocket webSocket) {
         CompletableFuture<WebSocketRestApiResponse> future = new CompletableFuture<>();
-        String url = restServerUrl + request.getPath();
         String method = request.getMethod();
         String body = request.getBody();
+        URI uri;
+        try {
+            uri = resolveRestApiUri(restServerUrl, request.getPath());
+        } catch (AuthorizationException | IllegalArgumentException e) {
+            // The client sent a path we refuse to forward, which is a bad request and not a server error.
+            // The reason is not echoed back, so that the response cannot be used to probe the check.
+            log.warn("Rejected the path of a forwarded request: {}", e.getMessage());
+            return CompletableFuture.completedFuture(
+                    new WebSocketRestApiResponse(request.getRequestId(), 400, "Invalid path"));
+        }
+        String url = uri.toString();
         try {
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
+                    .uri(uri)
                     .header("Content-Type", "application/json")
                     .header("Accept", "application/json")
                     .method(method, body == null
                             ? HttpRequest.BodyPublishers.noBody()
                             : HttpRequest.BodyPublishers.ofString(body));
 
-            // Forward client-provided headers (e.g., session/client identifiers) from request.headers.
-            String[] headers = request.getHeaders().entrySet().stream()
-                    .flatMap(e -> Stream.of(e.getKey(), e.getValue()))
-                    .toArray(String[]::new);
-            if (headers.length > 0) {
-                requestBuilder.headers(headers);
-            }
+            // The identity is taken from the authenticated upgrade request, never from the message
+            // payload: a client must not be able to act under an identity it did not authenticate with,
+            // and keeping credentials out of the frames keeps them out of the deflate window.
+            forwardAuthenticatedIdentity(webSocket, requestBuilder);
 
             HttpRequest httpRequest = requestBuilder.build();
             log.info("Forwarding {} request to {}", method, url);
@@ -143,6 +170,73 @@ public class WebSocketRestApiService implements Service {
             log.error(errorMessage, e);
             return CompletableFuture.failedFuture(e);
         }
+    }
+
+    /**
+     * The path comes from the message payload and therefore from the client, so it decides on its own
+     * what the forwarded request addresses. Appending it to the server URL unchecked lets a client
+     * redirect the call to a host of its choosing, because a path such as {@code @example.com/} turns
+     * the configured host into mere user info of the resulting URI, and the forwarded request carries
+     * the session credentials.
+     *
+     * <p>The checks run on the normalized URI, so that a traversal cannot pass them and still change
+     * where the request ends up.
+     */
+    static URI resolveRestApiUri(String restServerUrl, String path) throws AuthorizationException {
+        checkArgument(StringUtils.isNotEmpty(path), "Path must not be empty");
+        checkArgument(path.startsWith("/") && !path.startsWith("//"), "Path must be server absolute: %s", path);
+
+        URI uri = URI.create(restServerUrl + path).normalize();
+        URI restServerUri = URI.create(restServerUrl);
+        checkArgument(restServerUri.getScheme().equals(uri.getScheme())
+                        && restServerUri.getHost().equals(uri.getHost())
+                        && restServerUri.getPort() == uri.getPort()
+                        && uri.getRawUserInfo() == null,
+                "Path must not change the target of the request: %s", path);
+        // Checked after normalizing, so that a traversal cannot walk out of the REST API and reach
+        // another handler of the same server — the docs endpoint or a static file handler — with the
+        // credentials of the connection attached.
+        checkArgument(uri.getPath().equals(ApiConfig.REST_API_BASE_PATH)
+                        || uri.getPath().startsWith(ApiConfig.REST_API_BASE_PATH + "/"),
+                "Path must address the REST API: %s", path);
+
+        // The REST API applies this to incoming requests as well, but only when authorization is
+        // required, whereas a forwarded request has to be safe regardless of that setting.
+        URI_VALIDATOR.validate(uri);
+        return uri;
+    }
+
+    /**
+     * Copies the identity of the connection onto the forwarded request. A connection whose upgrade
+     * request cannot be resolved at all is a state we do not expect and refuse to forward for, whereas
+     * an upgrade request carrying no identity headers forwards none: with session handling enabled the
+     * handshake filter has already rejected such a connection, and with it disabled there is no
+     * identity to pass on and the REST API asks for none.
+     */
+    private static void forwardAuthenticatedIdentity(WebSocket webSocket, HttpRequest.Builder requestBuilder) {
+        HttpServletRequest upgradeRequest = findUpgradeRequest(webSocket)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Could not resolve the upgrade request of the WebSocket connection"));
+        copyHeader(upgradeRequest, requestBuilder, Headers.SESSION_ID);
+        copyHeader(upgradeRequest, requestBuilder, Headers.CLIENT_ID);
+    }
+
+    /**
+     * The upgrade request is where the connection's authenticated identity lives, so it is read from
+     * the WebSocket rather than from the message.
+     */
+    private static Optional<HttpServletRequest> findUpgradeRequest(WebSocket webSocket) {
+        return webSocket instanceof DefaultWebSocket defaultWebSocket
+                ? Optional.ofNullable(defaultWebSocket.getUpgradeRequest())
+                : Optional.empty();
+    }
+
+    private static void copyHeader(HttpServletRequest upgradeRequest,
+                                   HttpRequest.Builder requestBuilder,
+                                   String name) {
+        Optional.ofNullable(upgradeRequest.getHeader(name))
+                .filter(StringUtils::isNotEmpty)
+                .ifPresent(value -> requestBuilder.header(name, value));
     }
 
     private HttpClient getOrCreateHttpClient() {

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionRequest.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionRequest.java
@@ -18,6 +18,7 @@
 package bisq.api.web_socket.subscription;
 
 import bisq.api.web_socket.WebSocketMessage;
+import bisq.api.web_socket.util.JsonUtil;
 import bisq.common.json.JsonMapperProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.EqualsAndHashCode;
@@ -42,7 +43,7 @@ public class SubscriptionRequest implements WebSocketMessage {
         try {
             return Optional.of(JsonMapperProvider.get().readValue(json, SubscriptionRequest.class));
         } catch (JsonProcessingException e) {
-            log.error("Json deserialization failed. Message={}", json, e);
+            log.error("Json deserialization failed. Message={}", JsonUtil.redactCredentials(json), e);
         }
         return Optional.empty();
     }

--- a/api/src/main/java/bisq/api/web_socket/util/JsonUtil.java
+++ b/api/src/main/java/bisq/api/web_socket/util/JsonUtil.java
@@ -21,6 +21,22 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JsonUtil {
+    /**
+     * Clients released before the node derived the request identity from the WebSocket handshake put
+     * their session id into the message payload. The node ignores it, but a raw message must never
+     * reach a log file with it still readable, so it is blanked before logging.
+     *
+     * <p>Only the session id is treated as a secret. The client id is an identifier the node logs
+     * elsewhere anyway, and keeping it visible is what makes such a log line useful.
+     */
+    private static final Pattern SESSION_ID_PATTERN = Pattern.compile(
+            "(\"Bisq-Session-Id\"\\s*:\\s*\")[^\"]*(\")", Pattern.CASE_INSENSITIVE);
+    private static final String REDACTED = "$1***$2";
+
+    public static String redactCredentials(String json) {
+        return SESSION_ID_PATTERN.matcher(json).replaceAll(REDACTED);
+    }
+
     // We use by convention same class name. We get the type field set by the client.
     public static boolean hasExpectedJsonClassName(Class<?> clazz, String json) {
         String regex = "\"type\":\\s*\"([^\"]+)\""; // We use simple name

--- a/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateFilterTest.java
+++ b/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateFilterTest.java
@@ -1,0 +1,437 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.compression;
+
+import bisq.api.web_socket.compression.PerMessageDeflateFilter.ConnectionState;
+import bisq.api.web_socket.compression.PerMessageDeflateFilter.Frame;
+import bisq.api.web_socket.compression.PerMessageDeflateFilter.Inbound;
+import org.glassfish.grizzly.Buffer;
+import org.glassfish.grizzly.memory.Buffers;
+import org.glassfish.grizzly.memory.HeapMemoryManager;
+import org.glassfish.grizzly.memory.MemoryManager;
+import org.glassfish.grizzly.websockets.ProtocolError;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PerMessageDeflateFilterTest {
+    private static final byte OPCODE_CONTINUATION = 0x0;
+    private static final byte OPCODE_TEXT = 0x1;
+    private static final byte OPCODE_PING = 0x9;
+    private static final byte RSV1 = 0x40;
+    private static final byte[] MASK = {0x11, 0x22, 0x33, 0x44};
+
+    private final MemoryManager<?> memoryManager = new HeapMemoryManager();
+    private final ConnectionState state = new ConnectionState();
+
+    // Negotiation
+
+    @Test
+    void acceptsBareOffer() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate")).isTrue();
+    }
+
+    @Test
+    void acceptsOfferWithNoContextTakeoverParameters() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; client_no_context_takeover; server_no_context_takeover")).isTrue();
+    }
+
+    /**
+     * The client's window bounds the compressor at the other end, and RFC 7692 lets the server ignore
+     * the value: our Inflater always uses the largest window and decodes a stream produced with any
+     * smaller one, so such an offer must not cost the connection its compression.
+     */
+    @Test
+    void acceptsAnyClientWindowSizeAndIgnoresIt() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits")).isTrue();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=8")).isTrue();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=10")).isTrue();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=15")).isTrue();
+    }
+
+    /**
+     * The server's window bounds our own compressor, which java.util.zip cannot restrict, so anything
+     * but the largest has to be declined. An offer has to carry a value for it, so one without is
+     * declined as well.
+     */
+    @Test
+    void declinesAServerWindowSizeItCannotHonour() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; server_max_window_bits=15")).isTrue();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; server_max_window_bits=10")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; server_max_window_bits")).isFalse();
+    }
+
+    @Test
+    void declinesAWindowSizeOutsideTheRange() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=7")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=16")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=08")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=x")).isFalse();
+    }
+
+    @Test
+    void declinesUnknownParameterAndUnknownExtension() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; unexpected=1")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("x-webkit-deflate-frame")).isFalse();
+    }
+
+    @Test
+    void picksTheAcceptableOfferFromAList() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; server_max_window_bits=10, permessage-deflate")).isTrue();
+    }
+
+    // Codec
+
+    @Test
+    void deflateAndInflateRoundTrip() {
+        byte[] payload = repeat("{\"topic\":\"OFFERS\",\"payload\":\"abcdefghij\"}", 20);
+
+        byte[] compressed = PerMessageDeflateFilter.deflate(payload);
+
+        assertThat(compressed.length).isLessThan(payload.length);
+        assertThat(PerMessageDeflateFilter.inflate(compressed)).isEqualTo(payload);
+    }
+
+    @Test
+    void inflateRejectsGarbage() {
+        assertThatThrownBy(() -> PerMessageDeflateFilter.inflate(new byte[]{1, 2, 3, 4, 5, 6, 7, 8}))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    // Outbound
+
+    @Test
+    void outboundCompressesLargeTextFrame() {
+        byte[] payload = repeat("bisq", 100);
+        Buffer plain = Buffers.wrap(memoryManager, PerMessageDeflateFilter.buildFrame(OPCODE_TEXT, payload));
+
+        Buffer compressed = PerMessageDeflateFilter.deflateFrame(memoryManager, plain);
+
+        Frame frame = PerMessageDeflateFilter.parseFrame(compressed, compressed.position(), compressed.limit());
+        assertThat(frame.complete()).isTrue();
+        assertThat(frame.rsv1()).isTrue();
+        assertThat(frame.fin()).isTrue();
+        assertThat(frame.opcode()).isEqualTo(OPCODE_TEXT);
+        assertThat(frame.payloadLength()).isLessThan(payload.length);
+        assertThat(PerMessageDeflateFilter.inflate(payloadOf(compressed, frame))).isEqualTo(payload);
+    }
+
+    @Test
+    void outboundLeavesSmallAndIncompressibleFramesUntouched() {
+        Buffer small = Buffers.wrap(memoryManager,
+                PerMessageDeflateFilter.buildFrame(OPCODE_TEXT, "ping".getBytes(StandardCharsets.UTF_8)));
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, small)).isSameAs(small);
+
+        // Already compressed data does not shrink any further, so it must be sent as it is
+        byte[] incompressible = PerMessageDeflateFilter.deflate(repeat("bisq", 100));
+        Buffer frame = Buffers.wrap(memoryManager, PerMessageDeflateFilter.buildFrame(OPCODE_TEXT, incompressible));
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, frame)).isSameAs(frame);
+    }
+
+    @Test
+    void outboundLeavesMaskedFrameUntouched() {
+        Buffer masked = Buffers.wrap(memoryManager, maskedFrame(OPCODE_TEXT, false, true, repeat("bisq", 100)));
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, masked)).isSameAs(masked);
+    }
+
+    @Test
+    void outboundLeavesFrameItCannotParseUntouched() {
+        // The inbound size limit must not make a send fail: such a frame is forwarded as it is
+        byte[] header = {(byte) (0x80 | OPCODE_TEXT), 127, 0, 0, 0, 0, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        Buffer oversized = Buffers.wrap(memoryManager, header);
+
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, oversized)).isSameAs(oversized);
+    }
+
+    @Test
+    void outboundLeavesFragmentsUncompressed() {
+        // Clients that mishandle a compressed message split over several frames must not be exposed to
+        // one, so neither the first fragment nor a continuation may be compressed
+        byte[] payload = repeat("bisq", 100);
+        byte[] firstFragment = PerMessageDeflateFilter.buildFrame(OPCODE_TEXT, payload);
+        firstFragment[0] &= 0x7F;
+        Buffer notFinal = Buffers.wrap(memoryManager, firstFragment);
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, notFinal)).isSameAs(notFinal);
+
+        Buffer continuation = Buffers.wrap(memoryManager,
+                PerMessageDeflateFilter.buildFrame(OPCODE_CONTINUATION, payload));
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, continuation)).isSameAs(continuation);
+    }
+
+    @Test
+    void outboundLeavesControlFramesUntouched() {
+        Buffer ping = Buffers.wrap(memoryManager, PerMessageDeflateFilter.buildFrame(OPCODE_PING, repeat("x", 100)));
+        assertThat(PerMessageDeflateFilter.deflateFrame(memoryManager, ping)).isSameAs(ping);
+    }
+
+    // Inbound
+
+    @Test
+    void inboundForwardsUncompressedFramesUnchanged() {
+        Buffer input = Buffers.wrap(memoryManager, maskedFrame(OPCODE_TEXT, false, true, "hello".getBytes(StandardCharsets.UTF_8)));
+
+        Inbound inbound = PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state);
+
+        assertThat(inbound.passThrough()).isTrue();
+        assertThat(inbound.content()).isEmpty();
+    }
+
+    @Test
+    void inboundInflatesCompressedMessage() {
+        byte[] payload = repeat("subscribe", 30);
+        Buffer input = Buffers.wrap(memoryManager,
+                maskedFrame(OPCODE_TEXT, true, true, PerMessageDeflateFilter.deflate(payload)));
+
+        Inbound inbound = PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state);
+
+        assertThat(inbound.passThrough()).isFalse();
+        assertPlainTextFrame(inbound.content(), payload);
+    }
+
+    @Test
+    void inboundReassemblesCompressedFragments() {
+        byte[] payload = repeat("fragment", 30);
+        byte[] compressed = PerMessageDeflateFilter.deflate(payload);
+        int split = compressed.length / 2;
+        ByteArrayOutputStream input = new ByteArrayOutputStream();
+        input.writeBytes(maskedFrame(OPCODE_TEXT, true, false, slice(compressed, 0, split)));
+        input.writeBytes(maskedFrame(OPCODE_CONTINUATION, false, true, slice(compressed, split, compressed.length)));
+
+        Inbound inbound = PerMessageDeflateFilter.processInbound(memoryManager,
+                Optional.of(Buffers.wrap(memoryManager, input.toByteArray())), state);
+
+        assertPlainTextFrame(inbound.content(), payload);
+    }
+
+    @Test
+    void inboundBuffersPartialFrameUntilItIsComplete() {
+        byte[] payload = repeat("partial", 30);
+        byte[] frame = maskedFrame(OPCODE_TEXT, true, true, PerMessageDeflateFilter.deflate(payload));
+        int split = frame.length / 2;
+
+        Inbound first = PerMessageDeflateFilter.processInbound(memoryManager,
+                Optional.of(Buffers.wrap(memoryManager, slice(frame, 0, split))), state);
+        assertThat(first.passThrough()).isFalse();
+        assertThat(first.content()).isEmpty();
+
+        Inbound second = PerMessageDeflateFilter.processInbound(memoryManager,
+                Optional.of(Buffers.wrap(memoryManager, slice(frame, split, frame.length))), state);
+        assertPlainTextFrame(second.content(), payload);
+    }
+
+    @Test
+    void inboundPassesControlFrameInterleavedWithFragmentsThrough() {
+        byte[] payload = repeat("interleaved", 30);
+        byte[] compressed = PerMessageDeflateFilter.deflate(payload);
+        int split = compressed.length / 2;
+        ByteArrayOutputStream input = new ByteArrayOutputStream();
+        input.writeBytes(maskedFrame(OPCODE_TEXT, true, false, slice(compressed, 0, split)));
+        input.writeBytes(maskedFrame(OPCODE_PING, false, true, new byte[0]));
+        input.writeBytes(maskedFrame(OPCODE_CONTINUATION, false, true, slice(compressed, split, compressed.length)));
+
+        Inbound inbound = PerMessageDeflateFilter.processInbound(memoryManager,
+                Optional.of(Buffers.wrap(memoryManager, input.toByteArray())), state);
+
+        Buffer content = inbound.content().orElseThrow();
+        Frame ping = PerMessageDeflateFilter.parseFrame(content, content.position(), content.limit());
+        assertThat(ping.complete()).isTrue();
+        assertThat(ping.opcode()).isEqualTo(OPCODE_PING);
+
+        Frame text = PerMessageDeflateFilter.parseFrame(content, ping.end(), content.limit());
+        assertThat(text.complete()).isTrue();
+        assertThat(text.opcode()).isEqualTo(OPCODE_TEXT);
+        assertThat(text.rsv1()).isFalse();
+        assertThat(payloadOf(content, text)).isEqualTo(payload);
+    }
+
+    @Test
+    void inboundRejectsCompressedControlFrame() {
+        Buffer input = Buffers.wrap(memoryManager, maskedFrame(OPCODE_PING, true, true, new byte[0]));
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    @Test
+    void inboundReassemblesFrameDribbledByteByByte() {
+        byte[] payload = repeat("dribble", 30);
+        byte[] frame = maskedFrame(OPCODE_TEXT, true, true, PerMessageDeflateFilter.deflate(payload));
+
+        Inbound inbound = Inbound.nothing();
+        for (int i = 0; i < frame.length; i++) {
+            inbound = PerMessageDeflateFilter.processInbound(memoryManager,
+                    Optional.of(Buffers.wrap(memoryManager, slice(frame, i, i + 1))), state);
+            if (i < frame.length - 1) {
+                assertThat(inbound.content()).isEmpty();
+            }
+        }
+        assertPlainTextFrame(inbound.content(), payload);
+    }
+
+    @Test
+    void inboundRejectsNonMinimalLengthEncoding() {
+        byte[] header = {(byte) (0x80 | OPCODE_TEXT), 126, 0, 10};
+        Buffer input = Buffers.wrap(memoryManager, header);
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    @Test
+    void inboundRejectsOversizedFrame() {
+        byte[] header = {(byte) (0x80 | OPCODE_TEXT), (byte) (0x80 | 127),
+                0, 0, 0, 0, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        Buffer input = Buffers.wrap(memoryManager, header);
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    /**
+     * The per-frame limit does not bound a message split over several frames, so the accumulated size
+     * is what has to stop a peer from growing the buffer without end.
+     */
+    @Test
+    void inboundRejectsAMessageThatGrowsBeyondTheLimitAcrossFragments() {
+        int fragmentSize = 6 * 1024 * 1024;
+        ByteArrayOutputStream input = new ByteArrayOutputStream();
+        input.writeBytes(maskedFrame(OPCODE_TEXT, true, false, new byte[fragmentSize]));
+        input.writeBytes(maskedFrame(OPCODE_CONTINUATION, false, false, new byte[fragmentSize]));
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager,
+                Optional.of(Buffers.wrap(memoryManager, input.toByteArray())), state))
+                .isInstanceOf(PerMessageDeflateFilter.MessageTooLarge.class);
+    }
+
+    /**
+     * The zip bomb case the inflated-size limit exists for: a payload small enough to pass every other
+     * check that expands far beyond what we are willing to hold.
+     */
+    @Test
+    void inflateRejectsAPayloadThatExpandsBeyondTheLimit() {
+        byte[] bomb = PerMessageDeflateFilter.deflate(new byte[11 * 1024 * 1024]);
+        assertThat(bomb.length).isLessThan(64 * 1024);
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.inflate(bomb))
+                .isInstanceOf(PerMessageDeflateFilter.MessageTooLarge.class);
+    }
+
+    /**
+     * The frames of a compressed message are consumed here rather than forwarded, so the WebSocketFilter
+     * above never sees them and the fragmentation rules it would enforce have to be enforced here.
+     */
+    @Test
+    void inboundRejectsAContinuationWithoutAMessageToContinue() {
+        Buffer input = Buffers.wrap(memoryManager,
+                maskedFrame(OPCODE_CONTINUATION, false, true, "orphan".getBytes(StandardCharsets.UTF_8)));
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    @Test
+    void inboundRejectsANewDataFrameWhileAMessageIsStillOpen() {
+        ByteArrayOutputStream input = new ByteArrayOutputStream();
+        input.writeBytes(maskedFrame(OPCODE_TEXT, true, false, PerMessageDeflateFilter.deflate(repeat("open", 20))));
+        input.writeBytes(maskedFrame(OPCODE_TEXT, false, true, "interrupting".getBytes(StandardCharsets.UTF_8)));
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager,
+                Optional.of(Buffers.wrap(memoryManager, input.toByteArray())), state))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    /**
+     * RFC 6455 requires a client to mask. Unmasked, a compressed frame would be rebuilt as the unmasked
+     * frame the WebSocketFilter expects from us, so nothing further up could tell the two apart.
+     */
+    @Test
+    void inboundRejectsAnUnmaskedCompressedFrame() {
+        byte[] compressed = PerMessageDeflateFilter.deflate(repeat("unmasked", 20));
+        byte[] frame = PerMessageDeflateFilter.buildFrame(OPCODE_TEXT, compressed);
+        frame[0] |= RSV1;
+        Buffer input = Buffers.wrap(memoryManager, frame);
+
+        assertThatThrownBy(() -> PerMessageDeflateFilter.processInbound(memoryManager, Optional.of(input), state))
+                .isInstanceOf(ProtocolError.class);
+    }
+
+    // Helpers
+
+    private void assertPlainTextFrame(Optional<Buffer> maybeContent, byte[] expectedPayload) {
+        assertThat(maybeContent).isPresent();
+        Buffer content = maybeContent.get();
+        Frame frame = PerMessageDeflateFilter.parseFrame(content, content.position(), content.limit());
+        assertThat(frame.complete()).isTrue();
+        assertThat(frame.opcode()).isEqualTo(OPCODE_TEXT);
+        assertThat(frame.fin()).isTrue();
+        assertThat(frame.rsv1()).isFalse();
+        assertThat(payloadOf(content, frame)).isEqualTo(expectedPayload);
+    }
+
+    private static byte[] payloadOf(Buffer buffer, Frame frame) {
+        byte[] payload = new byte[frame.payloadLength()];
+        buffer.slice(frame.payloadStart(), frame.payloadStart() + frame.payloadLength()).get(payload);
+        if (frame.maskStart() >= 0) {
+            byte[] mask = new byte[4];
+            buffer.slice(frame.maskStart(), frame.maskStart() + 4).get(mask);
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] ^= mask[i % 4];
+            }
+        }
+        return payload;
+    }
+
+    /**
+     * Builds a frame as a client sends it: masked, and with RSV1 marking a compressed message.
+     */
+    private static byte[] maskedFrame(byte opcode, boolean rsv1, boolean fin, byte[] payload) {
+        byte[] plain = PerMessageDeflateFilter.buildFrame(opcode, payload);
+        int headerLength = plain.length - payload.length;
+        byte[] frame = new byte[plain.length + MASK.length];
+        System.arraycopy(plain, 0, frame, 0, headerLength);
+        if (!fin) {
+            frame[0] &= 0x7F;
+        }
+        if (rsv1) {
+            frame[0] |= RSV1;
+        }
+        frame[1] |= (byte) 0x80;
+        System.arraycopy(MASK, 0, frame, headerLength, MASK.length);
+        for (int i = 0; i < payload.length; i++) {
+            frame[headerLength + MASK.length + i] = (byte) (payload[i] ^ MASK[i % MASK.length]);
+        }
+        return frame;
+    }
+
+    private static byte[] slice(byte[] bytes, int from, int to) {
+        byte[] result = new byte[to - from];
+        System.arraycopy(bytes, from, result, 0, result.length);
+        return result;
+    }
+
+    private static byte[] repeat(String value, int times) {
+        return value.repeat(times).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateHandshakeStateTest.java
+++ b/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateHandshakeStateTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.compression;
+
+import org.glassfish.grizzly.Connection;
+import org.glassfish.grizzly.Grizzly;
+import org.glassfish.grizzly.attributes.IndexedAttributeHolder;
+import org.glassfish.grizzly.filterchain.FilterChainContext;
+import org.glassfish.grizzly.http.HttpContent;
+import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.http.HttpResponsePacket;
+import org.glassfish.grizzly.http.Protocol;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The offer belongs to the upgrade that carried it. Drives the handshake through the filter directly,
+ * because Grizzly closes a connection whose upgrade failed and an end-to-end test therefore cannot
+ * observe what the state does afterwards.
+ */
+class PerMessageDeflateHandshakeStateTest {
+    private static final String EXTENSIONS = "Sec-WebSocket-Extensions";
+
+    private final PerMessageDeflateFilter filter = new PerMessageDeflateFilter();
+    private Connection<?> connection;
+
+    @BeforeEach
+    void setUp() {
+        connection = mock(Connection.class);
+        when(connection.getAttributes()).thenReturn(new IndexedAttributeHolder(Grizzly.DEFAULT_ATTRIBUTE_BUILDER));
+    }
+
+    @Test
+    void confirmsTheExtensionForAnUpgradeThatOfferedIt() {
+        offerExtension();
+
+        assertThat(respondWith(101).getHeader(EXTENSIONS))
+                .isEqualTo("permessage-deflate; client_no_context_takeover; server_no_context_takeover");
+    }
+
+    @Test
+    void doesNotConfirmTheExtensionForAnUpgradeThatDidNotOfferIt() {
+        handshakeRequestWithout();
+
+        assertThat(respondWith(101).getHeader(EXTENSIONS)).isNull();
+    }
+
+    @Test
+    void forgetsTheOfferOfAnUpgradeThatFailed() {
+        offerExtension();
+        respondWith(400);
+
+        // The retry does not offer it, so it must not be confirmed either
+        handshakeRequestWithout();
+
+        assertThat(respondWith(101).getHeader(EXTENSIONS)).isNull();
+    }
+
+    private void offerExtension() {
+        HttpRequestPacket request = handshakeRequest();
+        request.addHeader(EXTENSIONS, "permessage-deflate");
+        filter.handleRead(contextFor(HttpContent.builder(request).build()));
+    }
+
+    private void handshakeRequestWithout() {
+        filter.handleRead(contextFor(HttpContent.builder(handshakeRequest()).build()));
+    }
+
+    private HttpResponsePacket respondWith(int status) {
+        HttpResponsePacket response = HttpResponsePacket.builder(handshakeRequest())
+                .protocol(Protocol.HTTP_1_1)
+                .status(status)
+                .build();
+        filter.handleWrite(contextFor(HttpContent.builder(response).build()));
+        return response;
+    }
+
+    private static HttpRequestPacket handshakeRequest() {
+        return HttpRequestPacket.builder()
+                .method("GET")
+                .uri("/websocket")
+                .protocol(Protocol.HTTP_1_1)
+                .header("Upgrade", "websocket")
+                .header("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .build();
+    }
+
+    private FilterChainContext contextFor(HttpContent message) {
+        FilterChainContext ctx = mock(FilterChainContext.class);
+        when(ctx.getConnection()).thenReturn(connection);
+        when(ctx.getMessage()).thenReturn(message);
+        return ctx;
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateIntegrationTest.java
+++ b/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateIntegrationTest.java
@@ -1,0 +1,522 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.compression;
+
+import org.glassfish.grizzly.filterchain.FilterChainBuilder;
+import org.glassfish.grizzly.filterchain.TransportFilter;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.NetworkListener;
+import org.glassfish.grizzly.websockets.WebSocket;
+import org.glassfish.grizzly.websockets.WebSocketAddOn;
+import org.glassfish.grizzly.websockets.WebSocketApplication;
+import org.glassfish.grizzly.websockets.WebSocketEngine;
+import org.glassfish.grizzly.websockets.WebSocketFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Drives the filter through a real Grizzly listener with a raw socket as the client, so that the parts
+ * the unit tests cannot reach are covered: where the add-on installs the filter, that the handshake
+ * response carries the negotiated extension, and that frames survive the round trip through the
+ * {@code WebSocketFilter}, which rejects anything with a reserved bit still set.
+ */
+class PerMessageDeflateIntegrationTest {
+    private static final String PATH = "/websocket-compression-test";
+    private static final String OFFER = "permessage-deflate";
+    private static final String NEGOTIATED =
+            "permessage-deflate; client_no_context_takeover; server_no_context_takeover";
+    // Long and repetitive, so that both directions are above MIN_SIZE_TO_COMPRESS and actually shrink
+    private static final String MESSAGE = "{\"topic\":\"OFFERS\",\"payload\":\"abcdefghij\"}".repeat(10);
+
+    // Asks the echo application to answer with a fragmented message instead of a single frame
+    private static final String FRAGMENT_COMMAND = "fragment-the-reply";
+
+    // A version the server does not speak, so the upgrade is refused before it can succeed
+    private static final String UNSUPPORTED_VERSION = "8";
+
+    private static final byte OPCODE_TEXT = 0x1;
+    private static final byte OPCODE_CLOSE = 0x8;
+
+    private HttpServer server;
+    private EchoApplication application;
+    private int port;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        port = findFreePort();
+        server = new HttpServer();
+        NetworkListener listener = new NetworkListener("test", "127.0.0.1", port);
+        listener.registerAddOn(new WebSocketAddOn());
+        listener.registerAddOn(new PerMessageDeflateAddOn());
+        server.addListener(listener);
+
+        application = new EchoApplication();
+        WebSocketEngine.getEngine().register("", PATH, application);
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        WebSocketEngine.getEngine().unregister(application);
+        server.shutdownNow();
+    }
+
+    @Test
+    void installsTheFilterDirectlyBelowTheWebSocketFilter() {
+        FilterChainBuilder builder = FilterChainBuilder.stateless()
+                .add(new TransportFilter())
+                .add(new WebSocketFilter());
+
+        new PerMessageDeflateAddOn().setup(null, builder);
+
+        List<Class<?>> types = builder.build().stream().map(Object::getClass).toList();
+        assertThat(types).containsExactly(TransportFilter.class, PerMessageDeflateFilter.class, WebSocketFilter.class);
+    }
+
+    @Test
+    void failsFastIfThereIsNoWebSocketFilterToInstallBelow() {
+        FilterChainBuilder builder = FilterChainBuilder.stateless().add(new TransportFilter());
+
+        assertThatThrownBy(() -> new PerMessageDeflateAddOn().setup(null, builder))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void compressesInBothDirections() throws Exception {
+        try (Client client = new Client(port)) {
+            assertThat(client.handshake(OFFER).get("sec-websocket-extensions")).isEqualTo(NEGOTIATED);
+
+            byte[] compressed = clientDeflate(MESSAGE.getBytes(StandardCharsets.UTF_8));
+            assertThat(compressed.length).isLessThan(MESSAGE.length());
+            client.send(OPCODE_TEXT, true, compressed);
+
+            Frame echo = client.read();
+            assertThat(echo.opcode()).isEqualTo(OPCODE_TEXT);
+            assertThat(echo.rsv1()).isTrue();
+            assertThat(echo.payload().length).isLessThan(MESSAGE.length());
+            assertThat(new String(clientInflate(echo.payload()), StandardCharsets.UTF_8)).isEqualTo(MESSAGE);
+        }
+    }
+
+    @Test
+    void acceptsAnUncompressedFrameOnACompressedConnection() throws Exception {
+        try (Client client = new Client(port)) {
+            client.handshake(OFFER);
+
+            client.send(OPCODE_TEXT, false, MESSAGE.getBytes(StandardCharsets.UTF_8));
+
+            assertThat(textOf(client.read())).isEqualTo(MESSAGE);
+        }
+    }
+
+    @Test
+    void reassemblesACompressedMessageSentAsFragments() throws Exception {
+        try (Client client = new Client(port)) {
+            client.handshake(OFFER);
+
+            byte[] compressed = clientDeflate(MESSAGE.getBytes(StandardCharsets.UTF_8));
+            int split = compressed.length / 2;
+            client.sendFrame(OPCODE_TEXT, true, false, Arrays.copyOfRange(compressed, 0, split));
+            client.sendFrame((byte) 0x0, false, true, Arrays.copyOfRange(compressed, split, compressed.length));
+
+            assertThat(textOf(client.read())).isEqualTo(MESSAGE);
+        }
+    }
+
+    @Test
+    void neverCompressesAFragmentedOutboundMessage() throws Exception {
+        // Several client stacks fail to inflate a compressed message split over several frames, so a
+        // fragmented reply has to go out uncompressed even on a compressed connection
+        try (Client client = new Client(port)) {
+            client.handshake(OFFER);
+
+            client.send(OPCODE_TEXT, false, FRAGMENT_COMMAND.getBytes(StandardCharsets.UTF_8));
+
+            Frame first = client.read();
+            assertThat(first.fin()).isFalse();
+            assertThat(first.rsv1()).isFalse();
+            Frame last = client.read();
+            assertThat(last.fin()).isTrue();
+            assertThat(last.rsv1()).isFalse();
+            assertThat(new String(first.payload(), StandardCharsets.UTF_8)
+                    + new String(last.payload(), StandardCharsets.UTF_8)).isEqualTo(MESSAGE);
+        }
+    }
+
+    @Test
+    void picksUpAnOfferSentOnASecondHeaderLine() throws Exception {
+        try (Client client = new Client(port)) {
+            Map<String, String> headers = client.handshake("permessage-deflate; server_max_window_bits=10", OFFER);
+
+            assertThat(headers.get("sec-websocket-extensions")).isEqualTo(NEGOTIATED);
+        }
+    }
+
+    @Test
+    void leavesTheConnectionUncompressedWhenTheClientDoesNotOffer() throws Exception {
+        try (Client client = new Client(port)) {
+            assertThat(client.handshake()).doesNotContainKey("sec-websocket-extensions");
+
+            client.send(OPCODE_TEXT, false, MESSAGE.getBytes(StandardCharsets.UTF_8));
+
+            Frame echo = client.read();
+            assertThat(echo.rsv1()).isFalse();
+            assertThat(new String(echo.payload(), StandardCharsets.UTF_8)).isEqualTo(MESSAGE);
+        }
+    }
+
+    @Test
+    void leavesTheConnectionUncompressedWhenItCannotHonourTheOffer() throws Exception {
+        try (Client client = new Client(port)) {
+            assertThat(client.handshake("permessage-deflate; server_max_window_bits=10"))
+                    .doesNotContainKey("sec-websocket-extensions");
+
+            client.send(OPCODE_TEXT, false, MESSAGE.getBytes(StandardCharsets.UTF_8));
+
+            assertThat(client.read().rsv1()).isFalse();
+        }
+    }
+
+    /**
+     * Pins why {@link PerMessageDeflateHandshakeStateTest#forgetsTheOfferOfAnUpgradeThatFailed()} has to
+     * drive the filter directly: a failed upgrade takes the connection with it, so a retry carrying no
+     * offer cannot be sent over it and the state left behind is not observable from out here. Should
+     * Grizzly ever keep the connection open, this fails and that assumption is worth revisiting.
+     */
+    @Test
+    void closesTheConnectionWhenTheUpgradeFails() throws Exception {
+        try (Client client = new Client(port)) {
+            assertThat(client.attemptFailingHandshake(PATH, OFFER)).doesNotContain("101");
+
+            assertThatThrownBy(client::handshake).isInstanceOf(IOException.class);
+        }
+    }
+
+    @Test
+    void closesWithTooBigOnAnOversizedFrame() throws Exception {
+        try (Client client = new Client(port)) {
+            client.handshake(OFFER);
+
+            // Header only: the declared length alone has to be enough to be rejected
+            client.write(new byte[]{(byte) (0x80 | OPCODE_TEXT), (byte) (0x80 | 127),
+                    0, 0, 0, 0, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+
+            Frame close = client.read();
+            assertThat(close.opcode()).isEqualTo(OPCODE_CLOSE);
+            assertThat(closeCodeOf(close)).isEqualTo(1009);
+        }
+    }
+
+    @Test
+    void closesWithAProtocolErrorOnALengthWithTheMostSignificantBitSet() throws Exception {
+        try (Client client = new Client(port)) {
+            client.handshake(OFFER);
+
+            // RFC 6455 requires the most significant bit of a 64 bit length to be 0, so this is a
+            // malformed frame rather than one that is merely larger than we accept
+            client.write(new byte[]{(byte) (0x80 | OPCODE_TEXT), (byte) (0x80 | 127),
+                    (byte) 0x80, 0, 0, 0, 0, 0, 0, 0});
+
+            Frame close = client.read();
+            assertThat(close.opcode()).isEqualTo(OPCODE_CLOSE);
+            assertThat(closeCodeOf(close)).isEqualTo(1002);
+        }
+    }
+
+    @Test
+    void closesWithAProtocolErrorOnACompressedControlFrame() throws Exception {
+        try (Client client = new Client(port)) {
+            client.handshake(OFFER);
+
+            client.send((byte) 0x9, true, new byte[0]);
+
+            Frame close = client.read();
+            assertThat(close.opcode()).isEqualTo(OPCODE_CLOSE);
+            assertThat(closeCodeOf(close)).isEqualTo(1002);
+        }
+    }
+
+    // Server
+
+    private static class EchoApplication extends WebSocketApplication {
+        @Override
+        public void onMessage(WebSocket socket, String text) {
+            if (FRAGMENT_COMMAND.equals(text)) {
+                int half = MESSAGE.length() / 2;
+                socket.stream(false, MESSAGE.substring(0, half));
+                socket.stream(true, MESSAGE.substring(half));
+            } else {
+                socket.send(text);
+            }
+        }
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static String textOf(Frame frame) throws Exception {
+        byte[] payload = frame.rsv1() ? clientInflate(frame.payload()) : frame.payload();
+        return new String(payload, StandardCharsets.UTF_8);
+    }
+
+    private static int closeCodeOf(Frame frame) {
+        return (frame.payload()[0] & 0xFF) << 8 | frame.payload()[1] & 0xFF;
+    }
+
+    // Client
+    //
+    // Deliberately does not reuse the filter's own codec, so that the round trip is verified against an
+    // independent implementation of RFC 7692 rather than against itself.
+
+    private record Frame(byte opcode, boolean rsv1, boolean fin, byte[] payload) {
+    }
+
+    private static byte[] clientDeflate(byte[] payload) {
+        Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        try {
+            deflater.setInput(payload);
+            deflater.finish();
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] chunk = new byte[1024];
+            while (!deflater.finished()) {
+                out.write(chunk, 0, deflater.deflate(chunk));
+            }
+            // A finished raw deflate stream ends with a final block, which the peer's inflater accepts
+            // as it is, so there is no tail to strip here.
+            return out.toByteArray();
+        } finally {
+            deflater.end();
+        }
+    }
+
+    private static byte[] clientInflate(byte[] compressed) throws Exception {
+        Inflater inflater = new Inflater(true);
+        try {
+            byte[] withTail = Arrays.copyOf(compressed, compressed.length + 4);
+            withTail[compressed.length + 2] = (byte) 0xFF;
+            withTail[compressed.length + 3] = (byte) 0xFF;
+            inflater.setInput(withTail);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] chunk = new byte[1024];
+            int count;
+            while ((count = inflater.inflate(chunk)) > 0) {
+                out.write(chunk, 0, count);
+            }
+            return out.toByteArray();
+        } finally {
+            inflater.end();
+        }
+    }
+
+    private static class Client implements AutoCloseable {
+        private final Socket socket;
+        private final InputStream in;
+        private final OutputStream out;
+        private final SecureRandom random = new SecureRandom();
+
+        Client(int port) throws IOException {
+            socket = new Socket();
+            socket.connect(new InetSocketAddress("127.0.0.1", port), 5000);
+            socket.setSoTimeout(10000);
+            in = socket.getInputStream();
+            out = socket.getOutputStream();
+        }
+
+        Map<String, String> handshake(String... extensionOffers) throws IOException {
+            write(handshakeRequest(PATH, extensionOffers));
+            List<String> lines = readHeaderLines();
+            String statusLine = lines.remove(0);
+            if (!statusLine.contains("101")) {
+                throw new IOException("Handshake failed: " + statusLine);
+            }
+            return parseHeaders(lines);
+        }
+
+        /**
+         * Sends an upgrade request that cannot succeed, by naming a protocol version the server does
+         * not speak.
+         *
+         * @return the status line of the response.
+         */
+        String attemptFailingHandshake(String path, String... extensionOffers) throws IOException {
+            write(handshakeRequest(path, UNSUPPORTED_VERSION, extensionOffers));
+            List<String> lines = readHeaderLines();
+            String statusLine = lines.remove(0);
+            drainBody(parseHeaders(lines));
+            return statusLine;
+        }
+
+        private byte[] handshakeRequest(String path, String... extensionOffers) {
+            return handshakeRequest(path, "13", extensionOffers);
+        }
+
+        private byte[] handshakeRequest(String path, String version, String... extensionOffers) {
+            byte[] key = new byte[16];
+            random.nextBytes(key);
+            StringBuilder request = new StringBuilder()
+                    .append("GET ").append(path).append(" HTTP/1.1\r\n")
+                    .append("Host: 127.0.0.1\r\n")
+                    .append("Upgrade: websocket\r\n")
+                    .append("Connection: Upgrade\r\n")
+                    .append("Sec-WebSocket-Version: ").append(version).append("\r\n")
+                    .append("Sec-WebSocket-Key: ").append(Base64.getEncoder().encodeToString(key)).append("\r\n");
+            for (String offer : extensionOffers) {
+                request.append("Sec-WebSocket-Extensions: ").append(offer).append("\r\n");
+            }
+            return request.append("\r\n").toString().getBytes(StandardCharsets.US_ASCII);
+        }
+
+        private List<String> readHeaderLines() throws IOException {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            while (!endsWithBlankLine(buffer.toByteArray())) {
+                buffer.write(readByte());
+            }
+            return new ArrayList<>(Arrays.asList(buffer.toString(StandardCharsets.US_ASCII).split("\r\n")));
+        }
+
+        private Map<String, String> parseHeaders(List<String> lines) {
+            Map<String, String> headers = new HashMap<>();
+            for (String line : lines) {
+                int separator = line.indexOf(':');
+                if (separator > 0) {
+                    headers.put(line.substring(0, separator).trim().toLowerCase(Locale.ROOT),
+                            line.substring(separator + 1).trim());
+                }
+            }
+            return headers;
+        }
+
+        /**
+         * Reads the error body away, so that it is not mistaken for the start of the next response.
+         */
+        private void drainBody(Map<String, String> headers) throws IOException {
+            int length = Integer.parseInt(headers.getOrDefault("content-length", "0"));
+            for (int i = 0; i < length; i++) {
+                readByte();
+            }
+        }
+
+        private static boolean endsWithBlankLine(byte[] bytes) {
+            int length = bytes.length;
+            return length >= 4 && bytes[length - 4] == '\r' && bytes[length - 3] == '\n'
+                    && bytes[length - 2] == '\r' && bytes[length - 1] == '\n';
+        }
+
+        void send(byte opcode, boolean rsv1, byte[] payload) throws IOException {
+            sendFrame(opcode, rsv1, true, payload);
+        }
+
+        void sendFrame(byte opcode, boolean rsv1, boolean fin, byte[] payload) throws IOException {
+            ByteArrayOutputStream frame = new ByteArrayOutputStream();
+            frame.write((fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode);
+            if (payload.length <= 125) {
+                frame.write(0x80 | payload.length);
+            } else {
+                frame.write(0x80 | 126);
+                frame.write(payload.length >>> 8);
+                frame.write(payload.length);
+            }
+            byte[] mask = new byte[4];
+            random.nextBytes(mask);
+            frame.write(mask, 0, mask.length);
+            for (int i = 0; i < payload.length; i++) {
+                frame.write(payload[i] ^ mask[i % 4]);
+            }
+            write(frame.toByteArray());
+        }
+
+        Frame read() throws IOException {
+            int firstByte = readByte();
+            int secondByte = readByte();
+            boolean fin = (firstByte & 0x80) != 0;
+            boolean rsv1 = (firstByte & 0x40) != 0;
+            byte opcode = (byte) (firstByte & 0x0F);
+            boolean masked = (secondByte & 0x80) != 0;
+            int length = secondByte & 0x7F;
+            if (length == 126) {
+                length = readByte() << 8 | readByte();
+            } else if (length == 127) {
+                long extended = 0;
+                for (int i = 0; i < 8; i++) {
+                    extended = extended << 8 | readByte();
+                }
+                length = (int) extended;
+            }
+            byte[] mask = masked ? readBytes(4) : null;
+            byte[] payload = readBytes(length);
+            if (mask != null) {
+                for (int i = 0; i < payload.length; i++) {
+                    payload[i] ^= mask[i % 4];
+                }
+            }
+            return new Frame(opcode, rsv1, fin, payload);
+        }
+
+        void write(byte[] bytes) throws IOException {
+            out.write(bytes);
+            out.flush();
+        }
+
+        private int readByte() throws IOException {
+            int value = in.read();
+            if (value < 0) {
+                throw new IOException("Connection closed by the server");
+            }
+            return value;
+        }
+
+        private byte[] readBytes(int count) throws IOException {
+            byte[] bytes = new byte[count];
+            for (int i = 0; i < count; i++) {
+                bytes[i] = (byte) readByte();
+            }
+            return bytes;
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+        }
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/rest_api_proxy/ClientSuppliedCredentialsTest.java
+++ b/api/src/test/java/bisq/api/web_socket/rest_api_proxy/ClientSuppliedCredentialsTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.rest_api_proxy;
+
+import bisq.api.web_socket.util.JsonUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Clients released before the node derived the request identity from the WebSocket handshake still put
+ * their session id into every message. The node ignores it, and must additionally make sure it neither
+ * travels any further into the request it forwards nor ends up readable in a log file.
+ */
+class ClientSuppliedCredentialsTest {
+    private static final String SESSION_ID = "session-id-value";
+
+    private static String requestJson(String headers) {
+        return "{\"type\":\"WebSocketRestApiRequest\","
+                + "\"requestId\":\"request-id\",\"method\":\"GET\",\"path\":\"/api/v1/settings/version\","
+                + "\"body\":\"\",\"headers\":" + headers + "}";
+    }
+
+    @Test
+    void credentialsAreStrippedFromTheRequest() {
+        WebSocketRestApiRequest request = parse(requestJson(
+                "{\"Bisq-Session-Id\":\"" + SESSION_ID + "\",\"Bisq-Client-Id\":\"client-id\"}"));
+
+        request.clearHeaders();
+
+        // Emptied rather than nulled, so the generated getter stays safe for anything added later
+        assertThat(request.getHeaders()).isEmpty();
+    }
+
+    @Test
+    void strippingCopesWithAMessageThatCarriesNoHeaders() {
+        WebSocketRestApiRequest withoutHeaders = parse(requestJson("null"));
+
+        withoutHeaders.clearHeaders();
+
+        assertThat(withoutHeaders.getHeaders()).isEmpty();
+    }
+
+    @Test
+    void strippedRequestCannotLeakTheSessionIdThroughToString() {
+        WebSocketRestApiRequest request = parse(requestJson("{\"Bisq-Session-Id\":\"" + SESSION_ID + "\"}"));
+        assertThat(request.toString()).contains(SESSION_ID);
+
+        request.clearHeaders();
+
+        assertThat(request.toString()).doesNotContain(SESSION_ID);
+    }
+
+    @Test
+    void rawMessagesAreRedactedBeforeLogging() {
+        String json = requestJson("{\"Bisq-Session-Id\":\"" + SESSION_ID + "\",\"Bisq-Client-Id\":\"client-id\"}");
+
+        String redacted = JsonUtil.redactCredentials(json);
+
+        assertThat(redacted).doesNotContain(SESSION_ID);
+        assertThat(redacted).contains("\"Bisq-Session-Id\":\"***\"");
+        // The client id is an identifier the node logs elsewhere; keeping it is what makes the line useful
+        assertThat(redacted).contains("client-id");
+        assertThat(redacted).contains("/api/v1/settings/version");
+    }
+
+    @Test
+    void redactionCopesWithFormattingAndCasing() {
+        assertThat(JsonUtil.redactCredentials("{\"bisq-session-id\" : \"" + SESSION_ID + "\"}"))
+                .doesNotContain(SESSION_ID);
+        assertThat(JsonUtil.redactCredentials("{\"Bisq-Session-Id\":\"\"}")).isEqualTo("{\"Bisq-Session-Id\":\"***\"}");
+        assertThat(JsonUtil.redactCredentials("no json at all")).isEqualTo("no json at all");
+    }
+
+    /**
+     * The shared mapper has FAIL_ON_UNKNOWN_PROPERTIES enabled, so the field cannot simply be deleted
+     * once clients stop sending credentials: a message of an already released client would then fail to
+     * parse and be dropped without any response, leaving the client waiting for a reply that never comes.
+     * Removing it has to wait until no released client sends the property at all.
+     */
+    @Test
+    void theHeadersFieldCannotBeRemovedWhileClientsStillSendIt() {
+        assertThat(WebSocketRestApiRequest.fromJson(requestJson("{\"Bisq-Session-Id\":\"" + SESSION_ID + "\"}")))
+                .isPresent();
+        assertThat(WebSocketRestApiRequest.fromJson("{\"type\":\"WebSocketRestApiRequest\","
+                + "\"requestId\":\"request-id\",\"method\":\"GET\",\"path\":\"/p\",\"body\":\"\","
+                + "\"aPropertyThisNodeDoesNotKnow\":1}"))
+                .isEmpty();
+    }
+
+    private static WebSocketRestApiRequest parse(String json) {
+        Optional<WebSocketRestApiRequest> request = WebSocketRestApiRequest.fromJson(json);
+        assertThat(request).isPresent();
+        return request.get();
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.rest_api_proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WebSocketRestApiServiceTest {
+    private static final String REST_SERVER_URL = "https://127.0.0.1:8090";
+
+    @Test
+    void resolvesPathAgainstTheRestApi() throws Exception {
+        assertThat(WebSocketRestApiService.resolveRestApiUri(REST_SERVER_URL, "/api/v1/settings/version"))
+                .hasToString("https://127.0.0.1:8090/api/v1/settings/version");
+    }
+
+    @Test
+    void keepsTheQuery() throws Exception {
+        assertThat(WebSocketRestApiService.resolveRestApiUri(REST_SERVER_URL, "/api/v1/offers?market=BTC-EUR"))
+                .hasToString("https://127.0.0.1:8090/api/v1/offers?market=BTC-EUR");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Turns the configured host into user info, so the request would go to the other host
+            "@evil.example.com/api/v1/user",
+            "@evil.example.com:443/api/v1/user",
+            "//evil.example.com/api/v1/user",
+            // Traversal the server would resolve only after we checked where the request goes
+            "/api/v1/%2e%2e/%2e%2e/doc/v1/",
+            // Not server absolute, so it would resolve against the port instead of the path
+            "api/v1/user",
+    })
+    void rejectsPathNotAddressingTheRestServer(String path) {
+        assertThatThrownBy(() -> WebSocketRestApiService.resolveRestApiUri(REST_SERVER_URL, path))
+                .isInstanceOf(Exception.class);
+    }
+
+    /**
+     * The literal form normalizes to a plain path with the host unchanged, so the target check passes it
+     * and the URI validator finds nothing left to object to. Only the base path check refuses it, which
+     * is what this pins: the encoded form above is caught earlier and the two must not drift apart.
+     */
+    @Test
+    void rejectsLiteralTraversalOutOfTheRestApi() {
+        assertThatThrownBy(() -> WebSocketRestApiService.resolveRestApiUri(REST_SERVER_URL, "/api/v1/../../doc/v1/"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void rejectsMissingPath(String path) {
+        assertThatThrownBy(() -> WebSocketRestApiService.resolveRestApiUri(REST_SERVER_URL, path))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void bracketsAnIpV6BindHost() {
+        assertThat(WebSocketRestApiService.toUriHost("::1")).isEqualTo("[::1]");
+        assertThat(WebSocketRestApiService.toUriHost("[::1]")).isEqualTo("[::1]");
+        assertThat(WebSocketRestApiService.toUriHost("127.0.0.1")).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    void resolvesPathAgainstAnIpV6RestApi() throws Exception {
+        assertThat(WebSocketRestApiService.resolveRestApiUri("https://[::1]:8090", "/api/v1/settings/version"))
+                .hasToString("https://[::1]:8090/api/v1/settings/version");
+    }
+}

--- a/apps/api-app/src/main/resources/api_app.conf
+++ b/apps/api-app/src/main/resources/api_app.conf
@@ -29,6 +29,8 @@ application {
         server={
             restEnabled=false
             websocketEnabled=true
+            # RFC 7692 permessage-deflate. Negotiated only if the client offers it.
+            websocketCompressionEnabled=true
             # grpcEnabled=false
 
             bind={

--- a/apps/desktop/desktop-app/src/main/resources/desktop.conf
+++ b/apps/desktop/desktop-app/src/main/resources/desktop.conf
@@ -29,6 +29,8 @@ application {
         server={
             restEnabled=false
             websocketEnabled=false
+            # RFC 7692 permessage-deflate. Negotiated only if the client offers it.
+            websocketCompressionEnabled=true
             # grpcEnabled=false
 
             bind={

--- a/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
+++ b/apps/node-monitor-web-app/src/main/resources/node_monitor.conf
@@ -29,6 +29,8 @@ application {
         server={
             restEnabled=true
             websocketEnabled=false
+            # RFC 7692 permessage-deflate. Negotiated only if the client offers it.
+            websocketCompressionEnabled=true
             # grpcEnabled=false
 
             bind={

--- a/apps/oracle-node-app/src/main/resources/oracle_node.conf
+++ b/apps/oracle-node-app/src/main/resources/oracle_node.conf
@@ -29,6 +29,8 @@ application {
         server={
             restEnabled=false
             websocketEnabled=false
+            # RFC 7692 permessage-deflate. Negotiated only if the client offers it.
+            websocketCompressionEnabled=true
             # grpcEnabled=false
 
             bind={

--- a/apps/seed-node-app/src/main/resources/seed_node.conf
+++ b/apps/seed-node-app/src/main/resources/seed_node.conf
@@ -29,6 +29,8 @@ application {
         server={
             restEnabled=false
             websocketEnabled=false
+            # RFC 7692 permessage-deflate. Negotiated only if the client offers it.
+            websocketCompressionEnabled=true
             # grpcEnabled=false
 
             bind={


### PR DESCRIPTION
Automated sync of #4903 from `for-mobile-based-on-2.1.11` to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket message compression using the permessage-deflate standard.
  * Enabled compression across API and node applications when supported by the client.
  * Improved REST request validation, including protection against traversal and host-escape paths.
  * Added IPv6-compatible REST endpoint handling.

* **Security**
  * Redacted session credentials from logs.
  * Prevented client-supplied credentials and headers from being forwarded in REST requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->