### PR TITLE
feature/fsm_threading_improvements

### DIFF
--- a/common/src/main/java/bisq/common/fsm/Fsm.java
+++ b/common/src/main/java/bisq/common/fsm/Fsm.java
@@ -61,19 +61,42 @@ public abstract class Fsm<M extends FsmModel> {
     abstract protected void configTransitions();
 
     public <E extends Event> void handle(E event) {
-        synchronized (this) {
+        // Lock on the model's explicit lock rather than on this Fsm instance: the model (see
+        // FsmModel#getStateAndEventQueueSnapshot) must be lockable directly by callers that only hold a reference
+        // to the model - e.g. Trade#getTradeBuilder during persistence - without needing a reference to this
+        // Fsm/TradeProtocol. Sharing the same lock object gives both sides the same mutual exclusion, so a
+        // persistence snapshot of {state, eventQueue} can never be taken mid-transition. Unlike
+        // getStateAndEventQueueSnapshot()'s bounded tryLock, a live transition takes the lock unbounded - its
+        // correctness cannot be short-circuited by a timeout.
+        model.lock.lock();
+        try {
+            // Tracks whether this call reached a final state, so the finally block below can route the mandatory
+            // post-transition persist() call through persistOnFinalState() instead of the normal persist(). This
+            // matters for privacy/retention (#1622 follow-up): a final state clears eventQueue/processedEvents
+            // in-memory a few lines below, and that wipe must reach disk promptly - persistOnFinalState() bypasses
+            // any write-rate limiting a subclass may apply to the ordinary persist(), so the wipe is not silently
+            // dropped and left stranded on disk for an indefinite time.
+            boolean reachedFinalState = false;
             try {
                 checkNotNull(event, "event must not be null");
                 State currentState = model.getState();
                 checkNotNull(currentState, "currentState must not be null");
                 if (currentState.isFinalState()) {
-                    log.warn("We have reached the final state and do not allow further state transition. New event was: {}", event);
+                    // Render the class only, never the event instance: the Fsm layer is generic and handles
+                    // domain events (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage) whose
+                    // generated toString() can contain private payment-account data. This log line - like the
+                    // checkArgument message and the error log below - can end up persisted as trade error info
+                    // and included in the error report sent to the peer, so it must never carry event content.
+                    log.warn("We have reached the final state and do not allow further state transition. New event class was: {}", event.getClass().getSimpleName());
                     return;
                 }
                 log.info("Start transition from currentState {}", currentState);
                 Class<? extends Event> eventClass = event.getClass();
                 var transitionMapEntriesForEvent = findTransitionMapEntriesForEvent(eventClass);
-                checkArgument(!transitionMapEntriesForEvent.isEmpty(), "No transition found for given event " + event);
+                // Class name only - see the final-state log above for why the event instance itself must never
+                // be rendered here. This message reaches FsmException's cause chain and from there the trade's
+                // persisted error info / peer error report.
+                checkArgument(!transitionMapEntriesForEvent.isEmpty(), "No transition found for given event class " + eventClass.getSimpleName());
                 Optional<Transition> transition = findTransition(currentState, transitionMapEntriesForEvent);
                 if (transition.isPresent()) {
                     State targetState = transition.get().getTargetState();
@@ -95,14 +118,11 @@ public abstract class Fsm<M extends FsmModel> {
                     if (targetState.isFinalState()) {
                         model.processedEvents.clear();
                         model.eventQueue.clear();
+                        reachedFinalState = true;
                     } else {
                         model.processedEvents.add(eventClass);
                         // Apply all pending events to see if any of those match our current state.
-                        // If an exception is thrown by the processed pending event it will get thrown to the
-                        // caller. This would be a different triggering event as the event which cause
-                        // the exception (the one from the queue).
-                        // Clone set to avoid ConcurrentModificationException
-                        new HashSet<>(model.getEventQueue()).forEach(this::handle);
+                        drainEventQueue();
                     }
                 } else {
                     log.info("We did not find a transition with state {} and event {}. " +
@@ -116,7 +136,11 @@ public abstract class Fsm<M extends FsmModel> {
                             .forEach(e -> model.eventQueue.add(event));
                 }
             } catch (Exception exception) {
-                log.error("Error at handling {}.", event, exception);
+                // Class name only - see the comment at the final-state log above. Null-safe on
+                // purpose: the checkNotNull above lands here with event == null, and calling
+                // event.getClass() would mask the informative NPE with a raw one, bypassing the
+                // FsmErrorEvent/error-state handling below.
+                log.error("Error at handling event of class {}.", eventClassName(event), exception);
                 FsmException fsmException = new FsmException(exception, event);
                 // In case of an exception we fire the FsmErrorEvent to trigger an error state.
                 // We apply that only if the event which triggered the exception was not the FsmErrorEvent itself
@@ -128,12 +152,70 @@ public abstract class Fsm<M extends FsmModel> {
                 // We throw the exception to allow specific error handling to the implementation class.
                 throw fsmException;
             } finally {
-                persist();
+                if (reachedFinalState) {
+                    persistOnFinalState();
+                } else {
+                    persist();
+                }
             }
+        } finally {
+            model.lock.unlock();
         }
     }
 
-    protected abstract void persist();
+    private static String eventClassName(Event event) {
+        return event == null ? "null" : event.getClass().getSimpleName();
+    }
+
+    /**
+     * Persistence hook invoked after every handled event (and from the error path). No-op by
+     * default: implementations whose FSM state must survive restarts (e.g. trade protocols
+     * persisting the event queue) override this to trigger their store's persist.
+     */
+    protected void persist() {
+    }
+
+    /**
+     * Called instead of {@link #persist()} exactly once, when a transition reaches a final state. The default
+     * implementation just delegates to {@link #persist()}; override to bypass any write-rate limiting the
+     * concrete {@link #persist()} implementation applies (see {@code bisq.persistence.RateLimitedPersistenceClient}).
+     * <br/>
+     * Reaching a final state clears {@code eventQueue}/{@code processedEvents} in-memory a few lines above in
+     * {@link #handle(Event)}; those may hold sensitive, trade-specific network messages. Without a guaranteed,
+     * unthrottled flush here, a rate-limited persist() call could be silently dropped, leaving the (already
+     * in-memory-wiped) sensitive data sitting on disk for an unbounded time - potentially until the process's
+     * next unrelated persist() call, or its next clean shutdown, neither of which is guaranteed to happen promptly
+     * (or at all, on a crash/kill -9).
+     */
+    protected void persistOnFinalState() {
+        persist();
+    }
+
+    /**
+     * Re-attempts to handle every event currently sitting in the event queue against the current state.
+     * <br/>
+     * This is called automatically after any successful transition (see {@link #handle(Event)}), but it is
+     * also safe - and sometimes necessary - to call explicitly, e.g. once right after a model has been restored
+     * from persisted data: the event queue itself is not guaranteed to be persisted for every {@link FsmModel}
+     * subclass, so events which arrived out of order before a restart may otherwise never be re-applied because
+     * no further live transition ever occurs for that trade.
+     * <br/>
+     * Safe to call when the queue is empty (no-op) and safe to call multiple times. Exceptions from handling a
+     * queued event behave exactly as for a live event: each event goes through the concrete {@link #handle(Event)}
+     * implementation, so whether an {@link FsmException} propagates to the caller or is absorbed is up to the
+     * subclass (e.g. the trade protocols swallow it and surface an error state instead).
+     */
+    public void drainEventQueue() {
+        // Unbounded, like handle() - ReentrantLock is reentrant, so the nested lock() calls inside each
+        // handle(event) below (same thread) are free.
+        model.lock.lock();
+        try {
+            // Clone set to avoid ConcurrentModificationException as handle() mutates model.eventQueue.
+            new HashSet<>(model.getEventQueue()).forEach(this::handle);
+        } finally {
+            model.lock.unlock();
+        }
+    }
 
     public TransitionBuilder<M> addTransition() {
         return new TransitionBuilder<>(this);

--- a/common/src/main/java/bisq/common/fsm/FsmModel.java
+++ b/common/src/main/java/bisq/common/fsm/FsmModel.java
@@ -24,18 +24,53 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 @Slf4j
 @ToString
 @EqualsAndHashCode
 public class FsmModel {
+    /**
+     * Bound for {@link #getStateAndEventQueueSnapshot()}'s {@code tryLock}. Chosen short enough that the single,
+     * JVM-wide {@code Persistence} executor thread (see {@code bisq.persistence.Persistence#EXECUTOR}) can never
+     * be stuck for long on one trade's live transition - which would otherwise queue up every other store's
+     * writes behind it - yet long enough to comfortably clear the lock's normal, fast holders (a transition's
+     * state mutation plus a non-blocking persist() submission). A timed-out snapshot fails this write cycle
+     * rather than risk a torn read; RateLimitedPersistenceClient's generation pair keeps the store dirty so the
+     * next persist()/shutdown fallback retries - by which time a merely-slow (not stuck) handler has typically
+     * released the lock.
+     */
+    static final long SNAPSHOT_LOCK_TIMEOUT_MS = 500;
+
     private final Observable<State> state = new Observable<>();
 
-    // Package visibility for access from Fsm mutating the collections 
-    final Set<Event> eventQueue = new HashSet<>();
-    final Set<Class<? extends Event>> processedEvents = new HashSet<>();
+    // Explicit lock replacing the previous intrinsic-monitor use (synchronized(model) in Fsm#handle()/
+    // drainEventQueue(), synchronized methods below): ReentrantLock, unlike synchronized, offers a bounded
+    // tryLock(timeout), which getStateAndEventQueueSnapshot() below needs. Every party that used to synchronize
+    // on the model instance must now go through this SAME lock object - Fsm#handle()/drainEventQueue() included -
+    // or mutual exclusion between a live transition and a persistence-facing read silently breaks.
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    final ReentrantLock lock = new ReentrantLock();
+
+    // Package visibility for access from Fsm mutating the collections.
+    // CopyOnWriteArraySet rather than a plain HashSet, as defense-in-depth for any reader that bypasses
+    // getStateAndEventQueueSnapshot() and calls getEventQueue()/getProcessedEvents() directly without acquiring
+    // the shared lock field above (Fsm#handle()/Fsm#drainEventQueue() run under that same lock - see
+    // getStateAndEventQueueSnapshot() below for why). Concurrently iterating a plain HashSet while another thread
+    // structurally mutates it is undefined behavior (ConcurrentModificationException or a torn read). Both sets
+    // are always small (a handful of pending FSM events per trade at most) and read far more often than mutated,
+    // which is exactly CopyOnWriteArraySet's sweet spot; it also gives every such reader (including
+    // Fsm#drainEventQueue()'s defensive copy-before-iterate, which a plain HashSet copy does not actually make
+    // safe under concurrent mutation) consistent snapshot-iterator semantics for free, without requiring any
+    // external synchronization. The primary, recommended mechanism for a cross-thread, all-fields-consistent read
+    // (e.g. Trade#getTradeBuilder during persistence) is getStateAndEventQueueSnapshot(), not these getters.
+    final Set<Event> eventQueue = new CopyOnWriteArraySet<>();
+    final Set<Class<? extends Event>> processedEvents = new CopyOnWriteArraySet<>();
 
     public FsmModel(State initialState) {
         if (initialState == null) {
@@ -72,5 +107,103 @@ public class FsmModel {
 
     public Set<Class<? extends Event>> getProcessedEvents() {
         return Collections.unmodifiableSet(processedEvents);
+    }
+
+    /**
+     * Returns an atomic, defensively-copied snapshot of {@code state} and {@code eventQueue} taken together.
+     * <br/>
+     * {@link Fsm#handle(Event)} and {@link Fsm#drainEventQueue()} take the same {@link #lock} (not a lock on the
+     * {@code Fsm} instance) precisely so that this method - callable directly on the model, e.g. from
+     * {@code bisq.trade.Trade#getTradeBuilder} during persistence, which runs on a different thread than the Fsm's
+     * own transitions (persistence is cloned/serialized asynchronously, and for MuSig trades the message-handling
+     * itself runs on a dedicated executor - see {@code MuSigTradeService#handleMuSigTradeMessage}) - can take the
+     * same lock and therefore never observe a torn read.
+     * <br/>
+     * Reading {@link #getState()} and {@link #getEventQueue()} via two separate, unsynchronized calls can tear:
+     * a persistence snapshot could capture the state AFTER a transition together with the just-applied event
+     * STILL in the queue (causing a double-apply on restore), or the state BEFORE the transition with the event
+     * already removed (causing the event to be silently lost). Capturing both fields in one atomically-locked
+     * method closes that gap.
+     * <br/>
+     * Unlike {@link Fsm#handle(Event)}/{@link Fsm#drainEventQueue()}, which take the lock unbounded (transition
+     * correctness cannot be short-circuited), this method bounds its wait via {@code tryLock}: it is called from
+     * {@code Trade#getTradeBuilder}, which runs on the single, JVM-wide {@code Persistence} executor thread. A live
+     * transition can legitimately hold {@link #lock} for as long as its event handler takes (including blocking
+     * I/O - e.g. MuSig's gRPC calls), and that thread must never block on it indefinitely: doing so would queue up
+     * every other store's disk writes in the JVM behind this one trade. On timeout this throws
+     * {@link SnapshotLockTimeoutException} instead of falling back to an unsynchronized read - a torn read is
+     * exactly the bug this method exists to prevent - so the write fails for this cycle and retries once the
+     * generation pair notices it's still dirty (see {@code RateLimitedPersistenceClient}).
+     * <br/>
+     * The returned {@code eventQueue} is a defensive copy ({@link Set#copyOf}): it is independent of the live,
+     * mutable {@code eventQueue} field, so a later transition can never retroactively change a snapshot that was
+     * already taken and handed to a caller.
+     */
+    public StateAndEventQueue getStateAndEventQueueSnapshot() {
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(SNAPSHOT_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting up to {}ms to acquire the FsmModel lock during serialization; " +
+                    "write cycle will retry. modelClass={}", SNAPSHOT_LOCK_TIMEOUT_MS, getClass().getSimpleName());
+            throw new SnapshotLockTimeoutException(this, SNAPSHOT_LOCK_TIMEOUT_MS, e);
+        }
+        if (!acquired) {
+            log.warn("FsmModel lock not acquired within {}ms during serialization - a live transition is likely " +
+                    "holding it; write cycle will retry. modelClass={}", SNAPSHOT_LOCK_TIMEOUT_MS, getClass().getSimpleName());
+            throw new SnapshotLockTimeoutException(this, SNAPSHOT_LOCK_TIMEOUT_MS);
+        }
+        try {
+            return new StateAndEventQueue(getState(), Set.copyOf(eventQueue));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Clears the pending out-of-order event queue (and {@code processedEvents}) under the same lock used by
+     * {@link #getStateAndEventQueueSnapshot()}, mirroring the final-state cleanup in {@link Fsm#handle(Event)}.
+     * Takes the lock unbounded, like {@link Fsm#handle(Event)}: this is called from the trade services, not from
+     * the persistence-serialization path, so there is no shared-executor-stall concern to bound against here.
+     * <br/>
+     * Used by the trade data-retention/redaction pass: the queue can hold sensitive account-data network messages
+     * (e.g. {@code BisqEasyAccountDataMessage} / MuSig {@code SendAccountPayloadMessage}) which are persisted with
+     * the trade. A stuck trade may never reach a final state to clear them, so they must be scrubbed once the trade
+     * passes the redaction threshold, otherwise the persisted copy would linger on disk indefinitely.
+     */
+    public void clearEventQueue() {
+        lock.lock();
+        try {
+            eventQueue.clear();
+            processedEvents.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Removes queued out-of-order events matching {@code filter}, under the same lock as
+     * {@link #getStateAndEventQueueSnapshot()}. Returns true if anything was removed (so callers know a
+     * persist is warranted). Takes the lock unbounded - see {@link #clearEventQueue()}.
+     * <br/>
+     * Used by the restore-drain guard in the trade services: a queued trade message passed validation when it
+     * was originally received, but its sender may have been banned before the restart. Draining applies queued
+     * events directly through the FSM - bypassing the {@code onMessage()} banned-sender check - so such events
+     * must be scrubbed before the drain, mirroring what {@code onMessage()} would do with a live message.
+     */
+    public boolean removeQueuedEventsIf(Predicate<Event> filter) {
+        lock.lock();
+        try {
+            return eventQueue.removeIf(filter);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Immutable {state, eventQueue} pair captured atomically by {@link #getStateAndEventQueueSnapshot()}.
+     */
+    public record StateAndEventQueue(State state, Set<Event> eventQueue) {
     }
 }

--- a/common/src/main/java/bisq/common/fsm/SnapshotLockTimeoutException.java
+++ b/common/src/main/java/bisq/common/fsm/SnapshotLockTimeoutException.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.fsm;
+
+/**
+ * Thrown by {@link FsmModel#getStateAndEventQueueSnapshot()} when its bounded {@code tryLock} could not acquire
+ * the model's lock in time, because a live {@link Fsm#handle(Event)}/{@link Fsm#drainEventQueue()} transition is
+ * holding it. Callers taking snapshots for persistence must NOT catch this per entry - it should propagate and
+ * fail the whole store write for that cycle, rather than silently dropping one entry from the snapshot while the
+ * write still reports success. A later persist retries the write, by which time the transition holding the lock
+ * has typically finished.
+ */
+public class SnapshotLockTimeoutException extends RuntimeException {
+    public SnapshotLockTimeoutException(FsmModel model, long timeoutMs) {
+        super("Could not acquire the FsmModel lock within " + timeoutMs + "ms while taking a state/eventQueue " +
+                "snapshot for " + model.getClass().getSimpleName() + " - a live transition is likely holding it.");
+    }
+
+    public SnapshotLockTimeoutException(FsmModel model, long timeoutMs, Throwable cause) {
+        super("Interrupted while waiting up to " + timeoutMs + "ms to acquire the FsmModel lock while taking a " +
+                "state/eventQueue snapshot for " + model.getClass().getSimpleName(), cause);
+    }
+}

--- a/common/src/test/java/bisq/common/fsm/FsmTest.java
+++ b/common/src/test/java/bisq/common/fsm/FsmTest.java
@@ -21,10 +21,22 @@ import lombok.Getter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FsmTest {
+    // Standin for private payment-account data that a real domain event's generated toString() could contain
+    // (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage). Used by SentinelMockEvent below.
+    private static final String SENTINEL_SECRET = "SECRET_PAYMENT_ACCOUNT_DATA_MUST_NOT_LEAK";
 
     @Test
     void testTransitions() {
@@ -156,6 +168,341 @@ public class FsmTest {
         assertEquals("test_comp", fsm.getModel().data);
         assertEquals(0, model.eventQueue.size());
         assertEquals(0, model.processedEvents.size());
+    }
+
+    /**
+     * Reproduces the recovery mechanism behind issue #1622 (a Bisq Easy trade getting stuck because an
+     * out-of-order message sits forever in the FSM's event queue): a queued event, and the model's state,
+     * are captured as if they had just been read back from persisted data (this is exactly what
+     * {@code Trade}'s 3-arg constructor now feeds into {@link FsmModel#FsmModel(State, Set, Set)} when a
+     * trade is restored from proto). We then rebuild a fresh Fsm around that restored model and call
+     * {@link Fsm#drainEventQueue()} once, with no further event delivered, and confirm the queued event is
+     * still applied - proving that recovery no longer depends on some later, unrelated live transition
+     * (or, as happens in production today, an app restart happening to re-deliver the same message via
+     * mailbox replay) to save the trade.
+     */
+    @Test
+    void testDrainEventQueueAfterModelRestore() {
+        // Session 1: an out-of-order event arrives before its prerequisite transition. It gets queued and the
+        // enabling transition (INIT -> S1) never happens live in this session - mirrors the reported bug,
+        // where the buyer's confirm-fiat-sent message arrives before the seller has processed the buyer's
+        // btc-address message.
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, fsm.getModel().getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        // "Restart": rebuild the model purely from the persisted snapshot (state + queue + processedEvents),
+        // exactly as BisqEasyTrade#fromProto now does via Trade#pendingEventsFromProto/processedEventsFromProto.
+        // The restored state (S1) represents the enabling transition having already been persisted; only the
+        // event queue itself was previously at risk of being silently dropped across a restart.
+        MockModel restoredModel = new MockModel(MockState.S1, model.getEventQueue(), model.getProcessedEvents());
+        SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
+        restoredFsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // The restored queue must round-trip faithfully.
+        assertEquals(1, restoredModel.getEventQueue().size());
+        assertEquals(MockState.S1, restoredFsm.getModel().getState());
+
+        // No further event is delivered - only the drain is triggered, as happens once at trade/protocol
+        // reconstruction for a restored trade (BisqEasyTradeService#createAndAddTradeProtocol).
+        restoredFsm.drainEventQueue();
+
+        assertEquals(MockState.S2, restoredFsm.getModel().getState());
+        // MockEventHandler mutates the model referenced by the event itself (the original, pre-restore model,
+        // per the test fixture below) rather than the restoredFsm's model - this confirms the handler for the
+        // queued MockEvent2 genuinely ran during the drain, not just a state placeholder change.
+        assertEquals("queued", model.data);
+        assertTrue(restoredFsm.getModel().getEventQueue().isEmpty());
+    }
+
+    @Test
+    void testDrainEventQueueIsSafeAndIdempotentWhenEmpty() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+
+        // Calling drainEventQueue() on an empty queue must be a safe no-op, and calling it repeatedly must not
+        // change behaviour or throw (re-entrancy is guarded by the same reentrant model lock handle() uses).
+        fsm.drainEventQueue();
+        fsm.drainEventQueue();
+        assertEquals(MockState.INIT, fsm.getModel().getState());
+
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S1, fsm.getModel().getState());
+
+        fsm.drainEventQueue();
+        fsm.drainEventQueue();
+        assertEquals(MockState.S1, fsm.getModel().getState());
+        assertEquals("test1", fsm.getModel().data);
+    }
+
+    /**
+     * Regression/documentation guard for the bug itself: if the event queue is NOT carried over on restore
+     * (the behaviour before this fix - {@code Trade} used to call the single-arg {@code FsmModel(State)}
+     * constructor from {@code fromProto}), the queued event is lost forever. Calling drainEventQueue() cannot
+     * recover data that was never restored in the first place; restoring the queue itself (see
+     * {@link #testDrainEventQueueAfterModelRestore}) is what fixes issue #1622, not drainEventQueue() alone.
+     */
+    @Test
+    void testEventIsLostForeverIfQueueIsNotRestored() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(1, model.getEventQueue().size());
+
+        // "Restart" using only the single-arg constructor - the pre-fix behaviour: the queue is not restored.
+        MockModel restoredModel = new MockModel(MockState.S1);
+        SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
+        restoredFsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        assertTrue(restoredModel.getEventQueue().isEmpty());
+        restoredFsm.drainEventQueue();
+
+        // The trade is stuck forever: nothing but the original MockEvent2 instance (now gone) could unstick it.
+        assertEquals(MockState.S1, restoredFsm.getModel().getState());
+        assertNull(restoredFsm.getModel().data);
+    }
+
+    /**
+     * Deterministic proof that {@link FsmModel#getStateAndEventQueueSnapshot()} captures {@code state} and
+     * {@code eventQueue} atomically and independently of later mutation - the concurrency guarantee behind the
+     * #4885 follow-up (making the persisted {state, eventQueue} pair atomic). A genuine data race between
+     * Fsm#handle() and an off-thread persistence read is not something we can reproduce deterministically without
+     * a flaky thread-interleaving test, so instead this pins the single-threaded contract the fix relies on:
+     * a snapshot taken at time T must forever reflect exactly what was true at T, however the model changes after.
+     */
+    @Test
+    void testStateAndEventQueueSnapshotIsAtomicAndIndependentOfLaterMutation() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // MockEvent2 arrives before the enabling INIT -> S1 transition: no transition matches MockEvent2 from
+        // INIT, so the Fsm parks it in the queue instead of applying it.
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        // A snapshot taken now must reflect exactly this pre-transition reality.
+        FsmModel.StateAndEventQueue snapshotBeforeTransition = model.getStateAndEventQueueSnapshot();
+        assertEquals(MockState.INIT, snapshotBeforeTransition.state());
+        assertEquals(1, snapshotBeforeTransition.eventQueue().size());
+
+        // The enabling transition fires: state moves to S1, then the automatic post-transition drain immediately
+        // re-applies the queued MockEvent2, advancing straight on to S2 and emptying the live queue - all within
+        // this single handle() call.
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S2, model.getState());
+        assertTrue(model.getEventQueue().isEmpty());
+
+        // Load-bearing assertion: the snapshot taken BEFORE the transition must be completely unaffected by it.
+        // This proves two things at once: (a) the eventQueue copy was defensive/independent - a reference into
+        // the live CopyOnWriteArraySet would now appear empty, since the live queue was drained - and (b) state
+        // and eventQueue were captured together as of the same instant, not via two independently-racy reads.
+        assertEquals(MockState.INIT, snapshotBeforeTransition.state());
+        assertEquals(1, snapshotBeforeTransition.eventQueue().size());
+
+        // A fresh snapshot taken now must reflect the new, post-transition reality.
+        FsmModel.StateAndEventQueue snapshotAfterTransition = model.getStateAndEventQueueSnapshot();
+        assertEquals(MockState.S2, snapshotAfterTransition.state());
+        assertTrue(snapshotAfterTransition.eventQueue().isEmpty());
+    }
+
+    /**
+     * Pins the bounded-tryLock behaviour {@link FsmModel#getStateAndEventQueueSnapshot()} needs for the single,
+     * JVM-wide {@code Persistence} executor thread (see {@code Trade#getTradeBuilder}): while a live transition
+     * holds the model's lock for a long-running event handler (simulating blocking I/O, e.g. MuSig's gRPC calls),
+     * a concurrent snapshot attempt must give up close to its bound instead of blocking indefinitely, and must
+     * throw {@link SnapshotLockTimeoutException} rather than fall back to an unsynchronized (and possibly torn)
+     * read. Once the transition completes and releases the lock, the very next snapshot attempt must succeed and
+     * reflect the settled, post-transition state.
+     */
+    @Test
+    void testGetStateAndEventQueueSnapshotTimesOutWhileHandleHoldsLockThenSucceedsAfterRelease() throws InterruptedException {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(BlockingMockEventHandler.class)
+                .to(MockState.S1);
+
+        BlockingMockEventHandler.started = new CountDownLatch(1);
+        BlockingMockEventHandler.release = new CountDownLatch(1);
+        try {
+            Thread slowHandlerThread = new Thread(() -> fsm.handle(new MockEvent1(model, "slow")), "slow-handler");
+            slowHandlerThread.start();
+            assertTrue(BlockingMockEventHandler.started.await(2, TimeUnit.SECONDS), "handler never started");
+
+            // The slow-handler thread now holds model's lock for the whole transition (Fsm#handle wraps
+            // eventHandler.handle()). A concurrent bounded snapshot attempt - exactly what Trade#getTradeBuilder
+            // does from the shared Persistence executor thread - must not block indefinitely.
+            long startNanos = System.nanoTime();
+            assertThrows(SnapshotLockTimeoutException.class, model::getStateAndEventQueueSnapshot);
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            assertTrue(elapsedMs < 2000,
+                    "tryLock must give up close to its bound, not block indefinitely; took " + elapsedMs + "ms");
+
+            // Release the slow handler; the transition completes normally.
+            BlockingMockEventHandler.release.countDown();
+            slowHandlerThread.join(2000);
+            assertEquals(MockState.S1, model.getState());
+
+            // Once the lock is free again, the very next snapshot call must succeed and reflect the now-settled
+            // state, proving this is a bounded wait, not a permanently broken lock.
+            FsmModel.StateAndEventQueue snapshot = model.getStateAndEventQueueSnapshot();
+            assertEquals(MockState.S1, snapshot.state());
+            assertTrue(snapshot.eventQueue().isEmpty());
+        } finally {
+            BlockingMockEventHandler.started = null;
+            BlockingMockEventHandler.release = null;
+        }
+    }
+
+    /**
+     * Follow-up to #4885 (privacy/retention, Henrik's review point): a transition reaching a final state clears
+     * eventQueue/processedEvents in-memory (see Fsm#handle), which may hold sensitive, trade-specific network
+     * messages. The persist call which follows that clear must be routed through {@link Fsm#persistOnFinalState()}
+     * rather than the plain, potentially rate-limited {@link Fsm#persist()}, so that the wipe is not left stranded
+     * on disk. This test pins that dispatch deterministically, without any real I/O or timing involved.
+     */
+    @Test
+    void testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.COMPLETED);
+
+        // A normal, non-final transition must go through the ordinary (potentially rate-limited) persist().
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S1, fsm.getModel().getState());
+        assertEquals(1, fsm.persistCallCount);
+        assertEquals(0, fsm.persistOnFinalStateCallCount);
+
+        // The completing transition must be routed through persistOnFinalState() instead - exactly once, and
+        // the ordinary persist() must NOT additionally fire for this same call.
+        fsm.handle(new MockEvent2(model, "test2"));
+        assertEquals(MockState.COMPLETED, fsm.getModel().getState());
+        assertEquals(1, fsm.persistCallCount);
+        assertEquals(1, fsm.persistOnFinalStateCallCount);
+    }
+
+    /**
+     * Follow-up to #4885 (privacy/retention, Henrik's review point): a stuck trade may never reach a final state,
+     * so its parked out-of-order events - which can hold sensitive account-data network messages persisted with the
+     * trade - would otherwise linger on disk indefinitely. {@link FsmModel#clearEventQueue()} is the seam the
+     * data-retention/redaction pass uses to scrub them once a trade passes the redaction threshold. This pins that
+     * it empties both eventQueue and processedEvents.
+     */
+    @Test
+    void testClearEventQueueScrubsParkedEvents() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // MockEvent2 arrives before its enabling transition, so the Fsm parks it in the queue (the stuck-trade shape).
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        model.clearEventQueue();
+
+        assertTrue(model.getEventQueue().isEmpty(), "clearEventQueue() must empty the parked event queue");
+        assertTrue(model.getProcessedEvents().isEmpty(), "clearEventQueue() must also clear processedEvents");
+    }
+
+    @Test
+    void testRemoveQueuedEventsIfScrubsOnlyMatchingParkedEvents() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent3.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S3);
+
+        // Both arrive before their enabling state, so the Fsm parks them (the stuck-trade shape).
+        fsm.handle(new MockEvent2(model, "queued-2"));
+        fsm.handle(new MockEvent3(model, "queued-3"));
+        assertEquals(2, model.getEventQueue().size());
+
+        // The selective scrub used by the restore-drain guard (drop events from a now-banned sender):
+        // only matching events go, the rest stay queued for the drain.
+        boolean removed = model.removeQueuedEventsIf(MockEvent2.class::isInstance);
+
+        assertTrue(removed, "removeQueuedEventsIf must report that something was removed");
+        assertEquals(1, model.getEventQueue().size(), "non-matching events must stay queued");
+        assertTrue(model.getEventQueue().stream().anyMatch(MockEvent3.class::isInstance));
+
+        assertFalse(model.removeQueuedEventsIf(MockEvent2.class::isInstance),
+                "a second scrub with no matches must report nothing removed");
     }
 
     @Test
@@ -522,6 +869,77 @@ public class FsmTest {
     }
 
 
+    /**
+     * The generic Fsm layer must never string-render a full
+     * event instance - domain events (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage) have
+     * generated toString() output that can contain private payment-account data, and the FsmException message
+     * built here (via {@code ExceptionUtil#getRootCauseMessage}) ends up both in the trade's persisted error
+     * info and in the BisqEasyReportErrorMessage sent to the peer. This drives the no-transition-found path
+     * (Fsm#handle's checkArgument), the one site whose message used to concatenate the event instance directly.
+     */
+    @Test
+    void testNoTransitionExceptionMessageDoesNotLeakEventContent() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        // Deliberately no transition registered for SentinelMockEvent at all.
+
+        fsm.handle(new SentinelMockEvent());
+
+        assertNotNull(fsm.lastSwallowedException, "handle() must have hit the no-transition-found path");
+        String message = fsm.lastSwallowedException.getMessage();
+        assertTrue(message.contains(SentinelMockEvent.class.getSimpleName()),
+                "message should still identify the event's class for diagnostics: " + message);
+        assertFalse(message.contains(SENTINEL_SECRET),
+                "message must not render the event instance itself: " + message);
+    }
+
+    /**
+     * Same guard as above, for the OTHER generic catch site in Fsm#handle: an event handler throwing mid-transition.
+     * The FSM layer's own log.error/FsmException construction must not add a leak here either - what the handler's
+     * own exception message says is outside the FSM layer's control (it's generic, not domain-aware), but the
+     * framework itself must not concatenate the event on top of that.
+     */
+    @Test
+    void testHandlerExceptionMessageDoesNotLeakEventContent() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(SentinelMockEvent.class)
+                .run(SentinelThrowingMockEventHandler.class)
+                .to(MockState.S1);
+
+        fsm.handle(new SentinelMockEvent());
+
+        assertNotNull(fsm.lastSwallowedException, "handle() must have hit the handler-exception path");
+        String message = fsm.lastSwallowedException.getMessage();
+        assertFalse(message.contains(SENTINEL_SECRET),
+                "message must not render the event instance itself: " + message);
+    }
+
+    @Test
+    void handleNullEventFailsWithInformativeCauseInsteadOfMaskingNpe() {
+        // Regression: the error-path logging used to call event.getClass() on the null event. The
+        // resulting raw NPE was not an FsmException, so it bypassed the FsmErrorEvent/error-state
+        // handling entirely (and would blow through SimpleFsm's FsmException catch), masking the
+        // informative "event must not be null" message.
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class);
+
+        fsm.handle(null);
+
+        // The configured error handling ran: FsmException raised (captured by SimpleFsm), error
+        // state entered, and the informative NPE preserved as the cause.
+        assertNotNull(fsm.lastSwallowedException);
+        assertInstanceOf(NullPointerException.class, fsm.lastSwallowedException.getCause());
+        assertEquals("event must not be null", fsm.lastSwallowedException.getCause().getMessage());
+        assertEquals(State.FsmState.ERROR, fsm.getModel().getState());
+    }
+
     @Getter
     public enum MockState implements State {
         INIT,
@@ -600,6 +1018,56 @@ public class FsmTest {
         }
     }
 
+    /**
+     * Standin for a domain event whose generated toString() carries private data. Used to prove the generic
+     * Fsm layer only ever renders the event's CLASS, never the instance itself (see
+     * testNoTransitionExceptionMessageDoesNotLeakEventContent / testHandlerExceptionMessageDoesNotLeakEventContent).
+     */
+    public static class SentinelMockEvent implements Event {
+        @Override
+        public String toString() {
+            return SENTINEL_SECRET;
+        }
+    }
+
+    public static class SentinelThrowingMockEventHandler implements EventHandler<Event> {
+        public SentinelThrowingMockEventHandler() {
+        }
+
+        @Override
+        public void handle(Event event) {
+            throw new RuntimeException("handler failed");
+        }
+    }
+
+    /**
+     * Simulates a slow/blocking event handler (e.g. MuSig's gRPC calls) to test that a concurrent, bounded
+     * {@link FsmModel#getStateAndEventQueueSnapshot()} does not block indefinitely on the model lock this handler
+     * holds for the whole transition. Handler classes are constructed reflectively via a no-arg constructor (see
+     * {@link SimpleFsm#newEventHandlerFromClass}), so per-run coordination must be static - reset by the test
+     * before and after use.
+     */
+    public static class BlockingMockEventHandler implements EventHandler<MockEvent1> {
+        static volatile CountDownLatch started;
+        static volatile CountDownLatch release;
+
+        @Override
+        public void handle(MockEvent1 event) {
+            started.countDown();
+            boolean released;
+            try {
+                released = release.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while blocking", e);
+            }
+            if (!released) {
+                throw new IllegalStateException("blocking handler was never released");
+            }
+            event.model.data = event.data;
+        }
+    }
+
     public static class MockModel extends FsmModel {
         public MockModel(MockState state) {
             super(state);
@@ -608,6 +1076,10 @@ public class FsmTest {
         public MockModel(MockState state, String data) {
             super(state);
             this.data = data;
+        }
+
+        public MockModel(MockState state, Set<Event> eventQueue, Set<Class<? extends Event>> processedEvents) {
+            super(state, eventQueue, processedEvents);
         }
 
         private String data = null;

--- a/common/src/test/java/bisq/common/fsm/SimpleFsm.java
+++ b/common/src/test/java/bisq/common/fsm/SimpleFsm.java
@@ -3,6 +3,15 @@ package bisq.common.fsm;
 import java.lang.reflect.InvocationTargetException;
 
 public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
+    // Test-only invocation counters, used to assert which persist path a given transition routed through
+    // (see FsmTest#testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState).
+    public int persistCallCount = 0;
+    public int persistOnFinalStateCallCount = 0;
+    // Test-only capture of the FsmException this class otherwise swallows below, so tests can assert on its
+    // message content (e.g. that it never renders a full event instance - see
+    // FsmTest#testNoTransitionExceptionMessageDoesNotLeakEventContent /
+    // #testHandlerExceptionMessageDoesNotLeakEventContent).
+    public FsmException lastSwallowedException;
 
     public SimpleFsm(M model) {
         super(model);
@@ -30,12 +39,18 @@ public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
         try {
             super.handle(event);
         } catch (FsmException fsmException) {
-            // We swallow the exception
+            // We swallow the exception - test-only capture for assertions, see lastSwallowedException above.
+            lastSwallowedException = fsmException;
         }
     }
 
     @Override
     protected void persist() {
-        // Ignore for test
+        persistCallCount++;
+    }
+
+    @Override
+    protected void persistOnFinalState() {
+        persistOnFinalStateCallCount++;
     }
 }


### PR DESCRIPTION
This is the first of a series of 5 PRs as explained in https://github.com/bisq-network/bisq2/pull/4885#issuecomment-5248651679

 - "PR A" extracted from #4885
 - implemented overall hardening of FSM state machine threading.
 - SnapshotLockTimeoutException — new, with javadoc explaining the must-propagate contract.
 - added AI generated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved state-machine concurrency and synchronization.
  * Added reliable snapshots of current state and queued events.
  * Added tools to clear, drain, or selectively remove queued events.
  * Improved final-state persistence handling.
  * Enhanced error reporting while avoiding exposure of event details.
* **Bug Fixes**
  * Fixed event-queue restoration and draining behavior.
  * Preserved informative handling for null events and lock timeouts.
* **Tests**
  * Added regression coverage for queue management, snapshots, persistence, timeouts, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->