### PR TITLE
Add MuSig custom payout persistence and P2P messages

### DIFF
--- a/application/src/main/java/bisq/application/ResolverConfig.java
+++ b/application/src/main/java/bisq/application/ResolverConfig.java
@@ -56,6 +56,7 @@ import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
 import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsResponse;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultRejectionMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.support.moderator.ReportToModeratorMessage;
 import bisq.trade.bisq_easy.protocol.messages.BisqEasyAccountDataMessage;
@@ -137,6 +138,7 @@ public class ResolverConfig {
         NetworkMessageResolver.addResolver("support.MuSigMediationRequest", MuSigMediationRequest.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigMediationStateChangeMessage", MuSigMediationStateChangeMessage.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigMediationResultAcceptanceMessage", MuSigMediationResultAcceptanceMessage.getNetworkMessageResolver());
+        NetworkMessageResolver.addResolver("support.MuSigMediationResultRejectionMessage", MuSigMediationResultRejectionMessage.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigDisputeCasePaymentDetailsRequest", MuSigDisputeCasePaymentDetailsRequest.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigDisputeCasePaymentDetailsResponse", MuSigDisputeCasePaymentDetailsResponse.getNetworkMessageResolver());
         NetworkMessageResolver.addResolver("support.MuSigArbitrationRequest", MuSigArbitrationRequest.getNetworkMessageResolver());

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultRejectionMessage.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultRejectionMessage.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.common.proto.ProtoResolver;
+import bisq.common.proto.UnresolvableProtobufMessageException;
+import bisq.common.validation.NetworkDataValidation;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.message.ExternalNetworkMessage;
+import bisq.network.p2p.message.SenderPublicKeyProvidingPayload;
+import bisq.network.p2p.services.data.storage.MetaData;
+import bisq.network.p2p.services.data.storage.mailbox.MailboxMessage;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.PublicKey;
+
+import static bisq.network.p2p.services.data.storage.MetaData.HIGH_PRIORITY;
+import static bisq.network.p2p.services.data.storage.MetaData.TTL_10_DAYS;
+
+@Slf4j
+@Getter
+@ToString
+@EqualsAndHashCode
+public final class MuSigMediationResultRejectionMessage implements MailboxMessage,
+        ExternalNetworkMessage,
+        SenderPublicKeyProvidingPayload {
+    private transient final MetaData metaData =
+            new MetaData(TTL_10_DAYS, HIGH_PRIORITY, getClass().getSimpleName());
+    private final String tradeId;
+    private final NetworkId senderNetworkId;
+    private final byte[] mediationResultHash;
+
+    public MuSigMediationResultRejectionMessage(String tradeId,
+                                                NetworkId senderNetworkId,
+                                                byte[] mediationResultHash) {
+        this.tradeId = tradeId;
+        this.senderNetworkId = senderNetworkId;
+        this.mediationResultHash = mediationResultHash.clone();
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        NetworkDataValidation.validateTradeId(tradeId);
+        NetworkDataValidation.validateHash(mediationResultHash);
+    }
+
+    @Override
+    public bisq.support.protobuf.MuSigMediationResultRejectionMessage.Builder getValueBuilder(
+            boolean serializeForHash) {
+        return bisq.support.protobuf.MuSigMediationResultRejectionMessage.newBuilder()
+                .setTradeId(tradeId)
+                .setSenderNetworkId(senderNetworkId.toProto(serializeForHash))
+                .setMediationResultHash(ByteString.copyFrom(mediationResultHash));
+    }
+
+    public static MuSigMediationResultRejectionMessage fromProto(
+            bisq.support.protobuf.MuSigMediationResultRejectionMessage proto) {
+        return new MuSigMediationResultRejectionMessage(
+                proto.getTradeId(),
+                NetworkId.fromProto(proto.getSenderNetworkId()),
+                proto.getMediationResultHash().toByteArray());
+    }
+
+    public static ProtoResolver<ExternalNetworkMessage> getNetworkMessageResolver() {
+        return any -> {
+            try {
+                bisq.support.protobuf.MuSigMediationResultRejectionMessage proto =
+                        any.unpack(bisq.support.protobuf.MuSigMediationResultRejectionMessage.class);
+                return MuSigMediationResultRejectionMessage.fromProto(proto);
+            } catch (InvalidProtocolBufferException e) {
+                throw new UnresolvableProtobufMessageException(e);
+            }
+        };
+    }
+
+    @Override
+    public double getCostFactor() {
+        return getCostFactor(0.1, 0.2);
+    }
+
+    @Override
+    public PublicKey getSenderPublicKey() {
+        return senderNetworkId.getPubKey().getPublicKey();
+    }
+
+    public byte[] getMediationResultHash() {
+        return mediationResultHash.clone();
+    }
+}

--- a/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultService.java
+++ b/support/src/main/java/bisq/support/mediation/mu_sig/MuSigMediationResultService.java
@@ -52,14 +52,14 @@ public final class MuSigMediationResultService {
         return verifyMediationResult(mediationResult, mediationResultSignature, publicKey);
     }
 
+    public static byte[] getMediationResultHash(MuSigMediationResult mediationResult) {
+        return DigestUtil.hash(mediationResult.serializeForHash());
+    }
+
     private static boolean verifyMediationResult(MuSigMediationResult mediationResult,
                                                 byte[] mediationResultSignature,
                                                 PublicKey publicKey) throws GeneralSecurityException {
         NetworkDataValidation.validateECSignature(mediationResultSignature);
         return SignatureUtil.verify(getMediationResultHash(mediationResult), mediationResultSignature, publicKey);
-    }
-
-    private static byte[] getMediationResultHash(MuSigMediationResult mediationResult) {
-        return DigestUtil.hash(mediationResult.serializeForHash());
     }
 }

--- a/support/src/main/proto/support.proto
+++ b/support/src/main/proto/support.proto
@@ -122,6 +122,12 @@ message MuSigMediationResultAcceptanceMessage {
   bool mediationResultAccepted = 3;
 }
 
+message MuSigMediationResultRejectionMessage {
+  string tradeId = 1;
+  network.identity.NetworkId senderNetworkId = 2;
+  bytes mediationResultHash = 3;
+}
+
 enum MuSigMediationIssueType {
   MUSIGMEDIATIONISSUETYPE_UNSPECIFIED = 0;
   MUSIGMEDIATIONISSUETYPE_PEER_CONTRACT_HASH_MISMATCH = 1;

--- a/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediationResultRejectionMessageTest.java
+++ b/support/src/test/java/bisq/support/mediation/mu_sig/MuSigMediationResultRejectionMessageTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.support.mediation.mu_sig;
+
+import bisq.network.p2p.message.ExternalNetworkMessage;
+import bisq.user.profile.UserProfile;
+import com.google.protobuf.Any;
+import org.junit.jupiter.api.Test;
+
+import static bisq.support.mu_sig.MuSigRequestSizeTestFixtures.TRADE_ID;
+import static bisq.support.mu_sig.MuSigRequestSizeTestFixtures.createUserProfile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MuSigMediationResultRejectionMessageTest {
+
+    @Test
+    void roundTripsThroughNetworkMessageResolver() {
+        byte[] mediationResultHash = createMediationResultHash();
+        MuSigMediationResultRejectionMessage message = createMessage(mediationResultHash);
+
+        Any any = Any.pack(message.resolveValueProto(false));
+        ExternalNetworkMessage restored =
+                MuSigMediationResultRejectionMessage.getNetworkMessageResolver().fromAny(any);
+
+        assertThat(restored).isEqualTo(message);
+        assertThat(((MuSigMediationResultRejectionMessage) restored).getMediationResultHash())
+                .containsExactly(mediationResultHash);
+    }
+
+    @Test
+    void defensivelyCopiesMediationResultHash() {
+        byte[] mediationResultHash = createMediationResultHash();
+        byte[] expectedHash = mediationResultHash.clone();
+        MuSigMediationResultRejectionMessage message = createMessage(mediationResultHash);
+
+        mediationResultHash[0] = 99;
+        byte[] returnedHash = message.getMediationResultHash();
+        returnedHash[1] = 99;
+
+        assertThat(message.getMediationResultHash()).containsExactly(expectedHash);
+    }
+
+    @Test
+    void rejectsInvalidMediationResultHash() {
+        assertThatThrownBy(() -> createMessage(new byte[19]))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> createMessage(new byte[21]))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static MuSigMediationResultRejectionMessage createMessage(byte[] mediationResultHash) {
+        UserProfile sender = createUserProfile("sender");
+        return new MuSigMediationResultRejectionMessage(
+                TRADE_ID,
+                sender.getNetworkId(),
+                mediationResultHash);
+    }
+
+    private static byte[] createMediationResultHash() {
+        return new byte[]{
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+        };
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigCustomPayoutPartyData.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigCustomPayoutPartyData.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.common.proto.PersistableProto;
+import bisq.trade.mu_sig.messages.grpc.CustomCloseTradeResponse;
+import bisq.trade.mu_sig.messages.grpc.CustomPayoutPsbt;
+import bisq.trade.mu_sig.messages.network.mu_sig_data.PeerCustomPayoutPsbt;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@EqualsAndHashCode
+@Getter
+public final class MuSigCustomPayoutPartyData implements PersistableProto {
+    private final Optional<CustomPayoutPsbt> myCustomPayoutPsbt;
+    private final Optional<PeerCustomPayoutPsbt> peersCustomPayoutPsbt;
+    private Optional<CustomCloseTradeResponse> myCustomCloseTradeResponse;
+
+    public static MuSigCustomPayoutPartyData forLocalParty(CustomPayoutPsbt myCustomPayoutPsbt) {
+        return new MuSigCustomPayoutPartyData(
+                Optional.of(myCustomPayoutPsbt),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    public static MuSigCustomPayoutPartyData forPeerParty(PeerCustomPayoutPsbt peersCustomPayoutPsbt) {
+        return new MuSigCustomPayoutPartyData(
+                Optional.empty(),
+                Optional.of(peersCustomPayoutPsbt),
+                Optional.empty());
+    }
+
+    private MuSigCustomPayoutPartyData(Optional<CustomPayoutPsbt> myCustomPayoutPsbt,
+                                       Optional<PeerCustomPayoutPsbt> peersCustomPayoutPsbt,
+                                       Optional<CustomCloseTradeResponse> myCustomCloseTradeResponse) {
+        this.myCustomPayoutPsbt = myCustomPayoutPsbt;
+        this.peersCustomPayoutPsbt = peersCustomPayoutPsbt;
+        this.myCustomCloseTradeResponse = myCustomCloseTradeResponse;
+
+        verify();
+    }
+
+    private void verify() {
+        boolean hasLocalData = myCustomPayoutPsbt.isPresent()
+                || myCustomCloseTradeResponse.isPresent();
+        boolean hasPeerData = peersCustomPayoutPsbt.isPresent();
+
+        checkArgument(hasLocalData != hasPeerData,
+                "Custom payout party data must contain either local data or peer data");
+        if (hasLocalData) {
+            checkArgument(myCustomPayoutPsbt.isPresent(),
+                    "Local custom payout data requires a local PSBT");
+        }
+    }
+
+    @Override
+    public bisq.trade.protobuf.MuSigCustomPayoutPartyData.Builder getBuilder(boolean serializeForHash) {
+        bisq.trade.protobuf.MuSigCustomPayoutPartyData.Builder builder =
+                bisq.trade.protobuf.MuSigCustomPayoutPartyData.newBuilder();
+        myCustomPayoutPsbt.ifPresent(value -> builder.setMyCustomPayoutPsbt(value.toProto(serializeForHash)));
+        peersCustomPayoutPsbt.ifPresent(value -> builder.setPeersCustomPayoutPsbt(value.toProto(serializeForHash)));
+        myCustomCloseTradeResponse.ifPresent(value ->
+                builder.setMyCustomCloseTradeResponse(value.toProto(serializeForHash)));
+        return builder;
+    }
+
+    @Override
+    public bisq.trade.protobuf.MuSigCustomPayoutPartyData toProto(boolean serializeForHash) {
+        return unsafeToProto(serializeForHash);
+    }
+
+    public static MuSigCustomPayoutPartyData fromProto(bisq.trade.protobuf.MuSigCustomPayoutPartyData proto) {
+        return new MuSigCustomPayoutPartyData(
+                proto.hasMyCustomPayoutPsbt()
+                        ? Optional.of(CustomPayoutPsbt.fromProto(proto.getMyCustomPayoutPsbt()))
+                        : Optional.empty(),
+                proto.hasPeersCustomPayoutPsbt()
+                        ? Optional.of(PeerCustomPayoutPsbt.fromProto(proto.getPeersCustomPayoutPsbt()))
+                        : Optional.empty(),
+                proto.hasMyCustomCloseTradeResponse()
+                        ? Optional.of(CustomCloseTradeResponse.fromProto(proto.getMyCustomCloseTradeResponse()))
+                        : Optional.empty());
+    }
+
+    boolean isLocalPartyData() {
+        return myCustomPayoutPsbt.isPresent();
+    }
+
+    boolean setMyCustomCloseTradeResponse(CustomCloseTradeResponse myCustomCloseTradeResponse) {
+        checkArgument(isLocalPartyData(), "A custom close response can only be stored with local party data");
+        if (this.myCustomCloseTradeResponse.isPresent()) {
+            return false;
+        }
+        this.myCustomCloseTradeResponse = Optional.of(myCustomCloseTradeResponse);
+        return true;
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeDisputeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeDisputeService.java
@@ -26,10 +26,12 @@ import bisq.support.arbitration.ArbitrationCaseState;
 import bisq.support.arbitration.mu_sig.MuSigArbitrationResult;
 import bisq.support.arbitration.mu_sig.MuSigArbitrationResultService;
 import bisq.support.arbitration.mu_sig.MuSigArbitrationStateChangeMessage;
-import bisq.support.mediation.MediationCaseState;
 import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
+import bisq.support.mediation.MediationCaseState;
+import bisq.support.mediation.MediationPayoutDistributionType;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultRejectionMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationResultService;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.trade.MuSigDisputeState;
@@ -92,7 +94,21 @@ final class MuSigTradeDisputeService {
     }
 
     public void rejectMediationResult(MuSigTrade trade) {
-        applyMediationResultAcceptance(trade, false);
+        Optional<MuSigMediationResult> optionalMediationResult =
+                trade.getTradeDispute().getMuSigMediationResult();
+        checkArgument(optionalMediationResult.isPresent());
+        MuSigMediationResult mediationResult = optionalMediationResult.orElseThrow();
+        if (mediationResult.getMediationPayoutDistributionType() == MediationPayoutDistributionType.NO_PAYOUT) {
+            log.warn("Cannot reject mediation result for trade {} because the result has no payout.", trade.getId());
+            return;
+        }
+        MuSigOpenTradeChannel channel = findChannelByTradeId(trade.getId()).orElseThrow();
+        byte[] mediationResultHash = MuSigMediationResultService.getMediationResultHash(mediationResult);
+        if (trade.getMyself().setMediationResultRejected()) {
+            persist.run();
+            muSigTraderMediationService.sendMediationResultRejectionMessage(
+                    trade.getId(), trade.getMyIdentity(), trade.getPeer(), mediationResultHash, channel);
+        }
     }
 
     public void requestArbitration(MuSigTrade trade) {
@@ -131,6 +147,10 @@ final class MuSigTradeDisputeService {
             findTradeAndChannelOrQueue(message.getTradeId(), envelopePayloadMessage)
                     .flatMap(tradeAndChannel -> verifyMediationResultAcceptanceMessage(message, tradeAndChannel, bannedUserService))
                     .ifPresent(tradeAndChannel -> processMediationResultAcceptanceMessage(message, tradeAndChannel));
+        } else if (envelopePayloadMessage instanceof MuSigMediationResultRejectionMessage message) {
+            findTradeAndChannelOrQueue(message.getTradeId(), envelopePayloadMessage)
+                    .flatMap(tradeAndChannel -> verifyMediationResultRejectionMessage(message, tradeAndChannel, bannedUserService))
+                    .ifPresent(tradeAndChannel -> processMediationResultRejectionMessage(message, tradeAndChannel));
         } else if (envelopePayloadMessage instanceof MuSigDisputeCasePaymentDetailsRequest message) {
             findTradeAndChannelOrQueue(message.getTradeId(), envelopePayloadMessage)
                     .flatMap(tradeAndChannel -> verifyDisputeCasePaymentDetailsRequest(message, tradeAndChannel, bannedUserService))
@@ -309,6 +329,60 @@ final class MuSigTradeDisputeService {
         }
 
         if (trade.getPeer().setMediationResultAccepted(message.isMediationResultAccepted())) {
+            persist.run();
+        }
+    }
+
+    private static Optional<MuSigTradeAndChannel> verifyMediationResultRejectionMessage(
+            MuSigMediationResultRejectionMessage message,
+            MuSigTradeAndChannel tradeAndChannel,
+            BannedUserService bannedUserService) {
+        if (!tradeAndChannel.trade().getPeer().getNetworkId().getId().equals(message.getSenderNetworkId().getId())) {
+            log.warn("Ignoring MuSigMediationResultRejectionMessage with unexpected senderNetworkId {} for trade {}.",
+                    message.getSenderNetworkId(), message.getTradeId());
+            return Optional.empty();
+        }
+
+        if (bannedUserService.isUserProfileBanned(message.getSenderNetworkId())) {
+            log.warn("Ignoring MuSigMediationResultRejectionMessage as sender is banned");
+            return Optional.empty();
+        }
+        return Optional.of(tradeAndChannel);
+    }
+
+    private void processMediationResultRejectionMessage(MuSigMediationResultRejectionMessage message,
+                                                        MuSigTradeAndChannel tradeAndChannel) {
+        MuSigTrade trade = tradeAndChannel.trade();
+        Optional<MuSigMediationResult> mediationResult = trade.getTradeDispute().getMuSigMediationResult();
+        if (mediationResult.isEmpty()) {
+            addPendingDisputeMessage(trade.getId(), message);
+            return;
+        }
+
+        MuSigMediationResult result = mediationResult.orElseThrow();
+        if (result.getMediationPayoutDistributionType() == MediationPayoutDistributionType.NO_PAYOUT) {
+            log.warn("Ignoring MuSigMediationResultRejectionMessage for trade {} because the result has no payout.",
+                    message.getTradeId());
+            return;
+        }
+
+        byte[] expectedHash = MuSigMediationResultService.getMediationResultHash(result);
+        if (!Arrays.equals(expectedHash, message.getMediationResultHash())) {
+            log.warn("Ignoring MuSigMediationResultRejectionMessage for trade {} because the result hash does not match.",
+                    message.getTradeId());
+            return;
+        }
+
+        MuSigTradeParty peer = trade.getPeer();
+        if (peer.isMediationResultRejected()) {
+            return;
+        }
+        if (peer.getCustomPayoutData().isPresent()) {
+            log.warn("Ignoring MuSigMediationResultRejectionMessage for trade {} because peer custom payout data is already stored.",
+                    message.getTradeId());
+            return;
+        }
+        if (peer.setMediationResultRejected()) {
             persist.run();
         }
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeParty.java
@@ -24,6 +24,8 @@ import bisq.common.data.ByteArray;
 import bisq.network.identity.NetworkId;
 import bisq.trade.TradeParty;
 import bisq.trade.mu_sig.messages.grpc.CloseTradeResponse;
+import bisq.trade.mu_sig.messages.grpc.CustomCloseTradeResponse;
+import bisq.trade.mu_sig.messages.grpc.CustomPayoutPsbt;
 import bisq.trade.mu_sig.messages.grpc.DepositPsbt;
 import bisq.trade.mu_sig.messages.grpc.NonceSharesMessage;
 import bisq.trade.mu_sig.messages.grpc.PartialSignaturesMessage;
@@ -31,6 +33,7 @@ import bisq.trade.mu_sig.messages.grpc.PubKeySharesResponse;
 import bisq.trade.mu_sig.messages.grpc.SwapTxSignatureResponse;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.NonceShares;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.PartialSignatures;
+import bisq.trade.mu_sig.messages.network.mu_sig_data.PeerCustomPayoutPsbt;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.PubKeyShares;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.SwapTxSignature;
 import lombok.EqualsAndHashCode;
@@ -38,6 +41,8 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -57,9 +62,13 @@ public final class MuSigTradeParty extends TradeParty {
     private Optional<ByteArray> peersOutputPrvKeyShare = Optional.empty();
     private Optional<AccountPayload<?>> accountPayload = Optional.empty();
     private final transient Observable<Optional<Boolean>> mediationResultAcceptedObservable = new Observable<>(Optional.empty());
+    private Optional<MuSigCustomPayoutPartyData> customPayoutData = Optional.empty();
+    private boolean mediationResultRejected;
 
     public MuSigTradeParty(NetworkId networkId) {
         super(networkId);
+
+        verify();
     }
 
     public MuSigTradeParty(NetworkId networkId,
@@ -76,7 +85,9 @@ public final class MuSigTradeParty extends TradeParty {
                            Optional<CloseTradeResponse> myCloseTradeResponse,
                            Optional<ByteArray> peersOutputPrvKeyShare,
                            Optional<AccountPayload<?>> accountPayload,
-                           Optional<Boolean> mediationResultAccepted) {
+                           Optional<Boolean> mediationResultAccepted,
+                           Optional<MuSigCustomPayoutPartyData> customPayoutData,
+                           boolean mediationResultRejected) {
         super(networkId);
 
         this.myPubKeySharesResponse = myPubKeySharesResponse;
@@ -93,6 +104,15 @@ public final class MuSigTradeParty extends TradeParty {
         this.peersOutputPrvKeyShare = peersOutputPrvKeyShare;
         this.accountPayload = accountPayload;
         mediationResultAcceptedObservable.set(mediationResultAccepted);
+        this.customPayoutData = customPayoutData;
+        this.mediationResultRejected = mediationResultRejected;
+
+        verify();
+    }
+
+    private void verify() {
+        checkArgument(!mediationResultRejected || customPayoutData.isEmpty(),
+                "Mediation rejection and custom payout data are mutually exclusive");
     }
 
     @Override
@@ -112,6 +132,8 @@ public final class MuSigTradeParty extends TradeParty {
         peersOutputPrvKeyShare.ifPresent(e -> builder.setPeersOutputPrvKeyShare(e.toProto(serializeForHash)));
         accountPayload.ifPresent(e -> builder.setAccountPayload(e.toProto(serializeForHash)));
         mediationResultAcceptedObservable.get().ifPresent(builder::setMediationResultAccepted);
+        customPayoutData.ifPresent(e -> builder.setCustomPayoutData(e.toProto(serializeForHash)));
+        builder.setMediationResultRejected(mediationResultRejected);
         return getTradePartyBuilder(serializeForHash).setMuSigTradeParty(builder);
     }
 
@@ -160,7 +182,11 @@ public final class MuSigTradeParty extends TradeParty {
                         : Optional.empty(),
                 muSigTradePartyProto.hasMediationResultAccepted()
                         ? Optional.of(muSigTradePartyProto.getMediationResultAccepted())
-                        : Optional.empty()
+                        : Optional.empty(),
+                muSigTradePartyProto.hasCustomPayoutData()
+                        ? Optional.of(MuSigCustomPayoutPartyData.fromProto(muSigTradePartyProto.getCustomPayoutData()))
+                        : Optional.empty(),
+                muSigTradePartyProto.getMediationResultRejected()
         );
     }
 
@@ -231,4 +257,36 @@ public final class MuSigTradeParty extends TradeParty {
     public ReadOnlyObservable<Optional<Boolean>> mediationResultAcceptedObservable() {
         return mediationResultAcceptedObservable;
     }
+
+    public boolean setMyCustomPayoutPsbt(CustomPayoutPsbt myCustomPayoutPsbt) {
+        return setCustomPayoutData(MuSigCustomPayoutPartyData.forLocalParty(myCustomPayoutPsbt));
+    }
+
+    public boolean setPeersCustomPayoutPsbt(PeerCustomPayoutPsbt peersCustomPayoutPsbt) {
+        return setCustomPayoutData(MuSigCustomPayoutPartyData.forPeerParty(peersCustomPayoutPsbt));
+    }
+
+    private boolean setCustomPayoutData(MuSigCustomPayoutPartyData customPayoutData) {
+        if (mediationResultRejected || this.customPayoutData.isPresent()) {
+            return false;
+        }
+        this.customPayoutData = Optional.of(customPayoutData);
+        return true;
+    }
+
+    public boolean setMyCustomCloseTradeResponse(CustomCloseTradeResponse myCustomCloseTradeResponse) {
+        return customPayoutData
+                .filter(MuSigCustomPayoutPartyData::isLocalPartyData)
+                .map(data -> data.setMyCustomCloseTradeResponse(myCustomCloseTradeResponse))
+                .orElse(false);
+    }
+
+    public boolean setMediationResultRejected() {
+        if (mediationResultRejected || customPayoutData.isPresent()) {
+            return false;
+        }
+        mediationResultRejected = true;
+        return true;
+    }
+
 }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -59,6 +59,7 @@ import bisq.settings.SettingsService;
 import bisq.support.arbitration.mu_sig.MuSigArbitrationStateChangeMessage;
 import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultRejectionMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.trade.ServiceProvider;
 import bisq.trade.exceptions.TradingNotAllowedException;
@@ -367,6 +368,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             }
         } else if (envelopePayloadMessage instanceof MuSigMediationStateChangeMessage ||
                 envelopePayloadMessage instanceof MuSigMediationResultAcceptanceMessage ||
+                envelopePayloadMessage instanceof MuSigMediationResultRejectionMessage ||
                 envelopePayloadMessage instanceof MuSigDisputeCasePaymentDetailsRequest ||
                 envelopePayloadMessage instanceof MuSigArbitrationStateChangeMessage) {
             synchronized (disputeStateLock) {

--- a/trade/src/main/java/bisq/trade/mu_sig/mediation/MuSigTraderMediationService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/mediation/MuSigTraderMediationService.java
@@ -37,6 +37,7 @@ import bisq.support.dispute.mu_sig.MuSigDisputeCaseDataMessage;
 import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsResponse;
 import bisq.support.mediation.mu_sig.MuSigMediationRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultRejectionMessage;
 import bisq.trade.MuSigDisputeState;
 import bisq.trade.mu_sig.MuSigTradeParty;
 import bisq.user.UserService;
@@ -178,6 +179,22 @@ public class MuSigTraderMediationService {
                 ? "muSig.mediation.result.accepted.tradeLogMessage"
                 : "muSig.mediation.result.rejected.tradeLogMessage";
         String encoded = Res.encode(key, channel.getMyUserIdentity().getUserName());
+        muSigOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
+    }
+
+    public void sendMediationResultRejectionMessage(String tradeId,
+                                                     Identity myIdentity,
+                                                     MuSigTradeParty peer,
+                                                     byte[] mediationResultHash,
+                                                     MuSigOpenTradeChannel channel) {
+        networkService.confidentialSend(new MuSigMediationResultRejectionMessage(tradeId,
+                        myIdentity.getNetworkId(),
+                        mediationResultHash),
+                peer.getNetworkId(),
+                myIdentity.getNetworkIdWithKeyPair());
+
+        String encoded = Res.encode("muSig.mediation.result.rejected.tradeLogMessage",
+                channel.getMyUserIdentity().getUserName());
         muSigOpenTradeChannelService.sendTradeLogMessage(encoded, channel);
     }
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCustomPayoutPsbtMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigCustomPayoutPsbtMessage.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network;
+
+import bisq.common.validation.BitcoinTransactionValidation;
+import bisq.common.validation.NetworkDataValidation;
+import bisq.network.identity.NetworkId;
+import com.google.protobuf.ByteString;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Slf4j
+@ToString(callSuper = true)
+@Getter
+public final class MuSigCustomPayoutPsbtMessage extends MuSigTradeMessage {
+    public static final int MAX_PSBT_SIZE = 10_000;
+
+    private final byte[] mediationResultHash;
+    private final String txId;
+    @ToString.Exclude
+    private final byte[] psbt;
+
+    public MuSigCustomPayoutPsbtMessage(String id,
+                                        String tradeId,
+                                        String protocolVersion,
+                                        NetworkId sender,
+                                        NetworkId receiver,
+                                        byte[] mediationResultHash,
+                                        String txId,
+                                        byte[] psbt) {
+        super(id, tradeId, protocolVersion, sender, receiver);
+        this.mediationResultHash = mediationResultHash.clone();
+        this.txId = txId;
+        this.psbt = psbt.clone();
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        super.verify();
+
+        NetworkDataValidation.validateHash(mediationResultHash);
+        checkArgument(BitcoinTransactionValidation.isValid(txId), "Invalid Bitcoin transaction ID");
+        checkArgument(psbt.length > 0, "PSBT must not be empty");
+        checkArgument(psbt.length <= MAX_PSBT_SIZE,
+                "PSBT must not exceed " + MAX_PSBT_SIZE + " bytes");
+    }
+
+    @Override
+    protected bisq.trade.protobuf.MuSigTradeMessage.Builder getMuSigTradeMessageBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.MuSigTradeMessage.newBuilder()
+                .setMuSigCustomPayoutPsbtMessage(toMuSigCustomPayoutPsbtMessageProto(serializeForHash));
+    }
+
+    private bisq.trade.protobuf.MuSigCustomPayoutPsbtMessage toMuSigCustomPayoutPsbtMessageProto(
+            boolean serializeForHash) {
+        bisq.trade.protobuf.MuSigCustomPayoutPsbtMessage.Builder builder =
+                getMuSigCustomPayoutPsbtMessageBuilder(serializeForHash);
+        return resolveBuilder(builder, serializeForHash).build();
+    }
+
+    private bisq.trade.protobuf.MuSigCustomPayoutPsbtMessage.Builder getMuSigCustomPayoutPsbtMessageBuilder(
+            boolean serializeForHash) {
+        return bisq.trade.protobuf.MuSigCustomPayoutPsbtMessage.newBuilder()
+                .setMediationResultHash(ByteString.copyFrom(mediationResultHash))
+                .setTxId(txId)
+                .setPsbt(ByteString.copyFrom(psbt));
+    }
+
+    public static MuSigCustomPayoutPsbtMessage fromProto(bisq.trade.protobuf.TradeMessage proto) {
+        bisq.trade.protobuf.MuSigCustomPayoutPsbtMessage message =
+                proto.getMuSigTradeMessage().getMuSigCustomPayoutPsbtMessage();
+        return new MuSigCustomPayoutPsbtMessage(
+                proto.getId(),
+                proto.getTradeId(),
+                proto.getProtocolVersion(),
+                NetworkId.fromProto(proto.getSender()),
+                NetworkId.fromProto(proto.getReceiver()),
+                message.getMediationResultHash().toByteArray(),
+                message.getTxId(),
+                message.getPsbt().toByteArray());
+    }
+
+    @Override
+    public double getCostFactor() {
+        return getCostFactor(0.1, 0.3);
+    }
+
+    public byte[] getMediationResultHash() {
+        return mediationResultHash.clone();
+    }
+
+    public byte[] getPsbt() {
+        return psbt.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MuSigCustomPayoutPsbtMessage that)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        return Objects.equals(txId, that.txId)
+                && Arrays.equals(mediationResultHash, that.mediationResultHash)
+                && Arrays.equals(psbt, that.psbt);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(mediationResultHash);
+        result = 31 * result + Objects.hashCode(txId);
+        result = 31 * result + Arrays.hashCode(psbt);
+        return result;
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigTradeMessage.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/MuSigTradeMessage.java
@@ -70,6 +70,7 @@ public abstract class MuSigTradeMessage extends TradeMessage {
             case PAYMENTRECEIVEDMESSAGE_F -> PaymentReceivedMessage_F.fromProto(proto);
             case COOPERATIVECLOSUREMESSAGE_G -> CooperativeClosureMessage_G.fromProto(proto);
             case MUSIGREPORTERRORMESSAGE -> MuSigReportErrorMessage.fromProto(proto);
+            case MUSIGCUSTOMPAYOUTPSBTMESSAGE -> MuSigCustomPayoutPsbtMessage.fromProto(proto);
             case MESSAGE_NOT_SET -> throw new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", proto);
         };
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/PeerCustomPayoutPsbt.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/mu_sig_data/PeerCustomPayoutPsbt.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network.mu_sig_data;
+
+import bisq.common.proto.NetworkProto;
+import bisq.common.validation.BitcoinTransactionValidation;
+import com.google.protobuf.ByteString;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class PeerCustomPayoutPsbt implements NetworkProto {
+    private final String txId;
+    private final byte[] psbt;
+
+    public PeerCustomPayoutPsbt(String txId, byte[] psbt) {
+        this.txId = txId;
+        this.psbt = psbt.clone();
+
+        verify();
+    }
+
+    @Override
+    public void verify() {
+        checkArgument(BitcoinTransactionValidation.isValid(txId), "Invalid Bitcoin transaction ID");
+        checkArgument(psbt.length > 0, "PSBT must not be empty");
+    }
+
+    @Override
+    public bisq.trade.protobuf.PeerCustomPayoutPsbt.Builder getBuilder(boolean serializeForHash) {
+        return bisq.trade.protobuf.PeerCustomPayoutPsbt.newBuilder()
+                .setTxId(txId)
+                .setPsbt(ByteString.copyFrom(psbt));
+    }
+
+    @Override
+    public bisq.trade.protobuf.PeerCustomPayoutPsbt toProto(boolean serializeForHash) {
+        return unsafeToProto(serializeForHash);
+    }
+
+    public static PeerCustomPayoutPsbt fromProto(bisq.trade.protobuf.PeerCustomPayoutPsbt proto) {
+        return new PeerCustomPayoutPsbt(
+                proto.getTxId(),
+                proto.getPsbt().toByteArray());
+    }
+
+    public String getTxId() {
+        return txId;
+    }
+
+    public byte[] getPsbt() {
+        return psbt.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PeerCustomPayoutPsbt that)) {
+            return false;
+        }
+
+        return Objects.equals(txId, that.txId)
+                && Arrays.equals(psbt, that.psbt);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(txId);
+        result = 31 * result + Arrays.hashCode(psbt);
+        return result;
+    }
+}

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -282,6 +282,7 @@ message MuSigTradeMessage {
     PaymentReceivedMessage_F paymentReceivedMessage_F = 27;
     CooperativeClosureMessage_G cooperativeClosureMessage_G = 28;
     MuSigReportErrorMessage muSigReportErrorMessage = 29;
+    MuSigCustomPayoutPsbtMessage muSigCustomPayoutPsbtMessage = 30;
   }
 }
 
@@ -333,4 +334,10 @@ message PaymentReceivedMessage_F {
 
 message CooperativeClosureMessage_G {
   common.ByteArray peerOutputPrvKeyShare = 1;
+}
+
+message MuSigCustomPayoutPsbtMessage {
+  bytes mediationResultHash = 1;
+  string txId = 2;
+  bytes psbt = 3;
 }

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -208,6 +208,17 @@ message SwapTxSignature {
   bytes peerOutputPrvKeyShare = 2;
 }
 
+message PeerCustomPayoutPsbt {
+  string txId = 1;
+  bytes psbt = 2;
+}
+
+message MuSigCustomPayoutPartyData {
+  optional musigrpc.CustomPayoutPsbt myCustomPayoutPsbt = 1;
+  optional PeerCustomPayoutPsbt peersCustomPayoutPsbt = 2;
+  optional musigrpc.CustomCloseTradeResponse myCustomCloseTradeResponse = 3;
+}
+
 // Trade domain
 message MuSigTradeParty {
   optional musigrpc.PubKeySharesResponse myPubKeySharesResponse = 1;
@@ -224,6 +235,8 @@ message MuSigTradeParty {
   optional common.ByteArray peersOutputPrvKeyShare = 12;
   optional account.AccountPayload accountPayload = 13;
   optional bool mediationResultAccepted = 14;
+  optional MuSigCustomPayoutPartyData customPayoutData = 15;
+  bool mediationResultRejected = 16;
 }
 
 enum MuSigDisputeState {

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigCustomPayoutPartyDataTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigCustomPayoutPartyDataTest.java
@@ -1,0 +1,245 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.ClearnetAddress;
+import bisq.common.network.TransportType;
+import bisq.network.identity.NetworkId;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.trade.mu_sig.messages.grpc.CustomCloseTradeResponse;
+import bisq.trade.mu_sig.messages.grpc.CustomPayoutPsbt;
+import bisq.trade.mu_sig.messages.network.mu_sig_data.PeerCustomPayoutPsbt;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MuSigCustomPayoutPartyDataTest {
+    private static final String TX_ID = "ab".repeat(32);
+    private static final byte[] LOCAL_PSBT = {1, 2, 3};
+    private static final byte[] PEER_PSBT = {4, 5, 6};
+
+    @Test
+    void localPartyDataRoundTripsThroughTradeParty() {
+        MuSigTradeParty party = new MuSigTradeParty(createNetworkId());
+        CustomPayoutPsbt localPsbt = new CustomPayoutPsbt(LOCAL_PSBT, TX_ID, 60_000, 40_000);
+        CustomCloseTradeResponse closeResponse = new CustomCloseTradeResponse(new byte[]{7, 8, 9});
+
+        assertThat(party.setMyCustomPayoutPsbt(localPsbt)).isTrue();
+        assertThat(party.setMyCustomCloseTradeResponse(closeResponse)).isTrue();
+
+        MuSigTradeParty restored = MuSigTradeParty.fromProto(party.toProto(false));
+
+        assertThat(restored.getCustomPayoutData()).isPresent();
+        MuSigCustomPayoutPartyData restoredData = restored.getCustomPayoutData().orElseThrow();
+        assertThat(restoredData.isLocalPartyData()).isTrue();
+        assertThat(restoredData.getMyCustomPayoutPsbt()).contains(localPsbt);
+        assertThat(restoredData.getPeersCustomPayoutPsbt()).isEmpty();
+        assertThat(restoredData.getMyCustomCloseTradeResponse()).contains(closeResponse);
+        assertThat(restored.isMediationResultRejected()).isFalse();
+    }
+
+    @Test
+    void peerPartyDataRoundTripsThroughTradeParty() {
+        MuSigTradeParty party = new MuSigTradeParty(createNetworkId());
+        PeerCustomPayoutPsbt peerPsbt = createPeerPsbt();
+
+        assertThat(party.setPeersCustomPayoutPsbt(peerPsbt)).isTrue();
+
+        MuSigTradeParty restored = MuSigTradeParty.fromProto(party.toProto(false));
+
+        assertThat(restored.getCustomPayoutData()).isPresent();
+        MuSigCustomPayoutPartyData restoredData = restored.getCustomPayoutData().orElseThrow();
+        assertThat(restoredData.isLocalPartyData()).isFalse();
+        assertThat(restoredData.getMyCustomPayoutPsbt()).isEmpty();
+        assertThat(restoredData.getPeersCustomPayoutPsbt()).contains(peerPsbt);
+        assertThat(restoredData.getMyCustomCloseTradeResponse()).isEmpty();
+    }
+
+    @Test
+    void peerPsbtDefensivelyCopiesByteArray() {
+        byte[] psbt = PEER_PSBT.clone();
+        PeerCustomPayoutPsbt peerPsbt = new PeerCustomPayoutPsbt(TX_ID, psbt);
+
+        psbt[0] = 99;
+        byte[] returnedPsbt = peerPsbt.getPsbt();
+        returnedPsbt[1] = 99;
+
+        assertThat(peerPsbt.getPsbt()).containsExactly(4, 5, 6);
+    }
+
+    @Test
+    void malformedPeerPsbtDataIsRejected() {
+        assertThatThrownBy(() -> new PeerCustomPayoutPsbt(
+                "gg".repeat(32),
+                PEER_PSBT))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PeerCustomPayoutPsbt(
+                TX_ID,
+                new byte[0]))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void malformedPartyDataIsRejectedDuringDeserialization() {
+        bisq.trade.protobuf.MuSigCustomPayoutPartyData empty =
+                bisq.trade.protobuf.MuSigCustomPayoutPartyData.getDefaultInstance();
+        bisq.trade.protobuf.MuSigCustomPayoutPartyData incompleteLocal =
+                bisq.trade.protobuf.MuSigCustomPayoutPartyData.newBuilder()
+                        .setMyCustomCloseTradeResponse(new CustomCloseTradeResponse(new byte[]{7}).toProto(false))
+                        .build();
+        bisq.trade.protobuf.MuSigCustomPayoutPartyData mixedOwnership =
+                bisq.trade.protobuf.MuSigCustomPayoutPartyData.newBuilder()
+                        .setMyCustomPayoutPsbt(createLocalPsbt().toProto(false))
+                        .setPeersCustomPayoutPsbt(createPeerPsbt().toProto(false))
+                        .build();
+
+        assertThatThrownBy(() -> MuSigCustomPayoutPartyData.fromProto(empty))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> MuSigCustomPayoutPartyData.fromProto(incompleteLocal))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> MuSigCustomPayoutPartyData.fromProto(mixedOwnership))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectionAndCustomPayoutDataAreMutuallyExclusive() {
+        MuSigTradeParty rejectingParty = new MuSigTradeParty(createNetworkId());
+
+        assertThat(rejectingParty.setMediationResultRejected()).isTrue();
+        assertThat(rejectingParty.setMediationResultRejected()).isFalse();
+        assertThat(rejectingParty.setMyCustomPayoutPsbt(createLocalPsbt())).isFalse();
+        assertThat(rejectingParty.getCustomPayoutData()).isEmpty();
+
+        MuSigTradeParty restoredRejectingParty = MuSigTradeParty.fromProto(rejectingParty.toProto(false));
+        assertThat(restoredRejectingParty.isMediationResultRejected()).isTrue();
+        assertThat(restoredRejectingParty.getCustomPayoutData()).isEmpty();
+
+        MuSigTradeParty signingParty = new MuSigTradeParty(createNetworkId());
+
+        assertThat(signingParty.setPeersCustomPayoutPsbt(createPeerPsbt())).isTrue();
+        assertThat(signingParty.setMediationResultRejected()).isFalse();
+        assertThat(signingParty.isMediationResultRejected()).isFalse();
+    }
+
+    @Test
+    void conflictingDataDoesNotReplaceStoredData() {
+        MuSigTradeParty party = new MuSigTradeParty(createNetworkId());
+        CustomPayoutPsbt firstPsbt = createLocalPsbt();
+        CustomPayoutPsbt conflictingPsbt = new CustomPayoutPsbt(new byte[]{9}, TX_ID, 70_000, 30_000);
+        CustomCloseTradeResponse firstCloseResponse = new CustomCloseTradeResponse(new byte[]{7});
+        CustomCloseTradeResponse conflictingCloseResponse = new CustomCloseTradeResponse(new byte[]{8});
+
+        assertThat(party.setMyCustomPayoutPsbt(firstPsbt)).isTrue();
+        assertThat(party.setMyCustomPayoutPsbt(firstPsbt)).isFalse();
+        assertThat(party.setMyCustomPayoutPsbt(conflictingPsbt)).isFalse();
+        assertThat(party.setMyCustomCloseTradeResponse(firstCloseResponse)).isTrue();
+        assertThat(party.setMyCustomCloseTradeResponse(firstCloseResponse)).isFalse();
+        assertThat(party.setMyCustomCloseTradeResponse(conflictingCloseResponse)).isFalse();
+
+        MuSigCustomPayoutPartyData storedData = party.getCustomPayoutData().orElseThrow();
+        assertThat(storedData.getMyCustomPayoutPsbt()).contains(firstPsbt);
+        assertThat(storedData.getMyCustomCloseTradeResponse()).contains(firstCloseResponse);
+    }
+
+    @Test
+    void peerCustomPayoutPsbtDoesNotReplaceStoredData() {
+        MuSigTradeParty party = new MuSigTradeParty(createNetworkId());
+        PeerCustomPayoutPsbt firstPsbt = createPeerPsbt();
+        PeerCustomPayoutPsbt duplicatePsbt = createPeerPsbt();
+        PeerCustomPayoutPsbt conflictingPsbt = new PeerCustomPayoutPsbt(TX_ID, new byte[]{7, 8, 9});
+
+        assertThat(party.setPeersCustomPayoutPsbt(firstPsbt)).isTrue();
+        assertThat(party.setPeersCustomPayoutPsbt(duplicatePsbt)).isFalse();
+        assertThat(party.setPeersCustomPayoutPsbt(conflictingPsbt)).isFalse();
+
+        MuSigCustomPayoutPartyData storedData = party.getCustomPayoutData().orElseThrow();
+        assertThat(storedData.getPeersCustomPayoutPsbt()).contains(firstPsbt);
+    }
+
+    @Test
+    void peerCustomPayoutPsbtCannotBeStoredAfterRejection() {
+        MuSigTradeParty party = new MuSigTradeParty(createNetworkId());
+
+        assertThat(party.setMediationResultRejected()).isTrue();
+        assertThat(party.setPeersCustomPayoutPsbt(createPeerPsbt())).isFalse();
+        assertThat(party.getCustomPayoutData()).isEmpty();
+    }
+
+    @Test
+    void closeResponseRequiresLocalCustomPayoutData() {
+        CustomCloseTradeResponse closeResponse = new CustomCloseTradeResponse(new byte[]{7});
+        MuSigTradeParty emptyParty = new MuSigTradeParty(createNetworkId());
+        MuSigTradeParty peerParty = new MuSigTradeParty(createNetworkId());
+        assertThat(peerParty.setPeersCustomPayoutPsbt(createPeerPsbt())).isTrue();
+
+        assertThat(emptyParty.setMyCustomCloseTradeResponse(closeResponse)).isFalse();
+        assertThat(peerParty.setMyCustomCloseTradeResponse(closeResponse)).isFalse();
+    }
+
+    @Test
+    void additiveFieldsPreserveExistingPartyData() {
+        bisq.trade.protobuf.TradeParty proto = bisq.trade.protobuf.TradeParty.newBuilder()
+                .setNetworkId(createNetworkId().toProto(false))
+                .setMuSigTradeParty(bisq.trade.protobuf.MuSigTradeParty.newBuilder()
+                        .setMediationResultAccepted(true))
+                .build();
+
+        MuSigTradeParty restored = MuSigTradeParty.fromProto(proto);
+
+        assertThat(restored.getMediationResultAccepted()).contains(true);
+        assertThat(restored.getCustomPayoutData()).isEmpty();
+        assertThat(restored.isMediationResultRejected()).isFalse();
+    }
+
+    @Test
+    void malformedPartyDecisionIsRejectedDuringDeserialization() {
+        MuSigCustomPayoutPartyData customPayoutData =
+                MuSigCustomPayoutPartyData.forLocalParty(createLocalPsbt());
+        bisq.trade.protobuf.TradeParty proto = bisq.trade.protobuf.TradeParty.newBuilder()
+                .setNetworkId(createNetworkId().toProto(false))
+                .setMuSigTradeParty(bisq.trade.protobuf.MuSigTradeParty.newBuilder()
+                        .setCustomPayoutData(customPayoutData.toProto(false))
+                        .setMediationResultRejected(true))
+                .build();
+
+        assertThatThrownBy(() -> MuSigTradeParty.fromProto(proto))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static CustomPayoutPsbt createLocalPsbt() {
+        return new CustomPayoutPsbt(LOCAL_PSBT, TX_ID, 60_000, 40_000);
+    }
+
+    private static PeerCustomPayoutPsbt createPeerPsbt() {
+        return new PeerCustomPayoutPsbt(
+                TX_ID,
+                PEER_PSBT);
+    }
+
+    private static NetworkId createNetworkId() {
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(Map.of(
+                TransportType.CLEAR, new ClearnetAddress("127.0.0.1", 9999)));
+        PubKey pubKey = new PubKey(KeyGeneration.generateDefaultEcKeyPair().getPublic(), "custom-payout-test-key");
+        return new NetworkId(addresses, pubKey);
+    }
+}

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeDisputeServiceTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeDisputeServiceTest.java
@@ -49,16 +49,19 @@ import bisq.security.keys.TorKeyGeneration;
 import bisq.security.pow.ProofOfWork;
 import bisq.support.arbitration.ArbitrationCaseState;
 import bisq.support.arbitration.mu_sig.MuSigArbitrationStateChangeMessage;
+import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
 import bisq.support.mediation.MediationCaseState;
 import bisq.support.mediation.MediationPayoutDistributionType;
 import bisq.support.mediation.MediationResultReason;
-import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResult;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultRejectionMessage;
+import bisq.support.mediation.mu_sig.MuSigMediationResultService;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.trade.MuSigDisputeState;
 import bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService;
 import bisq.trade.mu_sig.mediation.MuSigTraderMediationService;
+import bisq.trade.mu_sig.messages.network.mu_sig_data.PeerCustomPayoutPsbt;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
 import bisq.user.profile.UserProfile;
@@ -75,14 +78,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class MuSigTradeDisputeServiceTest {
+    private static final String TX_ID = "ab".repeat(32);
     private static final AtomicInteger FIXTURE_SEQUENCE = new AtomicInteger();
 
+    private BannedUserService bannedUserService;
     private MuSigOpenTradeChannelService muSigOpenTradeChannelService;
     private MuSigTraderMediationService muSigTraderMediationService;
     private MuSigTraderArbitrationService muSigTraderArbitrationService;
@@ -92,7 +100,7 @@ class MuSigTradeDisputeServiceTest {
 
     @BeforeEach
     void setUp() {
-        BannedUserService bannedUserService = mock(BannedUserService.class);
+        bannedUserService = mock(BannedUserService.class);
         muSigOpenTradeChannelService = mock(MuSigOpenTradeChannelService.class);
         muSigTraderMediationService = mock(MuSigTraderMediationService.class);
         muSigTraderArbitrationService = mock(MuSigTraderArbitrationService.class);
@@ -184,18 +192,63 @@ class MuSigTradeDisputeServiceTest {
     void givenTradeWithMediationResult_whenRejectMediationResult_thenMarksRejectedPersistsAndDelegates() {
         TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
         MuSigOpenTradeChannel channel = stubOpenTradeChannel(fixture);
-        fixture.tradeDispute().setMuSigMediationResult(createMediationResult());
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
 
         service.rejectMediationResult(fixture.trade());
 
-        assertThat(fixture.myself().getMediationResultAccepted()).contains(false);
+        assertThat(fixture.myself().isMediationResultRejected()).isTrue();
+        assertThat(fixture.myself().getMediationResultAccepted()).isEmpty();
         assertThat(persistCalls.get()).isEqualTo(1);
-        verify(muSigTraderMediationService).sendMediationResultAcceptanceMessage(
-                fixture.tradeId(),
-                fixture.identity(),
-                fixture.peer(),
-                false,
-                channel);
+        verify(muSigTraderMediationService).sendMediationResultRejectionMessage(
+                eq(fixture.tradeId()),
+                eq(fixture.identity()),
+                eq(fixture.peer()),
+                aryEq(MuSigMediationResultService.getMediationResultHash(mediationResult)),
+                eq(channel));
+    }
+
+    @Test
+    void givenTradeWithoutMediationResult_whenRejectMediationResult_thenThrowsAndDoesNotPersist() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_OPEN, true, false);
+        stubOpenTradeChannel(fixture);
+
+        assertThatThrownBy(() -> service.rejectMediationResult(fixture.trade()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(persistCalls.get()).isZero();
+        verifyNoInteractions(muSigTraderMediationService);
+    }
+
+    @Test
+    void givenNoPayoutMediationResult_whenRejectMediationResult_thenIgnoresRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        stubOpenTradeChannel(fixture);
+        fixture.tradeDispute().setMuSigMediationResult(createNoPayoutMediationResult());
+
+        service.rejectMediationResult(fixture.trade());
+
+        assertThat(fixture.myself().isMediationResultRejected()).isFalse();
+        assertThat(persistCalls.get()).isZero();
+        verifyNoInteractions(muSigTraderMediationService);
+    }
+
+    @Test
+    void givenAlreadyRejectedMediationResult_whenRejectAgain_thenDoesNotPersistOrSendAgain() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigOpenTradeChannel channel = stubOpenTradeChannel(fixture);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+
+        service.rejectMediationResult(fixture.trade());
+        service.rejectMediationResult(fixture.trade());
+
+        assertThat(persistCalls.get()).isEqualTo(1);
+        verify(muSigTraderMediationService, times(1)).sendMediationResultRejectionMessage(
+                eq(fixture.tradeId()),
+                eq(fixture.identity()),
+                eq(fixture.peer()),
+                aryEq(MuSigMediationResultService.getMediationResultHash(mediationResult)),
+                eq(channel));
     }
 
     @Test
@@ -303,6 +356,128 @@ class MuSigTradeDisputeServiceTest {
 
         assertThat(fixture.peer().getMediationResultAccepted()).contains(true);
         assertThat(persistCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void givenMatchingPeerRejection_whenOnDisputeMessage_thenMarksPeerRejectedAndPersists() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        registerTradeAndChannel(fixture);
+
+        service.onDisputeMessage(createPeerRejectionMessage(fixture, mediationResult));
+
+        assertThat(fixture.peer().isMediationResultRejected()).isTrue();
+        assertThat(persistCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void givenPeerRejectionBeforeMediationResult_whenResultBecomesAvailable_thenProcessesPendingRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_OPEN, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        registerTradeAndChannel(fixture);
+
+        service.onDisputeMessage(createPeerRejectionMessage(fixture, mediationResult));
+
+        assertThat(fixture.peer().isMediationResultRejected()).isFalse();
+        assertThat(persistCalls.get()).isZero();
+
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        service.maybeProcessPendingDisputeMessages(fixture.tradeId());
+
+        assertThat(fixture.peer().isMediationResultRejected()).isTrue();
+        assertThat(persistCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void givenMismatchingPeerRejection_whenOnDisputeMessage_thenIgnoresRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        registerTradeAndChannel(fixture);
+        byte[] mismatchingHash = MuSigMediationResultService.getMediationResultHash(mediationResult);
+        mismatchingHash[0] ^= 1;
+        MuSigMediationResultRejectionMessage message = new MuSigMediationResultRejectionMessage(
+                fixture.tradeId(), fixture.takerProfile().getNetworkId(), mismatchingHash);
+
+        service.onDisputeMessage(message);
+
+        assertThat(fixture.peer().isMediationResultRejected()).isFalse();
+        assertThat(persistCalls.get()).isZero();
+    }
+
+    @Test
+    void givenUnexpectedRejectionSender_whenOnDisputeMessage_thenIgnoresRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        registerTradeAndChannel(fixture);
+        MuSigMediationResultRejectionMessage message = new MuSigMediationResultRejectionMessage(
+                fixture.tradeId(),
+                fixture.mediator().orElseThrow().getNetworkId(),
+                MuSigMediationResultService.getMediationResultHash(mediationResult));
+
+        service.onDisputeMessage(message);
+
+        assertThat(fixture.peer().isMediationResultRejected()).isFalse();
+        assertThat(persistCalls.get()).isZero();
+    }
+
+    @Test
+    void givenBannedRejectionSender_whenOnDisputeMessage_thenIgnoresRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        registerTradeAndChannel(fixture);
+        when(bannedUserService.isUserProfileBanned(fixture.takerProfile().getNetworkId())).thenReturn(true);
+
+        service.onDisputeMessage(createPeerRejectionMessage(fixture, mediationResult));
+
+        assertThat(fixture.peer().isMediationResultRejected()).isFalse();
+        assertThat(persistCalls.get()).isZero();
+    }
+
+    @Test
+    void givenPeerPayoutData_whenOnDisputeMessage_thenIgnoresLaterRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        fixture.peer().setPeersCustomPayoutPsbt(new PeerCustomPayoutPsbt(TX_ID, new byte[]{1, 2, 3}));
+        registerTradeAndChannel(fixture);
+
+        service.onDisputeMessage(createPeerRejectionMessage(fixture, mediationResult));
+
+        assertThat(fixture.peer().isMediationResultRejected()).isFalse();
+        assertThat(fixture.peer().getCustomPayoutData()).isPresent();
+        assertThat(persistCalls.get()).isZero();
+    }
+
+    @Test
+    void givenDuplicatePeerRejection_whenOnDisputeMessage_thenPersistsOnlyFirstRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        registerTradeAndChannel(fixture);
+        MuSigMediationResultRejectionMessage message = createPeerRejectionMessage(fixture, mediationResult);
+
+        service.onDisputeMessage(message);
+        service.onDisputeMessage(message);
+
+        assertThat(fixture.peer().isMediationResultRejected()).isTrue();
+        assertThat(persistCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void givenNoPayoutResult_whenOnDisputeMessage_thenIgnoresPeerRejection() {
+        TradeFixture fixture = createTradeFixture(MuSigDisputeState.MEDIATION_CLOSED, true, false);
+        MuSigMediationResult mediationResult = createNoPayoutMediationResult();
+        fixture.tradeDispute().setMuSigMediationResult(mediationResult);
+        registerTradeAndChannel(fixture);
+
+        service.onDisputeMessage(createPeerRejectionMessage(fixture, mediationResult));
+
+        assertThat(fixture.peer().isMediationResultRejected()).isFalse();
+        assertThat(persistCalls.get()).isZero();
     }
 
     @Test
@@ -454,6 +629,11 @@ class MuSigTradeDisputeServiceTest {
         return channel;
     }
 
+    private void registerTradeAndChannel(TradeFixture fixture) {
+        tradeById.put(fixture.tradeId(), fixture.trade());
+        stubOpenTradeChannel(fixture);
+    }
+
     private AccountPayload<?> createNationalBankPayload(String id, String accountNr) {
         return new NationalBankAccountPayload(
                 id,
@@ -480,6 +660,26 @@ class MuSigTradeDisputeServiceTest {
                 Optional.empty(),
                 Optional.empty()
         );
+    }
+
+    private MuSigMediationResult createNoPayoutMediationResult() {
+        return new MuSigMediationResult(
+                new byte[20],
+                MediationResultReason.OTHER,
+                MediationPayoutDistributionType.NO_PAYOUT,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
+    private MuSigMediationResultRejectionMessage createPeerRejectionMessage(TradeFixture fixture,
+                                                                             MuSigMediationResult mediationResult) {
+        return new MuSigMediationResultRejectionMessage(
+                fixture.tradeId(),
+                fixture.takerProfile().getNetworkId(),
+                MuSigMediationResultService.getMediationResultHash(mediationResult));
     }
 
     private byte[] signatureBytes() {

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/MuSigCustomPayoutPsbtMessageTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/MuSigCustomPayoutPsbtMessageTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network;
+
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.ClearnetAddress;
+import bisq.common.network.TransportType;
+import bisq.network.identity.NetworkId;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.trade.protocol.messages.TradeMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MuSigCustomPayoutPsbtMessageTest {
+    private static final String TX_ID = "ab".repeat(32);
+
+    @Test
+    void roundTripsThroughTradeMessageResolver() {
+        MuSigCustomPayoutPsbtMessage message = createMessage(new byte[]{1, 2, 3});
+
+        bisq.trade.protobuf.TradeMessage proto = message.resolveValueProto(false);
+        TradeMessage restored = TradeMessage.fromProto(proto);
+
+        assertThat(proto.getMuSigTradeMessage().getMessageCase())
+                .isEqualTo(bisq.trade.protobuf.MuSigTradeMessage.MessageCase.MUSIGCUSTOMPAYOUTPSBTMESSAGE);
+        assertThat(restored).isEqualTo(message);
+    }
+
+    @Test
+    void defensivelyCopiesByteArrays() {
+        byte[] mediationResultHash = new byte[20];
+        byte[] psbt = {1, 2, 3};
+        MuSigCustomPayoutPsbtMessage message = createMessage(mediationResultHash, psbt);
+
+        mediationResultHash[0] = 99;
+        psbt[0] = 99;
+        byte[] returnedHash = message.getMediationResultHash();
+        byte[] returnedPsbt = message.getPsbt();
+        returnedHash[1] = 99;
+        returnedPsbt[1] = 99;
+
+        assertThat(message.getMediationResultHash()).containsOnly(0);
+        assertThat(message.getPsbt()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void excludesPsbtFromToString() {
+        MuSigCustomPayoutPsbtMessage message = createMessage(new byte[]{1, 2, 3});
+
+        assertThat(message.toString()).doesNotContain("psbt=");
+    }
+
+    @Test
+    void enforcesPsbtSizeLimit() {
+        assertThat(createMessage(new byte[MuSigCustomPayoutPsbtMessage.MAX_PSBT_SIZE]).getPsbt())
+                .hasSize(MuSigCustomPayoutPsbtMessage.MAX_PSBT_SIZE);
+        assertThatThrownBy(() -> createMessage(new byte[MuSigCustomPayoutPsbtMessage.MAX_PSBT_SIZE + 1]))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsInvalidPayload() {
+        assertThatThrownBy(() -> createMessage(new byte[19], new byte[]{1}))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> createMessage(new byte[20], "gg".repeat(32), new byte[]{1}))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> createMessage(new byte[20], new byte[0]))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static MuSigCustomPayoutPsbtMessage createMessage(byte[] psbt) {
+        return createMessage(new byte[20], psbt);
+    }
+
+    private static MuSigCustomPayoutPsbtMessage createMessage(byte[] mediationResultHash, byte[] psbt) {
+        return createMessage(mediationResultHash, TX_ID, psbt);
+    }
+
+    private static MuSigCustomPayoutPsbtMessage createMessage(byte[] mediationResultHash,
+                                                              String txId,
+                                                              byte[] psbt) {
+        return new MuSigCustomPayoutPsbtMessage(
+                "message-id",
+                "trade-id",
+                "1",
+                createNetworkId(9998, "sender-key"),
+                createNetworkId(9999, "receiver-key"),
+                mediationResultHash,
+                txId,
+                psbt);
+    }
+
+    private static NetworkId createNetworkId(int port, String keyId) {
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(Map.of(
+                TransportType.CLEAR, new ClearnetAddress("127.0.0.1", port)));
+        PubKey pubKey = new PubKey(KeyGeneration.generateDefaultEcKeyPair().getPublic(), keyId);
+        return new NetworkId(addresses, pubKey);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sharing and storing custom payout transaction data between trade parties.
  * Added support for recording custom close-trade responses.
  * Added mediation rejection status and dedicated rejection messaging for MuSig trades.
  * Added secure network messaging for custom payout details and mediation outcomes.

* **Bug Fixes**
  * Improved validation for malformed, incomplete, oversized, or conflicting payout data.
  * Prevented incompatible payout and mediation states from being recorded.
  * Improved protection of sensitive transaction data during storage and transmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->