### PR TITLE
Fail PriceQuote conversions on long overflow

### DIFF
--- a/api/src/main/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApi.java
@@ -333,10 +333,18 @@ public class OfferbookRestApi extends RestApiBase {
     }
 
     private Optional<OfferItemPresentationDto> createOfferListItemDto(BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
-        return OfferItemPresentationDtoFactory.create(userProfileService,
-                userIdentityService,
-                reputationService,
-                marketPriceService,
-                bisqEasyOfferbookMessage);
+        try {
+            return OfferItemPresentationDtoFactory.create(userProfileService,
+                    userIdentityService,
+                    reputationService,
+                    marketPriceService,
+                    bisqEasyOfferbookMessage);
+        } catch (RuntimeException e) {
+            // A single offer whose amounts cannot be converted at its price (an overflowing
+            // amount reaches longValueExact) must not abort the whole market listing with a
+            // 500. It is skipped like the WebSocket path already does for its own send.
+            log.warn("Skipping an offer that could not be mapped to a presentation dto", e);
+            return Optional.empty();
+        }
     }
 }

--- a/api/src/main/java/bisq/api/web_socket/domain/offers/NumOffersWebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/offers/NumOffersWebSocketService.java
@@ -23,10 +23,9 @@ import bisq.api.web_socket.subscription.Topic;
 import bisq.bisq_easy.BisqEasyOfferbookMessageService;
 import bisq.bisq_easy.BisqEasyService;
 import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
-import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
 import bisq.common.observable.Pin;
-import bisq.common.observable.collection.ObservableSet;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.user.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +44,7 @@ public class NumOffersWebSocketService extends SimpleObservableWebSocketService<
     private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
     private final Set<Pin> pins = new CopyOnWriteArraySet<>();
     @Nullable
-    private Pin channelsPin;
+    private Pin channelsPin, offerValidityRevisionPin;
 
     public NumOffersWebSocketService(SubscriberRepository subscriberRepository,
                                      ChatService chatService,
@@ -66,17 +65,11 @@ public class NumOffersWebSocketService extends SimpleObservableWebSocketService<
                     channelsPin = bisqEasyOfferbookChannelService.getChannels().addObserver(() -> {
                         pins.forEach(Pin::unbind);
                         pins.clear();
-                        bisqEasyOfferbookChannelService.getChannels().forEach(
-                                channel -> {
-                                    var code = channel.getMarket().getQuoteCurrencyCode();
-                                    ObservableSet<BisqEasyOfferbookMessage> chatMessages = channel.getChatMessages();
-                                    pins.add(chatMessages.addObserver(() -> {
-                                        var numOffers = (int) bisqEasyOfferbookMessageService.getOffers(channel).count();
-                                        numOffersByCurrencyCode.put(code, numOffers);
-                                    }));
-                                }
-                        );
+                        bisqEasyOfferbookChannelService.getChannels().forEach(channel ->
+                                pins.add(channel.getChatMessages().addObserver(() -> updateNumOffers(channel))));
                     });
+                    offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision()
+                            .addObserver(revision -> bisqEasyOfferbookChannelService.getChannels().forEach(this::updateNumOffers));
                     return true;
                 });
     }
@@ -89,10 +82,22 @@ public class NumOffersWebSocketService extends SimpleObservableWebSocketService<
                         channelsPin.unbind();
                         channelsPin = null;
                     }
+                    if (offerValidityRevisionPin != null) {
+                        offerValidityRevisionPin.unbind();
+                        offerValidityRevisionPin = null;
+                    }
                     pins.forEach(Pin::unbind);
                     pins.clear();
                     return result;
                 });
+    }
+
+    private synchronized void updateNumOffers(BisqEasyOfferbookChannel channel) {
+        String code = channel.getMarket().getQuoteCurrencyCode();
+        int numOffers = (int) bisqEasyOfferbookMessageService.getOffers(channel).count();
+        if (!Integer.valueOf(numOffers).equals(numOffersByCurrencyCode.get(code))) {
+            numOffersByCurrencyCode.put(code, numOffers);
+        }
     }
 
     @Override

--- a/api/src/test/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/offers/OfferbookRestApiTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.offers;
+
+import bisq.api.dto.presentation.offerbook.OfferItemPresentationDto;
+import bisq.api.dto.presentation.offerbook.OfferItemPresentationDtoFactory;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.user.UserService;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class OfferbookRestApiTest {
+    private final Market market = MarketRepository.getUSDBitcoinMarket();
+
+    @Test
+    void oneOverflowingOfferDoesNotAbortTheWholeMarketListing() {
+        ChatService chatService = mock(ChatService.class, RETURNS_DEEP_STUBS);
+        BisqEasyOfferbookChannelService channelService = chatService.getBisqEasyOfferbookChannelService();
+        BisqEasyOfferbookChannel channel = mock(BisqEasyOfferbookChannel.class);
+        when(channelService.findChannel(market)).thenReturn(Optional.of(channel));
+
+        BisqEasyOfferbookMessage validMessage = offerMessage();
+        BisqEasyOfferbookMessage overflowingMessage = offerMessage();
+        ObservableSet<BisqEasyOfferbookMessage> messages = new ObservableSet<>();
+        messages.add(validMessage);
+        messages.add(overflowingMessage);
+        when(channel.getChatMessages()).thenReturn(messages);
+
+        OfferbookRestApi api = new OfferbookRestApi(chatService,
+                mock(MarketPriceService.class),
+                mock(UserService.class, RETURNS_DEEP_STUBS));
+
+        OfferItemPresentationDto validDto = mock(OfferItemPresentationDto.class);
+        try (MockedStatic<OfferItemPresentationDtoFactory> factory = mockStatic(OfferItemPresentationDtoFactory.class)) {
+            factory.when(() -> OfferItemPresentationDtoFactory.create(any(), any(), any(), any(), eq(validMessage)))
+                    .thenReturn(Optional.of(validDto));
+            // The overflowing offer throws in the factory the way an amount conversion does,
+            // instead of aborting the whole endpoint stream with a 500.
+            factory.when(() -> OfferItemPresentationDtoFactory.create(any(), any(), any(), any(), eq(overflowingMessage)))
+                    .thenThrow(new ArithmeticException("overflow"));
+
+            Response response = api.getOffers("USD");
+
+            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+            @SuppressWarnings("unchecked")
+            List<OfferItemPresentationDto> entity = (List<OfferItemPresentationDto>) response.getEntity();
+            assertThat(entity).containsExactly(validDto);
+        }
+    }
+
+    private BisqEasyOfferbookMessage offerMessage() {
+        BisqEasyOfferbookMessage message = mock(BisqEasyOfferbookMessage.class);
+        when(message.hasBisqEasyOffer()).thenReturn(true);
+        return message;
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/domain/offers/NumOffersWebSocketServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/domain/offers/NumOffersWebSocketServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.domain.offers;
+
+import bisq.api.web_socket.subscription.SubscriberRepository;
+import bisq.bisq_easy.BisqEasyOfferbookMessageService;
+import bisq.bisq_easy.BisqEasyService;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.observable.Observable;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.user.UserService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NumOffersWebSocketServiceTest {
+    private static final Market MARKET = MarketRepository.getUSDBitcoinMarket();
+
+    @Test
+    void numOffersFollowsOfferValidityChangesWithoutChatMessageEvents() {
+        BisqEasyOfferbookChannel channel = new BisqEasyOfferbookChannel(MARKET);
+        BisqEasyOfferbookMessage message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getId()).thenReturn("offer-message-id");
+        when(message.getAuthorUserProfileId()).thenReturn("author-id");
+        when(message.hasBisqEasyOffer()).thenReturn(true);
+        channel.addChatMessage(message);
+        ObservableSet<BisqEasyOfferbookChannel> channels = new ObservableSet<>();
+        channels.add(channel);
+        ChatService chatService = mock(ChatService.class, RETURNS_DEEP_STUBS);
+        when(chatService.getBisqEasyOfferbookChannelService().getChannels()).thenReturn(channels);
+
+        Observable<Long> offerValidityRevision = new Observable<>(0L);
+        boolean[] offerIsValid = {false};
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        BisqEasyOfferbookMessageService messageService = mock(BisqEasyOfferbookMessageService.class);
+        when(messageService.getOfferValidityRevision()).thenReturn(offerValidityRevision);
+        when(messageService.getOffers(any(BisqEasyOfferbookChannel.class)))
+                .thenAnswer(invocation -> offerIsValid[0] ? Stream.of(offer) : Stream.empty());
+        BisqEasyService bisqEasyService = mock(BisqEasyService.class);
+        when(bisqEasyService.getBisqEasyOfferbookMessageService()).thenReturn(messageService);
+
+        NumOffersWebSocketService service = new NumOffersWebSocketService(mock(SubscriberRepository.class),
+                chatService,
+                mock(UserService.class),
+                bisqEasyService);
+        service.initialize().join();
+        assertEquals(Map.of("USD", 0), service.getObservable());
+        int[] numNotifications = {0};
+        service.getObservable().addObserver(() -> numNotifications[0]++);
+        int notificationsAtRegistration = numNotifications[0];
+
+        offerIsValid[0] = true;
+        offerValidityRevision.set(1L);
+        assertEquals(Map.of("USD", 1), service.getObservable());
+        assertEquals(notificationsAtRegistration + 1, numNotifications[0]);
+
+        offerValidityRevision.set(2L);
+        assertEquals(Map.of("USD", 1), service.getObservable());
+        assertEquals(notificationsAtRegistration + 1, numNotifications[0]);
+
+        offerIsValid[0] = false;
+        offerValidityRevision.set(3L);
+        assertEquals(Map.of("USD", 0), service.getObservable());
+        assertEquals(notificationsAtRegistration + 2, numNotifications[0]);
+
+        service.shutdown().join();
+        offerIsValid[0] = true;
+        offerValidityRevision.set(4L);
+        assertEquals(Map.of("USD", 0), service.getObservable());
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/offer/amount_selection/AmountSelectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/components/offer/amount_selection/AmountSelectionController.java
@@ -740,8 +740,17 @@ public class AmountSelectionController implements Controller {
         if (baseSideAmount == null) {
             return;
         }
-        maxOrFixedQuoteSideAmountInput.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
-        invertedMaxOrFixedQuoteSideAmountDisplay.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
+        Monetary quoteSideAmount;
+        try {
+            quoteSideAmount = priceQuote.toQuoteSideMonetary(baseSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", baseSideAmount);
+            return;
+        }
+        maxOrFixedQuoteSideAmountInput.setAmount(quoteSideAmount);
+        invertedMaxOrFixedQuoteSideAmountDisplay.setAmount(quoteSideAmount);
     }
 
     private void setMinQuoteFromBase() {
@@ -753,8 +762,17 @@ public class AmountSelectionController implements Controller {
         if (baseSideAmount == null) {
             return;
         }
-        minQuoteSideAmountInput.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
-        invertedMinQuoteSideAmountDisplay.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
+        Monetary quoteSideAmount;
+        try {
+            quoteSideAmount = priceQuote.toQuoteSideMonetary(baseSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", baseSideAmount);
+            return;
+        }
+        minQuoteSideAmountInput.setAmount(quoteSideAmount);
+        invertedMinQuoteSideAmountDisplay.setAmount(quoteSideAmount);
     }
 
     private void setMaxOrFixedBaseFromQuote() {
@@ -766,8 +784,17 @@ public class AmountSelectionController implements Controller {
         if (quoteSideAmount == null) {
             return;
         }
-        maxOrFixedBaseSideAmountDisplay.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
-        invertedMaxOrFixedBaseSideAmountInput.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
+        Monetary baseSideAmount;
+        try {
+            baseSideAmount = priceQuote.toBaseSideMonetary(quoteSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", quoteSideAmount);
+            return;
+        }
+        maxOrFixedBaseSideAmountDisplay.setAmount(baseSideAmount);
+        invertedMaxOrFixedBaseSideAmountInput.setAmount(baseSideAmount);
     }
 
     private void setMinBaseFromQuote() {
@@ -779,8 +806,17 @@ public class AmountSelectionController implements Controller {
         if (quoteSideAmount == null) {
             return;
         }
-        minBaseSideAmountDisplay.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
-        invertedMinBaseSideAmountInput.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
+        Monetary baseSideAmount;
+        try {
+            baseSideAmount = priceQuote.toBaseSideMonetary(quoteSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", quoteSideAmount);
+            return;
+        }
+        minBaseSideAmountDisplay.setAmount(baseSideAmount);
+        invertedMinBaseSideAmountInput.setAmount(baseSideAmount);
     }
 
     private void applyQuote() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItem.java
@@ -57,7 +57,7 @@ public class MarketChannelItem {
     private final SimpleIntegerProperty numOffers = new SimpleIntegerProperty(0);
     private final SimpleBooleanProperty isFavourite = new SimpleBooleanProperty(false);
     private final SimpleStringProperty numMarketNotifications = new SimpleStringProperty();
-    private Pin channelPin;
+    private Pin channelPin, offerValidityRevisionPin;
 
     MarketChannelItem(BisqEasyOfferbookChannel channel,
                       FavouriteMarketsService favouriteMarketsService,
@@ -80,10 +80,13 @@ public class MarketChannelItem {
 
     private void initialize() {
         channelPin = channel.getChatMessages().addObserver(this::updateNumOffers);
+        offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision()
+                .addObserver(revision -> updateNumOffers());
     }
 
     public void dispose() {
         channelPin.unbind();
+        offerValidityRevisionPin.unbind();
     }
 
     void refreshNotifications() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListController.java
@@ -38,6 +38,7 @@ import bisq.user.identity.UserIdentityService;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import lombok.Getter;
@@ -46,6 +47,7 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -61,8 +63,9 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
     private final UserIdentityService userIdentityService;
     private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
     private Pin showBuyOffersPin, showOfferListExpandedSettingsPin, offerMessagesPin, showMyOffersOnlyPin,
-            userIdentityPin, userProfileIdWithScoreChangePin;
+            userIdentityPin, userProfileIdWithScoreChangePin, offerValidityRevisionPin;
     private Subscription showBuyOffersFromModelPin, activeMarketPaymentsCountPin, showMyOffersOnlyFromModelPin;
+    private int channelBindingGeneration;
 
     public OfferbookListController(ServiceProvider serviceProvider) {
         settingsService = serviceProvider.getSettingsService();
@@ -78,6 +81,11 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
 
     public ReadOnlyBooleanProperty getShowOfferListExpanded() {
         return model.getShowOfferListExpanded();
+    }
+
+    @VisibleForTesting
+    OfferbookListModel getModel() {
+        return model;
     }
 
     @Override
@@ -97,6 +105,8 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
         showMyOffersOnlyFromModelPin = EasyBind.subscribe(model.getShowMyOffersOnly(), showMyOffersOnly -> updatePredicate());
         userIdentityPin = userIdentityService.getSelectedUserIdentityObservable().addObserver(userIdentity -> UIThread.run(this::updatePredicate));
         userProfileIdWithScoreChangePin = reputationService.getUserProfileIdWithScoreChange().addObserver(userProfileId -> UIThread.run(this::updatePredicate));
+        offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision().addObserver(revision ->
+                UIThread.run(this::reconcileSelectedChannelOffers));
     }
 
     @Override
@@ -110,11 +120,14 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
         activeMarketPaymentsCountPin.unsubscribe();
         if (offerMessagesPin != null) {
             offerMessagesPin.unbind();
+            offerMessagesPin = null;
         }
         showMyOffersOnlyPin.unbind();
         showMyOffersOnlyFromModelPin.unsubscribe();
         userIdentityPin.unbind();
         userProfileIdWithScoreChangePin.unbind();
+        offerValidityRevisionPin.unbind();
+        offerValidityRevisionPin = null;
     }
 
     private void disposeAndClearOfferbookListItems() {
@@ -135,23 +148,13 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
         }
         disposeAndClearOfferbookListItems();
         model.getChatMessageIds().clear();
+        int bindingGeneration = ++channelBindingGeneration;
         offerMessagesPin = channel.getChatMessages().addObserver(new CollectionObserver<>() {
             @Override
             public void onAdded(BisqEasyOfferbookMessage offerbookMessage) {
                 UIThread.runOnNextRenderFrame(() -> {
-                    if (!model.getChatMessageIds().contains(offerbookMessage.getId()) &&
-                            offerbookMessage.hasBisqEasyOffer()) {
-                        if (bisqEasyOfferbookMessageService.isValid(offerbookMessage)) {
-                            userProfileService.findUserProfile(offerbookMessage.getAuthorUserProfileId())
-                                    .ifPresent(authorUserProfile -> {
-                                        OfferbookListItem item = new OfferbookListItem(offerbookMessage,
-                                                authorUserProfile,
-                                                reputationService,
-                                                marketPriceService);
-                                        model.getOfferbookListItems().add(item);
-                                        model.getChatMessageIds().add(offerbookMessage.getId());
-                                    });
-                        }
+                    if (isShowing(channel, bindingGeneration)) {
+                        maybeAddOfferbookMessage(offerbookMessage);
                     }
                 });
             }
@@ -159,7 +162,8 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
             @Override
             public void onRemoved(Object element) {
                 UIThread.runOnNextRenderFrame(() -> {
-                    if (element instanceof BisqEasyOfferbookMessage && ((BisqEasyOfferbookMessage) element).hasBisqEasyOffer()) {
+                    if (isShowing(channel, bindingGeneration) &&
+                            element instanceof BisqEasyOfferbookMessage && ((BisqEasyOfferbookMessage) element).hasBisqEasyOffer()) {
                         BisqEasyOfferbookMessage offerMessage = (BisqEasyOfferbookMessage) element;
                         Optional<OfferbookListItem> toRemove = model.getOfferbookListItems().stream()
                                 .filter(item -> item.getBisqEasyOfferbookMessage().getId().equals(offerMessage.getId()))
@@ -176,11 +180,63 @@ public class OfferbookListController implements bisq.desktop.common.view.Control
             @Override
             public void onCleared() {
                 UIThread.runOnNextRenderFrame(() -> {
-                    disposeAndClearOfferbookListItems();
-                    model.getChatMessageIds().clear();
+                    if (isShowing(channel, bindingGeneration)) {
+                        disposeAndClearOfferbookListItems();
+                        model.getChatMessageIds().clear();
+                    }
                 });
             }
         });
+    }
+
+    private boolean isShowing(BisqEasyOfferbookChannel channel, int bindingGeneration) {
+        return offerMessagesPin != null &&
+                bindingGeneration == channelBindingGeneration &&
+                model.getChannel().get() == channel;
+    }
+
+    private void reconcileSelectedChannelOffers() {
+        BisqEasyOfferbookChannel channel = model.getChannel().get();
+        if (offerValidityRevisionPin == null || !isShowing(channel, channelBindingGeneration)) {
+            return;
+        }
+
+        List<OfferbookListItem> invalidItems = model.getOfferbookListItems().stream()
+                .filter(item -> !bisqEasyOfferbookMessageService.isValid(item.getBisqEasyOfferbookMessage()))
+                .toList();
+        invalidItems.forEach(item -> {
+            item.dispose();
+            model.getOfferbookListItems().remove(item);
+            model.getChatMessageIds().remove(item.getBisqEasyOfferbookMessage().getId());
+        });
+
+        channel.getChatMessages().forEach(this::maybeAddOfferbookMessage);
+    }
+
+    private void maybeAddOfferbookMessage(BisqEasyOfferbookMessage offerbookMessage) {
+        if (model.getChatMessageIds().contains(offerbookMessage.getId()) ||
+                !offerbookMessage.hasBisqEasyOffer() ||
+                !bisqEasyOfferbookMessageService.isValid(offerbookMessage)) {
+            return;
+        }
+
+        addOfferbookMessage(offerbookMessage);
+    }
+
+    private void addOfferbookMessage(BisqEasyOfferbookMessage offerbookMessage) {
+        userProfileService.findUserProfile(offerbookMessage.getAuthorUserProfileId())
+                .ifPresent(authorUserProfile -> {
+                    try {
+                        OfferbookListItem item = new OfferbookListItem(offerbookMessage,
+                                authorUserProfile,
+                                reputationService,
+                                marketPriceService);
+                        model.getOfferbookListItems().add(item);
+                        model.getChatMessageIds().add(offerbookMessage.getId());
+                    } catch (RuntimeException e) {
+                        log.warn("Could not create the list item for offer message {}", offerbookMessage.getId(), e);
+                    }
+                });
     }
 
     void onToggleOfferList() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
@@ -115,9 +115,10 @@ public class OfferbookListItem {
         offerAgeTooltipText = Res.get("user.profileCard.offers.table.columns.offerAge.tooltip",
                 DateFormatter.formatDateTime(bisqEasyOffer.getDate()));
 
+        // Compute before registering the observer: if this throws, no observer stays behind.
+        updatePriceSpecAsPercent();
         marketPriceByCurrencyMapPin = marketPriceService.getMarketPriceByCurrencyMap().addObserver(() ->
                 UIThread.run(this::updatePriceSpecAsPercent));
-        updatePriceSpecAsPercent();
     }
 
     void dispose() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount_and_price/amount/TradeWizardAmountController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/amount_and_price/amount/TradeWizardAmountController.java
@@ -786,54 +786,72 @@ public class TradeWizardAmountController implements Controller {
     }
 
     private boolean isValidAmountRange(BisqEasyOffer peersOffer) {
-        Optional<Monetary> myQuoteSideMinOrFixedAmount = OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, model.getQuoteSideAmountSpec().get(), MARKET_PRICE_SPEC, model.getMarket());
-        Optional<Monetary> peersQuoteSideMaxOrFixedAmount = OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, peersOffer);
-        if (myQuoteSideMinOrFixedAmount.isEmpty() || peersQuoteSideMaxOrFixedAmount.isEmpty()) {
-            return false;
-        }
-        if (myQuoteSideMinOrFixedAmount.get().round(0).getValue() > peersQuoteSideMaxOrFixedAmount.get().round(0).getValue()) {
-            return false;
-        }
+        // A peer offer whose amounts overflow at current prices cannot match; it must not
+        // propagate the conversion failure into the FX thread.
+        try {
+            Optional<Monetary> myQuoteSideMinOrFixedAmount = OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, model.getQuoteSideAmountSpec().get(), MARKET_PRICE_SPEC, model.getMarket());
+            Optional<Monetary> peersQuoteSideMaxOrFixedAmount = OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, peersOffer);
+            if (myQuoteSideMinOrFixedAmount.isEmpty() || peersQuoteSideMaxOrFixedAmount.isEmpty()) {
+                return false;
+            }
+            if (myQuoteSideMinOrFixedAmount.get().round(0).getValue() > peersQuoteSideMaxOrFixedAmount.get().round(0).getValue()) {
+                return false;
+            }
 
-        Optional<Monetary> myQuoteSideMaxOrFixedAmount = OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, model.getQuoteSideAmountSpec().get(), MARKET_PRICE_SPEC, model.getMarket());
-        Optional<Monetary> peersQuoteSideMinOrFixedAmount = OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, peersOffer);
-        if (myQuoteSideMaxOrFixedAmount.isEmpty() || peersQuoteSideMinOrFixedAmount.isEmpty()) {
-            return false;
-        }
-        if (myQuoteSideMaxOrFixedAmount.get().round(0).getValue() < peersQuoteSideMinOrFixedAmount.get().round(0).getValue()) {
-            return false;
-        }
+            Optional<Monetary> myQuoteSideMaxOrFixedAmount = OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, model.getQuoteSideAmountSpec().get(), MARKET_PRICE_SPEC, model.getMarket());
+            Optional<Monetary> peersQuoteSideMinOrFixedAmount = OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, peersOffer);
+            if (myQuoteSideMaxOrFixedAmount.isEmpty() || peersQuoteSideMinOrFixedAmount.isEmpty()) {
+                return false;
+            }
+            if (myQuoteSideMaxOrFixedAmount.get().round(0).getValue() < peersQuoteSideMinOrFixedAmount.get().round(0).getValue()) {
+                return false;
+            }
 
-        return true;
+            return true;
+        } catch (ArithmeticException e) {
+            return false;
+        }
     }
 
     private boolean isValidAmountLimit(BisqEasyOffer peersOffer, Monetary quoteSideAmount) {
-        Optional<Result> result = BisqEasyTradeAmountLimits.checkOfferAmountLimitForGivenAmount(reputationService,
-                userIdentityService,
-                userProfileService,
-                marketPriceService,
-                model.getMarket(),
-                quoteSideAmount,
-                peersOffer);
-        if (!result.map(Result::isValid).orElse(false)) {
+        // A peer offer whose amounts overflow at current prices cannot match; it must not
+        // propagate the conversion failure into the FX thread.
+        try {
+            Optional<Result> result = BisqEasyTradeAmountLimits.checkOfferAmountLimitForGivenAmount(reputationService,
+                    userIdentityService,
+                    userProfileService,
+                    marketPriceService,
+                    model.getMarket(),
+                    quoteSideAmount,
+                    peersOffer);
+            if (!result.map(Result::isValid).orElse(false)) {
+                return false;
+            }
+            return true;
+        } catch (ArithmeticException e) {
             return false;
         }
-        return true;
     }
 
 
     private boolean isValidAmountLimit(BisqEasyOffer peersOffer) {
-        if (!BisqEasyTradeAmountLimits.checkOfferAmountLimitForMaxOrFixedAmount(reputationService,
-                        userIdentityService,
-                        userProfileService,
-                        marketPriceService,
-                        peersOffer)
-                .map(BisqEasyTradeAmountLimits.Result::isValid)
-                .orElse(false)) {
+        // A peer offer whose amounts overflow at current prices cannot match; it must not
+        // propagate the conversion failure into the FX thread.
+        try {
+            if (!BisqEasyTradeAmountLimits.checkOfferAmountLimitForMaxOrFixedAmount(reputationService,
+                            userIdentityService,
+                            userProfileService,
+                            marketPriceService,
+                            peersOffer)
+                    .map(BisqEasyTradeAmountLimits.Result::isValid)
+                    .orElse(false)) {
+                return false;
+            }
+
+            return true;
+        } catch (ArithmeticException e) {
             return false;
         }
-
-        return true;
     }
 
     // Used for finding best price quote of available matching offers

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/trade_wizard/select_offer/TradeWizardSelectOfferController.java
@@ -163,11 +163,19 @@ public class TradeWizardSelectOfferController implements Controller {
             BisqEasyOfferbookChannel channel = optionalChannel.get();
             model.getMatchingOffers().setAll(channel.getChatMessages().stream()
                     .filter(chatMessage -> chatMessage.getBisqEasyOffer().isPresent())
-                    .map(chatMessage -> new TradeWizardSelectOfferView.ListItem(chatMessage.getBisqEasyOffer().get(),
-                            model,
-                            userProfileService,
-                            reputationService,
-                            marketPriceService))
+                    .flatMap(chatMessage -> {
+                        try {
+                            return java.util.stream.Stream.of(new TradeWizardSelectOfferView.ListItem(chatMessage.getBisqEasyOffer().get(),
+                                    model,
+                                    userProfileService,
+                                    reputationService,
+                                    marketPriceService));
+                        } catch (ArithmeticException e) {
+                            // The item formats the offer amounts at construction; an offer whose
+                            // amounts overflow at the current price is not listed.
+                            return java.util.stream.Stream.<TradeWizardSelectOfferView.ListItem>empty();
+                        }
+                    })
                     .collect(Collectors.toList()));
             model.getFilteredList().setPredicate(getPredicate());
         } else {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -83,6 +83,7 @@ import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
+import com.google.common.annotations.VisibleForTesting;
 import javafx.scene.Scene;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -92,6 +93,7 @@ import org.fxmisc.easybind.Subscription;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -129,10 +131,11 @@ public class ChatMessagesListController implements Controller {
     private final DontShowAgainService dontShowAgainService;
     private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
     private Pin selectedChannelPin, chatMessagesPin, bisqEasyOfferbookMessageTypeFilterPin, highlightedMessagePin,
-            ignoredUserProfileIdsPin;
+            ignoredUserProfileIdsPin, offerValidityRevisionPin;
     private Subscription selectedChannelSubscription, focusSubscription, scrollValuePin, scrollBarVisiblePin,
             layoutChildrenDonePin;
     private static final String DONT_SHOW_CHAT_RULES_WARNING_KEY = "privateChatRulesWarning";
+    private int channelBindingGeneration;
 
     public ChatMessagesListController(ServiceProvider serviceProvider,
                                       Consumer<UserProfile> mentionUserHandler,
@@ -165,6 +168,11 @@ public class ChatMessagesListController implements Controller {
         view = new ChatMessagesListView(model, this);
     }
 
+    @VisibleForTesting
+    ChatMessagesListModel getModel() {
+        return model;
+    }
+
     @Override
     public void onActivate() {
         model.getSortedChatMessages().setComparator(ChatMessageListItem::compareTo);
@@ -174,6 +182,9 @@ public class ChatMessagesListController implements Controller {
 
         ignoredUserProfileIdsPin = userProfileService.getIgnoredUserProfileIds()
                 .addObserver(() -> UIThread.run(this::updatePredicate));
+
+        offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision().addObserver(revision ->
+                UIThread.run(this::reconcileSelectedOfferbookMessages));
 
         if (selectedChannelPin != null) {
             selectedChannelPin.unbind();
@@ -209,6 +220,10 @@ public class ChatMessagesListController implements Controller {
         if (ignoredUserProfileIdsPin != null) {
             ignoredUserProfileIdsPin.unbind();
             ignoredUserProfileIdsPin = null;
+        }
+        if (offerValidityRevisionPin != null) {
+            offerValidityRevisionPin.unbind();
+            offerValidityRevisionPin = null;
         }
         if (selectedChannelPin != null) {
             selectedChannelPin.unbind();
@@ -707,21 +722,14 @@ public class ChatMessagesListController implements Controller {
     private <M extends ChatMessage, C extends ChatChannel<M>> Pin bindChatMessages(C channel) {
         // We clear and fill the list at channel change. The addObserver triggers the add method for each item,
         // but as we have a contains() check there it will not have any effect.
+        int bindingGeneration = ++channelBindingGeneration;
 
         Set<ChatMessageListItem<M, C>> items = channel.getChatMessages().stream()
                 .filter(chatMessage -> chatMessage.getChatMessageType() != TAKE_BISQ_EASY_OFFER)
                 .filter(chatMessage -> !(chatMessage instanceof BisqEasyOfferbookMessage bisqEasyOfferbookMessage) ||
                         bisqEasyOfferbookMessageService.isValid(bisqEasyOfferbookMessage))
-                .map(chatMessage -> new ChatMessageListItem<>(chatMessage,
-                        channel,
-                        marketPriceService,
-                        userProfileService,
-                        reputationService,
-                        bisqEasyTradeService,
-                        userIdentityService,
-                        networkService,
-                        resendMessageService,
-                        authorizedBondedRolesService))
+                .map(chatMessage -> tryCreateChatMessageListItem(chatMessage, channel))
+                .flatMap(Optional::stream)
                 .collect(Collectors.toCollection(LinkedHashSet::new)); // preserve insertion order
         model.getChatMessages().addAll(items);
         model.getChatMessageIds().clear();
@@ -744,30 +752,10 @@ public class ChatMessagesListController implements Controller {
             @Override
             public void onAdded(M chatMessage) {
                 UIThread.run(() -> {
-                    // Avoid to add already existing items
-                    if (model.getChatMessageIds().contains(chatMessage.getId())) {
-                        return;
-                    }
-                    if (chatMessage.getChatMessageType() == TAKE_BISQ_EASY_OFFER) {
-                        return;
-                    }
-                    if (chatMessage instanceof BisqEasyOfferbookMessage bisqEasyOfferbookMessage &&
-                            !bisqEasyOfferbookMessageService.isValid(bisqEasyOfferbookMessage)) {
+                    if (!isSelected(channel, bindingGeneration) || !maybeAddChatMessage(chatMessage, channel)) {
                         return;
                     }
 
-                    ChatMessageListItem<M, C> item = new ChatMessageListItem<>(chatMessage,
-                            channel,
-                            marketPriceService,
-                            userProfileService,
-                            reputationService,
-                            bisqEasyTradeService,
-                            userIdentityService,
-                            networkService,
-                            resendMessageService,
-                            authorizedBondedRolesService);
-                    model.getChatMessages().add(item);
-                    model.getChatMessageIds().add(chatMessage.getId());
                     maybeScrollDownOnNewItemAdded();
                     maybeAddExpiredMessagesIndicator();
                     updateHasBisqEasyOfferMessages();
@@ -777,7 +765,7 @@ public class ChatMessagesListController implements Controller {
             @Override
             public void onRemoved(Object element) {
                 UIThread.run(() -> {
-                    if (element instanceof ChatMessage chatMessage) {
+                    if (isSelected(channel, bindingGeneration) && element instanceof ChatMessage chatMessage) {
                         Optional<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> toRemove =
                                 model.getChatMessages().stream()
                                         .filter(item -> item.getChatMessage().getId().equals(chatMessage.getId()))
@@ -795,6 +783,9 @@ public class ChatMessagesListController implements Controller {
             @Override
             public void onCleared() {
                 UIThread.run(() -> {
+                    if (!isSelected(channel, bindingGeneration)) {
+                        return;
+                    }
                     model.getChatMessages().forEach(ChatMessageListItem::dispose);
                     model.getChatMessages().clear();
                     model.getChatMessageIds().clear();
@@ -802,6 +793,78 @@ public class ChatMessagesListController implements Controller {
                 });
             }
         });
+    }
+
+    private boolean isSelected(ChatChannel<?> channel, int bindingGeneration) {
+        return selectedChannelPin != null &&
+                bindingGeneration == channelBindingGeneration &&
+                model.getSelectedChannel().get() == channel;
+    }
+
+    private void reconcileSelectedOfferbookMessages() {
+        if (offerValidityRevisionPin == null ||
+                !(model.getSelectedChannel().get() instanceof BisqEasyOfferbookChannel channel) ||
+                !isSelected(channel, channelBindingGeneration)) {
+            return;
+        }
+
+        List<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> invalidItems =
+                model.getChatMessages().stream()
+                        .filter(item -> item.getChatMessage() instanceof BisqEasyOfferbookMessage offerbookMessage &&
+                                !bisqEasyOfferbookMessageService.isValid(offerbookMessage))
+                        .toList();
+        invalidItems.forEach(item -> {
+            item.dispose();
+            model.getChatMessages().remove(item);
+            model.getChatMessageIds().remove(item.getChatMessage().getId());
+        });
+
+        boolean wasMessageAdded = false;
+        for (BisqEasyOfferbookMessage message : channel.getChatMessages()) {
+            wasMessageAdded |= maybeAddChatMessage(message, channel);
+        }
+        if (wasMessageAdded) {
+            maybeScrollDownOnNewItemAdded();
+            maybeAddExpiredMessagesIndicator();
+        }
+        if (wasMessageAdded || !invalidItems.isEmpty()) {
+            updateHasBisqEasyOfferMessages();
+        }
+    }
+
+    private <M extends ChatMessage, C extends ChatChannel<M>> boolean maybeAddChatMessage(M chatMessage, C channel) {
+        if (model.getChatMessageIds().contains(chatMessage.getId()) ||
+                chatMessage.getChatMessageType() == TAKE_BISQ_EASY_OFFER ||
+                (chatMessage instanceof BisqEasyOfferbookMessage bisqEasyOfferbookMessage &&
+                        !bisqEasyOfferbookMessageService.isValid(bisqEasyOfferbookMessage))) {
+            return false;
+        }
+
+        Optional<ChatMessageListItem<M, C>> item = tryCreateChatMessageListItem(chatMessage, channel);
+        item.ifPresent(listItem -> {
+            model.getChatMessages().add(listItem);
+            model.getChatMessageIds().add(chatMessage.getId());
+        });
+        return item.isPresent();
+    }
+
+    private <M extends ChatMessage, C extends ChatChannel<M>> Optional<ChatMessageListItem<M, C>> tryCreateChatMessageListItem(M chatMessage,
+                                                                                                                                C channel) {
+        try {
+            return Optional.of(new ChatMessageListItem<>(chatMessage,
+                    channel,
+                    marketPriceService,
+                    userProfileService,
+                    reputationService,
+                    bisqEasyTradeService,
+                    userIdentityService,
+                    networkService,
+                    resendMessageService,
+                    authorizedBondedRolesService));
+        } catch (RuntimeException e) {
+            log.warn("Could not create the list item for chat message {}", chatMessage.getId(), e);
+            return Optional.empty();
+        }
     }
 
     private void publishChatMessageReaction(ChatMessage chatMessage, Reaction reaction, UserIdentity userIdentity) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/dashboard/DashboardController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/dashboard/DashboardController.java
@@ -55,7 +55,7 @@ public class DashboardController implements Controller {
     private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
     private final AlertNotificationsService alertNotificationsService;
     private final MuSigService muSigService;
-    private Pin selectedMarketPin, marketPricePin, getNumUserProfilesPin, isNotificationVisiblePin, unconsumedAlertsPin;
+    private Pin selectedMarketPin, marketPricePin, offerValidityRevisionPin, getNumUserProfilesPin, isNotificationVisiblePin, unconsumedAlertsPin;
     private final Set<Pin> channelsPins = new HashSet<>();
     private boolean allowUpdateOffersOnline;
     private Pin muSigActivatedPin;
@@ -92,6 +92,8 @@ public class DashboardController implements Controller {
         channelsPins.addAll(bisqEasyOfferbookChannelService.getChannels().stream()
                 .map(channel -> channel.getChatMessages().addObserver(this::updateOffersOnline))
                 .collect(Collectors.toSet()));
+        offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision()
+                .addObserver(revision -> updateOffersOnline());
 
         // We trigger a call of updateOffersOnline for each channel when registering our observer. But we only want one call, 
         // so we block execution of the code inside updateOffersOnline to only call it once.
@@ -107,11 +109,13 @@ public class DashboardController implements Controller {
         muSigActivatedPin.unbind();
         selectedMarketPin.unbind();
         marketPricePin.unbind();
+        offerValidityRevisionPin.unbind();
         getNumUserProfilesPin.unbind();
         isNotificationVisiblePin.unbind();
         unconsumedAlertsPin.unbind();
         channelsPins.forEach(Pin::unbind);
         channelsPins.clear();
+        allowUpdateOffersOnline = false;
     }
 
     public void onBuildReputation() {
@@ -138,12 +142,12 @@ public class DashboardController implements Controller {
     }
 
     private void updateOffersOnline() {
-        if (allowUpdateOffersOnline) {
-            UIThread.run(() -> {
+        UIThread.run(() -> {
+            if (allowUpdateOffersOnline) {
                 long numOffers = bisqEasyOfferbookMessageService.getAllOffers().count();
                 model.getOffersOnline().set(String.valueOf(numOffers));
-            });
-        }
+            }
+        });
     }
 
     private void handleBannerVisibility() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/dashboard/top_panel/DashboardTopPanel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/dashboard/top_panel/DashboardTopPanel.java
@@ -74,7 +74,7 @@ public class DashboardTopPanel {
         private final UserProfileService userProfileService;
         private final BisqEasyOfferbookChannelService bisqEasyOfferbookChannelService;
         private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
-        private Pin selectedMarketPin, marketPricePin, getNumUserProfilesPin;
+        private Pin selectedMarketPin, marketPricePin, offerValidityRevisionPin, getNumUserProfilesPin;
         private final Set<Pin> channelsPins = new HashSet<>();
         private boolean allowUpdateOffersOnline;
 
@@ -99,6 +99,8 @@ public class DashboardTopPanel {
             channelsPins.addAll(bisqEasyOfferbookChannelService.getChannels().stream()
                     .map(channel -> channel.getChatMessages().addObserver(this::updateOffersOnline))
                     .collect(Collectors.toSet()));
+            offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision()
+                    .addObserver(revision -> updateOffersOnline());
 
             // We trigger a call of updateOffersOnline for each channel when registering our observer. But we only want one call,
             // so we block execution of the code inside updateOffersOnline to only call it once.
@@ -110,9 +112,11 @@ public class DashboardTopPanel {
         public void onDeactivate() {
             selectedMarketPin.unbind();
             marketPricePin.unbind();
+            offerValidityRevisionPin.unbind();
             getNumUserProfilesPin.unbind();
             channelsPins.forEach(Pin::unbind);
             channelsPins.clear();
+            allowUpdateOffersOnline = false;
         }
 
         public void onBuildReputation() {
@@ -139,12 +143,12 @@ public class DashboardTopPanel {
         }
 
         private void updateOffersOnline() {
-            if (allowUpdateOffersOnline) {
-                UIThread.run(() -> {
+            UIThread.run(() -> {
+                if (allowUpdateOffersOnline) {
                     long numOffers = bisqEasyOfferbookMessageService.getAllOffers().count();
                     model.getOffersOnline().set(String.valueOf(numOffers));
-                });
-            }
+                }
+            });
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/components/amount_selection/MuSigAmountSelectionController.java
@@ -726,8 +726,17 @@ public class MuSigAmountSelectionController implements Controller {
         if (baseSideAmount == null) {
             return;
         }
-        maxOrFixedQuoteSideAmountInput.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
-        invertedMaxOrFixedQuoteSideAmountDisplay.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
+        Monetary quoteSideAmount;
+        try {
+            quoteSideAmount = priceQuote.toQuoteSideMonetary(baseSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", baseSideAmount);
+            return;
+        }
+        maxOrFixedQuoteSideAmountInput.setAmount(quoteSideAmount);
+        invertedMaxOrFixedQuoteSideAmountDisplay.setAmount(quoteSideAmount);
     }
 
     private void setMinQuoteFromBase() {
@@ -739,8 +748,17 @@ public class MuSigAmountSelectionController implements Controller {
         if (baseSideAmount == null) {
             return;
         }
-        minQuoteSideAmountInput.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
-        invertedMinQuoteSideAmountDisplay.setAmount(priceQuote.toQuoteSideMonetary(baseSideAmount));
+        Monetary quoteSideAmount;
+        try {
+            quoteSideAmount = priceQuote.toQuoteSideMonetary(baseSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", baseSideAmount);
+            return;
+        }
+        minQuoteSideAmountInput.setAmount(quoteSideAmount);
+        invertedMinQuoteSideAmountDisplay.setAmount(quoteSideAmount);
     }
 
     private void setMaxOrFixedBaseFromQuote() {
@@ -752,8 +770,17 @@ public class MuSigAmountSelectionController implements Controller {
         if (quoteSideAmount == null) {
             return;
         }
-        maxOrFixedBaseSideAmountDisplay.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
-        invertedMaxOrFixedBaseSideAmountInput.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
+        Monetary baseSideAmount;
+        try {
+            baseSideAmount = priceQuote.toBaseSideMonetary(quoteSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", quoteSideAmount);
+            return;
+        }
+        maxOrFixedBaseSideAmountDisplay.setAmount(baseSideAmount);
+        invertedMaxOrFixedBaseSideAmountInput.setAmount(baseSideAmount);
     }
 
     private void setMinBaseFromQuote() {
@@ -765,8 +792,17 @@ public class MuSigAmountSelectionController implements Controller {
         if (quoteSideAmount == null) {
             return;
         }
-        minBaseSideAmountDisplay.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
-        invertedMinBaseSideAmountInput.setAmount(priceQuote.toBaseSideMonetary(quoteSideAmount));
+        Monetary baseSideAmount;
+        try {
+            baseSideAmount = priceQuote.toBaseSideMonetary(quoteSideAmount);
+        } catch (ArithmeticException e) {
+            // An amount whose conversion overflows at the current price is ignored; the
+            // previously displayed amounts stay in place instead of showing a wrapped value.
+            log.warn("Ignoring an amount whose conversion overflows: {}", quoteSideAmount);
+            return;
+        }
+        minBaseSideAmountDisplay.setAmount(baseSideAmount);
+        invertedMinBaseSideAmountInput.setAmount(baseSideAmount);
     }
 
     private void applyQuote() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/offer/listing/MuSigOfferbookController.java
@@ -136,12 +136,23 @@ public class MuSigOfferbookController implements Controller {
                 UIThread.run(() -> {
                     String offerId = muSigOffer.getId();
                     if (!model.getMuSigOfferIds().contains(offerId)) {
-                        model.getMuSigOfferListItems().add(new MuSigOfferListItem(muSigOffer,
-                                marketPriceService,
-                                userProfileService,
-                                identityService,
-                                reputationService,
-                                accountService));
+                        MuSigOfferListItem item;
+                        try {
+                            item = new MuSigOfferListItem(muSigOffer,
+                                    marketPriceService,
+                                    userProfileService,
+                                    identityService,
+                                    reputationService,
+                                    accountService);
+                        } catch (ArithmeticException e) {
+                            // The item formats the offer amounts at construction; an offer whose
+                            // amounts overflow at the current price is not listed instead of
+                            // failing on the JavaFX thread.
+                            log.warn("Skipping offer {}: its amounts cannot be converted at the current market price",
+                                    offerId);
+                            return;
+                        }
+                        model.getMuSigOfferListItems().add(item);
                         model.getMuSigOfferIds().add(offerId);
                         updateFilteredMuSigOfferListItems();
                     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/onboarding/top_panel/MuSigDashboardTopPanel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/mu_sig/onboarding/top_panel/MuSigDashboardTopPanel.java
@@ -74,7 +74,7 @@ public class MuSigDashboardTopPanel {
         private final BisqEasyOfferbookChannelService bisqEasyOfferbookChannelService;
         //TODO
         private final BisqEasyOfferbookMessageService bisqEasyOfferbookMessageService;
-        private Pin selectedMarketPin, marketPricePin, getNumUserProfilesPin;
+        private Pin selectedMarketPin, marketPricePin, offerValidityRevisionPin, getNumUserProfilesPin;
         private final Set<Pin> channelsPins = new HashSet<>();
         private boolean allowUpdateOffersOnline;
 
@@ -99,6 +99,8 @@ public class MuSigDashboardTopPanel {
             channelsPins.addAll(bisqEasyOfferbookChannelService.getChannels().stream()
                     .map(channel -> channel.getChatMessages().addObserver(this::updateOffersOnline))
                     .collect(Collectors.toSet()));
+            offerValidityRevisionPin = bisqEasyOfferbookMessageService.getOfferValidityRevision()
+                    .addObserver(revision -> updateOffersOnline());
 
             // We trigger a call of updateOffersOnline for each channel when registering our observer. But we only want one call,
             // so we block execution of the code inside updateOffersOnline to only call it once.
@@ -110,9 +112,11 @@ public class MuSigDashboardTopPanel {
         public void onDeactivate() {
             selectedMarketPin.unbind();
             marketPricePin.unbind();
+            offerValidityRevisionPin.unbind();
             getNumUserProfilesPin.unbind();
             channelsPins.forEach(Pin::unbind);
             channelsPins.clear();
+            allowUpdateOffersOnline = false;
         }
 
         public void onBuildReputation() {
@@ -139,12 +143,12 @@ public class MuSigDashboardTopPanel {
         }
 
         private void updateOffersOnline() {
-            if (allowUpdateOffersOnline) {
-                UIThread.run(() -> {
+            UIThread.run(() -> {
+                if (allowUpdateOffersOnline) {
                     long numOffers = bisqEasyOfferbookMessageService.getAllOffers().count();
                     model.getOffersOnline().set(String.valueOf(numOffers));
-                });
-            }
+                }
+            });
         }
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
@@ -115,9 +115,10 @@ public class ProfileCardOfferListItem {
         offerAgeTooltipText = Res.get("user.profileCard.offers.table.columns.offerAge.tooltip",
                 DateFormatter.formatDateTime(bisqEasyOffer.getDate()));
 
+        // Compute before registering the observer: if this throws, no observer stays behind.
+        updatePriceSpecAsPercent();
         marketPriceByCurrencyMapPin = marketPriceService.getMarketPriceByCurrencyMap().addObserver(() ->
                 UIThread.run(this::updatePriceSpecAsPercent));
-        updatePriceSpecAsPercent();
     }
 
     void dispose() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewController.java
@@ -126,7 +126,15 @@ public class ProfileCardOverviewController implements Controller {
         List<Monetary> baseAmounts = getOffers(userProfileId)
                 .map(message -> message.getBisqEasyOffer().orElseThrow())
                 .filter(predicate)
-                .flatMap(offer -> OfferAmountUtil.findBaseSideMaxOrFixedAmount(marketPriceService, offer).stream())
+                .flatMap(offer -> {
+                    try {
+                        return OfferAmountUtil.findBaseSideMaxOrFixedAmount(marketPriceService, offer).stream();
+                    } catch (ArithmeticException e) {
+                        // An offer whose amounts overflow at the current price cannot contribute
+                        // to the total; it is hidden from the offer lists as invalid.
+                        return Stream.<Monetary>empty();
+                    }
+                })
                 .collect(Collectors.toList());
         return checkedBaseAmountSum(baseAmounts);
     }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/MarketChannelItemTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy.offerbook;
+
+import bisq.bisq_easy.BisqEasyOfferbookMessageService;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.notifications.ChatNotificationService;
+import bisq.common.market.MarketRepository;
+import bisq.common.observable.Observable;
+import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.settings.FavouriteMarketsService;
+import bisq.user.profile.UserProfileService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+class MarketChannelItemTest extends TestFxHeadlessSupport {
+    @Test
+    void numOffersFollowsOfferValidityChangesWithoutChatMessageEvents() {
+        BisqEasyOfferbookChannel channel = new BisqEasyOfferbookChannel(MarketRepository.getUSDBitcoinMarket());
+        Observable<Long> offerValidityRevision = new Observable<>(0L);
+        boolean[] offerIsValid = {false};
+        BisqEasyOfferbookMessageService messageService = mock(BisqEasyOfferbookMessageService.class);
+        when(messageService.getOfferValidityRevision()).thenReturn(offerValidityRevision);
+        when(messageService.getOffers(any(BisqEasyOfferbookChannel.class)))
+                .thenAnswer(invocation -> offerIsValid[0] ? Stream.of(mock(BisqEasyOffer.class)) : Stream.empty());
+
+        MarketChannelItem item = new MarketChannelItem(channel,
+                mock(FavouriteMarketsService.class),
+                mock(ChatNotificationService.class),
+                mock(MarketPriceService.class),
+                mock(UserProfileService.class),
+                messageService);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(item.getNumOffers().get()).isZero();
+
+        offerIsValid[0] = true;
+        offerValidityRevision.set(1L);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(item.getNumOffers().get()).isEqualTo(1);
+
+        item.dispose();
+        offerIsValid[0] = false;
+        offerValidityRevision.set(2L);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(item.getNumOffers().get()).isEqualTo(1);
+    }
+}

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListControllerTest.java
@@ -1,0 +1,291 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy.offerbook.offerbook_list;
+
+import bisq.bisq_easy.BisqEasyOfferbookMessageService;
+import bisq.bisq_easy.BisqEasySellersReputationBasedTradeAmountService;
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.ChatMessage;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.Observable;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.desktop.ServiceProvider;
+import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.settings.SettingsService;
+import bisq.user.UserService;
+import bisq.user.identity.UserIdentity;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+class OfferbookListControllerTest extends TestFxHeadlessSupport {
+    private static final Market MARKET = MarketRepository.getUSDBitcoinMarket();
+    // A base-side amount which converts to the quote side at one BTC price but overflows a
+    // long at a higher one: 5e18 sat * 1 USD fits, 5e18 sat * 50,000 USD does not.
+    private static final long BASE_SIDE_AMOUNT = 5_000_000_000_000_000_000L;
+    private static final double FITTING_PRICE = 1;
+    private static final double OVERFLOWING_PRICE = 50_000;
+
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+    private final ObservableSet<String> ignoredUserProfileIds = new ObservableSet<>();
+    private BisqEasyOfferbookMessageService messageService;
+    private UserProfileService userProfileService;
+    private ReputationService reputationService;
+    private OfferbookListController controller;
+    private BisqEasyOfferbookChannel channel;
+    private BisqEasyOfferbookMessage message;
+
+    @BeforeEach
+    void setUp() {
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        when(marketPriceService.findMarketPrice(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)));
+
+        UserProfile authorUserProfile = mock(UserProfile.class);
+        when(authorUserProfile.getNickName()).thenReturn("alice");
+        UserService userService = mock(UserService.class, RETURNS_DEEP_STUBS);
+        userProfileService = userService.getUserProfileService();
+        when(userProfileService.findUserProfile("author-id")).thenReturn(Optional.of(authorUserProfile));
+        when(userProfileService.getIgnoredUserProfileIds()).thenReturn(ignoredUserProfileIds);
+        when(userProfileService.isChatUserIgnored(any(String.class)))
+                .thenAnswer(invocation -> ignoredUserProfileIds.contains(invocation.<String>getArgument(0)));
+        when(userService.getUserIdentityService().getSelectedUserIdentityObservable()).thenReturn(new Observable<>(mock(UserIdentity.class)));
+        reputationService = mock(ReputationService.class);
+        when(reputationService.getReputationScore(any(UserProfile.class))).thenReturn(ReputationScore.NONE);
+        when(reputationService.getUserProfileIdWithScoreChange()).thenReturn(new Observable<>());
+        when(reputationService.getScoreByUserProfileId()).thenReturn(new ObservableHashMap<>());
+        when(userService.getReputationService()).thenReturn(reputationService);
+
+        BisqEasySellersReputationBasedTradeAmountService sellersReputationService =
+                mock(BisqEasySellersReputationBasedTradeAmountService.class);
+        when(sellersReputationService.hasSellerSufficientReputation(any(ChatMessage.class))).thenReturn(true);
+        messageService = new BisqEasyOfferbookMessageService(mock(ChatService.class, RETURNS_DEEP_STUBS),
+                userService,
+                sellersReputationService,
+                marketPriceService);
+        messageService.initialize().join();
+
+        SettingsService settingsService = mock(SettingsService.class, RETURNS_DEEP_STUBS);
+        when(settingsService.getShowBuyOffers()).thenReturn(new Observable<>(true));
+        when(settingsService.getShowOfferListExpanded()).thenReturn(new Observable<>(true));
+        when(settingsService.getShowMyOffersOnly()).thenReturn(new Observable<>(false));
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getSettingsService()).thenReturn(settingsService);
+        when(serviceProvider.getUserService()).thenReturn(userService);
+        when(serviceProvider.getBondedRolesService().getMarketPriceService()).thenReturn(marketPriceService);
+        when(serviceProvider.getBisqEasyService().getBisqEasyOfferbookMessageService()).thenReturn(messageService);
+
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getDirection()).thenReturn(Direction.BUY);
+        when(offer.getAmountSpec()).thenReturn(new BaseSideFixedAmountSpec(BASE_SIDE_AMOUNT));
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+        when(offer.getQuoteSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getBaseSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getDate()).thenReturn(1_700_000_000_000L);
+        message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getId()).thenReturn("offer-message-id");
+        when(message.getAuthorUserProfileId()).thenReturn("author-id");
+        when(message.hasBisqEasyOffer()).thenReturn(true);
+        when(message.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+
+        channel = new BisqEasyOfferbookChannel(MARKET);
+        WaitForAsyncUtils.asyncFx(() -> {
+            controller = new OfferbookListController(serviceProvider);
+            controller.onActivate();
+            controller.setSelectedChannel(channel);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @AfterEach
+    void tearDown() {
+        WaitForAsyncUtils.asyncFx(() -> controller.onDeactivate());
+        WaitForAsyncUtils.waitForFxEvents();
+        messageService.shutdown().join();
+    }
+
+    @Test
+    void offerReceivedBeforeItsMarketPriceIsListedOnceThePriceArrives(FxRobot robot) {
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).isEmpty();
+        assertThat(processedMessageIds()).isEmpty();
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).containsExactly("offer-message-id");
+        assertThat(processedMessageIds()).containsExactly("offer-message-id");
+    }
+
+    @Test
+    void listedOfferWhoseAmountsOverflowAtANewMarketPriceIsRemoved(FxRobot robot) {
+        putMarketPrice(FITTING_PRICE);
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).containsExactly("offer-message-id");
+
+        putMarketPrice(OVERFLOWING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).isEmpty();
+        assertThat(processedMessageIds()).isEmpty();
+        assertThat(messageService.isValid(message)).isFalse();
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).containsExactly("offer-message-id");
+    }
+
+    @Test
+    void listedOfferIsRemovedWhenItsMarketPriceDisappears(FxRobot robot) {
+        putMarketPrice(FITTING_PRICE);
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).containsExactly("offer-message-id");
+
+        marketPriceByCurrencyMap.remove(MARKET);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).isEmpty();
+        assertThat(processedMessageIds()).isEmpty();
+    }
+
+    @Test
+    void priceChangeAfterDeactivationDoesNotRepopulateTheList(FxRobot robot) {
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.asyncFx(() -> controller.onDeactivate());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).isEmpty();
+        assertThat(processedMessageIds()).isEmpty();
+        WaitForAsyncUtils.asyncFx(() -> controller.onActivate());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    void offerWhoseListItemCannotBeCreatedDoesNotBlockTheOthers(FxRobot robot) {
+        // Two mocks in the order the channel's set iterates them: the first one's list item
+        // construction fails (its author's reputation lookup throws), the second is fine.
+        List<BisqEasyOfferbookMessage> messages = new ArrayList<>(ConcurrentHashMap.<BisqEasyOfferbookMessage>newKeySet());
+        while (messages.size() < 2) {
+            messages.clear();
+            Set<BisqEasyOfferbookMessage> orderProbe = ConcurrentHashMap.newKeySet();
+            orderProbe.add(mock(BisqEasyOfferbookMessage.class));
+            orderProbe.add(mock(BisqEasyOfferbookMessage.class));
+            messages.addAll(orderProbe);
+        }
+        BisqEasyOfferbookMessage failingMessage = messages.get(0);
+        BisqEasyOfferbookMessage secondMessage = messages.get(1);
+        BisqEasyOffer offer = message.getBisqEasyOffer().orElseThrow();
+        when(failingMessage.getId()).thenReturn("failing-message-id");
+        when(failingMessage.getAuthorUserProfileId()).thenReturn("failing-author-id");
+        when(failingMessage.hasBisqEasyOffer()).thenReturn(true);
+        when(failingMessage.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        when(secondMessage.getId()).thenReturn("second-message-id");
+        when(secondMessage.getAuthorUserProfileId()).thenReturn("author-id");
+        when(secondMessage.hasBisqEasyOffer()).thenReturn(true);
+        when(secondMessage.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        UserProfile failingAuthor = mock(UserProfile.class);
+        when(userProfileService.findUserProfile("failing-author-id")).thenReturn(Optional.of(failingAuthor));
+        when(reputationService.getReputationScore(failingAuthor)).thenThrow(new IllegalStateException("test"));
+        channel.addChatMessage(failingMessage);
+        channel.addChatMessage(secondMessage);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).isEmpty();
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).containsExactly("second-message-id");
+        assertThat(processedMessageIds()).containsExactly("second-message-id");
+    }
+
+    @Test
+    void ignoringAndUnignoringTheMakerRemovesAndRestoresTheListedOffer(FxRobot robot) {
+        putMarketPrice(FITTING_PRICE);
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).containsExactly("offer-message-id");
+
+        ignoredUserProfileIds.add("author-id");
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).isEmpty();
+        assertThat(processedMessageIds()).isEmpty();
+
+        ignoredUserProfileIds.remove("author-id");
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).containsExactly("offer-message-id");
+    }
+
+    private void putMarketPrice(double price) {
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(price, "USD"));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+    }
+
+    private List<String> displayedMessageIds() {
+        return controller.getModel().getOfferbookListItems().stream()
+                .map(item -> item.getBisqEasyOfferbookMessage().getId())
+                .toList();
+    }
+
+    private Set<String> processedMessageIds() {
+        return controller.getModel().getChatMessageIds();
+    }
+}

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
@@ -125,4 +125,29 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
                 .isEqualTo(PercentageFormatter.formatToPercentWithSignAndSymbol(0.25));
         item.dispose();
     }
+
+    @Test
+    void disposedItemNoLongerFollowsMarketPriceUpdates() {
+        putMarketPrice(90_000);
+        OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
+        Optional<Double> percentAt90k = item.getPriceSpecAsPercent();
+
+        putMarketPrice(80_000);
+        WaitForAsyncUtils.waitForFxEvents();
+        Optional<Double> percentAt80k = item.getPriceSpecAsPercent();
+        assertThat(percentAt80k).isNotEqualTo(percentAt90k);
+
+        item.dispose();
+        putMarketPrice(70_000);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(item.getPriceSpecAsPercent()).isEqualTo(percentAt80k);
+    }
+
+    private void putMarketPrice(double price) {
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(price, "USD"));
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.of(marketPrice));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+    }
 }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListControllerTest.java
@@ -1,0 +1,265 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list;
+
+import bisq.bisq_easy.BisqEasyOfferbookMessageService;
+import bisq.bisq_easy.BisqEasySellersReputationBasedTradeAmountService;
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.ChatChannel;
+import bisq.chat.ChatChannelDomain;
+import bisq.chat.ChatMessage;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.Observable;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.desktop.ServiceProvider;
+import bisq.desktop.common.Transitions;
+import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.settings.ChatMessageType;
+import bisq.settings.SettingsService;
+import bisq.user.UserService;
+import bisq.user.identity.UserIdentity;
+import bisq.user.profile.UserProfile;
+import bisq.user.reputation.ReputationService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+@ResourceLock(value = "Transitions.settingsService", mode = ResourceAccessMode.READ_WRITE)
+class ChatMessagesListControllerTest extends TestFxHeadlessSupport {
+    private static final Market MARKET = MarketRepository.getUSDBitcoinMarket();
+    // 5e18 sat converts to the quote side at 1 USD per BTC but overflows a long at 50,000 USD.
+    private static final long BASE_SIDE_AMOUNT = 5_000_000_000_000_000_000L;
+    private static final double FITTING_PRICE = 1;
+    private static final double OVERFLOWING_PRICE = 50_000;
+
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+    private final Observable<ChatChannel<? extends ChatMessage>> selectedChannel = new Observable<>();
+    private BisqEasyOfferbookMessageService messageService;
+    private ChatMessagesListController controller;
+    private BisqEasyOfferbookChannel channel;
+    private BisqEasyOfferbookMessage message;
+
+    @BeforeEach
+    void setUp() {
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        when(marketPriceService.findMarketPrice(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)));
+
+        UserProfile authorUserProfile = mock(UserProfile.class);
+        when(authorUserProfile.getId()).thenReturn("author-id");
+        when(authorUserProfile.getNickName()).thenReturn("alice");
+        UserService userService = mock(UserService.class, RETURNS_DEEP_STUBS);
+        when(userService.getUserProfileService().findUserProfile("author-id")).thenReturn(Optional.of(authorUserProfile));
+        when(userService.getUserProfileService().getIgnoredUserProfileIds()).thenReturn(new ObservableSet<>());
+        when(userService.getUserIdentityService().getSelectedUserIdentityObservable()).thenReturn(new Observable<>(mock(UserIdentity.class)));
+        ReputationService reputationService = mock(ReputationService.class);
+        when(reputationService.findReputationScore(any(UserProfile.class))).thenReturn(Optional.empty());
+        when(reputationService.getUserProfileIdWithScoreChange()).thenReturn(new Observable<>());
+        when(reputationService.getScoreByUserProfileId()).thenReturn(new ObservableHashMap<>());
+        when(userService.getReputationService()).thenReturn(reputationService);
+
+        BisqEasySellersReputationBasedTradeAmountService sellersReputationService =
+                mock(BisqEasySellersReputationBasedTradeAmountService.class);
+        when(sellersReputationService.hasSellerSufficientReputation(any(ChatMessage.class))).thenReturn(true);
+        ChatService chatService = mock(ChatService.class, RETURNS_DEEP_STUBS);
+        when(chatService.getChatChannelSelectionServices().get(ChatChannelDomain.BISQ_EASY_OFFERBOOK).getSelectedChannel())
+                .thenReturn(selectedChannel);
+        messageService = new BisqEasyOfferbookMessageService(chatService, userService, sellersReputationService, marketPriceService);
+        messageService.initialize().join();
+
+        SettingsService settingsService = mock(SettingsService.class, RETURNS_DEEP_STUBS);
+        when(settingsService.getBisqEasyOfferbookMessageTypeFilter()).thenReturn(new Observable<>(ChatMessageType.ALL));
+        when(settingsService.getUseAnimations()).thenReturn(new Observable<>(false));
+        Transitions.setSettingsService(settingsService);
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getChatService()).thenReturn(chatService);
+        when(serviceProvider.getSettingsService()).thenReturn(settingsService);
+        when(serviceProvider.getUserService()).thenReturn(userService);
+        when(serviceProvider.getBondedRolesService().getMarketPriceService()).thenReturn(marketPriceService);
+        when(serviceProvider.getBondedRolesService().getAuthorizedBondedRolesService().getAuthorizedBondedRoleStream())
+                .thenAnswer(invocation -> Stream.empty());
+        when(serviceProvider.getBisqEasyService().getBisqEasyOfferbookMessageService()).thenReturn(messageService);
+        when(serviceProvider.getNetworkService().getMessageDeliveryStatusByMessageId()).thenReturn(new ObservableHashMap<>());
+        when(serviceProvider.getNetworkService().getResendMessageService()).thenReturn(Optional.empty());
+
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getDirection()).thenReturn(Direction.BUY);
+        when(offer.getAmountSpec()).thenReturn(new BaseSideFixedAmountSpec(BASE_SIDE_AMOUNT));
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+        when(offer.getQuoteSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getBaseSidePaymentMethodSpecs()).thenReturn(List.of());
+        message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getId()).thenReturn("offer-message-id");
+        when(message.getAuthorUserProfileId()).thenReturn("author-id");
+        when(message.hasBisqEasyOffer()).thenReturn(true);
+        when(message.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        when(message.getCitation()).thenReturn(Optional.empty());
+
+        channel = new BisqEasyOfferbookChannel(MARKET);
+        WaitForAsyncUtils.asyncFx(() -> {
+            controller = new ChatMessagesListController(serviceProvider,
+                    userProfile -> {
+                    },
+                    chatMessage -> {
+                    },
+                    chatMessage -> {
+                    },
+                    () -> {
+                    },
+                    ChatChannelDomain.BISQ_EASY_OFFERBOOK);
+            controller.onActivate();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        selectedChannel.set(channel);
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @AfterEach
+    void tearDown() {
+        WaitForAsyncUtils.asyncFx(() -> controller.onDeactivate());
+        WaitForAsyncUtils.waitForFxEvents();
+        messageService.shutdown().join();
+        Transitions.setSettingsService(null);
+    }
+
+    @Test
+    void offerMessageReceivedBeforeItsMarketPriceIsListedOnceThePriceArrives() {
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).doesNotContain("offer-message-id");
+        assertThat(processedMessageIds()).doesNotContain("offer-message-id");
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).contains("offer-message-id");
+        assertThat(processedMessageIds()).contains("offer-message-id");
+    }
+
+    @Test
+    void listedOfferMessageWhoseAmountsOverflowAtANewMarketPriceIsRemoved() {
+        putMarketPrice(FITTING_PRICE);
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(displayedMessageIds()).contains("offer-message-id");
+
+        putMarketPrice(OVERFLOWING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).doesNotContain("offer-message-id");
+        assertThat(processedMessageIds()).doesNotContain("offer-message-id");
+        assertThat(messageService.isValid(message)).isFalse();
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).contains("offer-message-id");
+    }
+
+    @Test
+    void priceChangeAfterDeactivationDoesNotRepopulateTheList() {
+        channel.addChatMessage(message);
+        WaitForAsyncUtils.asyncFx(() -> controller.onDeactivate());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        putMarketPrice(FITTING_PRICE);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).doesNotContain("offer-message-id");
+        assertThat(processedMessageIds()).doesNotContain("offer-message-id");
+        WaitForAsyncUtils.asyncFx(() -> controller.onActivate());
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    void messageWhoseListItemCannotBeCreatedDoesNotBreakTheChannelBinding() {
+        putMarketPrice(FITTING_PRICE);
+        Optional<BisqEasyOffer> offer = message.getBisqEasyOffer();
+        BisqEasyOfferbookMessage failingMessage = mock(BisqEasyOfferbookMessage.class);
+        when(failingMessage.getId()).thenReturn("failing-message-id");
+        when(failingMessage.getAuthorUserProfileId()).thenReturn("failing-author-id");
+        when(failingMessage.hasBisqEasyOffer()).thenReturn(true);
+        when(failingMessage.getBisqEasyOffer()).thenReturn(offer);
+        when(failingMessage.getCitation()).thenThrow(new IllegalStateException("test"));
+        BisqEasyOfferbookMessage laterMessage = mock(BisqEasyOfferbookMessage.class);
+        when(laterMessage.getId()).thenReturn("later-message-id");
+        when(laterMessage.getAuthorUserProfileId()).thenReturn("author-id");
+        when(laterMessage.hasBisqEasyOffer()).thenReturn(true);
+        when(laterMessage.getBisqEasyOffer()).thenReturn(offer);
+        when(laterMessage.getCitation()).thenReturn(Optional.empty());
+        BisqEasyOfferbookChannel otherChannel = new BisqEasyOfferbookChannel(new Market("BTC", "EUR", "Bitcoin", "Euro"));
+        otherChannel.addChatMessage(failingMessage);
+        otherChannel.addChatMessage(message);
+
+        selectedChannel.set(otherChannel);
+        WaitForAsyncUtils.waitForFxEvents();
+        otherChannel.addChatMessage(laterMessage);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(displayedMessageIds()).contains("offer-message-id", "later-message-id");
+        assertThat(displayedMessageIds()).doesNotContain("failing-message-id");
+    }
+
+    private void putMarketPrice(double price) {
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(price, "USD"));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+    }
+
+    private List<String> displayedMessageIds() {
+        return controller.getModel().getChatMessages().stream()
+                .map(item -> item.getChatMessage().getId())
+                .toList();
+    }
+
+    private Set<String> processedMessageIds() {
+        return controller.getModel().getChatMessageIds();
+    }
+}

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyOfferbookMessageService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyOfferbookMessageService.java
@@ -17,17 +17,28 @@
 
 package bisq.bisq_easy;
 
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.offer.amount.OfferAmountUtil;
 import bisq.chat.ChatService;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
 import bisq.common.application.Service;
+import bisq.common.observable.Observable;
+import bisq.common.observable.Pin;
+import bisq.common.observable.ReadOnlyObservable;
+import bisq.common.observable.map.HashMapObserver;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.user.UserService;
 import bisq.user.banned.BannedUserService;
 import bisq.user.profile.UserProfileService;
+import bisq.user.reputation.ReputationService;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
@@ -36,15 +47,84 @@ public class BisqEasyOfferbookMessageService implements Service {
     private final BisqEasyOfferbookChannelService bisqEasyOfferbookChannelService;
     private final BannedUserService bannedUserService;
     private final BisqEasySellersReputationBasedTradeAmountService bisqEasySellersReputationBasedTradeAmountService;
+    private final MarketPriceService marketPriceService;
     private final UserProfileService userProfileService;
+    private final ReputationService reputationService;
+    // Advances whenever an input of isValid changes without a chat message event (market prices,
+    // ignored or banned profiles, a maker's reputation score), so consumers which cache results
+    // of isValid, getOffers or getAllOffers recompute.
+    private final Observable<Long> offerValidityRevision = new Observable<>(0L);
+    @Nullable
+    private Pin marketPriceByCurrencyMapPin, ignoredUserProfileIdsPin, bannedUserProfileDataSetPin,
+            scoreByUserProfileIdPin;
 
     public BisqEasyOfferbookMessageService(ChatService chatService,
                                            UserService userService,
-                                           BisqEasySellersReputationBasedTradeAmountService bisqEasySellersReputationBasedTradeAmountService) {
+                                           BisqEasySellersReputationBasedTradeAmountService bisqEasySellersReputationBasedTradeAmountService,
+                                           MarketPriceService marketPriceService) {
         bisqEasyOfferbookChannelService = chatService.getBisqEasyOfferbookChannelService();
         bannedUserService = userService.getBannedUserService();
         userProfileService = userService.getUserProfileService();
+        reputationService = userService.getReputationService();
         this.bisqEasySellersReputationBasedTradeAmountService = bisqEasySellersReputationBasedTradeAmountService;
+        this.marketPriceService = marketPriceService;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> initialize() {
+        log.info("initialize");
+        // BisqEasySellersReputationBasedTradeAmountService is initialized first, so its cache is
+        // invalidated before consumers of the revision re-evaluate isValid.
+        marketPriceByCurrencyMapPin = marketPriceService.getMarketPriceByCurrencyMap()
+                .addObserver(this::incrementOfferValidityRevision);
+        ignoredUserProfileIdsPin = userProfileService.getIgnoredUserProfileIds()
+                .addObserver(this::incrementOfferValidityRevision);
+        bannedUserProfileDataSetPin = bannedUserService.getBannedUserProfileDataSet()
+                .addObserver(this::incrementOfferValidityRevision);
+        scoreByUserProfileIdPin = reputationService.getScoreByUserProfileId().addObserver(new HashMapObserver<>() {
+            @Override
+            public void put(String userProfileId, Long score) {
+                if (isMakerOfAnyOffer(userProfileId)) {
+                    incrementOfferValidityRevision();
+                }
+            }
+
+            @Override
+            public void putAll(Map<? extends String, ? extends Long> map) {
+                // Fired at registration with all known scores; one revision instead of one per score.
+                incrementOfferValidityRevision();
+            }
+
+            @Override
+            public void remove(Object userProfileId) {
+                if (userProfileId instanceof String id && isMakerOfAnyOffer(id)) {
+                    incrementOfferValidityRevision();
+                }
+            }
+
+            @Override
+            public void clear() {
+                incrementOfferValidityRevision();
+            }
+        });
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> shutdown() {
+        log.info("shutdown");
+        Stream.of(marketPriceByCurrencyMapPin, ignoredUserProfileIdsPin, bannedUserProfileDataSetPin, scoreByUserProfileIdPin)
+                .filter(Objects::nonNull)
+                .forEach(Pin::unbind);
+        marketPriceByCurrencyMapPin = null;
+        ignoredUserProfileIdsPin = null;
+        bannedUserProfileDataSetPin = null;
+        scoreByUserProfileIdPin = null;
+        return CompletableFuture.completedFuture(true);
+    }
+
+    public ReadOnlyObservable<Long> getOfferValidityRevision() {
+        return offerValidityRevision;
     }
 
     public Stream<BisqEasyOffer> getAllOffers() {
@@ -95,8 +175,42 @@ public class BisqEasyOfferbookMessageService implements Service {
         return isNotBanned(message) &&
                 isNotIgnored(message) &&
                 (isTextMessage(message) ||
-                        isBuyOffer(message) ||
-                        hasSellerSufficientReputation(message));
+                        (hasResolvableAmounts(message) &&
+                                (isBuyOffer(message) || hasSellerSufficientReputation(message))));
     }
 
+    // An offer whose amounts cannot be resolved on both sides - because a conversion overflows
+    // at its price, or because the required market price is missing and the conversions come
+    // back empty - cannot be rendered or taken: the rendering paths call orElseThrow on these
+    // values. Such an offer is invalid regardless of direction, so no list item is ever
+    // constructed from it. Probing both sides covers every conversion the rendering paths
+    // perform.
+    private boolean hasResolvableAmounts(BisqEasyOfferbookMessage message) {
+        return message.getBisqEasyOffer().map(offer -> {
+            try {
+                return OfferAmountUtil.findBaseSideMinOrFixedAmount(marketPriceService, offer.getAmountSpec(),
+                        offer.getPriceSpec(), offer.getMarket()).isPresent()
+                        && OfferAmountUtil.findBaseSideMaxOrFixedAmount(marketPriceService, offer.getAmountSpec(),
+                        offer.getPriceSpec(), offer.getMarket()).isPresent()
+                        && OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, offer.getAmountSpec(),
+                        offer.getPriceSpec(), offer.getMarket()).isPresent()
+                        && OfferAmountUtil.findQuoteSideMaxOrFixedAmount(marketPriceService, offer.getAmountSpec(),
+                        offer.getPriceSpec(), offer.getMarket()).isPresent();
+            } catch (ArithmeticException e) {
+                log.debug("Offer {} has amounts which cannot be converted at its price", offer.getId());
+                return false;
+            }
+        }).orElse(true);
+    }
+
+    private boolean isMakerOfAnyOffer(String userProfileId) {
+        return bisqEasyOfferbookChannelService.getChannels().stream()
+                .flatMap(BisqEasyOfferbookChannel::getBisqEasyOfferbookMessagesWithOffer)
+                .flatMap(message -> message.getBisqEasyOffer().stream())
+                .anyMatch(offer -> userProfileId.equals(offer.getMakersUserProfileId()));
+    }
+
+    private synchronized void incrementOfferValidityRevision() {
+        offerValidityRevision.set(offerValidityRevision.get() + 1);
+    }
 }

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasySellersReputationBasedTradeAmountService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasySellersReputationBasedTradeAmountService.java
@@ -22,6 +22,7 @@ import bisq.chat.ChatMessage;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
 import bisq.common.application.Service;
 import bisq.common.observable.Pin;
+import bisq.common.observable.map.HashMapObserver;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationScore;
@@ -40,7 +41,10 @@ public class BisqEasySellersReputationBasedTradeAmountService implements Service
     private final ReputationService reputationService;
     private final MarketPriceService marketPriceService;
     private final Map<String, Set<String>> sellOffersWithInsufficientReputationByMakersProfileId = new ConcurrentHashMap<>();
-    private Pin userProfileIdWithScoreChangePin;
+    // Guards a computation which started before an invalidation from re-inserting a stale result.
+    private final Object cacheInvalidationLock = new Object();
+    private long cacheInvalidationCount;
+    private Pin scoreByUserProfileIdPin, marketPriceByCurrencyMapPin;
 
     public BisqEasySellersReputationBasedTradeAmountService(UserProfileService userProfileService,
                                                             ReputationService reputationService,
@@ -58,15 +62,42 @@ public class BisqEasySellersReputationBasedTradeAmountService implements Service
     public CompletableFuture<Boolean> initialize() {
         log.info("initialize");
 
-        userProfileIdWithScoreChangePin = reputationService.getUserProfileIdWithScoreChange().addObserver(this::userProfileIdWithScoreChanged);
+        // The score map notifies on every put, unlike the equality-gated score change observable
+        // which stays silent when the same profile changes twice in a row.
+        scoreByUserProfileIdPin = reputationService.getScoreByUserProfileId().addObserver(new HashMapObserver<>() {
+            @Override
+            public void put(String userProfileId, Long score) {
+                userProfileScoreChanged(userProfileId);
+            }
+
+            @Override
+            public void remove(Object userProfileId) {
+                if (userProfileId instanceof String id) {
+                    userProfileScoreChanged(id);
+                }
+            }
+
+            @Override
+            public void clear() {
+                invalidateCache();
+            }
+        });
+        // The required reputation score derives from the offer amount in USD, so cached results
+        // become stale whenever market prices change.
+        marketPriceByCurrencyMapPin = marketPriceService.getMarketPriceByCurrencyMap()
+                .addObserver(this::marketPricesChanged);
 
         return CompletableFuture.completedFuture(true);
     }
 
     public CompletableFuture<Boolean> shutdown() {
-        if (userProfileIdWithScoreChangePin != null) {
-            userProfileIdWithScoreChangePin.unbind();
-            userProfileIdWithScoreChangePin = null;
+        if (scoreByUserProfileIdPin != null) {
+            scoreByUserProfileIdPin.unbind();
+            scoreByUserProfileIdPin = null;
+        }
+        if (marketPriceByCurrencyMapPin != null) {
+            marketPriceByCurrencyMapPin.unbind();
+            marketPriceByCurrencyMapPin = null;
         }
         return CompletableFuture.completedFuture(true);
     }
@@ -96,6 +127,10 @@ public class BisqEasySellersReputationBasedTradeAmountService implements Service
 
         String offerId = bisqEasyOffer.getId();
         String makersUserProfileId = bisqEasyOffer.getMakersUserProfileId();
+        long cacheInvalidationCountAtStart;
+        synchronized (cacheInvalidationLock) {
+            cacheInvalidationCountAtStart = cacheInvalidationCount;
+        }
         if (useCache) {
             // The computeIfPresent method invocation is performed atomically.
             Set<String> sellOffersWithInsufficientReputation = sellOffersWithInsufficientReputationByMakersProfileId
@@ -107,9 +142,18 @@ public class BisqEasySellersReputationBasedTradeAmountService implements Service
             }
         }
 
-        Optional<Long> requiredReputationScoreForMaxOrFixedAmount = BisqEasyTradeAmountLimits.findRequiredReputationScoreForMaxOrFixedAmount(marketPriceService, bisqEasyOffer);
+        Optional<Long> requiredReputationScoreForMaxOrFixedAmount;
+        Optional<Long> requiredReputationScoreForMinAmount;
+        try {
+            requiredReputationScoreForMaxOrFixedAmount = BisqEasyTradeAmountLimits.findRequiredReputationScoreForMaxOrFixedAmount(marketPriceService, bisqEasyOffer);
+            requiredReputationScoreForMinAmount = BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinAmount(marketPriceService, bisqEasyOffer);
+        } catch (ArithmeticException e) {
+            // The offer amount converts to the offer's fiat currency but overflows in USD, so the
+            // required score cannot be determined at current prices.
+            log.debug("Required reputation score for offer {} cannot be calculated at current prices", offerId);
+            return false;
+        }
         if (requiredReputationScoreForMaxOrFixedAmount.isPresent()) {
-            Optional<Long> requiredReputationScoreForMinAmount = BisqEasyTradeAmountLimits.findRequiredReputationScoreForMinAmount(marketPriceService, bisqEasyOffer);
             long requiredReputationScoreForMaxOrFixed = requiredReputationScoreForMaxOrFixedAmount.get();
             long requiredReputationScoreForMinOrFixed = requiredReputationScoreForMinAmount.orElse(requiredReputationScoreForMaxOrFixed);
             long sellersScore = userProfileService.findUserProfile(makersUserProfileId)
@@ -119,15 +163,19 @@ public class BisqEasySellersReputationBasedTradeAmountService implements Service
             boolean hasInsufficientReputation = BisqEasyTradeAmountLimits.withTolerance(sellersScore) < requiredReputationScoreForMinOrFixed;
             if (hasInsufficientReputation) {
                 if (useCache) {
-                    // The compute method invocation is performed atomically.
-                    sellOffersWithInsufficientReputationByMakersProfileId
-                            .compute(makersUserProfileId, (k, set) -> {
-                                if (set == null) {
-                                    set = ConcurrentHashMap.newKeySet();
-                                }
-                                set.add(offerId);
-                                return set;
-                            });
+                    synchronized (cacheInvalidationLock) {
+                        if (cacheInvalidationCountAtStart == cacheInvalidationCount) {
+                            // The compute method invocation is performed atomically.
+                            sellOffersWithInsufficientReputationByMakersProfileId
+                                    .compute(makersUserProfileId, (k, set) -> {
+                                        if (set == null) {
+                                            set = ConcurrentHashMap.newKeySet();
+                                        }
+                                        set.add(offerId);
+                                        return set;
+                                    });
+                        }
+                    }
                 }
                 return false;
             }
@@ -136,10 +184,22 @@ public class BisqEasySellersReputationBasedTradeAmountService implements Service
         return true;
     }
 
-    private void userProfileIdWithScoreChanged(String userProfileId) {
-        if (userProfileId != null) {
-            // We remove the cached data if we get any change of the users reputation score
+    private void userProfileScoreChanged(String userProfileId) {
+        // We remove the cached data if we get any change of the users reputation score
+        synchronized (cacheInvalidationLock) {
+            cacheInvalidationCount++;
             sellOffersWithInsufficientReputationByMakersProfileId.remove(userProfileId);
+        }
+    }
+
+    private void marketPricesChanged() {
+        invalidateCache();
+    }
+
+    private void invalidateCache() {
+        synchronized (cacheInvalidationLock) {
+            cacheInvalidationCount++;
+            sellOffersWithInsufficientReputationByMakersProfileId.clear();
         }
     }
 }

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyService.java
@@ -129,7 +129,10 @@ public class BisqEasyService implements Service {
         bisqEasySellersReputationBasedTradeAmountService = new BisqEasySellersReputationBasedTradeAmountService(userService.getUserProfileService(),
                 userService.getReputationService(),
                 marketPriceService);
-        bisqEasyOfferbookMessageService = new BisqEasyOfferbookMessageService(chatService, userService, bisqEasySellersReputationBasedTradeAmountService);
+        bisqEasyOfferbookMessageService = new BisqEasyOfferbookMessageService(chatService,
+                userService,
+                bisqEasySellersReputationBasedTradeAmountService,
+                marketPriceService);
 
         // Mobile push notifications for Bisq Easy trade-state transitions, mirroring the
         // proven Android nodeApp OpenTradesNotificationService whitelist. Dispatch is

--- a/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyTradeAmountLimits.java
+++ b/bisq-easy/src/main/java/bisq/bisq_easy/BisqEasyTradeAmountLimits.java
@@ -219,12 +219,17 @@ public class BisqEasyTradeAmountLimits {
                         return false;
                     }
 
-                    Optional<Result> result = checkOfferAmountLimitForMinAmount(reputationService,
-                            userIdentityService,
-                            userProfileService,
-                            marketPriceService,
-                            offer);
-                    if (!result.map(Result::isValid).orElse(false)) {
+                    try {
+                        Optional<Result> result = checkOfferAmountLimitForMinAmount(reputationService,
+                                userIdentityService,
+                                userProfileService,
+                                marketPriceService,
+                                offer);
+                        if (!result.map(Result::isValid).orElse(false)) {
+                            return false;
+                        }
+                    } catch (Exception e) {
+                        log.warn("Failed to evaluate min amount limit for offer {}: {}", offer.getId(), e.getMessage(), e);
                         return false;
                     }
 
@@ -232,7 +237,14 @@ public class BisqEasyTradeAmountLimits {
                 })
                 .toList();
         Optional<Monetary> lowest = filteredOffers.stream()
-                .map(offer -> OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, offer))
+                .map(offer -> {
+                    try {
+                        return OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, offer);
+                    } catch (Exception e) {
+                        log.warn("Failed to evaluate lowest amount for offer {}: {}", offer.getId(), e.getMessage(), e);
+                        return Optional.<Monetary>empty();
+                    }
+                })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .min(Monetary::compareTo);

--- a/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyOfferbookMessageServiceTest.java
+++ b/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasyOfferbookMessageServiceTest.java
@@ -1,0 +1,216 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bisq_easy;
+
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.ChatService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.common.monetary.PriceQuote;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.user.UserService;
+import bisq.user.banned.BannedUserProfileData;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BisqEasyOfferbookMessageServiceTest {
+    private final Market market = MarketRepository.getUSDBitcoinMarket();
+
+    private BisqEasyOfferbookMessageService createService() {
+        return createService(mock(MarketPriceService.class));
+    }
+
+    private BisqEasyOfferbookMessageService createService(MarketPriceService marketPriceService) {
+        ChatService chatService = mock(ChatService.class, RETURNS_DEEP_STUBS);
+        UserService userService = mock(UserService.class, RETURNS_DEEP_STUBS);
+        BisqEasySellersReputationBasedTradeAmountService sellersReputationService =
+                mock(BisqEasySellersReputationBasedTradeAmountService.class);
+        when(sellersReputationService.hasSellerSufficientReputation(any(BisqEasyOfferbookMessage.class))).thenReturn(true);
+        return new BisqEasyOfferbookMessageService(chatService,
+                userService,
+                sellersReputationService,
+                marketPriceService);
+    }
+
+    private BisqEasyOfferbookMessage messageWithOffer(Direction direction, long quoteSideFixedAmount) {
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMarket()).thenReturn(market);
+        when(offer.getDirection()).thenReturn(direction);
+        when(offer.getAmountSpec()).thenReturn(new QuoteSideFixedAmountSpec(quoteSideFixedAmount));
+        // A fixed price of one quote unit per BTC: converting the quote amount to the base
+        // side multiplies by 10^8.
+        when(offer.getPriceSpec()).thenReturn(new FixPriceSpec(PriceQuote.fromFiatPrice(0.0001, "USD")));
+        BisqEasyOfferbookMessage message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getAuthorUserProfileId()).thenReturn("author-id");
+        when(message.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        return message;
+    }
+
+    @Test
+    void offersWithConvertibleAmountsAreValid() {
+        BisqEasyOfferbookMessageService service = createService();
+        assertTrue(service.isValid(messageWithOffer(Direction.BUY, 50_000)));
+        assertTrue(service.isValid(messageWithOffer(Direction.SELL, 50_000)));
+    }
+
+    @Test
+    void offersWhoseAmountsCannotBeResolvedAreInvalid() {
+        BisqEasyOfferbookMessageService service = createService();
+        BisqEasyOfferbookMessage message = messageWithOffer(Direction.BUY, 50_000);
+        BisqEasyOffer offer = message.getBisqEasyOffer().orElseThrow();
+        // A market price spec without an available market price: the conversions return empty
+        // instead of throwing, and downstream list items call orElseThrow on them.
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+
+        assertFalse(service.isValid(message));
+    }
+
+    @Test
+    void marketPricedOfferCanBeRevalidatedOnceItsPriceArrives() {
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.findMarketPrice(market)).thenReturn(Optional.empty());
+        BisqEasyOfferbookMessageService service = createService(marketPriceService);
+        BisqEasyOfferbookMessage message = messageWithOffer(Direction.BUY, 50_000);
+        BisqEasyOffer offer = message.getBisqEasyOffer().orElseThrow();
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+
+        assertFalse(service.isValid(message));
+
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(50_000, "USD"));
+        when(marketPriceService.findMarketPrice(market)).thenReturn(Optional.of(marketPrice));
+
+        assertTrue(service.isValid(message));
+    }
+
+    @Test
+    void offersWhoseAmountConversionOverflowsAreInvalidForBothDirections() {
+        BisqEasyOfferbookMessageService service = createService();
+        // Long.MAX_VALUE quote units at a one-unit price: the base side overflows a long.
+        // Buy offers short-circuit the reputation check, so the resolvability gate must be
+        // independent of the offer direction.
+        assertFalse(service.isValid(messageWithOffer(Direction.BUY, Long.MAX_VALUE)));
+        assertFalse(service.isValid(messageWithOffer(Direction.SELL, Long.MAX_VALUE)));
+    }
+
+    @Test
+    void offerValidityRevisionAdvancesWhenIgnoredBannedOrMakerReputationChanges() {
+        ChatService chatService = mock(ChatService.class, RETURNS_DEEP_STUBS);
+        BisqEasyOfferbookChannel channel = new BisqEasyOfferbookChannel(market);
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getMakersUserProfileId()).thenReturn("maker-id");
+        BisqEasyOfferbookMessage makersMessage = mock(BisqEasyOfferbookMessage.class);
+        when(makersMessage.getId()).thenReturn("offer-message-id");
+        when(makersMessage.getAuthorUserProfileId()).thenReturn("author-id");
+        when(makersMessage.hasBisqEasyOffer()).thenReturn(true);
+        when(makersMessage.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        channel.addChatMessage(makersMessage);
+        ObservableSet<BisqEasyOfferbookChannel> channels = new ObservableSet<>();
+        channels.add(channel);
+        when(chatService.getBisqEasyOfferbookChannelService().getChannels()).thenReturn(channels);
+        UserService userService = mock(UserService.class, RETURNS_DEEP_STUBS);
+        ObservableSet<String> ignoredUserProfileIds = new ObservableSet<>();
+        when(userService.getUserProfileService().getIgnoredUserProfileIds()).thenReturn(ignoredUserProfileIds);
+        ObservableSet<BannedUserProfileData> bannedUserProfileDataSet = new ObservableSet<>();
+        when(userService.getBannedUserService().getBannedUserProfileDataSet()).thenReturn(bannedUserProfileDataSet);
+        ObservableHashMap<String, Long> scoreByUserProfileId = new ObservableHashMap<>();
+        when(userService.getReputationService().getScoreByUserProfileId()).thenReturn(scoreByUserProfileId);
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(new ObservableHashMap<>());
+        BisqEasyOfferbookMessageService service = new BisqEasyOfferbookMessageService(chatService,
+                userService,
+                mock(BisqEasySellersReputationBasedTradeAmountService.class),
+                marketPriceService);
+        service.initialize().join();
+        List<Long> observedRevisions = new ArrayList<>();
+        service.getOfferValidityRevision().addObserver(observedRevisions::add);
+        long revision = observedRevisions.get(0);
+
+        ignoredUserProfileIds.add("some-id");
+        assertEquals(List.of(revision, revision + 1), observedRevisions);
+
+        bannedUserProfileDataSet.add(mock(BannedUserProfileData.class));
+        assertEquals(List.of(revision, revision + 1, revision + 2), observedRevisions);
+
+        scoreByUserProfileId.put("not-a-maker-id", 1_000L);
+        scoreByUserProfileId.put("author-id", 1_000L);
+        assertEquals(List.of(revision, revision + 1, revision + 2), observedRevisions);
+
+        scoreByUserProfileId.put("maker-id", 1_000L);
+        scoreByUserProfileId.put("maker-id", 2_000L);
+        assertEquals(List.of(revision, revision + 1, revision + 2, revision + 3, revision + 4), observedRevisions);
+
+        scoreByUserProfileId.putAll(Map.of("maker-id", 3_000L, "not-a-maker-id", 3_000L, "other-maker-id", 3_000L));
+        assertEquals(List.of(revision, revision + 1, revision + 2, revision + 3, revision + 4, revision + 5), observedRevisions);
+
+        scoreByUserProfileId.remove("not-a-maker-id");
+        assertEquals(6, observedRevisions.size());
+
+        scoreByUserProfileId.remove("maker-id");
+        assertEquals(7, observedRevisions.size());
+
+        scoreByUserProfileId.clear();
+        assertEquals(8, observedRevisions.size());
+    }
+
+    @Test
+    void offerValidityRevisionAdvancesWhenMarketPricesChangeUntilShutdown() {
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        BisqEasyOfferbookMessageService service = createService(marketPriceService);
+        service.initialize().join();
+        List<Long> observedRevisions = new ArrayList<>();
+        service.getOfferValidityRevision().addObserver(observedRevisions::add);
+        long revisionAtRegistration = observedRevisions.get(0);
+
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        marketPriceByCurrencyMap.put(market, marketPrice);
+        marketPriceByCurrencyMap.put(market, mock(MarketPrice.class));
+
+        assertEquals(List.of(revisionAtRegistration, revisionAtRegistration + 1, revisionAtRegistration + 2),
+                observedRevisions);
+
+        service.shutdown().join();
+        marketPriceByCurrencyMap.put(market, mock(MarketPrice.class));
+
+        assertEquals(3, observedRevisions.size());
+    }
+}

--- a/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasySellersReputationBasedTradeAmountServiceTest.java
+++ b/bisq-easy/src/test/java/bisq/bisq_easy/BisqEasySellersReputationBasedTradeAmountServiceTest.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bisq_easy;
+
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BisqEasySellersReputationBasedTradeAmountServiceTest {
+    private static final Market MARKET = MarketRepository.getUSDBitcoinMarket();
+
+    @Test
+    void cachedInsufficientReputationIsReevaluatedWhenMarketPricesChange() {
+        ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        when(marketPriceService.findMarketPrice(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)));
+        when(marketPriceService.findMarketPriceQuote(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)).map(MarketPrice::getPriceQuote));
+
+        UserProfile seller = mock(UserProfile.class);
+        UserProfileService userProfileService = mock(UserProfileService.class);
+        when(userProfileService.findUserProfile("seller-id")).thenReturn(Optional.of(seller));
+        ReputationService reputationService = mock(ReputationService.class);
+        when(reputationService.getScoreByUserProfileId()).thenReturn(new ObservableHashMap<>());
+        ReputationScore reputationScore = mock(ReputationScore.class);
+        when(reputationScore.getTotalScore()).thenReturn(30_000L);
+        when(reputationService.getReputationScore(seller)).thenReturn(reputationScore);
+
+        // 0.002 BTC needs a score of 200 per USD: 40,000 at 100,000 USD/BTC and 20,000 at 50,000 USD/BTC.
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMakersUserProfileId()).thenReturn("seller-id");
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getDirection()).thenReturn(Direction.SELL);
+        when(offer.getAmountSpec()).thenReturn(new BaseSideFixedAmountSpec(200_000));
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+
+        BisqEasySellersReputationBasedTradeAmountService service =
+                new BisqEasySellersReputationBasedTradeAmountService(userProfileService, reputationService, marketPriceService);
+        service.initialize().join();
+
+        putMarketPrice(marketPriceByCurrencyMap, 100_000);
+        assertFalse(service.hasSellerSufficientReputation(offer));
+
+        putMarketPrice(marketPriceByCurrencyMap, 50_000);
+        assertTrue(service.hasSellerSufficientReputation(offer));
+    }
+
+    @Test
+    void checkStartedBeforeAPriceChangeDoesNotCacheItsStaleResult() {
+        ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        // While the first check runs, every price lookup keeps answering with the price the check
+        // started with, although the price change lands (and invalidates the cache) mid-check.
+        MarketPrice[] priceSeenByFirstCheck = {null};
+        boolean[] firstCheckRunning = {true};
+        when(marketPriceService.findMarketPrice(MARKET)).thenAnswer(invocation -> {
+            if (firstCheckRunning[0]) {
+                if (priceSeenByFirstCheck[0] == null) {
+                    priceSeenByFirstCheck[0] = marketPriceByCurrencyMap.get(MARKET);
+                    putMarketPrice(marketPriceByCurrencyMap, 50_000);
+                }
+                return Optional.of(priceSeenByFirstCheck[0]);
+            }
+            return Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET));
+        });
+        when(marketPriceService.findMarketPriceQuote(MARKET))
+                .thenAnswer(invocation -> marketPriceService.findMarketPrice(MARKET).map(MarketPrice::getPriceQuote));
+
+        UserProfile seller = mock(UserProfile.class);
+        UserProfileService userProfileService = mock(UserProfileService.class);
+        when(userProfileService.findUserProfile("seller-id")).thenReturn(Optional.of(seller));
+        ReputationService reputationService = mock(ReputationService.class);
+        when(reputationService.getScoreByUserProfileId()).thenReturn(new ObservableHashMap<>());
+        ReputationScore reputationScore = mock(ReputationScore.class);
+        when(reputationScore.getTotalScore()).thenReturn(30_000L);
+        when(reputationService.getReputationScore(seller)).thenReturn(reputationScore);
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMakersUserProfileId()).thenReturn("seller-id");
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getDirection()).thenReturn(Direction.SELL);
+        when(offer.getAmountSpec()).thenReturn(new BaseSideFixedAmountSpec(200_000));
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+        BisqEasySellersReputationBasedTradeAmountService service =
+                new BisqEasySellersReputationBasedTradeAmountService(userProfileService, reputationService, marketPriceService);
+        service.initialize().join();
+        putMarketPrice(marketPriceByCurrencyMap, 100_000);
+
+        assertFalse(service.hasSellerSufficientReputation(offer));
+        firstCheckRunning[0] = false;
+
+        assertTrue(service.hasSellerSufficientReputation(offer));
+    }
+
+    @Test
+    void offerWhoseUsdAmountOverflowsIsTreatedAsInsufficientReputationInsteadOfThrowing() {
+        Market eurMarket = new Market("BTC", "EUR", "Bitcoin", "Euro");
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(new ObservableHashMap<>());
+        PriceQuote eurQuote = PriceQuote.fromFiatPrice(90_000, "EUR");
+        PriceQuote usdQuote = PriceQuote.fromFiatPrice(100_000, "USD");
+        MarketPrice eurPrice = mock(MarketPrice.class);
+        when(eurPrice.getPriceQuote()).thenReturn(eurQuote);
+        MarketPrice usdPrice = mock(MarketPrice.class);
+        when(usdPrice.getPriceQuote()).thenReturn(usdQuote);
+        when(marketPriceService.findMarketPrice(eurMarket)).thenReturn(Optional.of(eurPrice));
+        when(marketPriceService.findMarketPriceQuote(eurMarket)).thenReturn(Optional.of(eurQuote));
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.of(usdPrice));
+        when(marketPriceService.findMarketPriceQuote(MARKET)).thenReturn(Optional.of(usdQuote));
+        ReputationService reputationService = mock(ReputationService.class);
+        when(reputationService.getScoreByUserProfileId()).thenReturn(new ObservableHashMap<>());
+        // 1e18 sat converts to 9e18 EUR units at 90,000 EUR/BTC, which fits a long, but to 1e19 USD
+        // units at 100,000 USD/BTC, which does not.
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMakersUserProfileId()).thenReturn("seller-id");
+        when(offer.getMarket()).thenReturn(eurMarket);
+        when(offer.getDirection()).thenReturn(Direction.SELL);
+        when(offer.getAmountSpec()).thenReturn(new BaseSideFixedAmountSpec(1_000_000_000_000_000_000L));
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+        BisqEasySellersReputationBasedTradeAmountService service =
+                new BisqEasySellersReputationBasedTradeAmountService(mock(UserProfileService.class), reputationService, marketPriceService);
+        service.initialize().join();
+
+        assertFalse(service.hasSellerSufficientReputation(offer));
+    }
+
+    @Test
+    void consecutiveScoreChangesOfTheSameMakerInvalidateTheCacheEachTime() {
+        ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+        MarketPriceService marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        when(marketPriceService.findMarketPrice(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)));
+        when(marketPriceService.findMarketPriceQuote(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)).map(MarketPrice::getPriceQuote));
+        putMarketPrice(marketPriceByCurrencyMap, 100_000);
+        UserProfile seller = mock(UserProfile.class);
+        UserProfileService userProfileService = mock(UserProfileService.class);
+        when(userProfileService.findUserProfile("seller-id")).thenReturn(Optional.of(seller));
+        ReputationService reputationService = mock(ReputationService.class);
+        ObservableHashMap<String, Long> scoreByUserProfileId = new ObservableHashMap<>();
+        when(reputationService.getScoreByUserProfileId()).thenReturn(scoreByUserProfileId);
+        ReputationScore reputationScore = mock(ReputationScore.class);
+        long[] totalScore = {30_000L};
+        when(reputationScore.getTotalScore()).thenAnswer(invocation -> totalScore[0]);
+        when(reputationService.getReputationScore(seller)).thenReturn(reputationScore);
+        // 0.002 BTC at 100,000 USD/BTC requires a score of 40,000.
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        when(offer.getMakersUserProfileId()).thenReturn("seller-id");
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getDirection()).thenReturn(Direction.SELL);
+        when(offer.getAmountSpec()).thenReturn(new BaseSideFixedAmountSpec(200_000));
+        when(offer.getPriceSpec()).thenReturn(new MarketPriceSpec());
+        BisqEasySellersReputationBasedTradeAmountService service =
+                new BisqEasySellersReputationBasedTradeAmountService(userProfileService, reputationService, marketPriceService);
+        service.initialize().join();
+
+        scoreByUserProfileId.put("seller-id", 30_000L);
+        assertFalse(service.hasSellerSufficientReputation(offer));
+
+        totalScore[0] = 50_000L;
+        scoreByUserProfileId.put("seller-id", 50_000L);
+        assertTrue(service.hasSellerSufficientReputation(offer));
+
+        totalScore[0] = 30_000L;
+        scoreByUserProfileId.put("seller-id", 30_000L);
+        assertFalse(service.hasSellerSufficientReputation(offer));
+
+        totalScore[0] = 50_000L;
+        scoreByUserProfileId.put("seller-id", 50_000L);
+        assertTrue(service.hasSellerSufficientReputation(offer));
+    }
+
+    private void putMarketPrice(ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap, double price) {
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(price, "USD"));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+    }
+}

--- a/common/src/main/java/bisq/common/monetary/PriceQuote.java
+++ b/common/src/main/java/bisq/common/monetary/PriceQuote.java
@@ -139,10 +139,12 @@ public final class PriceQuote implements Comparable<PriceQuote>, PersistableProt
      */
     public static PriceQuote from(Monetary baseSideMonetary, Monetary quoteSideMonetary) {
         checkArgument(baseSideMonetary.value != 0, "baseSideMonetary.value must not be 0");
+        // longValueExact: a price value that does not fit into a long must fail instead of
+        // silently wrapping into a plausible-looking wrong price.
         long value = BigDecimal.valueOf(quoteSideMonetary.value)
                 .movePointRight(baseSideMonetary.precision)
                 .divide(BigDecimal.valueOf(baseSideMonetary.value), RoundingMode.HALF_UP)
-                .longValue();
+                .longValueExact();
         return new PriceQuote(value, baseSideMonetary, quoteSideMonetary);
     }
 
@@ -157,9 +159,12 @@ public final class PriceQuote implements Comparable<PriceQuote>, PersistableProt
                 "baseSideMonetary must be the same type as the quote.baseSideMonetary.\n" +
                         "parameter baseSideMonetary=" + baseSideMonetary + "\n" +
                         "this.baseSideMonetary" + this.baseSideMonetary);
+        // setScale(DOWN) preserves the truncation toward zero longValue() applied;
+        // longValueExact makes an overflowing conversion fail instead of silently wrapping.
         long value = BigDecimal.valueOf(baseSideMonetary.value).multiply(BigDecimal.valueOf(this.value))
                 .movePointLeft(baseSideMonetary.precision)
-                .longValue();
+                .setScale(0, RoundingMode.DOWN)
+                .longValueExact();
         if (quoteSideMonetary instanceof Fiat) {
             return new Fiat(value,
                     quoteSideMonetary.code,
@@ -176,10 +181,12 @@ public final class PriceQuote implements Comparable<PriceQuote>, PersistableProt
                 "quoteSideMonetary must be the same type as the quote.quoteSideMonetary.\n" +
                         "parameter quoteSideMonetary=" + quoteSideMonetary + "\n" +
                         "this.quoteSideMonetary" + this.quoteSideMonetary);
+        // Explicit scale 0 keeps the HALF_UP rounding the plain divide applied;
+        // longValueExact makes an overflowing conversion fail instead of silently wrapping.
         long value = BigDecimal.valueOf(quoteSideMonetary.value)
                 .movePointRight(baseSideMonetary.precision)
-                .divide(BigDecimal.valueOf(this.value), RoundingMode.HALF_UP)
-                .longValue();
+                .divide(BigDecimal.valueOf(this.value), 0, RoundingMode.HALF_UP)
+                .longValueExact();
         if (baseSideMonetary instanceof Fiat) {
             return new Fiat(value,
                     baseSideMonetary.code,

--- a/common/src/test/java/bisq/common/monetary/MonetaryTest.java
+++ b/common/src/test/java/bisq/common/monetary/MonetaryTest.java
@@ -254,16 +254,7 @@ public class MonetaryTest {
         assertEquals(666667, priceQuote.getValue());
         assertEquals(0.00666667, priceQuote.asDouble());
 
-        //noinspection CatchMayIgnoreException
-        try {
-            // overflow as we movePointRight by 12 with xmr
-            xmr = Coin.asXmrFromFaceValue(15000000d);
-            btc = Coin.asBtcFromFaceValue(100000.0);
-            priceQuote = PriceQuote.from(xmr, btc);
-            assertEquals(666667, priceQuote.getValue());
-            assertEquals(0.00666667, priceQuote.asDouble());
-        } catch (Exception e) {
-            assertInstanceOf(ArithmeticException.class, e);
-        }
+        // overflow as we movePointRight by 12 with xmr
+        assertThrows(ArithmeticException.class, () -> Coin.asXmrFromFaceValue(15000000d));
     }
 }

--- a/common/src/test/java/bisq/common/monetary/PriceQuoteTest.java
+++ b/common/src/test/java/bisq/common/monetary/PriceQuoteTest.java
@@ -37,4 +37,46 @@ public class PriceQuoteTest {
         quoteSideMonetary = priceQuote.toQuoteSideMonetary(btc);
         assertEquals(1000000000, quoteSideMonetary.value);
     }
+
+    @Test
+    void toQuoteSideMonetaryTruncatesTowardZero() {
+        // 333_333_333 quote units per BTC: 1 sat converts to 3.33 quote units.
+        PriceQuote priceQuote = PriceQuote.fromFiatPrice(33333.3333, "USD");
+        assertEquals(3, priceQuote.toQuoteSideMonetary(Coin.asBtcFromValue(1)).value);
+        assertEquals(-3, priceQuote.toQuoteSideMonetary(Coin.asBtcFromValue(-1)).value);
+    }
+
+    @Test
+    void toBaseSideMonetaryRoundsHalfUp() {
+        // 3 quote units per BTC: 1 quote unit converts to 33_333_333.33 sats.
+        PriceQuote priceQuote = PriceQuote.fromFiatPrice(0.0003, "USD");
+        assertEquals(33_333_333, priceQuote.toBaseSideMonetary(Fiat.fromValue(1, "USD")).value);
+        assertEquals(66_666_667, priceQuote.toBaseSideMonetary(Fiat.fromValue(2, "USD")).value);
+    }
+
+    @Test
+    void toQuoteSideMonetaryThrowsOnOverflow() {
+        // 2^60 sats at 100k USD/BTC: the quote side is about 1.15 * 10^19, beyond long range.
+        // Wrapping produced a plausible-looking wrong amount instead of failing.
+        PriceQuote priceQuote = PriceQuote.fromFiatPrice(100_000, "USD");
+        assertThrows(ArithmeticException.class, () -> priceQuote.toQuoteSideMonetary(Coin.asBtcFromValue(1L << 60)));
+        assertThrows(ArithmeticException.class, () -> priceQuote.toQuoteSideMonetary(Coin.asBtcFromValue(-(1L << 60))));
+    }
+
+    @Test
+    void toBaseSideMonetaryThrowsOnOverflow() {
+        // Price value 1: the base side is the quote value times 10^8.
+        PriceQuote priceQuote = PriceQuote.fromFiatPrice(0.0001, "USD");
+        assertThrows(ArithmeticException.class, () ->
+                priceQuote.toBaseSideMonetary(Fiat.fromValue(Long.MAX_VALUE, "USD")));
+        assertThrows(ArithmeticException.class, () ->
+                priceQuote.toBaseSideMonetary(Fiat.fromValue(-Long.MAX_VALUE, "USD")));
+    }
+
+    @Test
+    void fromThrowsOnOverflow() {
+        // 1 sat of base against a Long.MAX_VALUE quote amount: the price value overflows.
+        assertThrows(ArithmeticException.class, () ->
+                PriceQuote.from(Coin.asBtcFromValue(1), Fiat.fromValue(Long.MAX_VALUE, "USD")));
+    }
 }

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
@@ -241,12 +241,17 @@ public class MuSigTradeAmountLimits {
                         return false;
                     }
 
-                    Optional<Result> result = checkOfferAmountLimitForMinAmount(reputationService,
-                            userIdentityService,
-                            userProfileService,
-                            marketPriceService,
-                            offer);
-                    if (!result.map(Result::isValid).orElse(false)) {
+                    try {
+                        Optional<Result> result = checkOfferAmountLimitForMinAmount(reputationService,
+                                userIdentityService,
+                                userProfileService,
+                                marketPriceService,
+                                offer);
+                        if (!result.map(Result::isValid).orElse(false)) {
+                            return false;
+                        }
+                    } catch (Exception e) {
+                        log.warn("Failed to evaluate min amount limit for offer {}: {}", offer.getId(), e.getMessage(), e);
                         return false;
                     }
 
@@ -254,7 +259,14 @@ public class MuSigTradeAmountLimits {
                 })
                 .toList();
         Optional<Monetary> lowest = filteredOffers.stream()
-                .map(offer -> OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, offer))
+                .map(offer -> {
+                    try {
+                        return OfferAmountUtil.findQuoteSideMinOrFixedAmount(marketPriceService, offer);
+                    } catch (Exception e) {
+                        log.warn("Failed to evaluate lowest amount for offer {}: {}", offer.getId(), e.getMessage(), e);
+                        return Optional.<Monetary>empty();
+                    }
+                })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .min(Monetary::compareTo);

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandler.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandler.java
@@ -199,8 +199,17 @@ public class BisqEasyTakeOfferRequestHandler extends BisqEasyTradeMessageHandler
                 takersContract.getPriceSpec(), market);
         checkArgument(priceQuote.isPresent(),
                 "PriceQuote is empty. Might be that no market price is available. marketPrice=" + marketPrice);
-        Optional<Monetary> amount = priceQuote.map(quote -> quote.toBaseSideMonetary(Monetary.from(takersContract.getQuoteSideAmount(),
-                market.getQuoteCurrencyCode())));
+        Optional<Monetary> amount;
+        try {
+            amount = priceQuote.map(quote -> quote.toBaseSideMonetary(Monetary.from(takersContract.getQuoteSideAmount(),
+                    market.getQuoteCurrencyCode())));
+        } catch (ArithmeticException e) {
+            // The contract amounts and, for a fixed price spec, the price quote come from the
+            // peer's request: a conversion that overflows or divides by zero marks a malformed
+            // request, rejected like any other failed amount validation.
+            throw new IllegalArgumentException("Converting the take offer request's quote side amount " +
+                    takersContract.getQuoteSideAmount() + " at the contract price failed: " + e.getMessage());
+        }
 
         long takersAmount = takersContract.getBaseSideAmount();
         long myAmount = amount.get().getValue(); // I am maker

--- a/trade/src/test/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandlerTest.java
+++ b/trade/src/test/java/bisq/trade/bisq_easy/protocol/messages/BisqEasyTakeOfferRequestHandlerTest.java
@@ -17,8 +17,15 @@
 
 package bisq.trade.bisq_easy.protocol.messages;
 
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.collection.ObservableSet;
 import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.network.identity.NetworkId;
+import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.FixPriceSpec;
 import bisq.trade.ServiceProvider;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.exceptions.TradeProtocolException;
@@ -28,6 +35,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,5 +63,48 @@ class BisqEasyTakeOfferRequestHandlerTest {
         // The rejection reason sent to the taker must not disclose that they have been ignored
         assertEquals(TradeProtocolFailure.OFFER_NOT_AVAILABLE, exception.getTradeProtocolFailure());
         assertFalse(exception.getMessage().toLowerCase().contains("ignor"));
+    }
+
+    @Test
+    void verifyRejectsTakeOfferRequestWithOverflowingAmountConversion() {
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        Market market = MarketRepository.getUSDBitcoinMarket();
+
+        BisqEasyOffer takersOffer = mock(BisqEasyOffer.class);
+        when(takersOffer.getId()).thenReturn("offer-id");
+        when(takersOffer.getMarket()).thenReturn(market);
+        when(takersOffer.getAmountSpec()).thenReturn(new QuoteSideFixedAmountSpec(Long.MAX_VALUE));
+
+        BisqEasyContract takersContract = mock(BisqEasyContract.class, RETURNS_DEEP_STUBS);
+        when(takersContract.getOffer()).thenReturn(takersOffer);
+        when(takersContract.getBaseSideAmount()).thenReturn(1L);
+        when(takersContract.getQuoteSideAmount()).thenReturn(Long.MAX_VALUE);
+        // A fixed price of one quote unit per BTC: converting the Long.MAX_VALUE quote amount
+        // to the base side multiplies by 10^8 and overflows a long.
+        when(takersContract.getPriceSpec()).thenReturn(new FixPriceSpec(PriceQuote.fromFiatPrice(0.0001, "USD")));
+
+        NetworkId takerNetworkId = mock(NetworkId.class, RETURNS_DEEP_STUBS);
+        when(takersContract.getTaker().getNetworkId()).thenReturn(takerNetworkId);
+
+        BisqEasyTakeOfferRequest message = mock(BisqEasyTakeOfferRequest.class, RETURNS_DEEP_STUBS);
+        when(message.getBisqEasyContract()).thenReturn(takersContract);
+        when(message.getSender()).thenReturn(takerNetworkId);
+
+        // The offer is matched through an existing trade with the same offer id.
+        when(serviceProvider.getChatService().getBisqEasyOfferbookChannelService().getChannels())
+                .thenReturn(new ObservableSet<>());
+        BisqEasyTrade existingTrade = mock(BisqEasyTrade.class, RETURNS_DEEP_STUBS);
+        when(existingTrade.getOffer().getId()).thenReturn("offer-id");
+        ObservableSet<BisqEasyTrade> trades = new ObservableSet<>();
+        trades.add(existingTrade);
+        when(serviceProvider.getBisqEasyTradeService().getTrades()).thenReturn(trades);
+        when(serviceProvider.getContractService().arePublicKeysMatching(any(java.security.PublicKey.class), any(java.security.PublicKey.class))).thenReturn(true);
+
+        BisqEasyTakeOfferRequestHandler handler =
+                new BisqEasyTakeOfferRequestHandler(serviceProvider, mock(BisqEasyTrade.class, RETURNS_DEEP_STUBS));
+
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> handler.verify(message));
+        assertTrue(exception.getMessage().contains("take offer request"));
     }
 }


### PR DESCRIPTION
Fixes #4910

The three amount conversions in `PriceQuote` ended in `BigDecimal.longValue()`, which silently wraps on long overflow: an amount that overflows when converted at a given price came out as a plausible-looking but wrong value instead of being rejected. Reachable from offer display and formatting, the create/take wizards, and one wire-facing site (the maker-side take-offer amount validation, where both the contract amounts and, for a fixed price spec, the price quote itself come verbatim from the peer's request).

### Fix

Seven commits, small to large blast radius (5–7 came out of review):

1. **Fail `PriceQuote` conversions on long overflow** — `longValueExact` with the rounding made explicit (`setScale(0, DOWN)` preserves the truncation on the quote side, the scale-0 `HALF_UP` divide preserves the rounding on the base side). In-range results are unchanged, including negative values; overflow throws `ArithmeticException`. Tests pin the rounding semantics and assert the overflow behavior of all three methods.
2. **Reject take offer requests with overflowing amounts** — the maker-side conversion is wrapped and rethrown as `IllegalArgumentException` with a clean message, matching how the other failed amount validations in that handler are reported (this also covers the already-reachable division by zero from a peer-supplied fixed price of value 0). The new test drives `verify()` to the conversion with a real fixed price spec and a `Long.MAX_VALUE` quote amount.
3. **Hide offers whose amounts cannot be resolved** — `BisqEasyOfferbookMessageService.isValid` now requires the offer's amounts to resolve on both sides (present and non-overflowing) before the direction-dependent checks; buy offers previously short-circuited the only path that touched the conversions. Rendering and matching paths that stream network offers without the validity gate get the same skip-on-failure treatment: profile-card overview totals, the MuSig offerbook list (no message validity chain exists there), the trade wizard's amount matching validators, the select-offer list construction, and the min/lowest amount evaluation in both `TradeAmountLimits` classes (whose highest-amount evaluation already caught per offer). Without this, one hostile offer would throw during list rendering on the JavaFX thread for every viewer.
4. **Ignore overflowing conversions in the amount selection components** — the passive-side setters convert once and skip the update on overflow, so the paired displays never show a wrapped value and always change together.
5. **Isolate offer mapping failures in the REST offer list** — one offer whose DTO cannot be built no longer fails the whole listing.
6. **Retry offers after market prices arrive** — the two Bisq Easy list controllers re-check offers that were skipped because their market price was not there yet.
7. **Propagate offer validity changes to all consumers** — `BisqEasyOfferbookMessageService` publishes one offer validity revision (market prices, ignore list, ban list, a maker's reputation score) and every consumer that caches results of `isValid` observes it: the market badges, the dashboard count, the `NUM_OFFERS` web socket topic and both list controllers, which now reconcile in both directions (invalid offers are removed together with their processed id, newly valid ones added; queued callbacks after deactivation or a channel switch are ignored). The sellers reputation service drops its negative cache on price changes (the required score is price-derived), never caches a result computed before an invalidation, treats a USD-overflowing amount as insufficient instead of throwing out of `isValid`, and observes the reputation score map instead of the equality-gated score change observable.

### Testing

- New unit tests: `PriceQuoteTest` (overflow in both sign directions for all three methods, truncation/HALF_UP semantics pinning incl. negatives), `BisqEasyTakeOfferRequestHandlerTest` (hostile request rejected at `verify()`), `BisqEasyOfferbookMessageServiceTest` (overflowing offers invalid in both directions, missing-market-price offers invalid, convertible offers valid). The lenient overflow try/catch in `MonetaryTest` is tightened into an assertion.
- Commits 6–7: observer-driven tests through the real service and a real market price map — `OfferbookListControllerTest` and `ChatMessagesListControllerTest` (offer before price, price change making the conversion overflow incl. re-add, price removal, ignore/un-ignore, revision after deactivation, a failing list item not blocking the others), `NumOffersWebSocketServiceTest`, `MarketChannelItemTest`, the revision sources in `BisqEasyOfferbookMessageServiceTest`, and `BisqEasySellersReputationBasedTradeAmountServiceTest` (price invalidation, in-flight check not re-caching a stale result, consecutive score changes, USD overflow).
- All module suites green: common, offer, bisq-easy, trade, api, mu-sig, desktop.
- The UI guards (wizard validators, list-item skips, amount-selection setters) have no controller test harness and are verified by inspection.

Manual A/B on a local CLEAR-net setup, with one client publishing an offer whose base-side amount overflows a long when converted to the quote side:

- On `main`, the offer renders in the offerbook with the silently wrapped amount (a negative fiat value), and the receiving client counts it as a valid offer.

<img width="1401" height="893" alt="Screenshot from 2026-08-12 11-24-55" src="https://github.com/user-attachments/assets/942a9e25-3dee-49a0-82ae-3c0a52ecd231" />


- On this branch, the same offer is hidden from the offerbook — the market shows one fewer offer and there is no error popup or log error, only a debug line.

 
<img width="1409" height="952" alt="Screenshot from 2026-08-12 11-25-20" src="https://github.com/user-attachments/assets/4444762e-73cb-4041-b271-bc90d19f2212" />


An honest offer created and taken across the same setup is unaffected.

### Remarks

- Failures on the wire path are classified like the handler's existing amount validations (`UNKNOWN` failure with a clean message). A dedicated `TradeProtocolFailure` value for malformed amounts would be a separate wire-visible change; happy to file it as a follow-up.
- Pre-existing and left out of commit 7 (not consumers of the cached validity): `OffersWebSocketService` and the REST offer count/list work on raw offers without a validity filter; the profile card and the trade wizard build one-shot snapshots at open; a maker profile arriving after or removed before its offer message is not re-evaluated. Happy to file follow-ups.
- One adjacent pre-existing issue is left out of scope: list items calling `PriceUtil.findPercentFromMarketPrice(...).orElseThrow()` throw `NoSuchElementException` for fixed-price offers in markets without a current market price (a different exception, so the guards here do not catch it). I can file it as a separate issue. Relatedly, `FixPriceSpec.verify()` is empty, so a peer can supply a zero or negative fixed price; the resulting division by zero is now contained at the conversion boundaries by this PR, but the root cause would be better fixed by validating the spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented currency-conversion overflows from interrupting amount selection, offer lists, profiles, API responses, and trade validation.
  * Invalid or unconvertible offers are now safely rejected or excluded while valid offers remain available.
  * Preserved previously displayed amounts when conversions cannot be completed.
  * Improved handling of empty, invalid, excessive, and malformed amount values.
  * Offerbooks and offer counts now refresh when market prices, reputation, or offer validity changes.

* **Tests**
  * Added coverage for conversion rounding, overflow handling, market-price updates, API listings, offerbook refreshes, and malformed take-offer requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

