### PR TITLE
Tolerate missing market price in offer list items

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
@@ -73,12 +73,12 @@ public class OfferbookListItem {
     private final long totalScore;
     private final Pin marketPriceByCurrencyMapPin;
     private final long offerAgeInDays;
+    private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
+    private final StringProperty priceTooltipText = new SimpleStringProperty();
     // Empty while the offer has no resolvable percentage (a fixed-price offer without a
     // market price yet); comparators place these after known values instead of treating
     // them as an exactly-at-market 0%.
     private OptionalDouble priceSpecAsPercent = OptionalDouble.empty();
-    private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
-    private final StringProperty priceTooltipText = new SimpleStringProperty();
 
     public OfferbookListItem(BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                              UserProfile senderUserProfile,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
@@ -48,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -72,7 +73,10 @@ public class OfferbookListItem {
     private final long totalScore;
     private final Pin marketPriceByCurrencyMapPin;
     private final long offerAgeInDays;
-    private double priceSpecAsPercent;
+    // Empty while the offer has no resolvable percentage (a fixed-price offer without a
+    // market price yet); comparators place these after known values instead of treating
+    // them as an exactly-at-market 0%.
+    private OptionalDouble priceSpecAsPercent = OptionalDouble.empty();
     private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
     private final StringProperty priceTooltipText = new SimpleStringProperty();
 
@@ -130,7 +134,7 @@ public class OfferbookListItem {
         // price arrives; the table cells bind to them so visible rows follow.
         PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
                 .ifPresent(percent -> {
-                    priceSpecAsPercent = percent;
+                    priceSpecAsPercent = OptionalDouble.of(percent);
                     formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
                     priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
                 });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
@@ -48,7 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.OptionalDouble;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -78,7 +78,7 @@ public class OfferbookListItem {
     // Empty while the offer has no resolvable percentage (a fixed-price offer without a
     // market price yet); comparators place these after known values instead of treating
     // them as an exactly-at-market 0%.
-    private OptionalDouble priceSpecAsPercent = OptionalDouble.empty();
+    private Optional<Double> priceSpecAsPercent = Optional.empty();
 
     public OfferbookListItem(BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                              UserProfile senderUserProfile,
@@ -134,7 +134,7 @@ public class OfferbookListItem {
         // price arrives; the table cells bind to them so visible rows follow.
         PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
                 .ifPresent(percent -> {
-                    priceSpecAsPercent = OptionalDouble.of(percent);
+                    priceSpecAsPercent = Optional.of(percent);
                     formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
                     priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
                 });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
@@ -40,6 +40,8 @@ import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
 import com.google.common.base.Joiner;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +73,8 @@ public class OfferbookListItem {
     private final Pin marketPriceByCurrencyMapPin;
     private final long offerAgeInDays;
     private double priceSpecAsPercent;
-    private String formattedPercentagePrice, priceTooltipText;
+    private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
+    private final StringProperty priceTooltipText = new SimpleStringProperty();
 
     public OfferbookListItem(BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                              UserProfile senderUserProfile,
@@ -122,9 +125,15 @@ public class OfferbookListItem {
     }
 
     private void updatePriceSpecAsPercent() {
-        priceSpecAsPercent = PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer).orElseThrow();
-        formattedPercentagePrice = PercentageFormatter.formatToPercentWithSignAndSymbol(priceSpecAsPercent);
-        priceTooltipText = PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer);
+        // A fixed-price offer in a market without a market price has no percent to derive;
+        // the properties keep their previous values and refresh through the observer once a
+        // price arrives; the table cells bind to them so visible rows follow.
+        PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
+                .ifPresent(percent -> {
+                    priceSpecAsPercent = percent;
+                    formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
+                    priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
+                });
     }
 
     private List<FiatPaymentMethod> retrieveAndSortFiatPaymentMethods() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItem.java
@@ -129,15 +129,13 @@ public class OfferbookListItem {
     }
 
     private void updatePriceSpecAsPercent() {
-        // A fixed-price offer in a market without a market price has no percent to derive;
-        // the properties keep their previous values and refresh through the observer once a
-        // price arrives; the table cells bind to them so visible rows follow.
-        PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
-                .ifPresent(percent -> {
-                    priceSpecAsPercent = Optional.of(percent);
-                    formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
-                    priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
-                });
+        // A fixed-price offer in a market without a market price has no percent to derive; the
+        // table cells bind to the properties, so visible rows follow once a price arrives.
+        priceSpecAsPercent = PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer);
+        formattedPercentagePrice.set(priceSpecAsPercent
+                .map(PercentageFormatter::formatToPercentWithSignAndSymbol)
+                .orElseGet(() -> Res.get("data.na")));
+        priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
     }
 
     private List<FiatPaymentMethod> retrieveAndSortFiatPaymentMethods() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListModel.java
@@ -32,7 +32,11 @@ import java.util.Set;
 @Getter
 class OfferbookListModel implements bisq.desktop.common.view.Model {
     private final Set<String> chatMessageIds = new HashSet<>();
-    private final ObservableList<OfferbookListItem> offerbookListItems = FXCollections.observableArrayList();
+    // Extractor on the formatted percentage: it is set together with the sortable
+    // percentage, so a market price that resolves a previously empty percentage emits a
+    // list-update event and the SortedList re-sorts the row to its new position.
+    private final ObservableList<OfferbookListItem> offerbookListItems =
+            FXCollections.observableArrayList(item -> new javafx.beans.Observable[]{item.getFormattedPercentagePrice()});
     private final FilteredList<OfferbookListItem> filteredOfferbookListItems = new FilteredList<>(offerbookListItems);
     private final StringProperty fiatAmountTitle = new SimpleStringProperty();
     private final BooleanProperty showBuyOffers = new SimpleBooleanProperty();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListModel.java
@@ -19,6 +19,7 @@ package bisq.desktop.main.content.bisq_easy.offerbook.offerbook_list;
 
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
+import javafx.beans.Observable;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -36,7 +37,7 @@ class OfferbookListModel implements bisq.desktop.common.view.Model {
     // percentage, so a market price that resolves a previously empty percentage emits a
     // list-update event and the SortedList re-sorts the row to its new position.
     private final ObservableList<OfferbookListItem> offerbookListItems =
-            FXCollections.observableArrayList(item -> new javafx.beans.Observable[]{item.getFormattedPercentagePrice()});
+            FXCollections.observableArrayList(item -> new Observable[]{item.getFormattedPercentagePrice()});
     private final FilteredList<OfferbookListItem> filteredOfferbookListItems = new FilteredList<>(offerbookListItems);
     private final StringProperty fiatAmountTitle = new SimpleStringProperty();
     private final BooleanProperty showBuyOffers = new SimpleBooleanProperty();

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
@@ -59,7 +59,6 @@ import org.fxmisc.easybind.Subscription;
 
 import java.util.Comparator;
 import java.util.Optional;
-import java.util.OptionalDouble;
 
 @Slf4j
 public class OfferbookListView extends bisq.desktop.common.view.View<VBox, OfferbookListModel, OfferbookListController> {
@@ -411,8 +410,8 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
                 .setCellFactory(getPriceCellFactory())
                 .build();
         priceColumn.setComparator((o1, o2) -> {
-            OptionalDouble p1 = o1.getPriceSpecAsPercent();
-            OptionalDouble p2 = o2.getPriceSpecAsPercent();
+            Optional<Double> p1 = o1.getPriceSpecAsPercent();
+            Optional<Double> p2 = o2.getPriceSpecAsPercent();
             if (p1.isEmpty() || p2.isEmpty()) {
                 // An offer without a resolvable percentage sorts after known ones, in
                 // both sort directions. JavaFX reverses the comparator's result for a
@@ -425,9 +424,9 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
                 return isDescending(priceColumn) ? -emptyLast : emptyLast;
             }
             if (o1.getBisqEasyOffer().getDirection().isSell()) {
-                return Double.compare(p1.getAsDouble(), p2.getAsDouble());
+                return Double.compare(p1.get(), p2.get());
             } else {
-                return Double.compare(p2.getAsDouble(), p1.getAsDouble());
+                return Double.compare(p2.get(), p1.get());
             }
         });
         tableView.getColumns().add(priceColumn);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
@@ -58,8 +58,8 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.util.Comparator;
-import java.util.OptionalDouble;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 @Slf4j
 public class OfferbookListView extends bisq.desktop.common.view.View<VBox, OfferbookListModel, OfferbookListController> {
@@ -404,34 +404,32 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
         tableView.getColumns().add(userProfileColumn);
         tableView.getSortOrder().add(userProfileColumn);
 
-        BisqTableColumn<OfferbookListItem>[] priceColumnHolder = new BisqTableColumn[1];
         BisqTableColumn<OfferbookListItem> priceColumn = new BisqTableColumn.Builder<OfferbookListItem>()
                 .title(Res.get("bisqEasy.offerbook.offerList.table.columns.price"))
                 .right()
                 .minWidth(75)
                 .setCellFactory(getPriceCellFactory())
-                .comparator((o1, o2) -> {
-                    OptionalDouble p1 = o1.getPriceSpecAsPercent();
-                    OptionalDouble p2 = o2.getPriceSpecAsPercent();
-                    if (p1.isEmpty() || p2.isEmpty()) {
-                        // An offer without a resolvable percentage sorts after known ones, in
-                        // both sort directions. JavaFX reverses the comparator's result for a
-                        // descending sort, so the empty ordering is pre-inverted there to keep
-                        // empties last either way.
-                        if (p1.isEmpty() == p2.isEmpty()) {
-                            return 0;
-                        }
-                        int emptyLast = p1.isEmpty() ? 1 : -1;
-                        return isDescending(priceColumnHolder[0]) ? -emptyLast : emptyLast;
-                    }
-                    if (o1.getBisqEasyOffer().getDirection().isSell()) {
-                        return Double.compare(p1.getAsDouble(), p2.getAsDouble());
-                    } else {
-                        return Double.compare(p2.getAsDouble(), p1.getAsDouble());
-                    }
-                })
                 .build();
-        priceColumnHolder[0] = priceColumn;
+        priceColumn.setComparator((o1, o2) -> {
+            OptionalDouble p1 = o1.getPriceSpecAsPercent();
+            OptionalDouble p2 = o2.getPriceSpecAsPercent();
+            if (p1.isEmpty() || p2.isEmpty()) {
+                // An offer without a resolvable percentage sorts after known ones, in
+                // both sort directions. JavaFX reverses the comparator's result for a
+                // descending sort, so the empty ordering is pre-inverted there to keep
+                // empties last either way.
+                if (p1.isEmpty() == p2.isEmpty()) {
+                    return 0;
+                }
+                int emptyLast = p1.isEmpty() ? 1 : -1;
+                return isDescending(priceColumn) ? -emptyLast : emptyLast;
+            }
+            if (o1.getBisqEasyOffer().getDirection().isSell()) {
+                return Double.compare(p1.getAsDouble(), p2.getAsDouble());
+            } else {
+                return Double.compare(p2.getAsDouble(), p1.getAsDouble());
+            }
+        });
         tableView.getColumns().add(priceColumn);
         tableView.getSortOrder().add(priceColumn);
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
@@ -58,6 +58,7 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
 import java.util.Comparator;
+import java.util.OptionalDouble;
 import java.util.Optional;
 
 @Slf4j
@@ -403,19 +404,34 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
         tableView.getColumns().add(userProfileColumn);
         tableView.getSortOrder().add(userProfileColumn);
 
+        BisqTableColumn<OfferbookListItem>[] priceColumnHolder = new BisqTableColumn[1];
         BisqTableColumn<OfferbookListItem> priceColumn = new BisqTableColumn.Builder<OfferbookListItem>()
                 .title(Res.get("bisqEasy.offerbook.offerList.table.columns.price"))
                 .right()
                 .minWidth(75)
                 .setCellFactory(getPriceCellFactory())
                 .comparator((o1, o2) -> {
+                    OptionalDouble p1 = o1.getPriceSpecAsPercent();
+                    OptionalDouble p2 = o2.getPriceSpecAsPercent();
+                    if (p1.isEmpty() || p2.isEmpty()) {
+                        // An offer without a resolvable percentage sorts after known ones, in
+                        // both sort directions. JavaFX reverses the comparator's result for a
+                        // descending sort, so the empty ordering is pre-inverted there to keep
+                        // empties last either way.
+                        if (p1.isEmpty() == p2.isEmpty()) {
+                            return 0;
+                        }
+                        int emptyLast = p1.isEmpty() ? 1 : -1;
+                        return isDescending(priceColumnHolder[0]) ? -emptyLast : emptyLast;
+                    }
                     if (o1.getBisqEasyOffer().getDirection().isSell()) {
-                        return Double.compare(o1.getPriceSpecAsPercent(), o2.getPriceSpecAsPercent());
+                        return Double.compare(p1.getAsDouble(), p2.getAsDouble());
                     } else {
-                        return Double.compare(o2.getPriceSpecAsPercent(), o1.getPriceSpecAsPercent());
+                        return Double.compare(p2.getAsDouble(), p1.getAsDouble());
                     }
                 })
                 .build();
+        priceColumnHolder[0] = priceColumn;
         tableView.getColumns().add(priceColumn);
         tableView.getSortOrder().add(priceColumn);
 
@@ -442,6 +458,10 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
                 .setCellFactory(getSettlementCellFactory())
                 .comparator(Comparator.comparing(OfferbookListItem::getBitcoinPaymentMethodsAsString))
                 .build());
+    }
+
+    private static boolean isDescending(TableColumn<?, ?> column) {
+        return column != null && column.getSortType() == TableColumn.SortType.DESCENDING;
     }
 
     private Callback<TableColumn<OfferbookListItem, OfferbookListItem>,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListView.java
@@ -479,13 +479,17 @@ public class OfferbookListView extends bisq.desktop.common.view.View<VBox, Offer
                 super.updateItem(item, empty);
 
                 if (item != null && !empty) {
-                    percentagePriceLabel.setText(item.getFormattedPercentagePrice());
+                    // Bound, not copied: the item updates the properties when a market price
+                    // arrives or changes, and the visible cell has to follow.
+                    percentagePriceLabel.textProperty().bind(item.getFormattedPercentagePrice());
                     percentagePriceLabel.setStyle(item.isFixPrice() ? "-fx-text-fill: -bisq2-green-lit-20" : "");
-                    tooltip.setText(item.getPriceTooltipText());
+                    tooltip.textProperty().bind(item.getPriceTooltipText());
                     percentagePriceLabel.setTooltip(tooltip);
                     setGraphic(percentagePriceLabel);
                 } else {
+                    percentagePriceLabel.textProperty().unbind();
                     percentagePriceLabel.setText("");
+                    tooltip.textProperty().unbind();
                     percentagePriceLabel.setTooltip(null);
                     setGraphic(null);
                 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
@@ -48,7 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.OptionalDouble;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -78,7 +78,7 @@ public class ProfileCardOfferListItem {
     // Empty while the offer has no resolvable percentage (a fixed-price offer without a
     // market price yet); comparators place these after known values instead of treating
     // them as an exactly-at-market 0%.
-    private OptionalDouble priceSpecAsPercent = OptionalDouble.empty();
+    private Optional<Double> priceSpecAsPercent = Optional.empty();
 
     public ProfileCardOfferListItem(BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                                     UserProfile senderUserProfile,
@@ -130,7 +130,7 @@ public class ProfileCardOfferListItem {
         // price arrives; the table cells bind to them so visible rows follow.
         PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
                 .ifPresent(percent -> {
-                    priceSpecAsPercent = OptionalDouble.of(percent);
+                    priceSpecAsPercent = Optional.of(percent);
                     formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
                     priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
                 });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
@@ -48,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -72,7 +73,10 @@ public class ProfileCardOfferListItem {
     private final long totalScore;
     private final Pin marketPriceByCurrencyMapPin;
     private final long offerAgeInDays;
-    private double priceSpecAsPercent;
+    // Empty while the offer has no resolvable percentage (a fixed-price offer without a
+    // market price yet); comparators place these after known values instead of treating
+    // them as an exactly-at-market 0%.
+    private OptionalDouble priceSpecAsPercent = OptionalDouble.empty();
     private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
     private final StringProperty priceTooltipText = new SimpleStringProperty();
 
@@ -126,7 +130,7 @@ public class ProfileCardOfferListItem {
         // price arrives; the table cells bind to them so visible rows follow.
         PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
                 .ifPresent(percent -> {
-                    priceSpecAsPercent = percent;
+                    priceSpecAsPercent = OptionalDouble.of(percent);
                     formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
                     priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
                 });

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
@@ -125,15 +125,13 @@ public class ProfileCardOfferListItem {
     }
 
     private void updatePriceSpecAsPercent() {
-        // A fixed-price offer in a market without a market price has no percent to derive;
-        // the properties keep their previous values and refresh through the observer once a
-        // price arrives; the table cells bind to them so visible rows follow.
-        PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
-                .ifPresent(percent -> {
-                    priceSpecAsPercent = Optional.of(percent);
-                    formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
-                    priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
-                });
+        // A fixed-price offer in a market without a market price has no percent to derive; the
+        // table cells bind to the properties, so visible rows follow once a price arrives.
+        priceSpecAsPercent = PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer);
+        formattedPercentagePrice.set(priceSpecAsPercent
+                .map(PercentageFormatter::formatToPercentWithSignAndSymbol)
+                .orElseGet(() -> Res.get("data.na")));
+        priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
     }
 
     private List<FiatPaymentMethod> retrieveAndSortFiatPaymentMethods() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
@@ -40,6 +40,8 @@ import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
 import com.google.common.base.Joiner;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +73,8 @@ public class ProfileCardOfferListItem {
     private final Pin marketPriceByCurrencyMapPin;
     private final long offerAgeInDays;
     private double priceSpecAsPercent;
-    private String formattedPercentagePrice, priceTooltipText;
+    private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
+    private final StringProperty priceTooltipText = new SimpleStringProperty();
 
     public ProfileCardOfferListItem(BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                                     UserProfile senderUserProfile,
@@ -118,9 +121,15 @@ public class ProfileCardOfferListItem {
     }
 
     private void updatePriceSpecAsPercent() {
-        priceSpecAsPercent = PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer).orElseThrow();
-        formattedPercentagePrice = PercentageFormatter.formatToPercentWithSignAndSymbol(priceSpecAsPercent);
-        priceTooltipText = PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer);
+        // A fixed-price offer in a market without a market price has no percent to derive;
+        // the properties keep their previous values and refresh through the observer once a
+        // price arrives; the table cells bind to them so visible rows follow.
+        PriceUtil.findPercentFromMarketPrice(marketPriceService, bisqEasyOffer)
+                .ifPresent(percent -> {
+                    priceSpecAsPercent = percent;
+                    formattedPercentagePrice.set(PercentageFormatter.formatToPercentWithSignAndSymbol(percent));
+                    priceTooltipText.set(PriceSpecFormatter.getFormattedPriceSpecWithOfferPrice(bisqEasyOffer.getPriceSpec(), marketPriceService, bisqEasyOffer));
+                });
     }
 
     private List<FiatPaymentMethod> retrieveAndSortFiatPaymentMethods() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItem.java
@@ -73,12 +73,12 @@ public class ProfileCardOfferListItem {
     private final long totalScore;
     private final Pin marketPriceByCurrencyMapPin;
     private final long offerAgeInDays;
+    private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
+    private final StringProperty priceTooltipText = new SimpleStringProperty();
     // Empty while the offer has no resolvable percentage (a fixed-price offer without a
     // market price yet); comparators place these after known values instead of treating
     // them as an exactly-at-market 0%.
     private OptionalDouble priceSpecAsPercent = OptionalDouble.empty();
-    private final StringProperty formattedPercentagePrice = new SimpleStringProperty();
-    private final StringProperty priceTooltipText = new SimpleStringProperty();
 
     public ProfileCardOfferListItem(BisqEasyOfferbookMessage bisqEasyOfferbookMessage,
                                     UserProfile senderUserProfile,

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersController.java
@@ -29,8 +29,10 @@ import bisq.desktop.common.view.Navigation;
 import bisq.desktop.overlay.OverlayController;
 import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationService;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ProfileCardOffersController implements Controller {
@@ -55,18 +57,37 @@ public class ProfileCardOffersController implements Controller {
 
     @Override
     public void onActivate() {
+        // The controller is cached: rows disposed at the last deactivation are rebuilt so their
+        // market price observers are live again.
+        model.getUserProfile().ifPresent(this::applyOffers);
     }
 
     @Override
     public void onDeactivate() {
-        model.getOfferbookListItems().forEach(ProfileCardOfferListItem::dispose);
+        disposeAndClearOffers();
+    }
+
+    @VisibleForTesting
+    ProfileCardOffersModel getModel() {
+        return model;
     }
 
     public void setUserProfile(UserProfile userProfile) {
+        model.setUserProfile(Optional.of(userProfile));
+        applyOffers(userProfile);
+    }
+
+    private void applyOffers(UserProfile userProfile) {
+        disposeAndClearOffers();
         model.getOfferbookListItems().setAll(bisqEasyOfferbookMessageService.getAllOfferbookMessagesWithOffer(userProfile.getId())
                 .map(userChatMessageWithOffer -> new ProfileCardOfferListItem(
                         userChatMessageWithOffer, userProfile, reputationService, marketPriceService))
                 .collect(Collectors.toList()));
+    }
+
+    private void disposeAndClearOffers() {
+        model.getOfferbookListItems().forEach(ProfileCardOfferListItem::dispose);
+        model.getOfferbookListItems().clear();
     }
 
     public String getNumberOffers() {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersModel.java
@@ -26,5 +26,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 public class ProfileCardOffersModel implements Model {
-    private final ObservableList<ProfileCardOfferListItem> offerbookListItems = FXCollections.observableArrayList();
+    // Extractor on the formatted percentage: it is set together with the sortable
+    // percentage, so a market price that resolves a previously empty percentage emits a
+    // list-update event and the SortedList re-sorts the row to its new position.
+    private final ObservableList<ProfileCardOfferListItem> offerbookListItems =
+            FXCollections.observableArrayList(item -> new javafx.beans.Observable[]{item.getFormattedPercentagePrice()});
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersModel.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.content.user.profile_card.offers;
 
 import bisq.desktop.common.view.Model;
+import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import lombok.Getter;
@@ -30,5 +31,5 @@ public class ProfileCardOffersModel implements Model {
     // percentage, so a market price that resolves a previously empty percentage emits a
     // list-update event and the SortedList re-sorts the row to its new position.
     private final ObservableList<ProfileCardOfferListItem> offerbookListItems =
-            FXCollections.observableArrayList(item -> new javafx.beans.Observable[]{item.getFormattedPercentagePrice()});
+            FXCollections.observableArrayList(item -> new Observable[]{item.getFormattedPercentagePrice()});
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersModel.java
@@ -18,15 +18,21 @@
 package bisq.desktop.main.content.user.profile_card.offers;
 
 import bisq.desktop.common.view.Model;
+import bisq.user.profile.UserProfile;
 import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
 
 @Slf4j
 @Getter
 public class ProfileCardOffersModel implements Model {
+    @Setter
+    private Optional<UserProfile> userProfile = Optional.empty();
     // Extractor on the formatted percentage: it is set together with the sortable
     // percentage, so a market price that resolves a previously empty percentage emits a
     // list-update event and the SortedList re-sorts the row to its new position.

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
@@ -26,6 +26,7 @@ import bisq.desktop.main.content.bisq_easy.BisqEasyViewUtils;
 import bisq.desktop.main.content.components.MarketImageComposition;
 import bisq.desktop.main.content.user.profile_card.ProfileCardView;
 import bisq.i18n.Res;
+import com.google.common.annotations.VisibleForTesting;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.CacheHint;
@@ -107,15 +108,13 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
                 .valueSupplier(ProfileCardOfferListItem::getFormattedRangeQuoteAmount)
                 .build());
 
-        BisqTableColumn<ProfileCardOfferListItem>[] priceColumnHolder = new BisqTableColumn[1];
         BisqTableColumn<ProfileCardOfferListItem> priceColumn = new BisqTableColumn.Builder<ProfileCardOfferListItem>()
                 .title(Res.get("user.profileCard.offers.table.columns.price"))
                 .right()
                 .minWidth(90)
-                .comparator(priceComparator(() -> priceColumnHolder[0]))
                 .setCellFactory(getPriceCellFactory())
                 .build();
-        priceColumnHolder[0] = priceColumn;
+        priceColumn.setComparator(priceComparator(priceColumn));
         tableView.getColumns().add(priceColumn);
 
         tableView.getColumns().add(new BisqTableColumn.Builder<ProfileCardOfferListItem>()
@@ -140,8 +139,8 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
     // Places offers with an unresolved percentage after those with a known one, in both sort
     // directions. JavaFX reverses the comparator result for a descending column, so the empty
     // ordering is pre-inverted for that case to stay last either way.
-    static java.util.Comparator<ProfileCardOfferListItem> priceComparator(
-            java.util.function.Supplier<TableColumn<?, ?>> columnSupplier) {
+    @VisibleForTesting
+    static Comparator<ProfileCardOfferListItem> priceComparator(TableColumn<?, ?> column) {
         return (o1, o2) -> {
             OptionalDouble p1 = o1.getPriceSpecAsPercent();
             OptionalDouble p2 = o2.getPriceSpecAsPercent();
@@ -150,7 +149,7 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
                     return 0;
                 }
                 int emptyLast = p1.isEmpty() ? 1 : -1;
-                return isDescending(columnSupplier.get()) ? -emptyLast : emptyLast;
+                return isDescending(column) ? -emptyLast : emptyLast;
             }
             return Double.compare(p1.getAsDouble(), p2.getAsDouble());
         };

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
@@ -195,12 +195,16 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
                 super.updateItem(item, empty);
 
                 if (item != null && !empty) {
-                    tooltip.setText(item.getPriceTooltipText());
-                    percentagePriceLabel.setText(item.getFormattedPercentagePrice());
+                    // Bound, not copied: the item updates the properties when a market price
+                    // arrives or changes, and the visible cell has to follow.
+                    tooltip.textProperty().bind(item.getPriceTooltipText());
+                    percentagePriceLabel.textProperty().bind(item.getFormattedPercentagePrice());
                     percentagePriceLabel.setTooltip(tooltip);
                     setGraphic(percentagePriceLabel);
                 } else {
+                    percentagePriceLabel.textProperty().unbind();
                     percentagePriceLabel.setText("");
+                    tooltip.textProperty().unbind();
                     percentagePriceLabel.setTooltip(null);
                     setGraphic(null);
                 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
@@ -40,7 +40,7 @@ import javafx.util.Callback;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
-import java.util.OptionalDouble;
+import java.util.Optional;
 
 @Slf4j
 public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, ProfileCardOffersController> {
@@ -142,8 +142,8 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
     @VisibleForTesting
     static Comparator<ProfileCardOfferListItem> priceComparator(TableColumn<?, ?> column) {
         return (o1, o2) -> {
-            OptionalDouble p1 = o1.getPriceSpecAsPercent();
-            OptionalDouble p2 = o2.getPriceSpecAsPercent();
+            Optional<Double> p1 = o1.getPriceSpecAsPercent();
+            Optional<Double> p2 = o2.getPriceSpecAsPercent();
             if (p1.isEmpty() || p2.isEmpty()) {
                 if (p1.isEmpty() == p2.isEmpty()) {
                     return 0;
@@ -151,7 +151,7 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
                 int emptyLast = p1.isEmpty() ? 1 : -1;
                 return isDescending(column) ? -emptyLast : emptyLast;
             }
-            return Double.compare(p1.getAsDouble(), p2.getAsDouble());
+            return Double.compare(p1.get(), p2.get());
         };
     }
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersView.java
@@ -39,6 +39,7 @@ import javafx.util.Callback;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
+import java.util.OptionalDouble;
 
 @Slf4j
 public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, ProfileCardOffersController> {
@@ -106,13 +107,16 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
                 .valueSupplier(ProfileCardOfferListItem::getFormattedRangeQuoteAmount)
                 .build());
 
-        tableView.getColumns().add(new BisqTableColumn.Builder<ProfileCardOfferListItem>()
+        BisqTableColumn<ProfileCardOfferListItem>[] priceColumnHolder = new BisqTableColumn[1];
+        BisqTableColumn<ProfileCardOfferListItem> priceColumn = new BisqTableColumn.Builder<ProfileCardOfferListItem>()
                 .title(Res.get("user.profileCard.offers.table.columns.price"))
                 .right()
                 .minWidth(90)
-                .comparator(Comparator.comparing(ProfileCardOfferListItem::getPriceSpecAsPercent))
+                .comparator(priceComparator(() -> priceColumnHolder[0]))
                 .setCellFactory(getPriceCellFactory())
-                .build());
+                .build();
+        priceColumnHolder[0] = priceColumn;
+        tableView.getColumns().add(priceColumn);
 
         tableView.getColumns().add(new BisqTableColumn.Builder<ProfileCardOfferListItem>()
                 .title(Res.get("user.profileCard.offers.table.columns.paymentMethods"))
@@ -127,6 +131,29 @@ public class ProfileCardOffersView extends View<VBox, ProfileCardOffersModel, Pr
                 .isSortable(false)
                 .setCellFactory(getGotToOfferCellFactory())
                 .build());
+    }
+
+    private static boolean isDescending(TableColumn<?, ?> column) {
+        return column != null && column.getSortType() == TableColumn.SortType.DESCENDING;
+    }
+
+    // Places offers with an unresolved percentage after those with a known one, in both sort
+    // directions. JavaFX reverses the comparator result for a descending column, so the empty
+    // ordering is pre-inverted for that case to stay last either way.
+    static java.util.Comparator<ProfileCardOfferListItem> priceComparator(
+            java.util.function.Supplier<TableColumn<?, ?>> columnSupplier) {
+        return (o1, o2) -> {
+            OptionalDouble p1 = o1.getPriceSpecAsPercent();
+            OptionalDouble p2 = o2.getPriceSpecAsPercent();
+            if (p1.isEmpty() || p2.isEmpty()) {
+                if (p1.isEmpty() == p2.isEmpty()) {
+                    return 0;
+                }
+                int emptyLast = p1.isEmpty() ? 1 : -1;
+                return isDescending(columnSupplier.get()) ? -emptyLast : emptyLast;
+            }
+            return Double.compare(p1.getAsDouble(), p2.getAsDouble());
+        };
     }
 
     private Callback<TableColumn<ProfileCardOfferListItem, ProfileCardOfferListItem>,

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
@@ -26,6 +26,7 @@ import bisq.common.observable.map.ObservableHashMap;
 import bisq.desktop.testutil.TestFxHeadlessSupport;
 import bisq.i18n.Res;
 import bisq.offer.Direction;
+import bisq.presentation.formatters.PercentageFormatter;
 import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.offer.price.spec.FixPriceSpec;
@@ -105,7 +106,8 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(item.getPriceSpecAsPercent()).hasValue(0.25);
-        assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
+        assertThat(item.getFormattedPercentagePrice().get())
+                .isEqualTo(PercentageFormatter.formatToPercentWithSignAndSymbol(0.25));
         assertThat(boundLabel.getText()).isEqualTo(item.getFormattedPercentagePrice().get());
         item.dispose();
     }
@@ -119,7 +121,8 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
         OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
 
         assertThat(item.getPriceSpecAsPercent()).hasValue(0.25);
-        assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
+        assertThat(item.getFormattedPercentagePrice().get())
+                .isEqualTo(PercentageFormatter.formatToPercentWithSignAndSymbol(0.25));
         item.dispose();
     }
 }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
@@ -24,6 +24,7 @@ import bisq.common.market.Market;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.i18n.Res;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
@@ -86,7 +87,8 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
         OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
 
         assertThat(item.getPriceSpecAsPercent()).isEmpty();
-        assertThat(item.getFormattedPercentagePrice().get()).isNull();
+        assertThat(item.getFormattedPercentagePrice().get()).isEqualTo(Res.get("data.na"));
+        assertThat(item.getPriceTooltipText().get()).contains("50000");
         item.dispose();
     }
 

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.bisq_easy.offerbook.offerbook_list;
+
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.user.profile.UserProfile;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+import javafx.scene.control.Label;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+class OfferbookListItemTest extends TestFxHeadlessSupport {
+    private static final Market MARKET = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+    private BisqEasyOfferbookMessage message;
+    private UserProfile senderUserProfile;
+    private ReputationService reputationService;
+    private MarketPriceService marketPriceService;
+
+    @BeforeEach
+    void setUp() {
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getQuoteSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getBaseSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getAmountSpec()).thenReturn(new QuoteSideFixedAmountSpec(40_000_000L));
+        when(offer.getPriceSpec()).thenReturn(new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")));
+        when(offer.getDirection()).thenReturn(Direction.BUY);
+        when(offer.getDate()).thenReturn(1_700_000_000_000L);
+
+        message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        when(message.getAuthorUserProfileId()).thenReturn("authorProfileId");
+
+        senderUserProfile = mock(UserProfile.class);
+        when(senderUserProfile.getNickName()).thenReturn("alice");
+
+        reputationService = mock(ReputationService.class);
+        when(reputationService.getReputationScore(senderUserProfile)).thenReturn(ReputationScore.NONE);
+
+        marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.empty());
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+    }
+
+    @Test
+    void fixedPriceOfferInMarketWithoutPriceConstructsWithoutPercent() {
+        OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
+
+        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.0);
+        assertThat(item.getFormattedPercentagePrice().get()).isNull();
+        item.dispose();
+    }
+
+    @Test
+    void percentAppearsWhenMarketPriceArrives() {
+        OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
+        Label boundLabel = new Label();
+        boundLabel.textProperty().bind(item.getFormattedPercentagePrice());
+
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(40_000, "USD"));
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.of(marketPrice));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.25);
+        assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
+        assertThat(boundLabel.getText()).isEqualTo(item.getFormattedPercentagePrice().get());
+        item.dispose();
+    }
+
+    @Test
+    void marketPricePresentAtConstructionSetsPercent() {
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(40_000, "USD"));
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.of(marketPrice));
+
+        OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
+
+        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.25);
+        assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
+        item.dispose();
+    }
+}

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/bisq_easy/offerbook/offerbook_list/OfferbookListItemTest.java
@@ -85,7 +85,7 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
     void fixedPriceOfferInMarketWithoutPriceConstructsWithoutPercent() {
         OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
 
-        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.0);
+        assertThat(item.getPriceSpecAsPercent()).isEmpty();
         assertThat(item.getFormattedPercentagePrice().get()).isNull();
         item.dispose();
     }
@@ -102,7 +102,7 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
         marketPriceByCurrencyMap.put(MARKET, marketPrice);
         WaitForAsyncUtils.waitForFxEvents();
 
-        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.25);
+        assertThat(item.getPriceSpecAsPercent()).hasValue(0.25);
         assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
         assertThat(boundLabel.getText()).isEqualTo(item.getFormattedPercentagePrice().get());
         item.dispose();
@@ -116,7 +116,7 @@ class OfferbookListItemTest extends TestFxHeadlessSupport {
 
         OfferbookListItem item = new OfferbookListItem(message, senderUserProfile, reputationService, marketPriceService);
 
-        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.25);
+        assertThat(item.getPriceSpecAsPercent()).hasValue(0.25);
         assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
         item.dispose();
     }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
@@ -85,7 +85,7 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
     void fixedPriceOfferInMarketWithoutPriceConstructsWithoutPercent() {
         ProfileCardOfferListItem item = new ProfileCardOfferListItem(message, senderUserProfile, reputationService, marketPriceService);
 
-        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.0);
+        assertThat(item.getPriceSpecAsPercent()).isEmpty();
         assertThat(item.getFormattedPercentagePrice().get()).isNull();
         item.dispose();
     }
@@ -102,9 +102,105 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
         marketPriceByCurrencyMap.put(MARKET, marketPrice);
         WaitForAsyncUtils.waitForFxEvents();
 
-        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.25);
+        assertThat(item.getPriceSpecAsPercent()).hasValue(0.25);
         assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
         assertThat(boundLabel.getText()).isEqualTo(item.getFormattedPercentagePrice().get());
         item.dispose();
+    }
+
+    @Test
+    void emptyPercentagesSortLastInBothDirections() {
+        ProfileCardOfferListItem atMarket = itemWithMarketPrice(50_000.0); // 0%
+        ProfileCardOfferListItem plus25 = itemWithMarketPrice(40_000.0);   // +25%
+        ProfileCardOfferListItem noPrice = itemWithMarketPrice(null);      // empty
+
+        javafx.scene.control.TableColumn<ProfileCardOfferListItem, ?> column = new javafx.scene.control.TableColumn<>();
+        java.util.Comparator<ProfileCardOfferListItem> comparator =
+                bisq.desktop.main.content.user.profile_card.offers.ProfileCardOffersView.priceComparator(() -> column);
+
+        column.setSortType(javafx.scene.control.TableColumn.SortType.ASCENDING);
+        assertThat(sortAsJavaFx(List.of(noPrice, plus25, atMarket), comparator, column))
+                .containsExactly(atMarket, plus25, noPrice);
+
+        column.setSortType(javafx.scene.control.TableColumn.SortType.DESCENDING);
+        assertThat(sortAsJavaFx(List.of(noPrice, atMarket, plus25), comparator, column))
+                .containsExactly(plus25, atMarket, noPrice);
+
+        atMarket.dispose();
+        plus25.dispose();
+        noPrice.dispose();
+    }
+
+    @Test
+    void resolvingAPercentageReSortsTheRow() {
+        ProfileCardOffersModel model = new ProfileCardOffersModel();
+        ObservableHashMap<Market, MarketPrice> priceMap = new ObservableHashMap<>();
+        MarketPriceService priceService = mock(MarketPriceService.class);
+        when(priceService.findMarketPrice(MARKET)).thenReturn(Optional.empty());
+        when(priceService.getMarketPriceByCurrencyMap()).thenReturn(priceMap);
+
+        ProfileCardOfferListItem known = itemWithMarketPrice(40_000.0); // +25%
+        ProfileCardOfferListItem resolving = new ProfileCardOfferListItem(
+                messageWithFixedPrice(50_000), senderUserProfile, reputationService, priceService);
+        model.getOfferbookListItems().addAll(known, resolving);
+
+        javafx.scene.control.TableColumn<ProfileCardOfferListItem, ?> column = new javafx.scene.control.TableColumn<>();
+        column.setSortType(javafx.scene.control.TableColumn.SortType.ASCENDING);
+        javafx.collections.transformation.SortedList<ProfileCardOfferListItem> sorted =
+                new javafx.collections.transformation.SortedList<>(model.getOfferbookListItems());
+        sorted.setComparator((o1, o2) -> bisq.desktop.main.content.user.profile_card.offers.ProfileCardOffersView
+                .priceComparator(() -> column).compare(o1, o2));
+
+        // Empty percentage sorts last initially.
+        assertThat(sorted).containsExactly(known, resolving);
+
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(100_000, "USD")); // -50%
+        when(priceService.findMarketPrice(MARKET)).thenReturn(Optional.of(marketPrice));
+        priceMap.put(MARKET, marketPrice);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Once the percentage resolves to -50% it moves ahead of the +25% row.
+        assertThat(sorted).containsExactly(resolving, known);
+
+        known.dispose();
+        resolving.dispose();
+    }
+
+    private static List<ProfileCardOfferListItem> sortAsJavaFx(List<ProfileCardOfferListItem> items,
+                                                               java.util.Comparator<ProfileCardOfferListItem> comparator,
+                                                               javafx.scene.control.TableColumn<?, ?> column) {
+        // Mirrors JavaFX TableColumnComparator: a descending column reverses the comparator result.
+        boolean descending = column.getSortType() == javafx.scene.control.TableColumn.SortType.DESCENDING;
+        java.util.Comparator<ProfileCardOfferListItem> effective = descending ? comparator.reversed() : comparator;
+        return items.stream().sorted(effective).collect(java.util.stream.Collectors.toList());
+    }
+
+    private ProfileCardOfferListItem itemWithMarketPrice(Double marketPriceValue) {
+        MarketPriceService priceService = mock(MarketPriceService.class);
+        when(priceService.getMarketPriceByCurrencyMap()).thenReturn(new ObservableHashMap<>());
+        if (marketPriceValue == null) {
+            when(priceService.findMarketPrice(MARKET)).thenReturn(Optional.empty());
+        } else {
+            MarketPrice marketPrice = mock(MarketPrice.class);
+            when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(marketPriceValue, "USD"));
+            when(priceService.findMarketPrice(MARKET)).thenReturn(Optional.of(marketPrice));
+        }
+        return new ProfileCardOfferListItem(messageWithFixedPrice(50_000), senderUserProfile, reputationService, priceService);
+    }
+
+    private BisqEasyOfferbookMessage messageWithFixedPrice(double fixedPrice) {
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getQuoteSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getBaseSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getAmountSpec()).thenReturn(new QuoteSideFixedAmountSpec(40_000_000L));
+        when(offer.getPriceSpec()).thenReturn(new FixPriceSpec(PriceQuote.fromFiatPrice(fixedPrice, "USD")));
+        when(offer.getDisplayDirection()).thenReturn(Direction.BUY);
+        when(offer.getDate()).thenReturn(1_700_000_000_000L);
+        BisqEasyOfferbookMessage msg = mock(BisqEasyOfferbookMessage.class);
+        when(msg.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        when(msg.getAuthorUserProfileId()).thenReturn("authorProfileId");
+        return msg;
     }
 }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.user.profile_card.offers;
+
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.user.profile.UserProfile;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+import javafx.scene.control.Label;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
+    private static final Market MARKET = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+    private BisqEasyOfferbookMessage message;
+    private UserProfile senderUserProfile;
+    private ReputationService reputationService;
+    private MarketPriceService marketPriceService;
+
+    @BeforeEach
+    void setUp() {
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getQuoteSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getBaseSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getAmountSpec()).thenReturn(new QuoteSideFixedAmountSpec(40_000_000L));
+        when(offer.getPriceSpec()).thenReturn(new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")));
+        when(offer.getDisplayDirection()).thenReturn(Direction.BUY);
+        when(offer.getDate()).thenReturn(1_700_000_000_000L);
+
+        message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        when(message.getAuthorUserProfileId()).thenReturn("authorProfileId");
+
+        senderUserProfile = mock(UserProfile.class);
+        when(senderUserProfile.getNickName()).thenReturn("alice");
+
+        reputationService = mock(ReputationService.class);
+        when(reputationService.getReputationScore(senderUserProfile)).thenReturn(ReputationScore.NONE);
+
+        marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.empty());
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+    }
+
+    @Test
+    void fixedPriceOfferInMarketWithoutPriceConstructsWithoutPercent() {
+        ProfileCardOfferListItem item = new ProfileCardOfferListItem(message, senderUserProfile, reputationService, marketPriceService);
+
+        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.0);
+        assertThat(item.getFormattedPercentagePrice().get()).isNull();
+        item.dispose();
+    }
+
+    @Test
+    void percentAppearsWhenMarketPriceArrives() {
+        ProfileCardOfferListItem item = new ProfileCardOfferListItem(message, senderUserProfile, reputationService, marketPriceService);
+        Label boundLabel = new Label();
+        boundLabel.textProperty().bind(item.getFormattedPercentagePrice());
+
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(40_000, "USD"));
+        when(marketPriceService.findMarketPrice(MARKET)).thenReturn(Optional.of(marketPrice));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(item.getPriceSpecAsPercent()).isEqualTo(0.25);
+        assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
+        assertThat(boundLabel.getText()).isEqualTo(item.getFormattedPercentagePrice().get());
+        item.dispose();
+    }
+}

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
@@ -26,6 +26,7 @@ import bisq.common.observable.map.ObservableHashMap;
 import bisq.desktop.testutil.TestFxHeadlessSupport;
 import bisq.i18n.Res;
 import bisq.offer.Direction;
+import bisq.presentation.formatters.PercentageFormatter;
 import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
 import bisq.offer.price.spec.FixPriceSpec;
@@ -109,7 +110,8 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
         WaitForAsyncUtils.waitForFxEvents();
 
         assertThat(item.getPriceSpecAsPercent()).hasValue(0.25);
-        assertThat(item.getFormattedPercentagePrice().get()).isNotNull();
+        assertThat(item.getFormattedPercentagePrice().get())
+                .isEqualTo(PercentageFormatter.formatToPercentWithSignAndSymbol(0.25));
         assertThat(boundLabel.getText()).isEqualTo(item.getFormattedPercentagePrice().get());
         item.dispose();
     }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
@@ -24,6 +24,7 @@ import bisq.common.market.Market;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.i18n.Res;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
@@ -90,7 +91,8 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
         ProfileCardOfferListItem item = new ProfileCardOfferListItem(message, senderUserProfile, reputationService, marketPriceService);
 
         assertThat(item.getPriceSpecAsPercent()).isEmpty();
-        assertThat(item.getFormattedPercentagePrice().get()).isNull();
+        assertThat(item.getFormattedPercentagePrice().get()).isEqualTo(Res.get("data.na"));
+        assertThat(item.getPriceTooltipText().get()).contains("50000");
         item.dispose();
     }
 

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOfferListItemTest.java
@@ -31,15 +31,19 @@ import bisq.offer.price.spec.FixPriceSpec;
 import bisq.user.profile.UserProfile;
 import bisq.user.reputation.ReputationScore;
 import bisq.user.reputation.ReputationService;
+import javafx.collections.transformation.SortedList;
 import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -114,15 +118,14 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
         ProfileCardOfferListItem plus25 = itemWithMarketPrice(40_000.0);   // +25%
         ProfileCardOfferListItem noPrice = itemWithMarketPrice(null);      // empty
 
-        javafx.scene.control.TableColumn<ProfileCardOfferListItem, ?> column = new javafx.scene.control.TableColumn<>();
-        java.util.Comparator<ProfileCardOfferListItem> comparator =
-                bisq.desktop.main.content.user.profile_card.offers.ProfileCardOffersView.priceComparator(() -> column);
+        TableColumn<ProfileCardOfferListItem, ?> column = new TableColumn<>();
+        Comparator<ProfileCardOfferListItem> comparator = ProfileCardOffersView.priceComparator(column);
 
-        column.setSortType(javafx.scene.control.TableColumn.SortType.ASCENDING);
+        column.setSortType(TableColumn.SortType.ASCENDING);
         assertThat(sortAsJavaFx(List.of(noPrice, plus25, atMarket), comparator, column))
                 .containsExactly(atMarket, plus25, noPrice);
 
-        column.setSortType(javafx.scene.control.TableColumn.SortType.DESCENDING);
+        column.setSortType(TableColumn.SortType.DESCENDING);
         assertThat(sortAsJavaFx(List.of(noPrice, atMarket, plus25), comparator, column))
                 .containsExactly(plus25, atMarket, noPrice);
 
@@ -144,12 +147,10 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
                 messageWithFixedPrice(50_000), senderUserProfile, reputationService, priceService);
         model.getOfferbookListItems().addAll(known, resolving);
 
-        javafx.scene.control.TableColumn<ProfileCardOfferListItem, ?> column = new javafx.scene.control.TableColumn<>();
-        column.setSortType(javafx.scene.control.TableColumn.SortType.ASCENDING);
-        javafx.collections.transformation.SortedList<ProfileCardOfferListItem> sorted =
-                new javafx.collections.transformation.SortedList<>(model.getOfferbookListItems());
-        sorted.setComparator((o1, o2) -> bisq.desktop.main.content.user.profile_card.offers.ProfileCardOffersView
-                .priceComparator(() -> column).compare(o1, o2));
+        TableColumn<ProfileCardOfferListItem, ?> column = new TableColumn<>();
+        column.setSortType(TableColumn.SortType.ASCENDING);
+        SortedList<ProfileCardOfferListItem> sorted = new SortedList<>(model.getOfferbookListItems());
+        sorted.setComparator(ProfileCardOffersView.priceComparator(column));
 
         // Empty percentage sorts last initially.
         assertThat(sorted).containsExactly(known, resolving);
@@ -168,12 +169,12 @@ class ProfileCardOfferListItemTest extends TestFxHeadlessSupport {
     }
 
     private static List<ProfileCardOfferListItem> sortAsJavaFx(List<ProfileCardOfferListItem> items,
-                                                               java.util.Comparator<ProfileCardOfferListItem> comparator,
-                                                               javafx.scene.control.TableColumn<?, ?> column) {
+                                                               Comparator<ProfileCardOfferListItem> comparator,
+                                                               TableColumn<?, ?> column) {
         // Mirrors JavaFX TableColumnComparator: a descending column reverses the comparator result.
-        boolean descending = column.getSortType() == javafx.scene.control.TableColumn.SortType.DESCENDING;
-        java.util.Comparator<ProfileCardOfferListItem> effective = descending ? comparator.reversed() : comparator;
-        return items.stream().sorted(effective).collect(java.util.stream.Collectors.toList());
+        boolean descending = column.getSortType() == TableColumn.SortType.DESCENDING;
+        Comparator<ProfileCardOfferListItem> effective = descending ? comparator.reversed() : comparator;
+        return items.stream().sorted(effective).collect(Collectors.toList());
     }
 
     private ProfileCardOfferListItem itemWithMarketPrice(Double marketPriceValue) {

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/offers/ProfileCardOffersControllerTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.user.profile_card.offers;
+
+import bisq.bisq_easy.BisqEasyOfferbookMessageService;
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
+import bisq.common.market.Market;
+import bisq.common.observable.map.ObservableHashMap;
+import bisq.desktop.ServiceProvider;
+import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.i18n.Res;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.QuoteSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.common.monetary.PriceQuote;
+import bisq.presentation.formatters.PercentageFormatter;
+import bisq.user.profile.UserProfile;
+import bisq.user.reputation.ReputationScore;
+import bisq.user.reputation.ReputationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(ApplicationExtension.class)
+class ProfileCardOffersControllerTest extends TestFxHeadlessSupport {
+    private static final Market MARKET = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+
+    private final ObservableHashMap<Market, MarketPrice> marketPriceByCurrencyMap = new ObservableHashMap<>();
+    private MarketPriceService marketPriceService;
+    private ProfileCardOffersController controller;
+    private UserProfile userProfile;
+
+    @BeforeEach
+    void setUp() {
+        marketPriceService = mock(MarketPriceService.class);
+        when(marketPriceService.getMarketPriceByCurrencyMap()).thenReturn(marketPriceByCurrencyMap);
+        when(marketPriceService.findMarketPrice(MARKET))
+                .thenAnswer(invocation -> Optional.ofNullable(marketPriceByCurrencyMap.get(MARKET)));
+
+        BisqEasyOffer offer = mock(BisqEasyOffer.class);
+        when(offer.getQuoteSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getBaseSidePaymentMethodSpecs()).thenReturn(List.of());
+        when(offer.getMarket()).thenReturn(MARKET);
+        when(offer.getAmountSpec()).thenReturn(new QuoteSideFixedAmountSpec(40_000_000L));
+        when(offer.getPriceSpec()).thenReturn(new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")));
+        when(offer.getDisplayDirection()).thenReturn(Direction.BUY);
+        when(offer.getDate()).thenReturn(1_700_000_000_000L);
+        BisqEasyOfferbookMessage message = mock(BisqEasyOfferbookMessage.class);
+        when(message.getBisqEasyOffer()).thenReturn(Optional.of(offer));
+        when(message.getAuthorUserProfileId()).thenReturn("profile-id");
+        userProfile = mock(UserProfile.class);
+        when(userProfile.getId()).thenReturn("profile-id");
+        when(userProfile.getNickName()).thenReturn("alice");
+
+        BisqEasyOfferbookMessageService messageService = mock(BisqEasyOfferbookMessageService.class);
+        when(messageService.getAllOfferbookMessagesWithOffer("profile-id")).thenAnswer(invocation -> Stream.of(message));
+        ReputationService reputationService = mock(ReputationService.class);
+        when(reputationService.getReputationScore(any(UserProfile.class))).thenReturn(ReputationScore.NONE);
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getBondedRolesService().getMarketPriceService()).thenReturn(marketPriceService);
+        when(serviceProvider.getBisqEasyService().getBisqEasyOfferbookMessageService()).thenReturn(messageService);
+        when(serviceProvider.getUserService().getReputationService()).thenReturn(reputationService);
+
+        WaitForAsyncUtils.asyncFx(() -> controller = new ProfileCardOffersController(serviceProvider));
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    void rowsRebuiltAfterReactivationStillFollowMarketPriceUpdates() {
+        WaitForAsyncUtils.asyncFx(() -> {
+            controller.setUserProfile(userProfile);
+            controller.onActivate();
+            controller.onDeactivate();
+            controller.onActivate();
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(controller.getModel().getOfferbookListItems()).hasSize(1);
+        ProfileCardOfferListItem item = controller.getModel().getOfferbookListItems().get(0);
+        assertThat(item.getFormattedPercentagePrice().get()).isEqualTo(Res.get("data.na"));
+
+        MarketPrice marketPrice = mock(MarketPrice.class);
+        when(marketPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(40_000, "USD"));
+        marketPriceByCurrencyMap.put(MARKET, marketPrice);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(item.getFormattedPercentagePrice().get())
+                .isEqualTo(PercentageFormatter.formatToPercentWithSignAndSymbol(0.25));
+        WaitForAsyncUtils.asyncFx(() -> controller.onDeactivate());
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(controller.getModel().getOfferbookListItems()).isEmpty();
+    }
+}


### PR DESCRIPTION
Fixes #4923

## Problem

Opening the Bisq Easy offerbook list or a maker's profile card offers tab crashes with `NoSuchElementException` when it contains a fixed-price offer in a market without a market price: both list items resolve the percent with `PriceUtil.findPercentFromMarketPrice(...).orElseThrow()`, which is empty for a fixed price without a market quote.

## Fix

Both items keep the percentage as `Optional<Double>`: while it cannot be derived the cell shows the localized `N/A` and the tooltip still shows the fixed price; the row recovers through the existing market-price observer when a price arrives. The formatted percentage and tooltip are `StringProperty`s bound by the table cells, so an already-rendered row updates on recovery instead of waiting for cell recycling.

## Tests

New `OfferbookListItemTest` and `ProfileCardOfferListItemTest`: the crash cases reproduced the exact exception before the fix, recovery on price arrival is asserted through a label bound to the property, and a control case covers the normal percent path.

## Manual testing

Local CLEAR-net setup: Alice with market prices creates a fixed-price BTC/USD offer; Bob runs with the market price service disabled (`application.bondedRoles.marketPrice.enabled=false`) and a fresh data dir.

- Bob without a market price: the offer renders in the offer list and in Alice's profile card with N/A in the price column and the fixed price in its tooltip, no error popup, no `NoSuchElementException` in the log (on main the list item construction throws).

<img width="1406" height="951" alt="Screenshot from 2026-08-18 19-31-19" src="https://github.com/user-attachments/assets/82bffafa-c3a6-4461-bc41-ae02ffc244e4" />
<img width="1406" height="951" alt="Screenshot from 2026-08-18 19-31-28" src="https://github.com/user-attachments/assets/7ac8bc46-bee2-4abe-b929-f3715b90c6ca" />





- Bob restarted with market prices, same data dir: the same row shows the percentage.

<img width="1406" height="951" alt="Screenshot from 2026-08-18 14-47-43" src="https://github.com/user-attachments/assets/d7fab30f-8d9f-4ff5-a2b0-a1ae4f5f295d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Percentage prices and tooltips now update when market-price data becomes available or changes.
  - Offers without market-price data no longer show incorrect percentages or cause errors.
  - Reused and refreshed offer entries retain accurate price displays.
  - Offers without percentage prices appear last when sorting.
  - Price lists automatically resort when percentage data becomes available.

- **Tests**
  - Added coverage for missing, delayed, and initially available market-price scenarios, including sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


