### PR TITLE
Update NETWORK_INFO on seed node role changes

### DIFF
--- a/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketService.java
@@ -26,6 +26,9 @@ import bisq.api.web_socket.subscription.Subscriber;
 import bisq.api.web_socket.subscription.SubscriberRepository;
 import bisq.api.web_socket.subscription.SubscriptionRequest;
 import bisq.api.web_socket.subscription.Topic;
+import bisq.bonded_roles.BondedRoleType;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRole;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
 import bisq.common.network.Address;
 import bisq.common.network.TransportType;
 import bisq.common.observable.Pin;
@@ -38,6 +41,7 @@ import bisq.network.p2p.node.CloseReason;
 import bisq.network.p2p.node.Connection;
 import bisq.network.p2p.node.Node;
 import bisq.network.p2p.services.data.inventory.InventoryService;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
 import bisq.network.p2p.services.peer_group.PeerGroupManager;
 import bisq.network.p2p.services.peer_group.PeerGroupService;
 import lombok.extern.slf4j.Slf4j;
@@ -65,15 +69,31 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
     private static final List<TransportType> TRANSPORT_PRIORITY = List.of(TransportType.TOR, TransportType.I2P, TransportType.CLEAR);
 
     private final NetworkService networkService;
+    private final AuthorizedBondedRolesService authorizedBondedRolesService;
     private final Node.Listener nodeListener;
+    private final AuthorizedBondedRolesService.Listener bondedRolesListener;
     private final Set<Pin> pins = new CopyOnWriteArraySet<>();
     @Nullable
     private volatile ServiceNode observedServiceNode;
 
     public NetworkInfoWebSocketService(SubscriberRepository subscriberRepository,
-                                       NetworkService networkService) {
+                                       NetworkService networkService,
+                                       AuthorizedBondedRolesService authorizedBondedRolesService) {
         super(subscriberRepository, Topic.NETWORK_INFO);
         this.networkService = networkService;
+        this.authorizedBondedRolesService = authorizedBondedRolesService;
+
+        bondedRolesListener = new AuthorizedBondedRolesService.Listener() {
+            @Override
+            public void onAuthorizedDataAdded(AuthorizedData authorizedData) {
+                onSeedRoleChanged(authorizedData);
+            }
+
+            @Override
+            public void onAuthorizedDataRemoved(AuthorizedData authorizedData) {
+                onSeedRoleChanged(authorizedData);
+            }
+        };
 
         nodeListener = new Node.Listener() {
             @Override
@@ -106,6 +126,8 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
 
     @Override
     public CompletableFuture<Boolean> initialize() {
+        authorizedBondedRolesService.addListener(bondedRolesListener);
+
         findPrimaryServiceNode().ifPresent(serviceNode -> {
             observedServiceNode = serviceNode;
             serviceNode.getDefaultNode().addListener(nodeListener);
@@ -120,6 +142,8 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
 
     @Override
     public CompletableFuture<Boolean> shutdown() {
+        authorizedBondedRolesService.removeListener(bondedRolesListener);
+
         ServiceNode serviceNode = observedServiceNode;
         if (serviceNode != null) {
             serviceNode.getDefaultNode().removeListener(nodeListener);
@@ -146,6 +170,16 @@ public class NetworkInfoWebSocketService extends BaseWebSocketService {
             send(subscribers, getJsonPayload(), topic, ModificationType.REPLACE);
         } catch (Exception e) {
             log.error("Failed to send network info update", e);
+        }
+    }
+
+    // Adding or removing a seed node bonded role mutates the seed set of the PeerGroupService, which reclassifies
+    // already established connections. AuthorizedBondedRolesService applies that change to the NetworkService before
+    // it notifies its listeners, so the payload we build here already reflects the new classification.
+    private void onSeedRoleChanged(AuthorizedData authorizedData) {
+        if (authorizedData.getAuthorizedDistributedData() instanceof AuthorizedBondedRole authorizedBondedRole
+                && authorizedBondedRole.getBondedRoleType() == BondedRoleType.SEED_NODE) {
+            onChange();
         }
     }
 

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
@@ -88,7 +88,9 @@ public class SubscriptionService implements Service {
         numUserProfilesWebSocketService = new NumUserProfilesWebSocketService(subscriberRepository, userService);
         tradeRestrictingAlertWebSocketService = new TradeRestrictingAlertWebSocketService(subscriberRepository, bondedRolesService.getAlertService());
         alertNotificationsWebSocketService = new AlertNotificationsWebSocketService(subscriberRepository, alertNotificationsService);
-        networkInfoWebSocketService = new NetworkInfoWebSocketService(subscriberRepository, networkService);
+        networkInfoWebSocketService = new NetworkInfoWebSocketService(subscriberRepository,
+                networkService,
+                bondedRolesService.getAuthorizedBondedRolesService());
     }
 
     @Override

--- a/api/src/test/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/domain/network/NetworkInfoWebSocketServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.domain.network;
+
+import bisq.api.web_socket.subscription.SubscriberRepository;
+import bisq.api.web_socket.subscription.SubscriptionRequest;
+import bisq.bonded_roles.BondedRoleType;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRole;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
+import bisq.common.network.TransportType;
+import bisq.network.NetworkService;
+import bisq.network.p2p.services.data.storage.auth.authorized.AuthorizedData;
+import org.glassfish.grizzly.impl.ReadyFutureImpl;
+import org.glassfish.grizzly.websockets.WebSocket;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NetworkInfoWebSocketServiceTest {
+
+    @Test
+    void seedRoleChangeIsPushedToSubscribers() {
+        SubscriberRepository subscriberRepository = new SubscriberRepository();
+        AuthorizedBondedRolesService authorizedBondedRolesService = mock(AuthorizedBondedRolesService.class);
+        NetworkInfoWebSocketService service = new NetworkInfoWebSocketService(subscriberRepository,
+                networkService(),
+                authorizedBondedRolesService);
+
+        service.initialize().join();
+
+        ArgumentCaptor<AuthorizedBondedRolesService.Listener> listenerCaptor =
+                ArgumentCaptor.forClass(AuthorizedBondedRolesService.Listener.class);
+        verify(authorizedBondedRolesService).addListener(listenerCaptor.capture());
+        AuthorizedBondedRolesService.Listener listener = listenerCaptor.getValue();
+
+        WebSocket webSocket = subscribe(subscriberRepository);
+
+        // Authorized data which is not a seed node role must not trigger an update
+        listener.onAuthorizedDataAdded(authorizedBondedRoleData(BondedRoleType.MEDIATOR));
+        verify(webSocket, never()).send(anyString());
+
+        // Adding and removing a seed node role reclassifies existing connections, so both must trigger an update.
+        // Subscriber.send dispatches to its own executor, so we await the sends instead of verifying immediately.
+        listener.onAuthorizedDataAdded(authorizedBondedRoleData(BondedRoleType.SEED_NODE));
+        listener.onAuthorizedDataRemoved(authorizedBondedRoleData(BondedRoleType.SEED_NODE));
+        verify(webSocket, timeout(1000).times(2)).send(anyString());
+
+        service.shutdown().join();
+        verify(authorizedBondedRolesService).removeListener(listener);
+    }
+
+    private NetworkService networkService() {
+        NetworkService networkService = mock(NetworkService.class);
+        when(networkService.getSupportedTransportTypes()).thenReturn(Set.of());
+        when(networkService.findDefaultNode(any(TransportType.class))).thenReturn(Optional.empty());
+        return networkService;
+    }
+
+    private WebSocket subscribe(SubscriberRepository subscriberRepository) {
+        WebSocket webSocket = mock(WebSocket.class, RETURNS_DEEP_STUBS);
+        doAnswer(invocation -> ReadyFutureImpl.create(null)).when(webSocket).send(anyString());
+        String requestJson = "{\"type\":\"SubscriptionRequest\",\"requestId\":\"request-1\",\"topic\":\"NETWORK_INFO\"}";
+        subscriberRepository.add(SubscriptionRequest.fromJson(requestJson).orElseThrow(), Optional.empty(), webSocket);
+        return webSocket;
+    }
+
+    private AuthorizedData authorizedBondedRoleData(BondedRoleType bondedRoleType) {
+        AuthorizedBondedRole authorizedBondedRole = mock(AuthorizedBondedRole.class);
+        when(authorizedBondedRole.getBondedRoleType()).thenReturn(bondedRoleType);
+        AuthorizedData authorizedData = mock(AuthorizedData.class);
+        when(authorizedData.getAuthorizedDistributedData()).thenReturn(authorizedBondedRole);
+        return authorizedData;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network information subscriptions now update automatically when seed-node authorization changes.
  * Unrelated bonded-role changes no longer trigger unnecessary updates.
  * Subscription listeners are cleanly removed when the service shuts down.

* **Tests**
  * Added coverage for seed-node role additions, removals, ignored role changes, and listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->