### PR TITLE
chore/fix_failing_api_test

### DIFF
--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -48,6 +48,7 @@ import bisq.api.rest_api.endpoints.trades.TradeRestApi;
 import bisq.api.rest_api.endpoints.user_identity.UserIdentityRestApi;
 import bisq.api.rest_api.endpoints.user_profile.UserProfileRestApi;
 import bisq.api.web_socket.WebSocketService;
+import bisq.api.web_socket.domain.ClosedTradeItemsService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.bisq_easy.BisqEasyService;
 import bisq.bonded_roles.BondedRolesService;
@@ -132,6 +133,7 @@ public class ApiService implements Service {
                       SettingsService settingsService,
                       BisqEasyService bisqEasyService,
                       OpenTradeItemsService openTradeItemsService,
+                      ClosedTradeItemsService closedTradeItemsService,
                       AccountService accountService,
                       ReputationService reputationService,
                       DeviceRegistrationService deviceRegistrationService) {
@@ -165,7 +167,8 @@ public class ApiService implements Service {
                 bondedRolesService.getMarketPriceService(),
                 userService,
                 supportedService,
-                tradeService);
+                tradeService,
+                closedTradeItemsService);
         TradeChatMessagesRestApi tradeChatMessagesRestApi = new TradeChatMessagesRestApi(chatService, userService);
         UserIdentityRestApi userIdentityRestApi = new UserIdentityRestApi(securityService, userService.getUserIdentityService(), bisqEasyService);
         MarketPriceRestApi marketPriceRestApi = new MarketPriceRestApi(bondedRolesService.getMarketPriceService());

--- a/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeIndexedItem.java
+++ b/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeIndexedItem.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.dto.presentation.closed_trades;
+
+// Server-only carrier wrapping the wire DTO with denormalized fields used purely for
+// in-memory filtering and sorting in the closed trades endpoint. Not serialized to clients;
+// transient strings stay on the server while only the slim dto is broadcast.
+//
+// Formatted strings (price/amounts) are cached here because BisqEasyTradeFormatter
+// allocates Monetary objects and applies locale-aware formatting on every call; doing that
+// per search keystroke across the full closed-trade history would be wasteful.
+//
+// Caveat: cached formatted strings are frozen at creation time. If the user changes the app
+// language at runtime, existing items keep the old locale's formatting until the trade is
+// re-added (e.g. on restart). Acceptable for now since these strings drive server-side
+// filter/sort only and are not sent to the client.
+public record ClosedTradeIndexedItem(
+        ClosedTradeListItemDto dto,
+        String market,
+        String directionalTitle,
+        String formattedMyRole,
+        String formattedPrice,
+        String formattedBaseAmount,
+        String formattedQuoteAmount,
+        String bitcoinSettlementMethodDisplayString,
+        String fiatPaymentMethodDisplayString
+) {
+}

--- a/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeListItemDto.java
+++ b/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeListItemDto.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.dto.presentation.closed_trades;
+
+import bisq.api.dto.common.monetary.PriceQuoteDto;
+import bisq.api.dto.trade.TradeRoleDto;
+import bisq.api.dto.trade.bisq_easy.protocol.BisqEasyTradeStateDto;
+import bisq.api.dto.user.profile.UserProfileDto;
+import bisq.api.dto.user.reputation.ReputationScoreDto;
+
+import java.util.Optional;
+
+// Slim wire DTO for the closed trades paginated endpoint.
+// Drops fields derivable on the client: market (use priceQuote.market), directionalTitle,
+// formattedDate/formattedTime (derive from contract.takeOfferDate), formattedMyRole and
+// isBuyer (derive from trade.tradeRole), isOnChainSettlement (compare bitcoinSettlementMethod
+// to "MAIN_CHAIN"), formattedPriceSpec (clients can format from the offer's price spec
+// fetched separately if a price-spec suffix is needed in the UI), and payment-method display
+// strings (client owns i18n; resolves from the paymentMethodName). Maker/taker user profiles
+// and the peer reputation score are kept as full DTOs so the client can render the catHash
+// avatar and StarRating without a follow-up lookup.
+public record ClosedTradeListItemDto(
+        TradeSlimDto trade,
+        UserProfileDto makerUserProfile,
+        UserProfileDto takerUserProfile,
+        Optional<UserProfileDto> mediatorUserProfile,
+        PriceQuoteDto priceQuote,
+        long baseAmount,
+        long quoteAmount,
+        String bitcoinSettlementMethod,
+        String fiatPaymentMethod,
+        ReputationScoreDto peersReputationScore,
+        Optional<String> paymentAccountData,
+        Optional<String> bitcoinPaymentData,
+        Optional<String> paymentProof,
+        Optional<Long> tradeCompletedDate
+) {
+    public record TradeSlimDto(
+            String id,
+            TradeRoleDto tradeRole,
+            BisqEasyTradeStateDto tradeState,
+            ContractSlimDto contract
+    ) {
+    }
+
+    public record ContractSlimDto(long takeOfferDate) {
+    }
+}

--- a/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeListItemDtoFactory.java
+++ b/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeListItemDtoFactory.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.dto.presentation.closed_trades;
+
+import bisq.api.dto.DtoMappings;
+import bisq.api.dto.common.monetary.PriceQuoteDto;
+import bisq.api.dto.trade.TradeRoleDto;
+import bisq.api.dto.trade.bisq_easy.protocol.BisqEasyTradeStateDto;
+import bisq.api.dto.user.profile.UserProfileDto;
+import bisq.api.dto.user.reputation.ReputationScoreDto;
+import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.trade.bisq_easy.BisqEasyTrade;
+import bisq.trade.bisq_easy.BisqEasyTradeFormatter;
+import bisq.trade.bisq_easy.protocol.BisqEasyClosedTrade;
+import bisq.user.profile.UserProfile;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+
+import java.util.Optional;
+
+public final class ClosedTradeListItemDtoFactory {
+    private ClosedTradeListItemDtoFactory() {
+    }
+
+    public static ClosedTradeIndexedItem create(BisqEasyClosedTrade closedTrade,
+                                                ReputationService reputationService) {
+        BisqEasyTrade trade = closedTrade.trade();
+        BisqEasyContract contract = trade.getContract();
+        UserProfile myUserProfile = closedTrade.myUserProfile();
+        UserProfile peersUserProfile = closedTrade.peerUserProfile();
+
+        TradeRoleDto tradeRoleDto = DtoMappings.TradeRoleMapping.fromBisq2Model(trade.getTradeRole());
+        BisqEasyTradeStateDto tradeStateDto = DtoMappings.BisqEasyTradeStateMapping.fromBisq2Model(trade.getTradeState());
+
+        UserProfileDto myUserProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(myUserProfile);
+        UserProfileDto peersUserProfileDto = DtoMappings.UserProfileMapping.fromBisq2Model(peersUserProfile);
+        UserProfileDto makerUserProfile = trade.isMaker() ? myUserProfileDto : peersUserProfileDto;
+        UserProfileDto takerUserProfile = trade.isMaker() ? peersUserProfileDto : myUserProfileDto;
+        Optional<UserProfileDto> mediatorUserProfile = contract.getMediator()
+                .map(DtoMappings.UserProfileMapping::fromBisq2Model);
+
+        PriceQuoteDto priceQuoteDto = DtoMappings.PriceQuoteMapping.fromBisq2Model(trade.getPriceQuote());
+
+        String bitcoinSettlementMethod = contract.getBaseSidePaymentMethodSpec().getPaymentMethodName();
+        String fiatPaymentMethod = contract.getQuoteSidePaymentMethodSpec().getPaymentMethodName();
+
+        ReputationScore peersReputationScore = reputationService.getReputationScore(peersUserProfile.getId());
+        ReputationScoreDto peersReputationScoreDto = DtoMappings.ReputationScoreMapping.fromBisq2Model(peersReputationScore);
+
+        ClosedTradeListItemDto dto = new ClosedTradeListItemDto(
+                new ClosedTradeListItemDto.TradeSlimDto(
+                        trade.getId(),
+                        tradeRoleDto,
+                        tradeStateDto,
+                        new ClosedTradeListItemDto.ContractSlimDto(contract.getTakeOfferDate())
+                ),
+                makerUserProfile,
+                takerUserProfile,
+                mediatorUserProfile,
+                priceQuoteDto,
+                contract.getBaseSideAmount(),
+                contract.getQuoteSideAmount(),
+                bitcoinSettlementMethod,
+                fiatPaymentMethod,
+                peersReputationScoreDto,
+                Optional.ofNullable(trade.getPaymentAccountData().get()),
+                Optional.ofNullable(trade.getBitcoinPaymentData().get()),
+                Optional.ofNullable(trade.getPaymentProof().get()),
+                trade.getTradeCompletedDate()
+        );
+
+        String market = trade.getOffer().getMarket().toString();
+        String directionalTitle = BisqEasyTradeFormatter.getDirectionalTitle(trade);
+        String formattedMyRole = BisqEasyTradeFormatter.getMakerTakerRole(trade);
+        String formattedPrice = BisqEasyTradeFormatter.formatPriceWithCode(trade);
+        String formattedBaseAmount = BisqEasyTradeFormatter.formatBaseSideAmount(trade);
+        String formattedQuoteAmount = BisqEasyTradeFormatter.formatQuoteSideAmount(trade);
+        String bitcoinSettlementMethodDisplayString = contract.getBaseSidePaymentMethodSpec().getShortDisplayString();
+        String fiatPaymentMethodDisplayString = contract.getQuoteSidePaymentMethodSpec().getShortDisplayString();
+
+        return new ClosedTradeIndexedItem(
+                dto,
+                market,
+                directionalTitle,
+                formattedMyRole,
+                formattedPrice,
+                formattedBaseAmount,
+                formattedQuoteAmount,
+                bitcoinSettlementMethodDisplayString,
+                fiatPaymentMethodDisplayString);
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/endpoints/RestApiBase.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/RestApiBase.java
@@ -17,9 +17,13 @@
 
 package bisq.api.rest_api.endpoints;
 
+import bisq.api.rest_api.pagination.PaginatedResponse;
+import bisq.api.rest_api.pagination.PaginationParams;
 import jakarta.ws.rs.core.Response;
 
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public abstract class RestApiBase {
     protected Response buildResponse(Response.Status status, Object entity) {
@@ -65,5 +69,23 @@ public abstract class RestApiBase {
         return Response.status(status)
                 .entity(Map.of("error", errorMessage))
                 .build();
+    }
+
+    protected <T> Response buildPaginatedResponse(List<T> items, PaginationParams pagination) {
+        return buildPaginatedResponse(items, pagination, Function.identity());
+    }
+
+    protected <S, T> Response buildPaginatedResponse(List<S> items,
+                                                     PaginationParams pagination,
+                                                     Function<S, T> mapper) {
+        PaginatedResponse<S> page = pagination.paginate(items);
+        List<T> mapped = page.items().stream().map(mapper).toList();
+        PaginatedResponse<T> body = new PaginatedResponse<>(
+                mapped,
+                page.page(),
+                page.pageSize(),
+                page.totalItems(),
+                page.totalPages());
+        return Response.status(Response.Status.OK).entity(body).build();
     }
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQuery.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQuery.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.trades;
+
+import bisq.api.dto.presentation.closed_trades.ClosedTradeIndexedItem;
+import bisq.api.dto.trade.TradeRoleDto;
+import bisq.api.dto.trade.bisq_easy.protocol.BisqEasyTradeStateDto;
+import bisq.api.rest_api.pagination.SortDirection;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ClosedTradesQuery {
+    private ClosedTradesQuery() {
+    }
+
+    public enum RoleFilter {
+        BUYER,
+        SELLER;
+
+        public boolean matches(TradeRoleDto tradeRole) {
+            return switch (this) {
+                case BUYER -> tradeRole == TradeRoleDto.BUYER_AS_MAKER || tradeRole == TradeRoleDto.BUYER_AS_TAKER;
+                case SELLER -> tradeRole == TradeRoleDto.SELLER_AS_MAKER || tradeRole == TradeRoleDto.SELLER_AS_TAKER;
+            };
+        }
+
+        public static Optional<RoleFilter> parse(Optional<String> value) {
+            return value
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .map(s -> {
+                        try {
+                            return RoleFilter.valueOf(s.toUpperCase(Locale.ROOT));
+                        } catch (IllegalArgumentException e) {
+                            String valid = Arrays.stream(RoleFilter.values())
+                                    .map(Enum::name)
+                                    .collect(Collectors.joining(", "));
+                            throw new IllegalArgumentException(
+                                    "Invalid role '" + s + "'. Valid values: " + valid + ".");
+                        }
+                    });
+        }
+    }
+
+    public static Set<BisqEasyTradeStateDto> parseStates(Collection<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Set.of();
+        }
+        Set<BisqEasyTradeStateDto> result = EnumSet.noneOf(BisqEasyTradeStateDto.class);
+        for (String raw : values) {
+            if (raw == null) continue;
+            for (String token : raw.split(",")) {
+                String s = token.trim();
+                if (s.isEmpty()) continue;
+                try {
+                    result.add(BisqEasyTradeStateDto.valueOf(s.toUpperCase(Locale.ROOT)));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(
+                            "Invalid state '" + s + "'. Valid values: " +
+                                    Arrays.stream(BisqEasyTradeStateDto.values())
+                                            .map(Enum::name)
+                                            .collect(Collectors.joining(", ")) + ".");
+                }
+            }
+        }
+        return result;
+    }
+
+    public enum SortField {
+        // DATE sorts by the trade-completion timestamp when present (more meaningful for closed
+        // trades since users care about when the trade finished), falling back to the take-offer
+        // timestamp for trades that never reached a completion state (e.g. cancelled before any
+        // completion event was recorded). takeOfferDate is monotonic and always populated, so
+        // the fallback guarantees a stable ordering even for never-completed trades.
+        DATE(Comparator
+                .comparingLong((ClosedTradeIndexedItem item) ->
+                        item.dto().tradeCompletedDate().orElse(item.dto().trade().contract().takeOfferDate()))
+                .thenComparing(item -> item.dto().trade().id())),
+        MARKET(Comparator.comparing(ClosedTradeIndexedItem::market, String.CASE_INSENSITIVE_ORDER)),
+        QUOTE_AMOUNT(Comparator.comparingLong(item -> item.dto().quoteAmount())),
+        BASE_AMOUNT(Comparator.comparingLong(item -> item.dto().baseAmount())),
+        ROLE(Comparator.comparing((ClosedTradeIndexedItem item) -> item.dto().trade().tradeRole()));
+
+        private final Comparator<ClosedTradeIndexedItem> comparator;
+
+        SortField(Comparator<ClosedTradeIndexedItem> comparator) {
+            this.comparator = comparator;
+        }
+
+        public Comparator<ClosedTradeIndexedItem> comparator(SortDirection direction) {
+            return direction == SortDirection.ASC ? comparator : comparator.reversed();
+        }
+
+        public static SortField parse(Optional<String> value, SortField fallback) {
+            return value
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .map(s -> {
+                        try {
+                            return SortField.valueOf(s.toUpperCase(Locale.ROOT));
+                        } catch (IllegalArgumentException e) {
+                            String valid = Arrays.stream(SortField.values())
+                                    .map(Enum::name)
+                                    .collect(Collectors.joining(", "));
+                            throw new IllegalArgumentException(
+                                    "Invalid sort field '" + s + "'. Valid values: " + valid + ".");
+                        }
+                    })
+                    .orElse(fallback);
+        }
+    }
+
+    public static List<ClosedTradeIndexedItem> apply(List<ClosedTradeIndexedItem> items,
+                                                     Optional<String> search,
+                                                     Optional<RoleFilter> role,
+                                                     Set<BisqEasyTradeStateDto> states,
+                                                     SortField sortBy,
+                                                     SortDirection direction) {
+        Stream<ClosedTradeIndexedItem> stream = items.stream();
+        if (role.isPresent()) {
+            RoleFilter r = role.get();
+            stream = stream.filter(item -> r.matches(item.dto().trade().tradeRole()));
+        }
+        if (!states.isEmpty()) {
+            stream = stream.filter(item -> states.contains(item.dto().trade().tradeState()));
+        }
+        Optional<String> needle = search
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.toLowerCase(Locale.ROOT));
+        if (needle.isPresent()) {
+            stream = stream.filter(item -> matches(item, needle.get()));
+        }
+        return stream.sorted(sortBy.comparator(direction)).toList();
+    }
+
+    private static boolean matches(ClosedTradeIndexedItem item, String needleLower) {
+        var dto = item.dto();
+        return contains(dto.trade().id(), needleLower)
+                || contains(item.market(), needleLower)
+                || contains(item.directionalTitle(), needleLower)
+                || contains(item.formattedMyRole(), needleLower)
+                || contains(item.formattedPrice(), needleLower)
+                || contains(item.formattedBaseAmount(), needleLower)
+                || contains(item.formattedQuoteAmount(), needleLower)
+                || contains(dto.makerUserProfile().userName(), needleLower)
+                || contains(dto.makerUserProfile().nym(), needleLower)
+                || contains(dto.takerUserProfile().userName(), needleLower)
+                || contains(dto.takerUserProfile().nym(), needleLower)
+                || contains(item.bitcoinSettlementMethodDisplayString(), needleLower)
+                || contains(item.fiatPaymentMethodDisplayString(), needleLower);
+    }
+
+    private static boolean contains(String value, String needleLower) {
+        return value.toLowerCase(Locale.ROOT).contains(needleLower);
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
@@ -23,6 +23,14 @@ import bisq.account.payment_method.BitcoinPaymentRail;
 import bisq.account.payment_method.PaymentMethodSpecUtil;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
+import bisq.api.dto.presentation.closed_trades.ClosedTradeIndexedItem;
+import bisq.api.dto.trade.bisq_easy.protocol.BisqEasyTradeStateDto;
+import bisq.api.rest_api.endpoints.RestApiBase;
+import bisq.api.rest_api.endpoints.offers.CreateOfferRequest;
+import bisq.api.rest_api.pagination.PaginatedResponse;
+import bisq.api.rest_api.pagination.PaginationParams;
+import bisq.api.rest_api.pagination.SortDirection;
+import bisq.api.web_socket.domain.ClosedTradeItemsService;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.chat.ChatChannelDomain;
 import bisq.chat.ChatChannelSelectionService;
@@ -36,8 +44,6 @@ import bisq.common.monetary.Fiat;
 import bisq.common.monetary.Monetary;
 import bisq.common.util.StringUtils;
 import bisq.contract.bisq_easy.BisqEasyContract;
-import bisq.api.rest_api.endpoints.RestApiBase;
-import bisq.api.rest_api.endpoints.offers.CreateOfferRequest;
 import bisq.i18n.Res;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.offer.price.spec.PriceSpec;
@@ -61,19 +67,23 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -94,12 +104,14 @@ public class TradeRestApi extends RestApiBase {
     private final BisqEasyOpenTradeChannelService bisqEasyOpenTradeChannelService;
     private final LeavePrivateChatManager leavePrivateChatManager;
     private final ChatChannelSelectionService offerbookChannelSelectionService;
+    private final ClosedTradeItemsService closedTradeItemsService;
 
     public TradeRestApi(ChatService chatService,
                         MarketPriceService marketPriceService,
                         UserService userService,
                         SupportService supportedService,
-                        TradeService tradeService) {
+                        TradeService tradeService,
+                        ClosedTradeItemsService closedTradeItemsService) {
         this.bisqEasyOfferbookChannelService = chatService.getBisqEasyOfferbookChannelService();
         offerbookChannelSelectionService = chatService.getChatChannelSelectionService(ChatChannelDomain.BISQ_EASY_OFFERBOOK);
         bisqEasyOpenTradeChannelService = chatService.getBisqEasyOpenTradeChannelService();
@@ -109,6 +121,59 @@ public class TradeRestApi extends RestApiBase {
         bannedUserService = userService.getBannedUserService();
         bisqEasyMediationRequestService = supportedService.getBisqEasyMediationRequestService();
         bisqEasyTradeService = tradeService.getBisqEasyTradeService();
+        this.closedTradeItemsService = closedTradeItemsService;
+    }
+
+    @GET
+    @Path("/closed")
+    @Operation(
+            summary = "Get closed trades",
+            description = "Returns closed trades (completed, cancelled, rejected, or failed) for the current user. " +
+                    "Paginated. Query params: 'page' (1-indexed, default 1), 'pageSize' (default 20, max 100), " +
+                    "'sortBy' (DATE|MARKET|QUOTE_AMOUNT|BASE_AMOUNT|ROLE, default DATE), " +
+                    "'direction' (ASC|DESC, default DESC), " +
+                    "'search' (case-insensitive substring matched against trade id, market, role, peer username/nym, " +
+                    "payment methods, formatted price/amount strings), " +
+                    "'role' (BUYER|SELLER, optional), " +
+                    "'state' (BisqEasyTradeStateDto value; repeatable or comma-separated, optional).",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Closed trades retrieved successfully",
+                            content = @Content(schema = @Schema(implementation = PaginatedResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid query parameters"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public Response getClosedTrades(@QueryParam("page") Integer page,
+                                    @QueryParam("pageSize") Integer pageSize,
+                                    @QueryParam("sortBy") String sortBy,
+                                    @QueryParam("direction") String direction,
+                                    @QueryParam("search") String search,
+                                    @QueryParam("role") String role,
+                                    @QueryParam("state") List<String> states) {
+        try {
+            ClosedTradesQuery.SortField field = ClosedTradesQuery.SortField.parse(
+                    Optional.ofNullable(sortBy), ClosedTradesQuery.SortField.DATE);
+            SortDirection sortDirection = SortDirection.parse(
+                    Optional.ofNullable(direction), SortDirection.DESC);
+            Optional<ClosedTradesQuery.RoleFilter> roleFilter = ClosedTradesQuery.RoleFilter.parse(
+                    Optional.ofNullable(role));
+            Set<BisqEasyTradeStateDto> stateFilter = ClosedTradesQuery.parseStates(states);
+            List<ClosedTradeIndexedItem> filtered = ClosedTradesQuery.apply(
+                    closedTradeItemsService.getItems().getList(),
+                    Optional.ofNullable(search),
+                    roleFilter,
+                    stateFilter,
+                    field,
+                    sortDirection);
+            return buildPaginatedResponse(filtered,
+                    PaginationParams.of(Optional.ofNullable(page), Optional.ofNullable(pageSize)),
+                    ClosedTradeIndexedItem::dto);
+        } catch (IllegalArgumentException e) {
+            return buildResponse(Response.Status.BAD_REQUEST, e.getMessage());
+        } catch (Exception e) {
+            log.error("Error retrieving closed trades", e);
+            return buildErrorResponse("An unexpected error occurred");
+        }
     }
 
     @POST

--- a/api/src/main/java/bisq/api/rest_api/pagination/PaginatedResponse.java
+++ b/api/src/main/java/bisq/api/rest_api/pagination/PaginatedResponse.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.pagination;
+
+import java.util.List;
+
+public record PaginatedResponse<T>(
+        List<T> items,
+        int page,
+        int pageSize,
+        long totalItems,
+        int totalPages
+) {
+}

--- a/api/src/main/java/bisq/api/rest_api/pagination/PaginationParams.java
+++ b/api/src/main/java/bisq/api/rest_api/pagination/PaginationParams.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.pagination;
+
+import java.util.List;
+import java.util.Optional;
+
+public record PaginationParams(int page, int pageSize) {
+    public static final int DEFAULT_PAGE = 1;
+    public static final int DEFAULT_PAGE_SIZE = 20;
+    public static final int MAX_PAGE_SIZE = 100;
+
+    public static PaginationParams of(Optional<Integer> page, Optional<Integer> pageSize) {
+        int resolvedPage = page.filter(p -> p >= 1).orElse(DEFAULT_PAGE);
+        int resolvedSize = pageSize.filter(s -> s >= 1)
+                .map(s -> Math.min(s, MAX_PAGE_SIZE))
+                .orElse(DEFAULT_PAGE_SIZE);
+        return new PaginationParams(resolvedPage, resolvedSize);
+    }
+
+    public <T> PaginatedResponse<T> paginate(List<T> items) {
+        int total = items.size();
+        int totalPages = (int) Math.ceil((double) total / pageSize);
+        if (page > totalPages && total > 0) {
+            throw new IllegalArgumentException(
+                    "Page " + page + " out of range; total pages: " + totalPages);
+        }
+        int fromIndex = Math.min((page - 1) * pageSize, total);
+        int toIndex = Math.min(fromIndex + pageSize, total);
+        return new PaginatedResponse<>(
+                items.subList(fromIndex, toIndex),
+                page,
+                pageSize,
+                total,
+                totalPages
+        );
+    }
+}

--- a/api/src/main/java/bisq/api/rest_api/pagination/SortDirection.java
+++ b/api/src/main/java/bisq/api/rest_api/pagination/SortDirection.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.pagination;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public enum SortDirection {
+    ASC,
+    DESC;
+
+    public static SortDirection parse(Optional<String> value, SortDirection fallback) {
+        return value
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> {
+                    try {
+                        return SortDirection.valueOf(s.toUpperCase(Locale.ROOT));
+                    } catch (IllegalArgumentException e) {
+                        throw new IllegalArgumentException(
+                                "Invalid sort direction '" + s + "'. Valid values: ASC, DESC.");
+                    }
+                })
+                .orElse(fallback);
+    }
+}

--- a/api/src/main/java/bisq/api/web_socket/domain/ClosedTradeItemsService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/ClosedTradeItemsService.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.domain;
+
+import bisq.api.dto.presentation.closed_trades.ClosedTradeIndexedItem;
+import bisq.api.dto.presentation.closed_trades.ClosedTradeListItemDtoFactory;
+import bisq.common.application.Service;
+import bisq.common.observable.Pin;
+import bisq.common.observable.collection.CollectionObserver;
+import bisq.common.observable.collection.ObservableArray;
+import bisq.trade.TradeService;
+import bisq.trade.bisq_easy.BisqEasyTradeService;
+import bisq.trade.bisq_easy.protocol.BisqEasyClosedTrade;
+import bisq.user.UserService;
+import bisq.user.reputation.ReputationService;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+public class ClosedTradeItemsService implements Service {
+    private final BisqEasyTradeService bisqEasyTradeService;
+    private final ReputationService reputationService;
+
+    @Getter
+    private final ObservableArray<ClosedTradeIndexedItem> items = new ObservableArray<>();
+    @Nullable
+    private Pin closedTradesPin;
+
+    public ClosedTradeItemsService(TradeService tradeService, UserService userService) {
+        bisqEasyTradeService = tradeService.getBisqEasyTradeService();
+        reputationService = userService.getReputationService();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> initialize() {
+        closedTradesPin = bisqEasyTradeService.getClosedTrades().addObserver(new CollectionObserver<>() {
+            @Override
+            public void onAdded(BisqEasyClosedTrade closedTrade) {
+                if (findListItem(closedTrade.trade().getId()).isEmpty()) {
+                    items.add(ClosedTradeListItemDtoFactory.create(closedTrade, reputationService));
+                }
+            }
+
+            @Override
+            public void onRemoved(Object element) {
+                if (element instanceof BisqEasyClosedTrade closedTrade) {
+                    findListItem(closedTrade.trade().getId()).ifPresent(items::remove);
+                }
+            }
+
+            @Override
+            public void onCleared() {
+                items.clear();
+            }
+        });
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> shutdown() {
+        log.info("shutdown");
+        if (closedTradesPin != null) {
+            closedTradesPin.unbind();
+            closedTradesPin = null;
+        }
+        items.clear();
+        return CompletableFuture.completedFuture(true);
+    }
+
+    private Optional<ClosedTradeIndexedItem> findListItem(String tradeId) {
+        return items.stream()
+                .filter(item -> item.dto().trade().id().equals(tradeId))
+                .findAny();
+    }
+}

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
@@ -29,6 +29,7 @@ import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
 import bisq.api.web_socket.domain.offers.NumOffersWebSocketService;
 import bisq.api.web_socket.domain.offers.OffersWebSocketService;
 import bisq.api.web_socket.domain.reputation.ReputationWebSocketService;
+import bisq.api.web_socket.domain.trade_restricting_alert.TradeRestrictingAlertWebSocketService;
 import bisq.api.web_socket.domain.trades.TradePropertiesWebSocketService;
 import bisq.api.web_socket.domain.trades.TradesWebSocketService;
 import bisq.api.web_socket.domain.user_profile.NumUserProfilesWebSocketService;

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -21,16 +21,35 @@ import bisq.api.access.AllowUnauthenticated;
 import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.trades.TradeRestApi;
+import bisq.api.web_socket.domain.OpenTradeItemsService;
+import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
+import bisq.api.web_socket.subscription.SubscriberRepository;
+import bisq.api.web_socket.subscription.SubscriptionService;
+import bisq.api.web_socket.subscription.Topic;
+import bisq.bisq_easy.BisqEasyService;
 import bisq.bisq_easy.BisqEasyTradeAmountLimits;
+import bisq.bonded_roles.BondedRolesService;
+import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
+import bisq.chat.ChatService;
+import bisq.network.NetworkService;
+import bisq.trade.TradeService;
+import bisq.user.UserService;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.grizzly.impl.ReadyFutureImpl;
+import org.glassfish.grizzly.websockets.WebSocket;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ConfigRestApiTest {
 
@@ -71,16 +90,58 @@ class ConfigRestApiTest {
 
     /**
      * Anti-drift guard: a declared feature must be backed by a real, wired endpoint/topic — never a
-     * key for something not implemented in this build. As features are added here, extend this check.
+     * key for something not implemented in this build.
+     * <p>
+     * Implemented as a switch <i>expression</i> on purpose: exhaustiveness is compile-checked, so
+     * adding an {@link ApiFeature} without extending this check breaks the build instead of being
+     * silently skipped (which is how NETWORK_INFO originally slipped past the old switch statement).
      */
     @Test
     void everyDeclaredFeatureIsBackedByARealImplementation() {
         for (ApiFeature feature : ApiFeature.values()) {
-            switch (feature) {
-                case CLOSED_TRADES -> assertThat(hasEndpoint(TradeRestApi.class, "/closed"))
-                        .as("closed-trades must expose GET /trades/closed")
-                        .isTrue();
-            }
+            boolean backed =
+                    switch (feature) {
+                        case CLOSED_TRADES -> hasEndpoint(TradeRestApi.class, "/closed");
+                        case NETWORK_INFO -> networkInfoSubscriptionIsServed();
+                    };
+            assertThat(backed)
+                    .as("feature '%s' is declared in /config/capabilities but not backed by a real implementation", feature.getKey())
+                    .isTrue();
+        }
+    }
+
+    /**
+     * Proves {@link Topic#NETWORK_INFO} is served through the real subscription path — a
+     * {@link bisq.api.web_socket.subscription.SubscriptionService} built the production way routes a
+     * NETWORK_INFO subscription request to its wired {@link NetworkInfoWebSocketService} and the
+     * subscriber ends up registered. Deleting the topic, the service, or its registration in
+     * SubscriptionService makes this fail (or not compile), which is the point of the guard.
+     */
+    private static boolean networkInfoSubscriptionIsServed() {
+        try {
+            SubscriptionService subscriptionService = new SubscriptionService(
+                    mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
+                    mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
+                    mock(ChatService.class, RETURNS_DEEP_STUBS),
+                    mock(TradeService.class, RETURNS_DEEP_STUBS),
+                    mock(UserService.class, RETURNS_DEEP_STUBS),
+                    mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                    mock(NetworkService.class, RETURNS_DEEP_STUBS),
+                    mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS));
+
+            WebSocket webSocket = mock(WebSocket.class);
+            when(webSocket.send(anyString())).thenReturn(ReadyFutureImpl.create(null));
+
+            String requestJson =
+                    "{\"type\":\"SubscriptionRequest\",\"requestId\":\"config-guard-1\",\"topic\":\"NETWORK_INFO\"}";
+            subscriptionService.onMessage(requestJson, webSocket);
+
+            Field field = SubscriptionService.class.getDeclaredField("subscriberRepository");
+            field.setAccessible(true);
+            SubscriberRepository subscriberRepository = (SubscriberRepository) field.get(subscriptionService);
+            return !subscriberRepository.findSubscribers(Topic.NETWORK_INFO).isEmpty();
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/api/src/test/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQueryTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQueryTest.java
@@ -1,0 +1,337 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.trades;
+
+import bisq.api.dto.common.monetary.PriceQuoteDto;
+import bisq.api.dto.presentation.closed_trades.ClosedTradeIndexedItem;
+import bisq.api.dto.presentation.closed_trades.ClosedTradeListItemDto;
+import bisq.api.dto.presentation.closed_trades.ClosedTradeListItemDto.ContractSlimDto;
+import bisq.api.dto.presentation.closed_trades.ClosedTradeListItemDto.TradeSlimDto;
+import bisq.api.dto.trade.TradeRoleDto;
+import bisq.api.dto.trade.bisq_easy.protocol.BisqEasyTradeStateDto;
+import bisq.api.dto.user.profile.UserProfileDto;
+import bisq.api.dto.user.reputation.ReputationScoreDto;
+import bisq.api.rest_api.pagination.SortDirection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClosedTradesQueryTest {
+
+    private static UserProfileDto profile(String userName, String nym) {
+        // Heavyweight network/PoW fields are unused by ClosedTradesQuery.matches();
+        // pass null so this test doesn't pull in the full DTO graph.
+        return new UserProfileDto(0, null, null, 0, null, null, null, null, nym, userName, 0L);
+    }
+
+    private static PriceQuoteDto priceQuote(long value) {
+        return new PriceQuoteDto(value, null, null, 0, 0, null);
+    }
+
+    private static ReputationScoreDto reputation() {
+        return new ReputationScoreDto(0L, 0d, 0);
+    }
+
+    private static ClosedTradeIndexedItem item(String tradeId,
+                                               TradeRoleDto role,
+                                               BisqEasyTradeStateDto state,
+                                               long takeOfferDate,
+                                               Optional<Long> tradeCompletedDate,
+                                               long quoteAmount,
+                                               long baseAmount,
+                                               long priceQuoteValue,
+                                               String market,
+                                               String makerUserName,
+                                               String takerUserName,
+                                               String btcMethodDisplay,
+                                               String fiatMethodDisplay,
+                                               String formattedPrice,
+                                               String formattedBaseAmount,
+                                               String formattedQuoteAmount,
+                                               String formattedMyRole,
+                                               String directionalTitle) {
+        ClosedTradeListItemDto dto = new ClosedTradeListItemDto(
+                new TradeSlimDto(tradeId, role, state, new ContractSlimDto(takeOfferDate)),
+                profile(makerUserName, "maker-nym"),
+                profile(takerUserName, "taker-nym"),
+                Optional.empty(),
+                priceQuote(priceQuoteValue),
+                baseAmount,
+                quoteAmount,
+                "MAIN_CHAIN",
+                "SEPA",
+                reputation(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                tradeCompletedDate
+        );
+        return new ClosedTradeIndexedItem(
+                dto, market, directionalTitle, formattedMyRole,
+                formattedPrice, formattedBaseAmount, formattedQuoteAmount,
+                btcMethodDisplay, fiatMethodDisplay);
+    }
+
+    private static ClosedTradeIndexedItem makerBuyer(String id, long takeOfferDate, Optional<Long> completed,
+                                                     long quoteAmount, long baseAmount, long price, String market) {
+        return item(id, TradeRoleDto.BUYER_AS_MAKER, BisqEasyTradeStateDto.BTC_CONFIRMED,
+                takeOfferDate, completed, quoteAmount, baseAmount, price, market,
+                "alice", "bob", "Bitcoin (Mainchain)", "SEPA",
+                "30000.00 USD/BTC", "0.10 BTC", "3000 USD",
+                "Maker", "Buy bitcoin");
+    }
+
+    private static ClosedTradeIndexedItem takerSeller(String id, long takeOfferDate, Optional<Long> completed,
+                                                      long quoteAmount, long baseAmount, long price, String market,
+                                                      BisqEasyTradeStateDto state) {
+        return item(id, TradeRoleDto.SELLER_AS_TAKER, state,
+                takeOfferDate, completed, quoteAmount, baseAmount, price, market,
+                "carol", "dave", "Bitcoin (Mainchain)", "Zelle",
+                "31000.00 USD/BTC", "0.20 BTC", "6200 USD",
+                "Taker", "Sell bitcoin");
+    }
+
+    @Test
+    void parseStates_emptyReturnsEmptySet() {
+        assertTrue(ClosedTradesQuery.parseStates(List.of()).isEmpty());
+        assertTrue(ClosedTradesQuery.parseStates(null).isEmpty());
+    }
+
+    @Test
+    void parseStates_acceptsCommaSeparated() {
+        Set<BisqEasyTradeStateDto> result = ClosedTradesQuery.parseStates(
+                List.of("BTC_CONFIRMED,REJECTED"));
+        assertEquals(Set.of(BisqEasyTradeStateDto.BTC_CONFIRMED, BisqEasyTradeStateDto.REJECTED), result);
+    }
+
+    @Test
+    void parseStates_acceptsRepeated() {
+        Set<BisqEasyTradeStateDto> result = ClosedTradesQuery.parseStates(
+                List.of("btc_confirmed", "REJECTED"));
+        assertEquals(Set.of(BisqEasyTradeStateDto.BTC_CONFIRMED, BisqEasyTradeStateDto.REJECTED), result);
+    }
+
+    @Test
+    void parseStates_invalidThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ClosedTradesQuery.parseStates(List.of("NOT_A_STATE")));
+    }
+
+    @Test
+    void roleFilter_buyerIncludesBothBuyerRoles() {
+        assertTrue(ClosedTradesQuery.RoleFilter.BUYER.matches(TradeRoleDto.BUYER_AS_MAKER));
+        assertTrue(ClosedTradesQuery.RoleFilter.BUYER.matches(TradeRoleDto.BUYER_AS_TAKER));
+        assertEquals(false, ClosedTradesQuery.RoleFilter.BUYER.matches(TradeRoleDto.SELLER_AS_MAKER));
+    }
+
+    @Test
+    void roleFilter_invalidThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ClosedTradesQuery.RoleFilter.parse(Optional.of("nope")));
+    }
+
+    @Test
+    void apply_emptyCorpusReturnsEmpty() {
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void apply_dateSortPrefersTradeCompletedDateOverTakeOfferDate() {
+        // Trade A took offer earlier but completed later than B.
+        ClosedTradeIndexedItem a = makerBuyer("A", 100L, Optional.of(500L), 100, 10, 30000, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("B", 200L, Optional.of(300L), 200, 20, 31000, "BTC/EUR",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> desc = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(a, b), desc);
+        List<ClosedTradeIndexedItem> asc = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.ASC);
+        assertEquals(List.of(b, a), asc);
+    }
+
+    @Test
+    void apply_dateSortFallsBackToTakeOfferDateWhenCompletedAbsent() {
+        ClosedTradeIndexedItem a = makerBuyer("A", 100L, Optional.empty(), 100, 10, 30000, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("B", 200L, Optional.empty(), 200, 20, 31000, "BTC/EUR",
+                BisqEasyTradeStateDto.REJECTED);
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(b, a), result);
+    }
+
+    @Test
+    void apply_marketSortAscDesc() {
+        ClosedTradeIndexedItem usd = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem eur = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/EUR",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> asc = ClosedTradesQuery.apply(
+                List.of(usd, eur), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.MARKET, SortDirection.ASC);
+        assertEquals(List.of(eur, usd), asc);
+    }
+
+    @Test
+    void apply_quoteAmountSort() {
+        ClosedTradeIndexedItem small = makerBuyer("A", 1L, Optional.of(1L), 100, 10, 30000, "BTC/USD");
+        ClosedTradeIndexedItem big = takerSeller("B", 1L, Optional.of(1L), 999, 20, 31000, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> desc = ClosedTradesQuery.apply(
+                List.of(small, big), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.QUOTE_AMOUNT, SortDirection.DESC);
+        assertEquals(List.of(big, small), desc);
+    }
+
+    @Test
+    void apply_baseAmountSort() {
+        ClosedTradeIndexedItem small = makerBuyer("A", 1L, Optional.of(1L), 100, 5, 30000, "BTC/USD");
+        ClosedTradeIndexedItem big = takerSeller("B", 1L, Optional.of(1L), 100, 50, 30000, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> asc = ClosedTradesQuery.apply(
+                List.of(small, big), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.BASE_AMOUNT, SortDirection.ASC);
+        assertEquals(List.of(small, big), asc);
+    }
+
+    @Test
+    void apply_roleSort() {
+        ClosedTradeIndexedItem maker = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem taker = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> asc = ClosedTradesQuery.apply(
+                List.of(taker, maker), Optional.empty(), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.ROLE, SortDirection.ASC);
+        assertEquals(List.of(maker, taker), asc);
+    }
+
+    @Test
+    void apply_roleFilterBuyer() {
+        ClosedTradeIndexedItem buyer = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem seller = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(buyer, seller), Optional.empty(),
+                Optional.of(ClosedTradesQuery.RoleFilter.BUYER), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(buyer), result);
+    }
+
+    @Test
+    void apply_stateFilter() {
+        ClosedTradeIndexedItem confirmed = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem rejected = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.REJECTED);
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(confirmed, rejected), Optional.empty(), Optional.empty(),
+                Set.of(BisqEasyTradeStateDto.REJECTED),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(rejected), result);
+    }
+
+    @Test
+    void apply_searchByTradeId() {
+        ClosedTradeIndexedItem a = makerBuyer("alpha-id", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("beta-id", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.of("ALPH"), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(a), result);
+    }
+
+    @Test
+    void apply_searchByPeerUserName() {
+        ClosedTradeIndexedItem a = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.of("carol"), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(b), result);
+    }
+
+    @Test
+    void apply_searchByFormattedPrice() {
+        ClosedTradeIndexedItem a = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        // a -> "30000.00 USD/BTC", b -> "31000.00 USD/BTC"
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.of("31000"), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(b), result);
+    }
+
+    @Test
+    void apply_searchByFormattedBaseAmount() {
+        ClosedTradeIndexedItem a = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        // a -> "0.10 BTC"
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a), Optional.of("0.10"), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(a), result);
+    }
+
+    @Test
+    void apply_searchByFiatMethodDisplay() {
+        ClosedTradeIndexedItem a = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        // a -> SEPA, b -> Zelle
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.of("zelle"), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(List.of(b), result);
+    }
+
+    @Test
+    void apply_searchBlankIgnored() {
+        ClosedTradeIndexedItem a = makerBuyer("A", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD");
+        ClosedTradeIndexedItem b = takerSeller("B", 1L, Optional.of(1L), 1, 1, 1, "BTC/USD",
+                BisqEasyTradeStateDto.BTC_CONFIRMED);
+        List<ClosedTradeIndexedItem> result = ClosedTradesQuery.apply(
+                List.of(a, b), Optional.of("   "), Optional.empty(), Set.of(),
+                ClosedTradesQuery.SortField.DATE, SortDirection.DESC);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void sortField_parseFallback() {
+        assertEquals(ClosedTradesQuery.SortField.DATE,
+                ClosedTradesQuery.SortField.parse(Optional.empty(), ClosedTradesQuery.SortField.DATE));
+        assertEquals(ClosedTradesQuery.SortField.MARKET,
+                ClosedTradesQuery.SortField.parse(Optional.of("market"), ClosedTradesQuery.SortField.DATE));
+    }
+
+    @Test
+    void sortField_parseInvalidThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ClosedTradesQuery.SortField.parse(Optional.of("nope"), ClosedTradesQuery.SortField.DATE));
+    }
+}

--- a/api/src/test/java/bisq/api/rest_api/endpoints/trades/TradeRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/trades/TradeRestApiTest.java
@@ -21,6 +21,7 @@ import bisq.account.payment_method.BitcoinPaymentMethod;
 import bisq.account.payment_method.BitcoinPaymentMethodSpec;
 import bisq.account.payment_method.BitcoinPaymentRail;
 import bisq.api.rest_api.error.TradingNotAllowedExceptionMapper;
+import bisq.api.web_socket.domain.ClosedTradeItemsService;
 import bisq.contract.bisq_easy.BisqEasyContract;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.chat.ChatChannelDomain;
@@ -122,6 +123,7 @@ class TradeRestApiTest {
                 mock(MarketPriceService.class),
                 userService,
                 supportService,
-                tradeService);
+                tradeService,
+                mock(ClosedTradeItemsService.class));
     }
 }

--- a/api/src/test/java/bisq/api/rest_api/pagination/PaginationParamsTest.java
+++ b/api/src/test/java/bisq/api/rest_api/pagination/PaginationParamsTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.pagination;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaginationParamsTest {
+
+    private static List<Integer> range(int n) {
+        return IntStream.range(0, n).boxed().toList();
+    }
+
+    @Test
+    void of_appliesDefaultsWhenAbsent() {
+        PaginationParams p = PaginationParams.of(Optional.empty(), Optional.empty());
+        assertEquals(PaginationParams.DEFAULT_PAGE, p.page());
+        assertEquals(PaginationParams.DEFAULT_PAGE_SIZE, p.pageSize());
+    }
+
+    @Test
+    void of_clampsPageSizeAboveMax() {
+        PaginationParams p = PaginationParams.of(Optional.of(1), Optional.of(PaginationParams.MAX_PAGE_SIZE * 10));
+        assertEquals(PaginationParams.MAX_PAGE_SIZE, p.pageSize());
+    }
+
+    @Test
+    void of_replacesNonPositivePageWithDefault() {
+        PaginationParams p = PaginationParams.of(Optional.of(0), Optional.of(10));
+        assertEquals(PaginationParams.DEFAULT_PAGE, p.page());
+    }
+
+    @Test
+    void of_replacesNonPositivePageSizeWithDefault() {
+        PaginationParams p = PaginationParams.of(Optional.of(1), Optional.of(0));
+        assertEquals(PaginationParams.DEFAULT_PAGE_SIZE, p.pageSize());
+    }
+
+    @Test
+    void paginate_emptyListReturnsEmptyPageWithoutThrowing() {
+        PaginationParams p = PaginationParams.of(Optional.of(1), Optional.of(20));
+        PaginatedResponse<Integer> resp = p.paginate(List.of());
+        assertTrue(resp.items().isEmpty());
+        assertEquals(1, resp.page());
+        assertEquals(20, resp.pageSize());
+        assertEquals(0L, resp.totalItems());
+        assertEquals(0, resp.totalPages());
+    }
+
+    @Test
+    void paginate_firstPageOfPartialLastPage() {
+        PaginationParams p = PaginationParams.of(Optional.of(1), Optional.of(3));
+        PaginatedResponse<Integer> resp = p.paginate(range(7));
+        assertEquals(List.of(0, 1, 2), resp.items());
+        assertEquals(7L, resp.totalItems());
+        assertEquals(3, resp.totalPages());
+    }
+
+    @Test
+    void paginate_lastPagePartial() {
+        PaginationParams p = PaginationParams.of(Optional.of(3), Optional.of(3));
+        PaginatedResponse<Integer> resp = p.paginate(range(7));
+        assertEquals(List.of(6), resp.items());
+        assertEquals(3, resp.totalPages());
+    }
+
+    @Test
+    void paginate_pageEqualsTotalPagesNotThrown() {
+        PaginationParams p = PaginationParams.of(Optional.of(2), Optional.of(5));
+        PaginatedResponse<Integer> resp = p.paginate(range(10));
+        assertEquals(List.of(5, 6, 7, 8, 9), resp.items());
+        assertEquals(2, resp.totalPages());
+    }
+
+    @Test
+    void paginate_pageBeyondTotalThrows() {
+        PaginationParams p = PaginationParams.of(Optional.of(5), Optional.of(3));
+        assertThrows(IllegalArgumentException.class, () -> p.paginate(range(7)));
+    }
+
+    @Test
+    void paginate_pageAboveOneOnEmptyListDoesNotThrow() {
+        // Documents the empty-corpus edge: totalPages=0 short-circuits the bounds check.
+        PaginationParams p = PaginationParams.of(Optional.of(99), Optional.of(20));
+        PaginatedResponse<Integer> resp = p.paginate(List.of());
+        assertTrue(resp.items().isEmpty());
+        assertEquals(0, resp.totalPages());
+    }
+}

--- a/apps/api-app/src/main/java/bisq/api_app/ApiApplicationService.java
+++ b/apps/api-app/src/main/java/bisq/api_app/ApiApplicationService.java
@@ -30,6 +30,7 @@ import bisq.common.platform.OS;
 import bisq.contract.ContractService;
 import bisq.api.ApiConfig;
 import bisq.api.ApiService;
+import bisq.api.web_socket.domain.ClosedTradeItemsService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.identity.IdentityService;
 import bisq.java_se.application.JavaSeApplicationService;
@@ -88,6 +89,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
     private final BisqEasyService bisqEasyService;
     private final ApiService apiService;
     private final OpenTradeItemsService openTradeItemsService;
+    private final ClosedTradeItemsService closedTradeItemsService;
     private final BurningmanService burningmanService;
     @Nullable
     private Pin difficultyAdjustmentServicePin;
@@ -166,6 +168,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
                 tradeService);
 
         openTradeItemsService = new OpenTradeItemsService(chatService, tradeService, userService);
+        closedTradeItemsService = new ClosedTradeItemsService(tradeService, userService);
 
         ApiConfig apiConfig = ApiConfig.from(getConfig("api"));
         apiService = new ApiService(apiConfig,
@@ -181,6 +184,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
                 settingsService,
                 bisqEasyService,
                 openTradeItemsService,
+                closedTradeItemsService,
                 accountService,
                 userService.getReputationService(),
                 notificationService.getMobileNotificationService().getDeviceRegistrationService());
@@ -218,6 +222,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
                 .thenCompose(result -> tradeService.initialize())
                 .thenCompose(result -> bisqEasyService.initialize())
                 .thenCompose(result -> openTradeItemsService.initialize())
+                .thenCompose(result -> closedTradeItemsService.initialize())
                 .thenCompose(result -> apiService.initialize())
                 .orTimeout(5, TimeUnit.MINUTES)
                 .whenComplete((success, throwable) -> {
@@ -254,6 +259,7 @@ public class ApiApplicationService extends JavaSeApplicationService {
         // Move shutdown work off the current thread and use ExecutorFactory.commonForkJoinPool() instead.
         // We shut down services in opposite order as they are initialized
         return supplyAsync(() -> apiService.shutdown()
+                .thenCompose(result -> closedTradeItemsService.shutdown())
                 .thenCompose(result -> openTradeItemsService.shutdown())
                 .thenCompose(result -> bisqEasyService.shutdown())
                 .thenCompose(result -> tradeService.shutdown())

--- a/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
+++ b/apps/desktop/desktop-app/src/main/java/bisq/desktop_app/DesktopApplicationService.java
@@ -20,6 +20,7 @@ package bisq.desktop_app;
 import bisq.account.AccountService;
 import bisq.api.ApiConfig;
 import bisq.api.ApiService;
+import bisq.api.web_socket.domain.ClosedTradeItemsService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.application.ShutDownHandler;
 import bisq.application.State;
@@ -106,6 +107,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
     private final WebcamAppService webcamAppService;
     private final ApiService apiService;
     private final OpenTradeItemsService openTradeItemsService;
+    private final ClosedTradeItemsService closedTradeItemsService;
     private final MuSigService muSigService;
     private final BurningmanService burningmanService;
     public DesktopApplicationService(String[] args, ShutDownHandler shutDownHandler) {
@@ -218,6 +220,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
         webcamAppService = new WebcamAppService(config);
 
         openTradeItemsService = new OpenTradeItemsService(chatService, tradeService, userService);
+        closedTradeItemsService = new ClosedTradeItemsService(tradeService, userService);
 
         ApiConfig apiConfig = ApiConfig.from(getConfig("api"));
         apiService = new ApiService(apiConfig,
@@ -233,6 +236,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
                 settingsService,
                 bisqEasyService,
                 openTradeItemsService,
+                closedTradeItemsService,
                 accountService,
                 userService.getReputationService(),
                 notificationService.getMobileNotificationService().getDeviceRegistrationService());
@@ -302,6 +306,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
                 .thenCompose(result -> dontShowAgainService.initialize())
                 .thenCompose(result -> webcamAppService.initialize())
                 .thenCompose(result -> openTradeItemsService.initialize())
+                .thenCompose(result -> closedTradeItemsService.initialize())
                 .thenCompose(result -> apiService.initialize())
                 .orTimeout(STARTUP_TIMEOUT_SEC, TimeUnit.SECONDS)
                 .handle((result, throwable) -> {
@@ -332,6 +337,7 @@ public class DesktopApplicationService extends JavaSeApplicationService {
         // In case a shutdown method completes exceptionally we log the error and map the result to `false` to not
         // interrupt the shutdown sequence.
         return supplyAsync(() -> apiService.shutdown().exceptionally(this::logError)
+                .thenCompose(result -> closedTradeItemsService.shutdown().exceptionally(this::logError))
                 .thenCompose(result -> openTradeItemsService.shutdown().exceptionally(this::logError))
                 .thenCompose(result -> webcamAppService.shutdown().exceptionally(this::logError))
                 .thenCompose(result -> dontShowAgainService.shutdown().exceptionally(this::logError))


### PR DESCRIPTION
### Brief 

Fixes the ConfigRestApiTest.everyDeclaredFeatureIsBackedByARealImplementation() failure on main. The test was doing its job: the API capabilities work synced to main declares closed-trades in /config/capabilities, but the actual closed trades API from #4787 (bd4aaeef0c) was never synced - so main was advertising an endpoint it doesn't serve. 

This cherry-picks that commit to main (one import conflict resolved, plus adapting the newer TradeRestApiTest on main to the extra constructor arg). Also hardns anti-drift guard: switch statement → switch expression so it's compile-time exhaustive - that's how NETWORK_INFO slipped past the check unnoticed; and adds the missing NETWORK_INFO backing check.

### Commit logs

 - sync-to-main missing PR bringing bd4aaeef0c commit in + conflict resolution and necessary adaptations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a paginated closed-trades API endpoint.
  * Added filtering by search text, buyer/seller role, and trade state.
  * Added sorting by completion date, market, amounts, or role in ascending or descending order.
  * Added pagination metadata, including page size, total items, and total pages.
  * Closed-trade results include relevant trade, pricing, payment, settlement, reputation, and completion details.
* **Bug Fixes**
  * Invalid filter, sorting, and pagination parameters now return clear client errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->