### PR TITLE
bugfix/android_sequenced_collection_crash_inventory_request_polic

### DIFF
--- a/common/src/main/java/bisq/common/facades/JdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/JdkFacade.java
@@ -17,6 +17,7 @@
 
 package bisq.common.facades;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -36,4 +37,13 @@ public interface JdkFacade {
     void redirectError(ProcessBuilder processBuilder);
 
     void redirectOutput(ProcessBuilder processBuilder);
+
+    // The JDK 21 SequencedCollection methods List.removeFirst()/addFirst()/getFirst() only exist on
+    // Android 15+ (API 35) and crash older devices with NoSuchMethodError.
+
+    <T> T removeFirst(List<T> list);
+
+    <T> void addFirst(List<T> list, T element);
+
+    <T> T getFirst(List<T> list);
 }

--- a/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
@@ -20,6 +20,7 @@ package bisq.common.facades.android;
 import bisq.common.facades.JdkFacade;
 
 import java.io.File;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class AndroidJdkFacade implements JdkFacade {
@@ -51,5 +52,22 @@ public class AndroidJdkFacade implements JdkFacade {
     public void redirectOutput(ProcessBuilder processBuilder) {
         // ProcessBuilder.Redirect.DISCARD not supported on Android
         processBuilder.redirectError(new File("/dev/null"));
+    }
+
+    @Override
+    public <T> T removeFirst(List<T> list) {
+        // List.removeFirst/addFirst crash Android below API 35
+        return list.remove(0);
+    }
+
+    @Override
+    public <T> void addFirst(List<T> list, T element) {
+        // List.removeFirst/addFirst crash Android below API 35
+        list.add(0, element);
+    }
+
+    @Override
+    public <T> T getFirst(List<T> list) {
+        return list.get(0);
     }
 }

--- a/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
+++ b/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
@@ -21,6 +21,7 @@ import bisq.common.facades.JdkFacade;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.management.ManagementFactory;
+import java.util.List;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -44,5 +45,20 @@ public class JavaSeJdkFacade implements JdkFacade {
     @Override
     public void redirectOutput(ProcessBuilder processBuilder) {
         processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+    }
+
+    @Override
+    public <T> T removeFirst(List<T> list) {
+        return list.removeFirst();
+    }
+
+    @Override
+    public <T> void addFirst(List<T> list, T element) {
+        list.addFirst(element);
+    }
+
+    @Override
+    public <T> T getFirst(List<T> list) {
+        return list.getFirst();
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
@@ -17,7 +17,6 @@
 
 package bisq.network.p2p.node.authorization;
 
-import bisq.common.facades.FacadeProvider;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.node.Feature;
 import bisq.network.p2p.node.authorization.token.equi_hash.EquiHashTokenService;
@@ -140,7 +139,7 @@ public class AuthorizationService {
         return myPreferredAuthorizationTokenTypes.stream()
                 .filter(peersAuthorizationTokenTypes::contains)
                 .findFirst()
-                .orElseGet(() -> FacadeProvider.getJdkFacade().getFirst(peersAuthorizationTokenTypes));
+                .orElseGet(() -> peersAuthorizationTokenTypes.get(0));
     }
 
     private static List<AuthorizationTokenType> toAuthorizationTypes(Collection<Feature> features) {

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p.node.authorization;
 
+import bisq.common.facades.FacadeProvider;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.node.Feature;
 import bisq.network.p2p.node.authorization.token.equi_hash.EquiHashTokenService;
@@ -139,7 +140,7 @@ public class AuthorizationService {
         return myPreferredAuthorizationTokenTypes.stream()
                 .filter(peersAuthorizationTokenTypes::contains)
                 .findFirst()
-                .orElseGet(peersAuthorizationTokenTypes::getFirst);
+                .orElseGet(() -> FacadeProvider.getJdkFacade().getFirst(peersAuthorizationTokenTypes));
     }
 
     private static List<AuthorizationTokenType> toAuthorizationTypes(Collection<Feature> features) {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestPolicy.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestPolicy.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p.services.data.inventory;
 
+import bisq.common.facades.FacadeProvider;
 import bisq.common.network.Address;
 import bisq.common.util.CollectionUtil;
 import bisq.network.p2p.node.Connection;
@@ -132,11 +133,11 @@ class InventoryRequestPolicy {
                 .limit(config.getMaxSeedsForRequest())
                 .collect(Collectors.toCollection(ArrayList::new));
         if (!seeds.isEmpty()) {
-            Connection selectedSeed = seeds.removeFirst();
+            Connection selectedSeed = FacadeProvider.getJdkFacade().removeFirst(seeds);
             candidates.addAll(seeds);
 
             candidates = CollectionUtil.toShuffledList(candidates);
-            candidates.addFirst(selectedSeed); // ensure seed at front
+            FacadeProvider.getJdkFacade().addFirst(candidates, selectedSeed); // ensure seed at front
         }
 
         int limit = config.getMaxPendingRequestsAtPeriodicRequests();


### PR DESCRIPTION
### Motivation

with latest release Bisq Easy (mobile) 0.11.0 Google Play warns us that it could crash on Android 15 devices because of the code modified here (usage of certain list apis)

### Analysis

that code has been running in production in Android 15 devices as far as we are aware and haven't caused the warned issue... So we proceeded with the release anyways, but we propose this change to avoid future warnings and potential crashes in some devices (Android fragmentation).

### Conservative Solution

 - used JdkFacade to keep existing code for the rest of Bisq2 but change the usage of firstOf for Android, conservatively protecting from crashes in Android 15 running devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list handling for inventory requests across supported Java and Android environments.
  * Added compatibility for Android versions that do not support newer list APIs.
  * Improved peer authorization token selection across supported platforms.
  * Preserved existing candidate-selection behavior while improving cross-platform reliability.
  * Reduced the risk of platform-specific issues when processing inventory data and selecting peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->