### PR TITLE
chore: sync #4920 to main — chore/closed_trades_main_follow_ups_and_test_improvement

### DIFF
--- a/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeIndexedItem.java
+++ b/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeIndexedItem.java
@@ -38,6 +38,48 @@ public record ClosedTradeIndexedItem(
         String formattedBaseAmount,
         String formattedQuoteAmount,
         String bitcoinSettlementMethodDisplayString,
-        String fiatPaymentMethodDisplayString
+        String fiatPaymentMethodDisplayString,
+        // Pre-lowercased concatenation of every searchable field, so the search filter does a
+        // single contains() per item instead of lowercasing each field on every keystroke.
+        String searchBlob
 ) {
+    /**
+     * Canonical way to build an item — computes {@link #searchBlob} from the same fields the
+     * search filter matches on, so the two cannot drift apart.
+     */
+    public static ClosedTradeIndexedItem of(ClosedTradeListItemDto dto,
+                                            String market,
+                                            String directionalTitle,
+                                            String formattedMyRole,
+                                            String formattedPrice,
+                                            String formattedBaseAmount,
+                                            String formattedQuoteAmount,
+                                            String bitcoinSettlementMethodDisplayString,
+                                            String fiatPaymentMethodDisplayString) {
+        String searchBlob = String.join("\n",
+                        dto.trade().id(),
+                        market,
+                        directionalTitle,
+                        formattedMyRole,
+                        formattedPrice,
+                        formattedBaseAmount,
+                        formattedQuoteAmount,
+                        dto.makerUserProfile().userName(),
+                        dto.makerUserProfile().nym(),
+                        dto.takerUserProfile().userName(),
+                        dto.takerUserProfile().nym(),
+                        bitcoinSettlementMethodDisplayString,
+                        fiatPaymentMethodDisplayString)
+                .toLowerCase(java.util.Locale.ROOT);
+        return new ClosedTradeIndexedItem(dto,
+                market,
+                directionalTitle,
+                formattedMyRole,
+                formattedPrice,
+                formattedBaseAmount,
+                formattedQuoteAmount,
+                bitcoinSettlementMethodDisplayString,
+                fiatPaymentMethodDisplayString,
+                searchBlob);
+    }
 }

--- a/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeListItemDtoFactory.java
+++ b/api/src/main/java/bisq/api/dto/presentation/closed_trades/ClosedTradeListItemDtoFactory.java
@@ -59,6 +59,9 @@ public final class ClosedTradeListItemDtoFactory {
         String bitcoinSettlementMethod = contract.getBaseSidePaymentMethodSpec().getPaymentMethodName();
         String fiatPaymentMethod = contract.getQuoteSidePaymentMethodSpec().getPaymentMethodName();
 
+        // Snapshot taken when the item is indexed; it can go stale until the item is rebuilt
+        // (e.g. on restart). Acceptable for a closed-trade list — this is historical context,
+        // not the live reputation surface.
         ReputationScore peersReputationScore = reputationService.getReputationScore(peersUserProfile.getId());
         ReputationScoreDto peersReputationScoreDto = DtoMappings.ReputationScoreMapping.fromBisq2Model(peersReputationScore);
 
@@ -93,7 +96,7 @@ public final class ClosedTradeListItemDtoFactory {
         String bitcoinSettlementMethodDisplayString = contract.getBaseSidePaymentMethodSpec().getShortDisplayString();
         String fiatPaymentMethodDisplayString = contract.getQuoteSidePaymentMethodSpec().getShortDisplayString();
 
-        return new ClosedTradeIndexedItem(
+        return ClosedTradeIndexedItem.of(
                 dto,
                 market,
                 directionalTitle,

--- a/api/src/main/java/bisq/api/rest_api/endpoints/RestApiBase.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/RestApiBase.java
@@ -86,6 +86,6 @@ public abstract class RestApiBase {
                 page.pageSize(),
                 page.totalItems(),
                 page.totalPages());
-        return Response.status(Response.Status.OK).entity(body).build();
+        return buildOkResponse(body);
     }
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQuery.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQuery.java
@@ -96,14 +96,21 @@ public final class ClosedTradesQuery {
         // timestamp for trades that never reached a completion state (e.g. cancelled before any
         // completion event was recorded). takeOfferDate is monotonic and always populated, so
         // the fallback guarantees a stable ordering even for never-completed trades.
+        // Every field appends the trade id as a final tie-breaker: equal primary values must order
+        // deterministically, or items can repeat or vanish across page requests when the source
+        // list shifts between fetches.
         DATE(Comparator
                 .comparingLong((ClosedTradeIndexedItem item) ->
                         item.dto().tradeCompletedDate().orElse(item.dto().trade().contract().takeOfferDate()))
                 .thenComparing(item -> item.dto().trade().id())),
-        MARKET(Comparator.comparing(ClosedTradeIndexedItem::market, String.CASE_INSENSITIVE_ORDER)),
-        QUOTE_AMOUNT(Comparator.comparingLong(item -> item.dto().quoteAmount())),
-        BASE_AMOUNT(Comparator.comparingLong(item -> item.dto().baseAmount())),
-        ROLE(Comparator.comparing((ClosedTradeIndexedItem item) -> item.dto().trade().tradeRole()));
+        MARKET(Comparator.comparing(ClosedTradeIndexedItem::market, String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(item -> item.dto().trade().id())),
+        QUOTE_AMOUNT(Comparator.comparingLong((ClosedTradeIndexedItem item) -> item.dto().quoteAmount())
+                .thenComparing(item -> item.dto().trade().id())),
+        BASE_AMOUNT(Comparator.comparingLong((ClosedTradeIndexedItem item) -> item.dto().baseAmount())
+                .thenComparing(item -> item.dto().trade().id())),
+        ROLE(Comparator.comparing((ClosedTradeIndexedItem item) -> item.dto().trade().tradeRole())
+                .thenComparing(item -> item.dto().trade().id()));
 
         private final Comparator<ClosedTradeIndexedItem> comparator;
 
@@ -159,23 +166,8 @@ public final class ClosedTradesQuery {
     }
 
     private static boolean matches(ClosedTradeIndexedItem item, String needleLower) {
-        var dto = item.dto();
-        return contains(dto.trade().id(), needleLower)
-                || contains(item.market(), needleLower)
-                || contains(item.directionalTitle(), needleLower)
-                || contains(item.formattedMyRole(), needleLower)
-                || contains(item.formattedPrice(), needleLower)
-                || contains(item.formattedBaseAmount(), needleLower)
-                || contains(item.formattedQuoteAmount(), needleLower)
-                || contains(dto.makerUserProfile().userName(), needleLower)
-                || contains(dto.makerUserProfile().nym(), needleLower)
-                || contains(dto.takerUserProfile().userName(), needleLower)
-                || contains(dto.takerUserProfile().nym(), needleLower)
-                || contains(item.bitcoinSettlementMethodDisplayString(), needleLower)
-                || contains(item.fiatPaymentMethodDisplayString(), needleLower);
-    }
-
-    private static boolean contains(String value, String needleLower) {
-        return value.toLowerCase(Locale.ROOT).contains(needleLower);
+        // The blob is precomputed lowercase over all searchable fields (see ClosedTradeIndexedItem.of),
+        // so filtering is one contains() per item instead of lowercasing each field per keystroke.
+        return item.searchBlob().contains(needleLower);
     }
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
@@ -137,7 +137,10 @@ public class TradeRestApi extends RestApiBase {
                     "'role' (BUYER|SELLER, optional), " +
                     "'state' (BisqEasyTradeStateDto value; repeatable or comma-separated, optional).",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Closed trades retrieved successfully",
+                    @ApiResponse(responseCode = "200",
+                            description = "Closed trades retrieved successfully. PaginatedResponse whose " +
+                                    "'items' are ClosedTradeListItemDto (generic binding not expressible in " +
+                                    "the schema annotation since PaginatedResponse is a record).",
                             content = @Content(schema = @Schema(implementation = PaginatedResponse.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid query parameters"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -159,7 +162,9 @@ public class TradeRestApi extends RestApiBase {
                     Optional.ofNullable(role));
             Set<BisqEasyTradeStateDto> stateFilter = ClosedTradesQuery.parseStates(states);
             List<ClosedTradeIndexedItem> filtered = ClosedTradesQuery.apply(
-                    closedTradeItemsService.getItems().getList(),
+                    // Snapshot, not the live synchronized list: iteration during a concurrent
+                    // trade-close would throw ConcurrentModificationException.
+                    closedTradeItemsService.getItemsSnapshot(),
                     Optional.ofNullable(search),
                     roleFilter,
                     stateFilter,
@@ -169,7 +174,7 @@ public class TradeRestApi extends RestApiBase {
                     PaginationParams.of(Optional.ofNullable(page), Optional.ofNullable(pageSize)),
                     ClosedTradeIndexedItem::dto);
         } catch (IllegalArgumentException e) {
-            return buildResponse(Response.Status.BAD_REQUEST, e.getMessage());
+            return buildErrorResponse(Response.Status.BAD_REQUEST, e.getMessage());
         } catch (Exception e) {
             log.error("Error retrieving closed trades", e);
             return buildErrorResponse("An unexpected error occurred");

--- a/api/src/main/java/bisq/api/rest_api/pagination/PaginationParams.java
+++ b/api/src/main/java/bisq/api/rest_api/pagination/PaginationParams.java
@@ -25,11 +25,20 @@ public record PaginationParams(int page, int pageSize) {
     public static final int DEFAULT_PAGE_SIZE = 20;
     public static final int MAX_PAGE_SIZE = 100;
 
+    /**
+     * Defaults apply only when a parameter is absent. An explicitly supplied value below 1 is a
+     * client error and is rejected (the endpoints map {@link IllegalArgumentException} to 400)
+     * rather than silently replaced — silent replacement would hide client bugs behind page 1.
+     */
     public static PaginationParams of(Optional<Integer> page, Optional<Integer> pageSize) {
-        int resolvedPage = page.filter(p -> p >= 1).orElse(DEFAULT_PAGE);
-        int resolvedSize = pageSize.filter(s -> s >= 1)
-                .map(s -> Math.min(s, MAX_PAGE_SIZE))
-                .orElse(DEFAULT_PAGE_SIZE);
+        page.filter(p -> p < 1).ifPresent(p -> {
+            throw new IllegalArgumentException("page must be >= 1, got: " + p);
+        });
+        pageSize.filter(s -> s < 1).ifPresent(s -> {
+            throw new IllegalArgumentException("pageSize must be >= 1, got: " + s);
+        });
+        int resolvedPage = page.orElse(DEFAULT_PAGE);
+        int resolvedSize = pageSize.map(s -> Math.min(s, MAX_PAGE_SIZE)).orElse(DEFAULT_PAGE_SIZE);
         return new PaginationParams(resolvedPage, resolvedSize);
     }
 
@@ -40,8 +49,10 @@ public record PaginationParams(int page, int pageSize) {
             throw new IllegalArgumentException(
                     "Page " + page + " out of range; total pages: " + totalPages);
         }
-        int fromIndex = Math.min((page - 1) * pageSize, total);
-        int toIndex = Math.min(fromIndex + pageSize, total);
+        // Long arithmetic: with total == 0 the out-of-range guard above does not fire, and an
+        // extreme page value would overflow int multiplication into a negative fromIndex.
+        int fromIndex = (int) Math.min((long) (page - 1) * pageSize, total);
+        int toIndex = (int) Math.min((long) fromIndex + pageSize, total);
         return new PaginatedResponse<>(
                 items.subList(fromIndex, toIndex),
                 page,

--- a/api/src/main/java/bisq/api/web_socket/domain/ClosedTradeItemsService.java
+++ b/api/src/main/java/bisq/api/web_socket/domain/ClosedTradeItemsService.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -90,5 +91,19 @@ public class ClosedTradeItemsService implements Service {
         return items.stream()
                 .filter(item -> item.dto().trade().id().equals(tradeId))
                 .findAny();
+    }
+
+    /**
+     * Immutable snapshot for iteration off the mutation path. The backing list is a
+     * {@link java.util.Collections#synchronizedList(java.util.List)}, whose per-call
+     * synchronization does NOT cover iteration — streaming it while a trade closes concurrently
+     * throws ConcurrentModificationException. Copying under the list's monitor is the contract
+     * that javadoc requires.
+     */
+    public List<ClosedTradeIndexedItem> getItemsSnapshot() {
+        List<ClosedTradeIndexedItem> list = items.getList();
+        synchronized (list) {
+            return List.copyOf(list);
+        }
     }
 }

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -21,9 +21,9 @@ import bisq.api.access.AllowUnauthenticated;
 import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.trades.TradeRestApi;
+import bisq.api.web_socket.domain.BaseWebSocketService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
-import bisq.api.web_socket.subscription.SubscriberRepository;
 import bisq.api.web_socket.subscription.SubscriptionService;
 import bisq.api.web_socket.subscription.Topic;
 import bisq.bisq_easy.BisqEasyService;
@@ -37,19 +37,16 @@ import bisq.user.UserService;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
-import org.glassfish.grizzly.impl.ReadyFutureImpl;
-import org.glassfish.grizzly.websockets.WebSocket;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ConfigRestApiTest {
 
@@ -86,62 +83,51 @@ class ConfigRestApiTest {
         assertThat(dto.apiVersion()).isNotBlank();
         assertThat(dto.features()).containsExactlyElementsOf(ApiFeature.allKeys());
         assertThat(dto.features()).contains(ApiFeature.CLOSED_TRADES.getKey());
+        assertThat(dto.features()).contains(ApiFeature.NETWORK_INFO.getKey());
+    }
+
+    /**
+     * The keys are the wire contract capability-gated clients match on, so they must stay stable even
+     * if the enum constants get renamed.
+     */
+    @Test
+    void featureKeysAreStableWireIdentifiers() {
+        assertThat(ApiFeature.CLOSED_TRADES.getKey()).isEqualTo("closed-trades");
+        assertThat(ApiFeature.NETWORK_INFO.getKey()).isEqualTo("network-info");
     }
 
     /**
      * Anti-drift guard: a declared feature must be backed by a real, wired endpoint/topic — never a
      * key for something not implemented in this build.
      * <p>
-     * Implemented as a switch <i>expression</i> on purpose: exhaustiveness is compile-checked, so
-     * adding an {@link ApiFeature} without extending this check breaks the build instead of being
-     * silently skipped (which is how NETWORK_INFO originally slipped past the old switch statement).
+     * A switch <i>expression</i> on purpose: exhaustiveness is compile-checked, so adding an
+     * {@link ApiFeature} without extending this check breaks the build instead of being silently
+     * skipped (arrow-form switch statements over enums are not exhaustiveness-checked, which is
+     * how a feature could otherwise ship unguarded). Each case asserts its own specifics and
+     * yields; the yielded value exists only to force the expression form.
      */
     @Test
     void everyDeclaredFeatureIsBackedByARealImplementation() {
         for (ApiFeature feature : ApiFeature.values()) {
-            boolean backed =
-                    switch (feature) {
-                        case CLOSED_TRADES -> hasEndpoint(TradeRestApi.class, "/closed");
-                        case NETWORK_INFO -> networkInfoSubscriptionIsServed();
-                    };
-            assertThat(backed)
-                    .as("feature '%s' is declared in /config/capabilities but not backed by a real implementation", feature.getKey())
-                    .isTrue();
-        }
-    }
-
-    /**
-     * Proves {@link Topic#NETWORK_INFO} is served through the real subscription path — a
-     * {@link bisq.api.web_socket.subscription.SubscriptionService} built the production way routes a
-     * NETWORK_INFO subscription request to its wired {@link NetworkInfoWebSocketService} and the
-     * subscriber ends up registered. Deleting the topic, the service, or its registration in
-     * SubscriptionService makes this fail (or not compile), which is the point of the guard.
-     */
-    private static boolean networkInfoSubscriptionIsServed() {
-        try {
-            SubscriptionService subscriptionService = new SubscriptionService(
-                    mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
-                    mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
-                    mock(ChatService.class, RETURNS_DEEP_STUBS),
-                    mock(TradeService.class, RETURNS_DEEP_STUBS),
-                    mock(UserService.class, RETURNS_DEEP_STUBS),
-                    mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
-                    mock(NetworkService.class, RETURNS_DEEP_STUBS),
-                    mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS));
-
-            WebSocket webSocket = mock(WebSocket.class);
-            when(webSocket.send(anyString())).thenReturn(ReadyFutureImpl.create(null));
-
-            String requestJson =
-                    "{\"type\":\"SubscriptionRequest\",\"requestId\":\"config-guard-1\",\"topic\":\"NETWORK_INFO\"}";
-            subscriptionService.onMessage(requestJson, webSocket);
-
-            Field field = SubscriptionService.class.getDeclaredField("subscriberRepository");
-            field.setAccessible(true);
-            SubscriberRepository subscriberRepository = (SubscriberRepository) field.get(subscriptionService);
-            return !subscriberRepository.findSubscribers(Topic.NETWORK_INFO).isEmpty();
-        } catch (Exception e) {
-            return false;
+            boolean checked = switch (feature) {
+                case CLOSED_TRADES -> {
+                    assertThat(hasEndpoint(TradeRestApi.class, "/closed"))
+                            .as("closed-trades must expose GET /trades/closed")
+                            .isTrue();
+                    yield true;
+                }
+                case NETWORK_INFO -> {
+                    BaseWebSocketService service = routeTopic(Topic.NETWORK_INFO);
+                    assertThat(service)
+                            .as("SubscriptionService must route NETWORK_INFO to a live NetworkInfoWebSocketService")
+                            .isInstanceOf(NetworkInfoWebSocketService.class);
+                    assertThat(topicOf(service))
+                            .as("network-info must be backed by a service bound to Topic.NETWORK_INFO")
+                            .isEqualTo(Topic.NETWORK_INFO);
+                    yield true;
+                }
+            };
+            assertThat(checked).isTrue();
         }
     }
 
@@ -155,6 +141,42 @@ class ConfigRestApiTest {
         assertThat(ConfigRestApi.class.isAnnotationPresent(AllowUnauthenticated.class))
                 .as("/config must be @AllowUnauthenticated — it has no RestPermissionMapping rule and would otherwise 403")
                 .isTrue();
+    }
+
+    private static Topic topicOf(BaseWebSocketService service) {
+        try {
+            Field field = BaseWebSocketService.class.getDeclaredField("topic");
+            field.setAccessible(true);
+            return (Topic) field.get(service);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not read the topic of " + service.getClass().getSimpleName(), e);
+        }
+    }
+
+    /**
+     * Resolves the topic through a real {@link SubscriptionService} so the check covers the constructor
+     * wiring and the routing switch, not just a field declaration.
+     */
+    @SuppressWarnings("unchecked")
+    private static BaseWebSocketService routeTopic(Topic topic) {
+        SubscriptionService subscriptionService = new SubscriptionService(
+                mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
+                mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
+                mock(ChatService.class, RETURNS_DEEP_STUBS),
+                mock(TradeService.class, RETURNS_DEEP_STUBS),
+                mock(UserService.class, RETURNS_DEEP_STUBS),
+                mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS));
+        try {
+            Method method = SubscriptionService.class.getDeclaredMethod("findWebSocketService", Topic.class);
+            method.setAccessible(true);
+            Optional<BaseWebSocketService> routed =
+                    (Optional<BaseWebSocketService>) method.invoke(subscriptionService, topic);
+            return routed.orElseThrow(() -> new AssertionError("SubscriptionService does not route " + topic));
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not resolve the WebSocketService for " + topic, e);
+        }
     }
 
     private static boolean hasEndpoint(Class<?> resource, String path) {

--- a/api/src/test/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQueryTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/trades/ClosedTradesQueryTest.java
@@ -87,7 +87,7 @@ class ClosedTradesQueryTest {
                 Optional.empty(),
                 tradeCompletedDate
         );
-        return new ClosedTradeIndexedItem(
+        return ClosedTradeIndexedItem.of(
                 dto, market, directionalTitle, formattedMyRole,
                 formattedPrice, formattedBaseAmount, formattedQuoteAmount,
                 btcMethodDisplay, fiatMethodDisplay);
@@ -195,6 +195,23 @@ class ClosedTradesQueryTest {
                 List.of(usd, eur), Optional.empty(), Optional.empty(), Set.of(),
                 ClosedTradesQuery.SortField.MARKET, SortDirection.ASC);
         assertEquals(List.of(eur, usd), asc);
+    }
+
+    @Test
+    void apply_equalPrimarySortValuesOrderDeterministicallyByTradeId() {
+        // Equal primary keys must tie-break on trade id, or items can repeat/vanish across page
+        // requests when the source list order shifts between fetches.
+        ClosedTradeIndexedItem c = makerBuyer("C", 1L, Optional.of(1L), 100, 10, 30000, "BTC/USD");
+        ClosedTradeIndexedItem a = makerBuyer("A", 1L, Optional.of(1L), 100, 10, 30000, "BTC/USD");
+        ClosedTradeIndexedItem b = makerBuyer("B", 1L, Optional.of(1L), 100, 10, 30000, "BTC/USD");
+        List<ClosedTradeIndexedItem> input = List.of(c, a, b);
+
+        for (ClosedTradesQuery.SortField field : ClosedTradesQuery.SortField.values()) {
+            List<ClosedTradeIndexedItem> asc = ClosedTradesQuery.apply(
+                    input, Optional.empty(), Optional.empty(), Set.of(), field, SortDirection.ASC);
+            assertEquals(List.of(a, b, c), asc,
+                    "equal " + field + " values must order by trade id");
+        }
     }
 
     @Test

--- a/api/src/test/java/bisq/api/rest_api/pagination/PaginationParamsTest.java
+++ b/api/src/test/java/bisq/api/rest_api/pagination/PaginationParamsTest.java
@@ -47,15 +47,31 @@ class PaginationParamsTest {
     }
 
     @Test
-    void of_replacesNonPositivePageWithDefault() {
-        PaginationParams p = PaginationParams.of(Optional.of(0), Optional.of(10));
-        assertEquals(PaginationParams.DEFAULT_PAGE, p.page());
+    void of_rejectsExplicitNonPositivePage() {
+        // Absent -> default, but an explicitly supplied invalid value is a client error: silently
+        // replacing it with page 1 would hide client bugs.
+        assertThrows(IllegalArgumentException.class,
+                () -> PaginationParams.of(Optional.of(0), Optional.of(10)));
+        assertThrows(IllegalArgumentException.class,
+                () -> PaginationParams.of(Optional.of(-3), Optional.of(10)));
     }
 
     @Test
-    void of_replacesNonPositivePageSizeWithDefault() {
-        PaginationParams p = PaginationParams.of(Optional.of(1), Optional.of(0));
-        assertEquals(PaginationParams.DEFAULT_PAGE_SIZE, p.pageSize());
+    void of_rejectsExplicitNonPositivePageSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PaginationParams.of(Optional.of(1), Optional.of(0)));
+        assertThrows(IllegalArgumentException.class,
+                () -> PaginationParams.of(Optional.of(1), Optional.of(-1)));
+    }
+
+    @Test
+    void paginate_extremePageOnEmptyListDoesNotOverflow() {
+        // With an empty list the page-out-of-range guard does not fire; int multiplication of an
+        // extreme page value would overflow negative and subList would throw.
+        PaginationParams p = PaginationParams.of(Optional.of(Integer.MAX_VALUE), Optional.of(PaginationParams.MAX_PAGE_SIZE));
+        PaginatedResponse<Integer> resp = p.paginate(List.of());
+        assertTrue(resp.items().isEmpty());
+        assertEquals(0L, resp.totalItems());
     }
 
     @Test


### PR DESCRIPTION
Manual sync of #4920 from `for-mobile-based-on-2.1.11` to `main` (with conflict resolution in `ConfigRestApiTest` — took the #4920 version, which supersedes main's variant from the previous sync de0700c67a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved closed-trade search performance and consistency.
  * Added deterministic ordering when trades share the same sort value.
  * Added safe snapshots for closed-trade results during concurrent updates.

* **Bug Fixes**
  * Invalid page and page-size values are now rejected clearly.
  * Prevented pagination overflow issues on extreme page numbers.
  * Improved stability when retrieving closed-trade data during updates.

* **Tests**
  * Expanded coverage for search ordering, pagination validation, overflow handling, and network information routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->