### PR TITLE
Specify MuSig mediated custom payout

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,9 @@
+# Domain specifications
+
+This directory contains specifications for intended Bisq domain behavior. Package-local Markdown files may document the
+current implementation and should link here when a canonical specification exists.
+
+## Specifications
+
+* [Account timestamp attestation](account_timestamp.md)
+* [MuSig mediation](trade/mu_sig/mediation/README.md)

--- a/docs/specs/trade/mu_sig/mediation/README.md
+++ b/docs/specs/trade/mu_sig/mediation/README.md
@@ -1,0 +1,19 @@
+# MuSig mediation specifications
+
+Status: **Proposed target behavior; not yet fully implemented.**
+
+The mediated custom payout integration is tracked by
+[bisq-network/bisq2#4888](https://github.com/bisq-network/bisq2/issues/4888). The custom payout RPC definitions are
+already present, but the complete Java flow and the required MuSig service behavior are not.
+
+The specification is split by concern:
+
+* [Mediated custom payout settlement](custom-payout-settlement.md) defines the domain flow, prerequisites, state
+  boundaries, payout rules, and first-version failure behavior.
+* [Mediated custom payout interface](custom-payout-interface.md) defines the Java, MuSig service, and P2P responsibilities
+  and the contract at their boundaries.
+
+The package-local
+[trader mediation specification](../../../../../trade/src/main/java/bisq/trade/mu_sig/mediation/specification.md)
+describes the current Java mediation implementation. It remains separate because the target behavior in these documents
+has not yet been implemented.

--- a/docs/specs/trade/mu_sig/mediation/custom-payout-interface.md
+++ b/docs/specs/trade/mu_sig/mediation/custom-payout-interface.md
@@ -1,0 +1,255 @@
+# Mediated custom payout interface for MuSig trades
+
+## Status and purpose
+
+This document defines the proposed contract between Bisq2 Java, the local MuSig service, and the traders' P2P protocol
+for the first mediated custom payout integration. It complements the
+[settlement specification](custom-payout-settlement.md).
+
+The existing `SignCustomPayoutTx` and `CustomCloseTrade` RPC schemas remain unchanged. This document does not assume that
+all required service behavior is implemented; in particular, broadcast is currently a placeholder.
+
+## Responsibility boundary
+
+| Concern | Owner | Required behavior |
+|---|---|---|
+| Mediation eligibility and trader decision | Java | Validate the signed result and decide whether local signing is permitted. |
+| Application state and persistence | Java | Retain local and peer settlement artifacts and coordinate the normal trade state. |
+| Trader-to-trader communication | Java/P2P | Exchange authenticated, result-bound partial PSBTs and result-bound rejections. |
+| Custom payout RPCs | MuSig service | Return the local partial PSBT and report successful custom closure only with the interface guarantees below. |
+| Local trade completion | Java | Complete after a successful `CustomCloseTrade` response in the first version. |
+
+Java does not construct or sign the Bitcoin transaction. The mediator signs the proposed distribution but does not sign
+the Bitcoin transaction.
+
+## gRPC contract
+
+### `SignCustomPayoutTx`
+
+Java calls `SignCustomPayoutTx(CustomPayoutPsbtRequest)` to request a locally signed partial PSBT.
+
+`CustomPayoutPsbtRequest` contains:
+
+| Field | Meaning |
+|---|---|
+| `tradeId` | Selects the existing service-side trade context. |
+| `sellersPayoutAmountExcludingFee` | The exact seller gross payout from the immutable signed mediation result, before custom payout fees. Both roles pass the same value. |
+| `feeRate` | Fee rate in satoshis per 1,000 weight units (`sat/kwu`). |
+
+The request does not contain the buyer gross payout amount.
+
+On success the service returns `CustomPayoutPsbt`:
+
+| Field | Meaning |
+|---|---|
+| `psbt` | The custom payout PSBT partially signed by the local trader for both inputs. |
+| `txId` | The transaction ID of the common unsigned custom payout transaction. |
+| `buyersPayoutAmountIncludingFee` | The actual buyer output value after the buyer fee share was deducted. |
+| `sellersPayoutAmountIncludingFee` | The actual seller output value after the seller fee share was deducted. |
+
+The two payout field names are potentially misleading: they are post-fee output values, not gross amounts with an
+additional fee. Java validates them against the gross mediation amounts and must not deduct a second fee. Java does not
+reproduce service-side fee or dust calculations.
+
+### `CustomCloseTrade`
+
+Java calls `CustomCloseTrade(CustomCloseTradeRequest)` only after it has both its own partial PSBT and the peer's matching,
+result-bound partial PSBT.
+
+`CustomCloseTradeRequest` contains:
+
+| Field | Meaning |
+|---|---|
+| `tradeId` | Selects the service-side trade context and its local partial PSBT. |
+| `peersCustomPayoutPsbt` | The peer's serialized partial PSBT received through the P2P protocol. |
+
+On success, `CustomCloseTradeResponse.customPayoutTx` contains the finalized transaction and establishes that the peer
+PSBT was accepted for the expected custom payout. It also means the Bitcoin backend accepted that transaction for
+broadcast or reported that the identical transaction was already known. It does not mean mempool observation or
+blockchain confirmation. The already-known case is important because both clients independently call this RPC for the
+same transaction.
+
+### RPC identity
+
+The first integration adds no `settlementId`, mediation-result hash, buyer gross payout, or other RPC field.
+
+At the RPC boundary, `tradeId` selects the service-side trade context and the existing request fields describe the
+operation. At the Java/P2P boundary, `mediationResultHash` binds peer artifacts to the signed proposal, while the RPC
+response's `txId` identifies the concrete unsigned transaction.
+
+This is sufficient only for the one-shot first iteration. No idempotency or restart guarantee may be inferred from
+`tradeId` alone.
+
+## P2P contract
+
+### Positive response: partial PSBT
+
+There is no separate positive-acceptance message. `MuSigCustomPayoutPsbtMessage` is the only positive response sent to
+the peer and is carried as a dedicated confidential mailbox message under `MuSigTradeMessage`.
+
+The target flow therefore removes the existing `MuSigMediationResultAcceptanceMessage` and does not persist or consult
+the existing `mediationResultAccepted` value.
+
+It uses the normal `TradeMessage` envelope:
+
+* `id`: one stable outgoing ID for this partial PSBT
+* `tradeId`
+* `protocolVersion`
+* `sender`
+* `receiver`
+
+Its message-specific payload is:
+
+| Field | Meaning |
+|---|---|
+| `mediationResultHash` | The 20-byte `DigestUtil.hash(mediationResult.serializeForHash())` of the exact result accepted by the signer. |
+| `txId` | The transaction ID returned by the local MuSig service. |
+| `psbt` | The serialized partial PSBT returned by the local MuSig service. |
+
+The P2P payload must remain independent of the gRPC DTO. The sender copies the required values from its stored local RPC
+result; the receiver represents them as peer/domain data rather than storing a peer-supplied gRPC object.
+
+Each trader sends this message after successful local signing so that either client can later finalize independently.
+
+### Negative response: rejection
+
+`MuSigMediationResultRejectionMessage` communicates rejection of a mediation result whose payout distribution type is
+not `NO_PAYOUT`. It identifies the trade and sender and carries `mediationResultHash` so the receiver can verify that both
+traders refer to the same immutable result.
+
+Positive intent is never inferred from message delivery or from a Boolean. It is represented by the result-bound local or
+peer PSBT. Rejection remains a one-way result-bound fact.
+
+### No final publication message in the first version
+
+The first version has no separate P2P message announcing final transaction publication. Both clients receive the peer
+PSBT and independently obtain their own `CustomCloseTradeResponse`. A later publication message may be considered for
+recovery, but it cannot replace a successful custom-close response or authoritative chain observation.
+
+### Transport acknowledgements
+
+A transport acknowledgement proves only that the peer's network layer received and decrypted a structurally valid
+envelope. It does not prove:
+
+* business or contextual validity
+* peer signature validity
+* durable peer storage
+* readiness to finalize
+
+Transport delivery status must never advance custom payout settlement state by itself.
+
+## Java validation contract
+
+### Before `SignCustomPayoutTx`
+
+Java must verify:
+
+* the local trade and corresponding service-side trade context are expected to exist
+* the signed mediation result is immutable, authentic, and bound to the trade contract
+* the result's payout distribution type is not `NO_PAYOUT` and the gross payouts distribute the full trade pot
+* the exact fully signed DepositTx reached the normal `DEPOSIT_TX_CONFIRMED` transition
+* the local state is in the exact signing allowlist defined by the settlement specification
+* the peer has not already rejected this result
+* local rejection, custom signing, and the message F boundary are serialized per trade
+* the provisional fee rate is valid for the first iteration
+
+This check is not an authoritative query of the Bitcoin UTXO set and does not prove that the inputs remain unspent.
+
+### On a local signing response
+
+Java must verify:
+
+* `txId` is present and syntactically valid
+* the partial PSBT is present
+* both returned actual payouts are non-negative and no greater than their gross payout amounts
+* the response does not conflict with an already stored response for this trade
+
+Java stores the successful response before constructing the P2P message.
+
+The mediation result and its mediator signature are write-once for the lifetime of the trade. Reopening mediation through
+`MEDIATION_RE_OPENED` changes the dispute state but does not permit replacing either value. The local signing
+response is therefore associated with the trade's single stored result. Before constructing the outgoing P2P message or
+invoking `CustomCloseTrade`, Java requires the stored result and its verified signature to be present and computes
+`mediationResultHash` from that result. It does not persist a duplicate result hash with the local RPC response.
+
+### On a peer PSBT
+
+Java validates in this order:
+
+1. Authenticate and validate the normal message envelope, trade ID, protocol version, sender, and receiver. The sender
+   must be the expected trade peer and must not be banned.
+2. Require a syntactically valid 64-character hexadecimal transaction ID.
+3. Require a non-empty PSBT within a named implementation size limit.
+4. If the immutable mediation result is not yet available, keep the exact message pending in the existing live-process
+   MuSig pending-message mechanism and do not use it.
+5. Recompute the hash of the stored result and require it to equal `mediationResultHash`.
+6. Reject the PSBT if a peer rejection for this result was stored first.
+7. Once the local PSBT exists, require the peer's claimed `txId` to equal the locally returned `txId`.
+8. Store peer data before invoking `CustomCloseTrade` and never replace it with conflicting data.
+
+The two serialized PSBTs are not expected to be equal. The peer's claimed transaction ID is a Java pre-check only;
+`CustomCloseTrade` success is required before Java treats the peer PSBT as accepted for the expected transaction.
+
+### Before local completion
+
+Java calls `CustomCloseTrade` only when the immutable result, local PSBT, and contextually valid matching peer PSBT are
+available. On success, Java validates and stores the returned final transaction before moving to the existing buyer or
+seller closed state.
+
+## Persistence and ordering contract
+
+Custom payout progress is related to, but separate from, `MuSigTradeState` and `MuSigDisputeState`. The implementation
+must inspect these dimensions together rather than create a combined enum value for every possible combination.
+
+Each `MuSigTradeParty` owns optional grouped `MuSigCustomPayoutPartyData`. The persisted model distinguishes data produced
+locally from data received from the peer:
+
+* local party data retains the successful local `CustomPayoutPsbt` response and may later retain the successful
+  `CustomCloseTradeResponse`
+* peer party data retains an independent `PeerCustomPayoutPsbt` containing the claimed transaction ID and serialized peer
+  PSBT without embedding a gRPC DTO
+* rejection remains a one-way fact associated with the rejecting local or peer party
+
+The normal `TradeMessage.id` and the message payload's `mediationResultHash` are validated at the P2P boundary but are not
+duplicated in party persistence. The existing network resend and delivery infrastructure owns the complete outgoing
+message and its stable ID.
+
+Fields are write-once. Repeating the same stored value is a no-op, and conflicting peer data must not replace the first
+stored value. Peer rejection and a peer PSBT are mutually exclusive decision artifacts, and their check-and-store
+operations must be serialized per trade.
+
+Payout amounts, the signed mediation result, normal state, dispute state, DepositTx confirmation, network delivery status,
+and the provisional fee rate remain owned by their existing models and must not be duplicated in custom payout data. Both
+local and peer custom payout data rely on the immutable mediation result owned by the trade dispute model; Java recomputes
+`mediationResultHash` from that result when needed.
+
+The first version uses the normal MuSig handler and FSM persistence flow after successful processing. It adds no special
+pre-call requested state, awaited peer-message checkpoint, or durable pending-message queue.
+
+## Error and completion contract
+
+For the first iteration:
+
+* `SignCustomPayoutTx` and `CustomCloseTrade` are one-shot calls with no automatic retry.
+* A signing error or missing response produces no outgoing PSBT and keeps the normal close path blocked after dispatch.
+* A close error or missing response does not select another settlement or reopen normal cooperative closure.
+* Peer unavailability causes an indefinite pending state; a rejection received before a PSBT causes a blocked state.
+* A successful `CustomCloseTrade` response completes the local Java trade without waiting for confirmation.
+
+These rules are conservative because an RPC transport failure does not reveal whether the service changed state, signed,
+or accepted a transaction for broadcast before the response was lost.
+
+## Joint contract still to confirm
+
+The following server-side interface behavior must be agreed before production recovery behavior is built:
+
+* authoritative checking of whether the expected inputs have already been spent
+* durable storage of the service-side trade context, local PSBT, final transaction, and broadcast outcome
+* idempotent replay and restart reconciliation under the unchanged RPC schemas
+* structured errors that distinguish permanent, retryable, and ambiguous outcomes
+* reconciliation after a lost `SignCustomPayoutTx` or `CustomCloseTrade` response
+* role-specific fallback after a custom payout signature has been released
+* transaction-status reporting, conflicting-spend detection, and reorganization behavior
+
+These open points do not change the first-version happy path, but they prevent treating that first iteration as a complete
+production recovery design.

--- a/docs/specs/trade/mu_sig/mediation/custom-payout-settlement.md
+++ b/docs/specs/trade/mu_sig/mediation/custom-payout-settlement.md
@@ -1,0 +1,312 @@
+# Mediated custom payout settlement for MuSig trades
+
+## Status
+
+This document specifies the proposed first-version behavior for closing a mediated MuSig trade with a cooperative custom
+payout. It is the target contract for [issue #4888](https://github.com/bisq-network/bisq2/issues/4888), not a description
+of the current Java implementation.
+
+The `SignCustomPayoutTx` and `CustomCloseTrade` RPCs are already available. The complete Java integration and parts of
+the required service-side interface behavior, including broadcast, are not yet implemented. Requirements that need
+further joint design are listed under [Deferred decisions](#deferred-decisions).
+
+## Scope
+
+This specification covers the flow after a mediator has produced a signed mediation result whose payout distribution
+type is not `NO_PAYOUT`, including:
+
+* prerequisites for calling `SignCustomPayoutTx`
+* prerequisites for calling `CustomCloseTrade`
+* P2P communication between the traders
+* custom payout progress and persistence
+* first-version retry, failure, and recovery behavior
+
+It does not cover:
+
+* mediator case investigation or payout calculation
+* arbitration or non-cooperative recovery
+* UI design
+
+## Settlement model
+
+The mediator authenticates a proposed payout split but does not sign a Bitcoin transaction. The custom payout remains
+cooperative: both traders must accept the same signed result and sign the same transaction before it can be finalized.
+
+The transaction spends both payout outputs of the fully signed DepositTx. Each output has a Taproot script-path policy
+that requires one buyer signature and one seller signature. Each trader therefore creates a PSBT that partially signs
+both inputs. Combining the two PSBTs supplies the two required signatures for each input.
+
+The signatures commit to the complete unsigned transaction. A signature cannot be reused with a different payout,
+fee, destination, or input set. Independently created PSBTs for the same transaction have the same transaction ID even
+though their serialized PSBT bytes differ because they contain different signatures.
+
+### Normal-flow message names
+
+This specification refers to three existing messages from the normal cooperative close flow:
+
+* message E is `PaymentInitiatedMessage_E`, sent from the buyer after initiating the fiat payment
+* message F is `PaymentReceivedMessage_F`, sent from the seller after confirming receipt of the fiat payment
+* message G is `CooperativeClosureMessage_G`, sent from the buyer while completing normal cooperative closure
+
+## Eligibility and signing window
+
+### Opening mediation
+
+Mediation may be opened once the fully signed DepositTx exists and is known locally. A prepared or partially signed
+deposit PSBT is insufficient. DepositTx confirmation is not required merely to open mediation.
+
+A mediation result may be received and displayed before custom payout signing becomes available. The result does not
+prove DepositTx confirmation and must not be used as a substitute for normal transaction observation.
+
+### Results eligible for custom payout
+
+The stored mediation result must be immutable, signed by the contract mediator, valid for the trade contract, and
+allocate the full trade pot between buyer and seller.
+
+The result and its mediator signature are write-once for the lifetime of the trade. Reopening mediation changes the
+dispute state but does not permit replacing either value.
+
+`NO_PAYOUT` is a valid mediator outcome, but it is not a cooperative custom payout proposal. For `NO_PAYOUT`, the client:
+
+* offers neither `Accept` nor `Reject` for this flow
+* records no trader custom payout decision
+* creates and sends no partial PSBT
+* calls neither custom payout RPC
+
+### DepositTx confirmation prerequisite
+
+Custom payout signing requires the normal validated transition for the exact fully signed DepositTx to
+`MuSigTradeState.DEPOSIT_TX_CONFIRMED`. The current protocol threshold is one blockchain confirmation. Later eligible
+normal states inherit this fact; custom payout data must not duplicate a separate confirmation flag.
+
+The local `Accept` action is unavailable until this and all other stable signing prerequisites are satisfied. The client
+must not intentionally persist an accepted-but-waiting decision for an already known missing prerequisite.
+
+### Java signing-state allowlist
+
+Immediately before calling `SignCustomPayoutTx`, the local `MuSigTradeState` must be exactly one of:
+
+* `DEPOSIT_TX_CONFIRMED`
+* `BUYER_INITIATED_PAYMENT`
+* `SELLER_RECEIVED_INITIATED_PAYMENT_MESSAGE`
+
+The signing window therefore remains open before and after normal-flow message E, but closes at the local message F
+boundary:
+
+| Normal-flow point | May custom signing start? |
+|---|---|
+| Before the fully signed DepositTx is known locally | No |
+| DepositTx known but not confirmed | No |
+| `DEPOSIT_TX_CONFIRMED`, before message E | Yes |
+| After message E and before message F | Yes |
+| Seller starts the action that creates message F | No |
+| Buyer starts processing message F | No |
+| Message G or any final state | No |
+
+This allowlist is an application-state guard. It does not prove that the DepositTx payout outputs remain unspent.
+
+### Serialization with normal closure
+
+Starting `SignCustomPayoutTx` and crossing the local message F boundary must be serialized per trade.
+
+* If message F starts first, custom payout signing must not start and the normal cooperative flow continues.
+* If custom signing starts first, normal F processing waits for the signing outcome and must not invoke an incompatible
+  normal-close RPC.
+
+After custom signing succeeds, messages E, F, and G may still be authenticated and retained as payment-status information,
+but they must not cause Java to invoke the normal cooperative-close RPCs.
+
+## Trader decisions
+
+### Acceptance
+
+When `Accept` is available and selected, Java revalidates the prerequisites, atomically acquires the local signing path
+against rejection and message F, and immediately calls `SignCustomPayoutTx`.
+
+Acceptance has no independent persisted Boolean and no separate positive-acceptance P2P message. A successfully stored
+local partial PSBT is the local positive artifact; the result-bound peer PSBT message is the positive artifact observed
+by the other trader.
+
+The trader does not wait for the peer to accept or come online before producing and sending a partial PSBT. Receiving a
+peer PSBT also does not authorize local signing: the local trader must make their own decision and satisfy the local
+signing gate.
+
+### Rejection
+
+A trader may reject a result whose payout distribution type is not `NO_PAYOUT` only before the local signing path has
+been granted. Rejection is one-way, is bound to the exact result through its hash, creates no signature, and prevents a
+later local custom payout signature.
+
+If a peer has already supplied a contextually valid PSBT, a later peer rejection cannot revoke that released signature.
+If a peer rejection was stored first, a later PSBT from that peer conflicts with the stored decision and cannot be used.
+
+For each peer and mediation result, the first contextually valid decision artifact stored by Java wins:
+
+* an exact repeat is idempotent
+* rejection followed by a PSBT keeps the rejection
+* a PSBT followed by rejection keeps the PSBT
+* conflicting data never replaces the first stored artifact
+
+This Java rule resolves application-level ordering only. A successful `CustomCloseTrade` response is still required
+before Java treats both PSBTs as a completed custom payout.
+
+## First-version end-to-end flow
+
+Alice and Bob below identify the first and second trader to accept; either may be buyer or seller.
+
+```mermaid
+sequenceDiagram
+    participant M as Mediator
+    participant AJ as Alice Java
+    participant AS as Alice MuSig service
+    participant BJ as Bob Java
+    participant BS as Bob MuSig service
+
+    M-->>AJ: Signed mediation result (type is not NO_PAYOUT)
+    M-->>BJ: Same signed mediation result
+
+    Note over AJ,BJ: Accept remains unavailable until local signing prerequisites are satisfied
+
+    AJ->>AJ: Alice accepts and acquires signing path
+    AJ->>AS: SignCustomPayoutTx
+    AS-->>AJ: Alice partial PSBT and txId
+    AJ->>AJ: Validate and store local result
+    AJ-->>BJ: Result-bound Alice partial PSBT
+
+    Note over BJ: Bob may have been offline and accepts later
+
+    BJ->>BJ: Bob accepts and acquires signing path
+    BJ->>BS: SignCustomPayoutTx
+    BS-->>BJ: Bob partial PSBT and same txId
+    BJ->>BJ: Validate and store local result
+    BJ-->>AJ: Result-bound Bob partial PSBT
+
+    BJ->>BS: CustomCloseTrade(Alice PSBT)
+    BS-->>BJ: Final transaction accepted for broadcast
+    BJ->>BJ: Store response and complete locally
+
+    AJ->>AS: CustomCloseTrade(Bob PSBT)
+    AS-->>AJ: Same final transaction accepted or already known
+    AJ->>AJ: Store response and complete locally
+```
+
+Each client sends its locally created partial PSBT. This lets both clients independently finalize when they are online;
+the traders do not have to be online at the same time.
+
+## Payout and fee rules
+
+The full trade pot is:
+
+```text
+totalPayoutAmount = tradeAmount
+                  + buyerSecurityDeposit
+                  + sellerSecurityDeposit
+```
+
+For a mediation result whose payout distribution type is not `NO_PAYOUT`:
+
+```text
+buyerGrossPayout + sellerGrossPayout = totalPayoutAmount
+```
+
+The mediation amounts are gross allocations before the custom payout mining fee. Both clients pass the exact mediator
+`proposedSellerPayoutAmount` as `sellersPayoutAmountExcludingFee`; Java does not deduct a fee first. The request contains
+no buyer gross payout field.
+
+For the first Java integration, both clients use the current prepared-transaction default fee rate of `2,500 sat/kwu`
+(`10 sat/vB`). This is a temporary implementation assumption, not the production fee-agreement contract.
+If the clients use different fee rates, they construct different transactions and return different transaction IDs;
+Java must reject the mismatch and leave the settlement stalled rather than attempt unsafe finalization.
+
+Despite their current `IncludingFee` names, `buyersPayoutAmountIncludingFee` and
+`sellersPayoutAmountIncludingFee` are the actual transaction output amounts after fee deduction. Java requires each
+returned amount to be non-negative and no greater than the corresponding proposed payout amount. Java must not deduct
+another fee.
+
+Java does not reproduce service-side fee or script-specific dust calculations. If `SignCustomPayoutTx` returns an error,
+Java stores no local PSBT and sends no peer PSBT message.
+
+## PSBT exchange and finalization
+
+After a successful `SignCustomPayoutTx` response, Java validates and stores the local result before sending the partial
+PSBT in a dedicated confidential mailbox message. The message binds the signature to:
+
+* the immutable mediation result through `mediationResultHash`
+* the concrete unsigned transaction through the RPC-returned `txId`
+
+A peer PSBT may arrive before the local trader decides. Java may retain it after contextual validation, but it must not
+trigger local signing or finalization. Once a local PSBT exists, Java requires the peer's claimed transaction ID to match
+the local transaction ID. The PSBT byte arrays are not compared because they contain different signatures.
+
+Matching Java metadata is necessary but not sufficient. Java treats the peer PSBT as usable for completion only after
+`CustomCloseTrade` succeeds.
+
+Java calls `CustomCloseTrade` only when both the local and peer result-bound partial PSBTs are available. Each client
+makes this call independently.
+
+## Completion boundary
+
+The interface defines finalization and broadcast as one `CustomCloseTrade` operation. A successful response means the
+Bitcoin backend accepted the exact finalized transaction for broadcast or reported that the identical transaction was
+already known. It does not mean that the transaction is confirmed.
+
+For the first version, a successful response is the local terminal event. Java stores the returned final transaction and
+uses the existing role-specific terminal state:
+
+* buyer: `BUYER_CLOSED_TRADE`
+* seller: `SELLER_CLOSED_TRADE`
+
+There is no custom-payout-specific terminal `MuSigTradeState`, and completion does not wait for mempool observation or a
+blockchain confirmation. Completed-trade presentation uses the custom payout transaction ID, not the DepositTx ID.
+
+No final-transaction P2P notification is required in the first version because each trader receives a successful local
+`CustomCloseTrade` response.
+
+## First-version failure behavior
+
+The initial integration follows the existing one-shot MuSig RPC handling pattern:
+
+* each custom payout RPC is called at most once
+* no separate persisted requested-or-unknown state is introduced
+* no automatic RPC retry or restart reconciliation is attempted
+* successful responses and validated peer artifacts use the normal trade persistence flow
+
+Once `SignCustomPayoutTx` is dispatched, an error or missing response cannot prove that the service did not sign. Java
+therefore sends no PSBT without a successful response, but it also must not resume normal cooperative closure, choose a
+different settlement, or retry blindly. The first-version flow fails or stalls conservatively.
+
+After a local PSBT is created and sent, an offline or unresponsive peer leaves settlement pending without an automatic
+timeout. A valid peer rejection received before a peer PSBT leaves settlement blocked. Neither condition automatically
+changes the payout, creates another signature, resumes normal cooperative closure, starts forced closure, or enters
+arbitration.
+
+A `CustomCloseTrade` error likewise does not authorize a blind retry, a different settlement, or normal cooperative
+closure. These limitations make the first iteration suitable for implementing and testing the happy path, but not the
+complete production recovery contract.
+
+## Security requirements
+
+* Do not request a wallet signature before all business and local-state prerequisites are satisfied.
+* Use only the payout addresses fixed during trade setup; a mediation message must not introduce payout addresses.
+* Bind every peer artifact to the exact immutable mediation result.
+* Treat result hashes and claimed transaction IDs as untrusted metadata until the applicable validation succeeds.
+* Apply a named maximum size before accepting or parsing a peer PSBT.
+* Do not log raw PSBTs, signatures, derivation metadata, or transaction bytes at normal log levels.
+* Treat the local gRPC endpoint as security-sensitive; localhost binding alone is not authorization.
+* Never silently change payout amounts, fee rate, destinations, or transaction inputs after a signature may have been
+  produced.
+
+## Deferred decisions
+
+The following are intentionally outside the first happy-path contract and require joint interface agreement before the
+corresponding production behavior is implemented:
+
+* the production fee source and how both clients agree on the same value
+* authoritative live checking that the expected DepositTx outputs remain unspent
+* RPC idempotency and reconciliation after an error or process restart, using the unchanged RPC schemas
+* durable service-side trade, PSBT, final-transaction, and broadcast state
+* structured RPC errors and ambiguous-outcome handling
+* durable handling of a peer message received before all validation context exists
+* safe role-specific recovery after a trader has released a custom payout signature, including the current seller-side
+  recovery gap
+* chain observation, conflicting-spend detection, transaction eviction, and reorganization handling

--- a/trade/src/main/java/bisq/trade/mu_sig/mediation/specification.md
+++ b/trade/src/main/java/bisq/trade/mu_sig/mediation/specification.md
@@ -2,7 +2,10 @@
 
 ### Scope
 
-This document describes the mediation process from the perspective of a trader.
+This document describes the current mediation implementation from the perspective of a trader.
+
+The proposed target behavior for cooperative custom payout is documented in the
+[canonical MuSig mediation specifications](../../../../../../../../docs/specs/trade/mu_sig/mediation/README.md).
 
 In scope:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an overview of Bisq domain specifications, including account timestamp attestation and MuSig mediation.
  * Documented proposed MuSig mediation behavior, including custom payout interfaces and settlement flows.
  * Clarified eligibility, signing, validation, persistence, completion, rejection, and failure-handling requirements.
  * Documented current implementation limitations, pending recovery considerations, and deferred production decisions.
  * Updated mediation documentation to reference the canonical specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->