### PR TITLE
chore: sync #4914 to main — feature/new_permissions_support_for_node_and_connect_upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,9 @@ docker/data_dirs
 /tx
 /.java-version
 
-# sym link to bisq2-umbrel repo
+# sym link to bisq2-* repos
 bisq2-umbrel
+bisq2-startos
 
 # Directory for temp files
 /temp

--- a/api/src/main/java/bisq/api/ApiConfig.java
+++ b/api/src/main/java/bisq/api/ApiConfig.java
@@ -58,7 +58,10 @@ public final class ApiConfig {
     private final int sessionTtlInMinutes;
 
     // TODO This should move to typesafe config
-    private final Set<Permission> grantedPermissions = Set.of(Permission.values());
+    // Auto-grantable ("standard") permissions only — identical to all values today, but the
+    // moment a sensitive permission is declared it is excluded here by construction: pairing
+    // never hands out sensitive capabilities; those need an explicit per-device approval flow.
+    private final Set<Permission> grantedPermissions = Permission.autoGrantable();
 
     public ApiConfig(
             ApiAccessTransportType apiAccessTransportType,

--- a/api/src/main/java/bisq/api/access/filter/authz/RestApiAuthorizationFilter.java
+++ b/api/src/main/java/bisq/api/access/filter/authz/RestApiAuthorizationFilter.java
@@ -9,11 +9,13 @@ import jakarta.annotation.Priority;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,8 +49,17 @@ public class RestApiAuthorizationFilter extends RestApiFilter {
             Set<Permission> granted = optionalPermissionSet.get();
             Permission required = permissionService.getPermissionMapping().getRequiredPermission(requestUri.getPath(), context.getMethod());
             if (!permissionService.hasPermission(granted, required)) {
-                throw new AuthorizationException(String.format("Required permission %s not granted. Granted permissions: %s",
-                        required.name(), granted));
+                // Structured body so clients can distinguish "this grant lacks one permission"
+                // (e.g. paired before the node gained a feature — fixable by re-pairing) from a
+                // plain 403 and prompt the user instead of showing a generic error. The caller
+                // already knows its own grant, so naming the missing permission leaks nothing.
+                log.warn("REST authz failed: required permission {} not granted. requestUri={}", required.name(), requestUri);
+                context.abortWith(Response.status(Response.Status.FORBIDDEN)
+                        .entity(Map.of("error", "permission_not_granted",
+                                "required", required.name()))
+                        .type(MediaType.APPLICATION_JSON_TYPE)
+                        .build());
+                return;
             }
         } catch (AuthorizationException | IllegalArgumentException | ForbiddenException e) {
             log.warn("REST authz failed. requestUri={}", requestUri, e);

--- a/api/src/main/java/bisq/api/access/pairing/PairingService.java
+++ b/api/src/main/java/bisq/api/access/pairing/PairingService.java
@@ -34,7 +34,10 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
@@ -176,19 +179,34 @@ public class PairingService {
         }
     }
 
-    private void writePairingQrCodeToDataDir(String pairingQrCode) {
+    // Package-private for testing
+    void writePairingQrCodeToDataDir(String pairingQrCode) {
+        Path path = appDataDirPath.resolve("pairing_qr_code.txt");
         try {
-            Path path = appDataDirPath.resolve("pairing_qr_code.txt");
             StringBuilder content = new StringBuilder(pairingQrCode);
             try {
                 content.append("\n\n\n").append(TextQrCodeRenderer.render(pairingQrCode));
             } catch (Exception e) {
                 log.warn("Failed to render text QR code", e);
             }
-            FileMutatorUtils.writeToPath(content.toString(), path);
+            // The file is rewritten on every code regeneration. Write to a temp file and move
+            // atomically so a concurrent reader never observes a truncated payload.
+            Path tempPath = appDataDirPath.resolve("pairing_qr_code.txt.tmp");
+            FileMutatorUtils.writeToPath(content.toString(), tempPath);
+            try {
+                Files.move(tempPath, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tempPath, path, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                // ATOMIC_MOVE with an existing target is implementation specific and can fail
+                // with a plain IOException (e.g. a concurrent reader holding the file on
+                // Windows). Losing atomicity for one rotation is better than not updating.
+                log.warn("Atomic move of pairing QR code failed, falling back to non-atomic replace", e);
+                Files.move(tempPath, path, StandardCopyOption.REPLACE_EXISTING);
+            }
             log.info("Pairing QR code written to {}", path);
         } catch (IOException e) {
-            log.error("Error at write pairing QR code to disk at {}", appDataDirPath.resolve("pairing_qr_code.txt"), e);
+            log.error("Error at write pairing QR code to disk at {}", path, e);
         }
     }
 }

--- a/api/src/main/java/bisq/api/access/permissions/Permission.java
+++ b/api/src/main/java/bisq/api/access/permissions/Permission.java
@@ -20,27 +20,87 @@ package bisq.api.access.permissions;
 import bisq.common.proto.ProtoEnum;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * The id must not be changed as it is used for the serialisation.
+ * <p>
+ * {@code autoGrantable} encodes the standard-vs-sensitive distinction: a grantAll grant expands
+ * only to auto-grantable permissions (see {@link PermissionSet}), so already-paired clients gain
+ * future NORMAL features automatically but can never silently acquire a security-sensitive
+ * capability.
+ * <p>
+ * SECURE BY DEFAULT: the single-argument constructor marks a permission SENSITIVE
+ * ({@code autoGrantable = false}). A new permission is therefore excluded from grantAll unless it
+ * explicitly opts in via {@code STANDARD}, making "is this safe to auto-grant?" a conscious
+ * decision at declaration time. Forgetting to decide fails closed — the permission requires an
+ * explicit per-device grant rather than silently joining grantAll.
  */
 public enum Permission implements ProtoEnum {
-    TRADE_CHAT_CHANNELS(0),
-    EXPLORER(1),
-    MARKET_PRICE(2),
-    OFFERBOOK(3),
-    PAYMENT_ACCOUNTS(4),
-    REPUTATION(5),
-    SETTINGS(6),
-    TRADES(7),
-    USER_IDENTITIES(8),
-    USER_PROFILES(9),
-    MOBILE_DEVICES(10);
+    TRADE_CHAT_CHANNELS(0, Kind.STANDARD),
+    EXPLORER(1, Kind.STANDARD),
+    MARKET_PRICE(2, Kind.STANDARD),
+    OFFERBOOK(3, Kind.STANDARD),
+    PAYMENT_ACCOUNTS(4, Kind.STANDARD),
+    REPUTATION(5, Kind.STANDARD),
+    SETTINGS(6, Kind.STANDARD),
+    TRADES(7, Kind.STANDARD),
+    USER_IDENTITIES(8, Kind.STANDARD),
+    USER_PROFILES(9, Kind.STANDARD),
+    MOBILE_DEVICES(10, Kind.STANDARD);
+
+    /** Grant classification. Named so a declaration reads as an explicit security decision. */
+    public enum Kind {
+        /** Auto-grantable: covered by grantAll, gained automatically by already-paired clients. */
+        STANDARD,
+        /** Security-sensitive: never covered by grantAll, always needs an explicit per-device grant. */
+        SENSITIVE
+    }
 
     @Getter
     private final int id;
+    private final Kind kind;
 
+    // Sensitive by default: an id-only declaration is treated as SENSITIVE so a forgotten
+    // classification fails closed. Standard permissions must opt in explicitly with Kind.STANDARD.
     Permission(int id) {
+        this(id, Kind.SENSITIVE);
+    }
+
+    Permission(int id, Kind kind) {
         this.id = id;
+        this.kind = kind;
+    }
+
+    public boolean isAutoGrantable() {
+        return kind == Kind.STANDARD;
+    }
+
+    /**
+     * All permissions a grantAll grant expands to — the "standard" set. Sensitive permissions
+     * (autoGrantable = false) are excluded by construction and must be granted explicitly.
+     * <p>
+     * Ordered by {@code id} into an insertion-ordered set: this feeds the grantAll expansion
+     * serialized by {@code PermissionSet.getBuilder}, and an unspecified iteration order (as a
+     * plain immutable Set has) would make the proto's repeated field non-deterministic across
+     * runs, breaking serializeForHash stability. Set semantics are unchanged — equality stays
+     * order-independent, so promotion/folding comparisons are unaffected.
+     */
+    public static Set<Permission> autoGrantable() {
+        // Unmodifiable AND insertion-ordered: PermissionSet caches this in a static field and
+        // returns it directly from getPermissions(), so a mutable set would let any caller alter
+        // the grantAll expansion for every client (and, once sensitive permissions exist, add
+        // one). LinkedHashSet keeps the id order needed for serializeForHash determinism.
+        LinkedHashSet<Permission> ordered = Arrays.stream(values())
+                .filter(Permission::isAutoGrantable)
+                .sorted(Comparator.comparingInt(Permission::getId))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return Collections.unmodifiableSet(ordered);
     }
 
     @Override

--- a/api/src/main/java/bisq/api/access/permissions/PermissionService.java
+++ b/api/src/main/java/bisq/api/access/permissions/PermissionService.java
@@ -20,7 +20,6 @@ package bisq.api.access.permissions;
 import bisq.api.access.persistence.ApiAccessStoreService;
 import lombok.Getter;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -39,11 +38,19 @@ public class PermissionService<T extends PermissionMapping> {
     }
 
     public void putPermissions(String clientId, Set<Permission> permissions) {
-        apiAccessStoreService.putPermissions(clientId, permissions);
+        // A grant EXACTLY equal to this version's auto-grantable ("standard") set is stored as
+        // grantAll so it keeps covering standard permissions added by future versions. Strict
+        // equality on purpose: a grant that additionally carries a sensitive permission must
+        // stay explicit — folding it into grantAll would drop the sensitive permission from the
+        // expansion (grantAll never covers sensitive ones; see PermissionSet).
+        PermissionSet permissionSet = permissions.equals(Permission.autoGrantable())
+                ? PermissionSet.grantAll()
+                : new PermissionSet(permissions);
+        apiAccessStoreService.putPermissions(clientId, permissionSet);
     }
 
     public Optional<Set<Permission>> findPermissions(String clientId) {
         return Optional.ofNullable(apiAccessStoreService.getPermissionsByClientId().get(clientId))
-                .map(Collections::unmodifiableSet);
+                .map(PermissionSet::getPermissions);
     }
 }

--- a/api/src/main/java/bisq/api/access/permissions/PermissionSet.java
+++ b/api/src/main/java/bisq/api/access/permissions/PermissionSet.java
@@ -23,13 +23,42 @@ import lombok.Getter;
 
 import java.util.Set;
 
-// Just a wrapper for easier proto handling of a map with a hashset as value
+/**
+ * Wrapper for easier proto handling of a map with a hashset as value.
+ * <p>
+ * A grant is either explicit (a fixed set of permissions) or {@code grantAll}. A grantAll
+ * grant expands to the running version's AUTO-GRANTABLE permissions at read time (see
+ * {@link Permission#autoGrantable()}), so clients paired before a node upgrade automatically
+ * cover standard permissions added later — but never security-sensitive ones, which always
+ * require an explicit per-device grant. Persisting the pairing-time expansion instead would
+ * silently lock paired clients out of endpoints guarded by permissions added after pairing.
+ */
 public final class PermissionSet implements PersistableProto {
+    // grantAll expands to the auto-grantable ("standard") permissions only — NEVER to sensitive
+    // ones (Permission.autoGrantable = false), which always require an explicit per-device grant.
+    // Today every permission is auto-grantable, so this equals the full enum; that changes the
+    // day the first sensitive permission is declared, with no code change needed here.
+    private static final Set<Permission> AUTO_GRANTABLE_PERMISSIONS = Permission.autoGrantable();
+
+    private final Set<Permission> explicitPermissions;
     @Getter
-    private final Set<Permission> permissions;
+    private final boolean grantAll;
 
     public PermissionSet(Set<Permission> permissions) {
-        this.permissions = permissions;
+        this(permissions, false);
+    }
+
+    private PermissionSet(Set<Permission> explicitPermissions, boolean grantAll) {
+        this.explicitPermissions = Set.copyOf(explicitPermissions);
+        this.grantAll = grantAll;
+    }
+
+    public static PermissionSet grantAll() {
+        return new PermissionSet(Set.of(), true);
+    }
+
+    public Set<Permission> getPermissions() {
+        return grantAll ? AUTO_GRANTABLE_PERMISSIONS : explicitPermissions;
     }
 
     @Override
@@ -39,11 +68,17 @@ public final class PermissionSet implements PersistableProto {
 
     @Override
     public bisq.api.protobuf.PermissionSet.Builder getBuilder(boolean serializeForHash) {
+        // For grantAll we serialize the current expansion as well, so a node downgraded to a
+        // version without the grantAll field still reads a full grant from the explicit list.
         return bisq.api.protobuf.PermissionSet.newBuilder()
-                .addAllPermissions(permissions.stream().map(Permission::toProtoEnum).toList());
+                .addAllPermissions(getPermissions().stream().map(Permission::toProtoEnum).toList())
+                .setGrantAll(grantAll);
     }
 
     public static PermissionSet fromProto(bisq.api.protobuf.PermissionSet proto) {
+        if (proto.getGrantAll()) {
+            return grantAll();
+        }
         return new PermissionSet(ProtobufUtils.fromProtoEnumSet(Permission.class, proto.getPermissionsList()));
     }
 }

--- a/api/src/main/java/bisq/api/access/permissions/RestPermissionMapping.java
+++ b/api/src/main/java/bisq/api/access/permissions/RestPermissionMapping.java
@@ -23,6 +23,28 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Maps REST paths to required permissions. Unmapped paths are rejected (fail-closed).
+ * <p>
+ * For devs adding new endpoints or permissions:
+ * <ul>
+ * <li>Prefer mapping a new endpoint to an existing permission when one fits semantically —
+ *     established precedent: {@code /trade-restricting-alert} and {@code /alert-notifications}
+ *     map to {@link Permission#SETTINGS}.</li>
+ * <li>When adding a new {@link Permission} value, ids are append-only and must never be reused.
+ *     Already-paired clients holding a grantAll grant gain new non-sensitive permissions
+ *     automatically at read time (see {@link PermissionSet}) — no re-pairing needed. Explicit
+ *     grants are never expanded.</li>
+ * <li>Coordinate with a Connect app release: apps without the tolerant pairing-code decoder
+ *     (bisq-mobile, 2026-08) reject pairing codes that carry more permissions than they know,
+ *     so new permissions break pairing for older apps.</li>
+ * <li>Security-sensitive permissions (e.g. anything wallet/spend related) are never covered by
+ *     the grantAll expansion — declare them with {@code autoGrantable = false} on the
+ *     {@link Permission} enum and the exclusion is enforced by construction (see
+ *     {@link PermissionSet}); they then always require an explicit per-device grant with
+ *     deliberate approval.</li>
+ * </ul>
+ */
 @Slf4j
 public final class RestPermissionMapping implements PermissionMapping {
     private final List<PermissionRule> rules;

--- a/api/src/main/java/bisq/api/access/persistence/ApiAccessStore.java
+++ b/api/src/main/java/bisq/api/access/persistence/ApiAccessStore.java
@@ -30,23 +30,29 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
 final class ApiAccessStore implements PersistableStore<ApiAccessStore> {
+    // Informational only — a pre-grantAll node rewrites the store from its own model and drops
+    // this field, so it cannot survive a downgrade and MUST NOT gate any security decision.
+    // Promotion to grantAll is evidence-based instead; see promoteIfFullStandardGrant.
+    private static final int PERMISSIONS_SCHEMA_VERSION = 1;
+
+    private transient boolean promotedEntriesDuringLoad;
+
     @Getter(AccessLevel.PACKAGE)
     private final Map<String, ClientProfile> clientProfileByIdMap = new ConcurrentHashMap<>();
     @Getter(AccessLevel.PACKAGE)
-    private final Map<String, Set<Permission>> permissionsByClientId = new ConcurrentHashMap<>();
+    private final Map<String, PermissionSet> permissionsByClientId = new ConcurrentHashMap<>();
 
     ApiAccessStore() {
         this(new HashMap<>(), new HashMap<>());
     }
 
     private ApiAccessStore(Map<String, ClientProfile> clientProfileByIdMap,
-                           Map<String, Set<Permission>> permissionsByClientId) {
+                           Map<String, PermissionSet> permissionsByClientId) {
         this.clientProfileByIdMap.putAll(clientProfileByIdMap);
         this.permissionsByClientId.putAll(permissionsByClientId);
     }
@@ -59,7 +65,8 @@ final class ApiAccessStore implements PersistableStore<ApiAccessStore> {
                                 e -> e.getValue().toProto(serializeForHash))))
                 .putAllPermissionsByClientId(permissionsByClientId.entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey,
-                                e -> new PermissionSet(e.getValue()).toProto(serializeForHash))));
+                                e -> e.getValue().toProto(serializeForHash))))
+                .setPermissionsSchemaVersion(PERMISSIONS_SCHEMA_VERSION);
     }
 
     @Override
@@ -71,11 +78,72 @@ final class ApiAccessStore implements PersistableStore<ApiAccessStore> {
         Map<String, ClientProfile> clientProfileByIdMap = proto.getClientProfileByIdMapMap().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
                         e -> ClientProfile.fromProto(e.getValue())));
-        Map<String, Set<Permission>> permissionsByClientId = proto.getPermissionsByClientIdMap().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        e -> PermissionSet.fromProto(e.getValue()).getPermissions()));
-        return new ApiAccessStore(clientProfileByIdMap,
-                permissionsByClientId);
+        Map<String, PermissionSet> permissionsByClientId = new HashMap<>();
+        boolean anyPromoted = false;
+        for (Map.Entry<String, bisq.api.protobuf.PermissionSet> e : proto.getPermissionsByClientIdMap().entrySet()) {
+            PermissionSet loaded = PermissionSet.fromProto(e.getValue());
+            PermissionSet effective = promoteIfFullStandardGrant(e.getKey(), loaded);
+            anyPromoted |= effective != loaded;
+            permissionsByClientId.put(e.getKey(), effective);
+        }
+        ApiAccessStore store = new ApiAccessStore(clientProfileByIdMap, permissionsByClientId);
+        store.promotedEntriesDuringLoad = anyPromoted;
+        return store;
+    }
+
+    /**
+     * Whether this load promoted any entry to grantAll. The promotion happens in memory only —
+     * {@code ApiAccessStoreService#onPersistedApplied} checks this flag and persists, so the
+     * promotion reaches disk on the same boot that computed it. Without that write-back, a node
+     * that never pairs a new client would keep the old explicit list on disk, and a later
+     * version with more permissions would no longer recognise it as a full grant (the client
+     * would silently fall back to a restricted set).
+     */
+    boolean hadPromotedEntriesDuringLoad() {
+        return promotedEntriesDuringLoad;
+    }
+
+    /**
+     * Evidence-based promotion, applied on every load and deliberately NOT gated on
+     * {@code permissionsSchemaVersion}: no in-store marker survives a downgrade, because a
+     * pre-grantAll node rebuilds the proto from its own domain model on persist and thereby
+     * drops fields it does not know. Trusting a version stamp would let a downgrade/upgrade
+     * cycle silently promote a deliberately restricted entry to full access.
+     * <p>
+     * Instead the entry's own content is the evidence: only a set EXACTLY equal to the running
+     * version's auto-grantable ("standard") set is promoted — at that moment promotion grants
+     * nothing extra, it only keeps the grant covering standard permissions added by future
+     * versions (the semantics every full grant was issued with). Strict equality, not
+     * containsAll: a set that additionally holds a sensitive permission must stay explicit,
+     * otherwise promotion would silently drop the sensitive grant from the grantAll expansion.
+     * <p>
+     * Trade-off: a full grant persisted by an older version and first re-read by a binary that
+     * has since gained permissions is NOT promoted and that client keeps the old set (fails
+     * closed; re-pairing restores full access) — mitigated by the persist-after-promotion in
+     * {@code ApiAccessStoreService#onPersistedApplied}.
+     * <p>
+     * KNOWN RESIDUAL (not reachable today — no live path persists a genuinely restricted
+     * non-grantAll grant; every pairing grants the full standard set, folded to grantAll at
+     * write time by {@code PermissionService#putPermissions}). The equality is against the
+     * RUNNING binary's autoGrantable set, so a deliberately restricted grant is indistinguishable
+     * from a full grant of an OLDER version whose standard set happened to equal it: read by that
+     * older binary it would be promoted (and persisted) as grantAll, then re-expand on upgrade —
+     * regaining a standard permission it was never granted. This becomes reachable only once a
+     * feature can persist a genuinely restricted grant (granular-permission editor / sensitive-
+     * permission per-device flow); that feature must first introduce a downgrade-durable marker
+     * distinguishing "deliberate restriction" from "legacy full grant", or accept this as a
+     * documented residual. Sensitive permissions are unaffected either way: a set containing one
+     * can never equal any version's autoGrantable set, so it is never promotable.
+     */
+    private static PermissionSet promoteIfFullStandardGrant(String clientId, PermissionSet permissionSet) {
+        if (permissionSet.isGrantAll()) {
+            return permissionSet;
+        }
+        if (permissionSet.getPermissions().equals(Permission.autoGrantable())) {
+            log.info("Promoting full standard permission set of client {} to grantAll", clientId);
+            return PermissionSet.grantAll();
+        }
+        return permissionSet;
     }
 
     @Override

--- a/api/src/main/java/bisq/api/access/persistence/ApiAccessStoreService.java
+++ b/api/src/main/java/bisq/api/access/persistence/ApiAccessStoreService.java
@@ -18,7 +18,7 @@
 package bisq.api.access.persistence;
 
 import bisq.api.access.identity.ClientProfile;
-import bisq.api.access.permissions.Permission;
+import bisq.api.access.permissions.PermissionSet;
 import bisq.persistence.DbSubDirectory;
 import bisq.persistence.Persistence;
 import bisq.persistence.PersistenceService;
@@ -27,8 +27,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class ApiAccessStoreService extends RateLimitedPersistenceClient<ApiAccessStore> {
@@ -45,12 +43,23 @@ public class ApiAccessStoreService extends RateLimitedPersistenceClient<ApiAcces
         return Map.copyOf(persistableStore.getClientProfileByIdMap());
     }
 
-    public Map<String, Set<Permission>> getPermissionsByClientId() {
-        return persistableStore.getPermissionsByClientId().entrySet().stream()
-                .collect(Collectors.toUnmodifiableMap(
-                        Map.Entry::getKey,
-                        e -> Set.copyOf(e.getValue())
-                ));
+    public Map<String, PermissionSet> getPermissionsByClientId() {
+        return Map.copyOf(persistableStore.getPermissionsByClientId());
+    }
+
+    /**
+     * Write grantAll promotions back to disk on the boot that computed them. Without this, a
+     * node that never pairs a new client keeps the old explicit permission list on disk, and a
+     * later version with additional permissions no longer recognises it as a full standard
+     * grant — the client would silently fall back to a restricted set (see
+     * {@code ApiAccessStore#promoteIfFullStandardGrant}).
+     */
+    @Override
+    public void onPersistedApplied(ApiAccessStore persisted) {
+        if (persisted.hadPromotedEntriesDuringLoad()) {
+            log.info("Persisting grantAll promotions computed while loading the store");
+            persist();
+        }
     }
 
     public void putClientProfile(String clientId, ClientProfile clientProfile) {
@@ -58,8 +67,8 @@ public class ApiAccessStoreService extends RateLimitedPersistenceClient<ApiAcces
         persist();
     }
 
-    public void putPermissions(String clientId, Set<Permission> permissions) {
-        persistableStore.getPermissionsByClientId().put(clientId, permissions);
+    public void putPermissions(String clientId, PermissionSet permissionSet) {
+        persistableStore.getPermissionsByClientId().put(clientId, permissionSet);
         persist();
     }
 

--- a/api/src/main/proto/api.proto
+++ b/api/src/main/proto/api.proto
@@ -38,6 +38,10 @@ enum Permission {
 
 message PermissionSet {
   repeated Permission permissions = 1;
+  // When true the client is granted all current and future auto-grantable permissions,
+  // never sensitive ones. The expanded list is still written to `permissions` so nodes
+  // running a version without this field keep working after a downgrade.
+  bool grantAll = 2;
 }
 
 message ClientProfile {
@@ -50,4 +54,9 @@ message ClientProfile {
 message ApiAccessStore {
   map<string, ClientProfile> clientProfileByIdMap = 2;
   map<string, PermissionSet> permissionsByClientId = 3;
+  // Informational only. A node running a version without this field rewrites the store from
+  // its own model and drops it, so it cannot survive a downgrade and must never gate a
+  // security decision. Promotion of entries to grantAll is evidence-based at load time
+  // (only a set exactly matching the running version's auto-grantable permission set is promoted).
+  uint32 permissionsSchemaVersion = 4;
 }

--- a/api/src/test/java/bisq/api/access/filter/authz/RestApiAuthorizationFilterTest.java
+++ b/api/src/test/java/bisq/api/access/filter/authz/RestApiAuthorizationFilterTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.filter.authz;
+
+import bisq.api.access.filter.Headers;
+import bisq.api.access.permissions.Permission;
+import bisq.api.access.permissions.PermissionService;
+import bisq.api.access.permissions.RestPermissionMapping;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RestApiAuthorizationFilterTest {
+
+    @SuppressWarnings("unchecked")
+    private static PermissionService<RestPermissionMapping> permissionService(Set<Permission> granted) {
+        RestPermissionMapping mapping = mock(RestPermissionMapping.class);
+        when(mapping.getRequiredPermission("/api/v1/offerbook/markets", "GET")).thenReturn(Permission.OFFERBOOK);
+        PermissionService<RestPermissionMapping> permissionService = mock(PermissionService.class);
+        when(permissionService.getPermissionMapping()).thenReturn(mapping);
+        when(permissionService.findPermissions("client-1")).thenReturn(Optional.of(granted));
+        when(permissionService.hasPermission(granted, Permission.OFFERBOOK))
+                .thenReturn(granted.contains(Permission.OFFERBOOK));
+        return permissionService;
+    }
+
+    private static ContainerRequestContext requestContext() {
+        ContainerRequestContext context = mock(ContainerRequestContext.class, RETURNS_DEEP_STUBS);
+        when(context.getUriInfo().getRequestUri()).thenReturn(URI.create("http://127.0.0.1:8090/api/v1/offerbook/markets"));
+        when(context.getMethod()).thenReturn("GET");
+        when(context.getHeaderString(Headers.CLIENT_ID)).thenReturn("client-1");
+        return context;
+    }
+
+    @Test
+    void missingPermissionAborts403WithStructuredBodyNamingThePermission() {
+        // The connect app parses this body to prompt "re-pair to enable new features" instead of
+        // a generic error — the case where a client paired before the node gained a permission.
+        Set<Permission> grantedWithoutOfferbook = EnumSet.of(Permission.SETTINGS, Permission.TRADES);
+        RestApiAuthorizationFilter filter = new RestApiAuthorizationFilter(permissionService(grantedWithoutOfferbook));
+        ContainerRequestContext context = requestContext();
+
+        filter.doFilter(context);
+
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(context).abortWith(captor.capture());
+        Response response = captor.getValue();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
+        // Filter-aborted responses bypass @Produces resolution, so the type must be set explicitly.
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+        assertThat(response.getEntity())
+                .isEqualTo(Map.of("error", "permission_not_granted", "required", Permission.OFFERBOOK.name()));
+    }
+
+    @Test
+    void grantedPermissionPassesWithoutAborting() {
+        RestApiAuthorizationFilter filter = new RestApiAuthorizationFilter(permissionService(EnumSet.allOf(Permission.class)));
+        ContainerRequestContext context = requestContext();
+
+        filter.doFilter(context);
+
+        verify(context, never()).abortWith(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void unknownClientAborts403WithoutTheStructuredBody() {
+        // Revoked/unknown clients keep the bare 403: the session-path handling in the client
+        // already routes that case to re-pairing, and the body must not aid probing.
+        @SuppressWarnings("unchecked")
+        PermissionService<RestPermissionMapping> permissionService = mock(PermissionService.class, RETURNS_DEEP_STUBS);
+        when(permissionService.findPermissions("client-1")).thenReturn(Optional.empty());
+        RestApiAuthorizationFilter filter = new RestApiAuthorizationFilter(permissionService);
+        ContainerRequestContext context = requestContext();
+
+        filter.doFilter(context);
+
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        verify(context).abortWith(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(Response.Status.FORBIDDEN.getStatusCode());
+        assertThat(captor.getValue().getEntity()).isNull();
+    }
+}

--- a/api/src/test/java/bisq/api/access/pairing/PairingServiceTest.java
+++ b/api/src/test/java/bisq/api/access/pairing/PairingServiceTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.pairing;
+
+import bisq.api.ApiConfig;
+import bisq.api.access.permissions.PermissionService;
+import bisq.api.access.persistence.ApiAccessStoreService;
+import bisq.common.file.FileReaderUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+class PairingServiceTest {
+    private PairingService pairingService(Path appDataDir) {
+        return new PairingService(mock(ApiConfig.class),
+                appDataDir,
+                mock(ApiAccessStoreService.class),
+                mock(PermissionService.class));
+    }
+
+    @Test
+    void writeCreatesPairingQrCodeFile(@TempDir Path tempDir) throws IOException {
+        pairingService(tempDir).writePairingQrCodeToDataDir("first-payload");
+
+        Path file = tempDir.resolve("pairing_qr_code.txt");
+        assertTrue(Files.exists(file));
+        assertTrue(FileReaderUtils.readUTF8String(file).startsWith("first-payload"));
+    }
+
+    @Test
+    void writeReplacesExistingPairingQrCodeFile(@TempDir Path tempDir) throws IOException {
+        // The node rotates the code every few minutes, so after the first rotation the
+        // target file always exists — replacement must succeed and leave no temp file.
+        PairingService service = pairingService(tempDir);
+        service.writePairingQrCodeToDataDir("first-payload");
+
+        service.writePairingQrCodeToDataDir("second-payload");
+
+        Path file = tempDir.resolve("pairing_qr_code.txt");
+        assertTrue(FileReaderUtils.readUTF8String(file).startsWith("second-payload"));
+        assertFalse(Files.exists(tempDir.resolve("pairing_qr_code.txt.tmp")));
+    }
+
+    @Test
+    void atomicMoveNotSupportedFallsBackToPlainReplace(@TempDir Path tempDir) throws IOException {
+        PairingService service = pairingService(tempDir);
+        service.writePairingQrCodeToDataDir("first-payload");
+
+        try (MockedStatic<Files> files = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            files.when(() -> Files.move(any(Path.class), any(Path.class),
+                            eq(StandardCopyOption.ATOMIC_MOVE), eq(StandardCopyOption.REPLACE_EXISTING)))
+                    .thenThrow(new AtomicMoveNotSupportedException("tmp", "target", "not supported"));
+            service.writePairingQrCodeToDataDir("second-payload");
+        }
+
+        Path file = tempDir.resolve("pairing_qr_code.txt");
+        assertTrue(FileReaderUtils.readUTF8String(file).startsWith("second-payload"));
+        assertFalse(Files.exists(tempDir.resolve("pairing_qr_code.txt.tmp")));
+    }
+
+    @Test
+    void atomicMoveIoFailureFallsBackToPlainReplace(@TempDir Path tempDir) throws IOException {
+        // ATOMIC_MOVE onto an existing target is implementation specific and can fail with a
+        // plain IOException (e.g. a concurrent reader holding the file on Windows).
+        PairingService service = pairingService(tempDir);
+        service.writePairingQrCodeToDataDir("first-payload");
+
+        try (MockedStatic<Files> files = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            files.when(() -> Files.move(any(Path.class), any(Path.class),
+                            eq(StandardCopyOption.ATOMIC_MOVE), eq(StandardCopyOption.REPLACE_EXISTING)))
+                    .thenThrow(new IOException("target file is in use"));
+            service.writePairingQrCodeToDataDir("second-payload");
+        }
+
+        Path file = tempDir.resolve("pairing_qr_code.txt");
+        assertTrue(FileReaderUtils.readUTF8String(file).startsWith("second-payload"));
+        assertFalse(Files.exists(tempDir.resolve("pairing_qr_code.txt.tmp")));
+    }
+}

--- a/api/src/test/java/bisq/api/access/permissions/PermissionServiceTest.java
+++ b/api/src/test/java/bisq/api/access/permissions/PermissionServiceTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.permissions;
+
+import bisq.api.access.persistence.ApiAccessStoreService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PermissionServiceTest {
+    private ApiAccessStoreService apiAccessStoreService;
+    private PermissionService<RestPermissionMapping> permissionService;
+
+    @BeforeEach
+    void setUp() {
+        apiAccessStoreService = mock(ApiAccessStoreService.class);
+        permissionService = new PermissionService<>(apiAccessStoreService, new RestPermissionMapping());
+    }
+
+    @Test
+    void grantCoveringAllPermissionsIsStoredAsGrantAll() {
+        permissionService.putPermissions("client-1", Permission.autoGrantable());
+
+        ArgumentCaptor<PermissionSet> captor = ArgumentCaptor.forClass(PermissionSet.class);
+        verify(apiAccessStoreService).putPermissions(eq("client-1"), captor.capture());
+        assertTrue(captor.getValue().isGrantAll());
+    }
+
+    @Test
+    void partialGrantIsStoredExplicitly() {
+        Set<Permission> subset = Set.of(Permission.OFFERBOOK, Permission.MARKET_PRICE);
+
+        permissionService.putPermissions("client-1", subset);
+
+        ArgumentCaptor<PermissionSet> captor = ArgumentCaptor.forClass(PermissionSet.class);
+        verify(apiAccessStoreService).putPermissions(eq("client-1"), captor.capture());
+        assertFalse(captor.getValue().isGrantAll());
+        assertEquals(subset, captor.getValue().getPermissions());
+    }
+
+    @Test
+    void findPermissionsExpandsGrantAllToAllPermissions() {
+        when(apiAccessStoreService.getPermissionsByClientId())
+                .thenReturn(Map.of("client-1", PermissionSet.grantAll()));
+
+        Optional<Set<Permission>> found = permissionService.findPermissions("client-1");
+
+        assertTrue(found.isPresent());
+        assertEquals(Permission.autoGrantable(), found.get());
+    }
+
+    @Test
+    void findPermissionsReturnsStoredExplicitSubsetAsIs() {
+        Set<Permission> subset = Set.of(Permission.MARKET_PRICE);
+        when(apiAccessStoreService.getPermissionsByClientId())
+                .thenReturn(Map.of("client-1", new PermissionSet(subset)));
+
+        Optional<Set<Permission>> found = permissionService.findPermissions("client-1");
+
+        assertTrue(found.isPresent());
+        assertEquals(subset, found.get());
+        assertFalse(permissionService.hasPermission(found.get(), Permission.TRADES));
+    }
+
+    @Test
+    void findPermissionsIsEmptyForUnknownClient() {
+        when(apiAccessStoreService.getPermissionsByClientId()).thenReturn(Map.of());
+
+        assertTrue(permissionService.findPermissions("unknown").isEmpty());
+    }
+}

--- a/api/src/test/java/bisq/api/access/permissions/PermissionSetTest.java
+++ b/api/src/test/java/bisq/api/access/permissions/PermissionSetTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.permissions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PermissionSetTest {
+    @Test
+    void grantAllExpandsToAllPermissionsOfTheRunningVersion() {
+        PermissionSet permissionSet = PermissionSet.grantAll();
+
+        assertTrue(permissionSet.isGrantAll());
+        assertEquals(Permission.autoGrantable(), permissionSet.getPermissions());
+    }
+
+    @Test
+    void explicitSetIsReturnedAsIs() {
+        Set<Permission> explicit = Set.of(Permission.OFFERBOOK, Permission.TRADES);
+        PermissionSet permissionSet = new PermissionSet(explicit);
+
+        assertFalse(permissionSet.isGrantAll());
+        assertEquals(explicit, permissionSet.getPermissions());
+    }
+
+    @Test
+    void grantAllSurvivesProtoRoundTrip() {
+        bisq.api.protobuf.PermissionSet proto = PermissionSet.grantAll().toProto(false);
+        PermissionSet fromProto = PermissionSet.fromProto(proto);
+
+        assertTrue(fromProto.isGrantAll());
+        assertEquals(Permission.autoGrantable(), fromProto.getPermissions());
+    }
+
+    @Test
+    void grantAllSerializesExpandedListForDowngradedNodes() {
+        // A node downgraded to a version without the grantAll field only reads the explicit
+        // list, so the full expansion must be present in the proto. Simulate the legacy read
+        // path (ProtobufUtils.fromProtoEnumSet on the repeated field) to prove it.
+        bisq.api.protobuf.PermissionSet proto = PermissionSet.grantAll().toProto(false);
+
+        Set<Permission> legacyRead = bisq.common.proto.ProtobufUtils.fromProtoEnumSet(Permission.class, proto.getPermissionsList());
+        assertEquals(Permission.autoGrantable(), legacyRead);
+    }
+
+    @Test
+    void unknownEnumValuesInProtoAreDroppedNotEscalated() {
+        // Version skew / corruption must shrink the effective grant, never expand it.
+        bisq.api.protobuf.PermissionSet proto = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addPermissions(Permission.OFFERBOOK.toProtoEnum())
+                .addPermissionsValue(9999)
+                .build();
+
+        PermissionSet fromProto = PermissionSet.fromProto(proto);
+
+        assertFalse(fromProto.isGrantAll());
+        assertEquals(Set.of(Permission.OFFERBOOK), fromProto.getPermissions());
+    }
+
+    @Test
+    void emptyExplicitGrantSurvivesProtoRoundTrip() {
+        PermissionSet empty = new PermissionSet(Set.of());
+        PermissionSet fromProto = PermissionSet.fromProto(empty.toProto(false));
+
+        assertFalse(fromProto.isGrantAll());
+        assertTrue(fromProto.getPermissions().isEmpty());
+    }
+
+    @Test
+    void explicitSetSurvivesProtoRoundTrip() {
+        Set<Permission> explicit = Set.of(Permission.SETTINGS);
+        bisq.api.protobuf.PermissionSet proto = new PermissionSet(explicit).toProto(false);
+        PermissionSet fromProto = PermissionSet.fromProto(proto);
+
+        assertFalse(fromProto.isGrantAll());
+        assertEquals(explicit, fromProto.getPermissions());
+    }
+
+    @Test
+    void legacyProtoWithoutGrantAllFieldYieldsExplicitSet() {
+        // Simulates a store entry written before the grantAll field existed.
+        bisq.api.protobuf.PermissionSet legacyProto = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addAllPermissions(Set.of(Permission.OFFERBOOK).stream().map(Permission::toProtoEnum).toList())
+                .build();
+
+        PermissionSet fromProto = PermissionSet.fromProto(legacyProto);
+
+        assertFalse(fromProto.isGrantAll());
+        assertEquals(Set.of(Permission.OFFERBOOK), fromProto.getPermissions());
+    }
+}

--- a/api/src/test/java/bisq/api/access/permissions/PermissionTest.java
+++ b/api/src/test/java/bisq/api/access/permissions/PermissionTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.permissions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PermissionTest {
+
+    @Test
+    void everyCurrentPermissionIsStandard() {
+        // The 11 current permissions are all standard. This documents that intent; the security
+        // guarantee itself comes from the SENSITIVE default (an id-only declaration is not
+        // auto-grantable), so a forgotten classification fails closed rather than silently
+        // joining grantAll. Whoever adds the first sensitive permission updates this test AND
+        // verifies its explicit per-device grant flow.
+        assertTrue(Arrays.stream(Permission.values()).allMatch(Permission::isAutoGrantable),
+                "a sensitive permission was introduced — update this test and verify its explicit-grant flow");
+    }
+
+    @Test
+    void autoGrantableEqualsAllValuesWhileNoSensitivePermissionExists() {
+        assertEquals(EnumSet.allOf(Permission.class), Permission.autoGrantable());
+    }
+
+    @Test
+    void autoGrantableSetIsUnmodifiable() {
+        // PermissionSet caches this in a static field and returns it directly from
+        // getPermissions(); a mutable set would let any caller alter the grantAll expansion for
+        // every client (and add a sensitive permission once one exists).
+        assertThrows(UnsupportedOperationException.class,
+                () -> Permission.autoGrantable().add(Permission.OFFERBOOK));
+        assertThrows(UnsupportedOperationException.class,
+                () -> Permission.autoGrantable().clear());
+    }
+}

--- a/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreServiceTest.java
+++ b/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.persistence;
+
+import bisq.api.access.permissions.Permission;
+import bisq.api.access.permissions.PermissionSet;
+import bisq.persistence.Persistence;
+import bisq.persistence.PersistenceService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the persist-after-promotion write-back: a grantAll promotion computed while loading
+ * the store must reach disk on the same boot. Without it, a node that never pairs a new client
+ * keeps the old explicit permission list on disk, and a later version with more permissions no
+ * longer recognises the entry as a full standard grant — silently re-restricting the client
+ * (the exact v1 -> v2 -> v3 rollout gap from the PR review).
+ */
+class ApiAccessStoreServiceTest {
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ApiAccessStoreService serviceWith(Persistence persistence) {
+        PersistenceService persistenceService = mock(PersistenceService.class, RETURNS_DEEP_STUBS);
+        when(persistenceService.getOrCreatePersistence(any(), any(), any())).thenReturn(persistence);
+        when(persistence.persistAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+        // Stubbed so the RateLimitedPersistenceClient shutdown hook doesn't NPE on getStorePath().
+        when(persistence.getStorePath()).thenReturn(Path.of("test-store"));
+        return new ApiAccessStoreService(persistenceService);
+    }
+
+    private static bisq.api.protobuf.ApiAccessStore legacyStoreWithFullStandardGrant(String clientId) {
+        // Legacy-shaped entry: an explicit list equal to the full standard set, no grantAll flag.
+        bisq.api.protobuf.PermissionSet legacyFullGrant = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addAllPermissions(Permission.autoGrantable().stream().map(Permission::toProtoEnum).toList())
+                .build();
+        return bisq.api.protobuf.ApiAccessStore.newBuilder()
+                .putPermissionsByClientId(clientId, legacyFullGrant)
+                .build();
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void readPersistedPromotesAndWritesGrantAllBackSoItSurvivesRestart() {
+        Persistence persistence = mock(Persistence.class);
+        // read() deserializes (and promotes) the legacy store, exactly as production does.
+        when(persistence.read()).thenReturn(Optional.of(
+                ApiAccessStore.fromProto(legacyStoreWithFullStandardGrant("legacy-client"))));
+        ApiAccessStoreService service = serviceWith(persistence);
+
+        // Drives the real chain: read() -> applyPersisted() -> onPersistedApplied() -> persist().
+        service.readPersisted();
+
+        // Capture what actually reaches disk and prove the promotion is in it — not just that
+        // persistAsync was called.
+        ArgumentCaptor<ApiAccessStore> captor = ArgumentCaptor.forClass(ApiAccessStore.class);
+        verify(persistence).persistAsync(captor.capture());
+        PermissionSet written = captor.getValue().getPermissionsByClientId().get("legacy-client");
+        assertTrue(written.isGrantAll(), "the written store must carry the promoted grantAll entry");
+
+        // Round-trip the written bytes to prove grantAll survives a subsequent restart's read.
+        ApiAccessStore reloaded = ApiAccessStore.fromProto(captor.getValue().toProto(false));
+        assertTrue(reloaded.getPermissionsByClientId().get("legacy-client").isGrantAll(),
+                "grantAll must survive a restart round-trip of the written store");
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void readPersistedDoesNotWriteBackWhenNothingWasPromoted() {
+        Persistence persistence = mock(Persistence.class);
+        // Already grantAll on disk — nothing promoted, nothing to write back.
+        ApiAccessStore alreadyGrantAll = ApiAccessStore.fromProto(bisq.api.protobuf.ApiAccessStore.newBuilder()
+                .putPermissionsByClientId("client-1", PermissionSet.grantAll().toProto(false))
+                .setPermissionsSchemaVersion(1)
+                .build());
+        when(persistence.read()).thenReturn(Optional.of(alreadyGrantAll));
+        ApiAccessStoreService service = serviceWith(persistence);
+
+        service.readPersisted();
+
+        verify(persistence, never()).persistAsync(any());
+    }
+}

--- a/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreTest.java
+++ b/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.access.persistence;
+
+import bisq.api.access.permissions.Permission;
+import bisq.api.access.permissions.PermissionSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApiAccessStoreTest {
+    @Test
+    void fullPermissionSetIsPromotedToGrantAllOnLoad() {
+        // An entry already covering every permission of the running version is promoted to
+        // grantAll: promotion grants nothing extra at that moment, it only keeps the grant
+        // covering permissions added later — which is what every full grant was issued to mean.
+        // This is how pre-grantAll stores (always full grants) gain forward coverage.
+        bisq.api.protobuf.PermissionSet fullEntry = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addAllPermissions(EnumSet.allOf(Permission.class).stream().map(Permission::toProtoEnum).toList())
+                .build();
+        bisq.api.protobuf.ApiAccessStore proto = bisq.api.protobuf.ApiAccessStore.newBuilder()
+                .putPermissionsByClientId("legacy-client", fullEntry)
+                .build();
+
+        ApiAccessStore store = ApiAccessStore.fromProto(proto);
+
+        PermissionSet migrated = store.getPermissionsByClientId().get("legacy-client");
+        assertTrue(migrated.isGrantAll());
+        assertEquals(Permission.autoGrantable(), migrated.getPermissions());
+    }
+
+    @Test
+    void subsetEntryIsNeverPromotedRegardlessOfSchemaVersion() {
+        // The schema version cannot gate promotion: a pre-grantAll node rewrites the store
+        // from its own model and drops the version field, so it does not survive a downgrade.
+        // A subset must stay a subset whatever version stamp the store carries.
+        bisq.api.protobuf.PermissionSet subset = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addPermissions(Permission.OFFERBOOK.toProtoEnum())
+                .build();
+        for (int schemaVersion : new int[]{0, 1}) {
+            bisq.api.protobuf.ApiAccessStore proto = bisq.api.protobuf.ApiAccessStore.newBuilder()
+                    .putPermissionsByClientId("restricted-client", subset)
+                    .setPermissionsSchemaVersion(schemaVersion)
+                    .build();
+
+            PermissionSet loaded = ApiAccessStore.fromProto(proto).getPermissionsByClientId().get("restricted-client");
+
+            assertFalse(loaded.isGrantAll(), "subset must not be promoted at schema version " + schemaVersion);
+            assertEquals(Set.of(Permission.OFFERBOOK), loaded.getPermissions());
+        }
+    }
+
+    @Test
+    void downgradeRewriteCycleDoesNotEscalateRestrictedEntries() {
+        // new -> old -> new: a store written by this version, then rewritten by a pre-grantAll
+        // node (which rebuilds the proto from its own model: grantAll entries were loaded as
+        // their expanded permission list, and the grantAll + schemaVersion fields are dropped),
+        // then loaded by this version again.
+        ApiAccessStore newStore = new ApiAccessStore();
+        newStore.getPermissionsByClientId().put("full-client", PermissionSet.grantAll());
+        newStore.getPermissionsByClientId().put("restricted-client", new PermissionSet(Set.of(Permission.OFFERBOOK)));
+
+        bisq.api.protobuf.ApiAccessStore v1Proto = newStore.toProto(false);
+
+        // Simulate the pre-grantAll node's rewrite: only the expanded permission lists survive.
+        bisq.api.protobuf.ApiAccessStore.Builder oldNodeRewrite = bisq.api.protobuf.ApiAccessStore.newBuilder();
+        v1Proto.getPermissionsByClientIdMap().forEach((clientId, entry) ->
+                oldNodeRewrite.putPermissionsByClientId(clientId,
+                        bisq.api.protobuf.PermissionSet.newBuilder()
+                                .addAllPermissions(entry.getPermissionsList())
+                                .build()));
+
+        ApiAccessStore reloaded = ApiAccessStore.fromProto(oldNodeRewrite.build());
+
+        // The former grantAll entry serialized its full expansion, so the evidence rule
+        // re-promotes it; the restricted entry must come back exactly as it was.
+        assertTrue(reloaded.getPermissionsByClientId().get("full-client").isGrantAll());
+        PermissionSet restricted = reloaded.getPermissionsByClientId().get("restricted-client");
+        assertFalse(restricted.isGrantAll());
+        assertEquals(Set.of(Permission.OFFERBOOK), restricted.getPermissions());
+    }
+
+    @Test
+    void grantAllEntrySurvivesStoreRoundTrip() {
+        ApiAccessStore store = new ApiAccessStore();
+        store.getPermissionsByClientId().put("client-1", PermissionSet.grantAll());
+
+        bisq.api.protobuf.ApiAccessStore proto = store.toProto(false);
+        ApiAccessStore reloaded = ApiAccessStore.fromProto(proto);
+
+        assertEquals(1, proto.getPermissionsSchemaVersion());
+        PermissionSet reloadedSet = reloaded.getPermissionsByClientId().get("client-1");
+        assertTrue(reloadedSet.isGrantAll());
+        assertEquals(Permission.autoGrantable(), reloadedSet.getPermissions());
+    }
+
+    @Test
+    void explicitSubsetSurvivesStoreRoundTrip() {
+        ApiAccessStore store = new ApiAccessStore();
+        store.getPermissionsByClientId().put("client-1", new PermissionSet(Set.of(Permission.MARKET_PRICE)));
+
+        ApiAccessStore reloaded = ApiAccessStore.fromProto(store.toProto(false));
+
+        PermissionSet reloadedSet = reloaded.getPermissionsByClientId().get("client-1");
+        assertFalse(reloadedSet.isGrantAll());
+        assertEquals(Set.of(Permission.MARKET_PRICE), reloadedSet.getPermissions());
+    }
+}


### PR DESCRIPTION
Automated sync of #4914 from `for-mobile-based-on-2.1.11` to `main`. Clean cherry-pick, no conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added grant-all access for standard permissions while keeping sensitive permissions explicit.
  - Improved permission storage and compatibility across upgrades and downgrades.
  - Authorization failures now return structured JSON details.

- **Bug Fixes**
  - QR-code files are replaced more safely, with fallback support when atomic replacement is unavailable.

- **Tests**
  - Added coverage for permissions, authorization responses, persistence migration, compatibility, and QR-code file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->