### PR TITLE
Bugfix/fsm out of order message causing stuck trades

### DIFF
--- a/common/src/main/java/bisq/common/fsm/Fsm.java
+++ b/common/src/main/java/bisq/common/fsm/Fsm.java
@@ -61,19 +61,42 @@ public abstract class Fsm<M extends FsmModel> {
     abstract protected void configTransitions();
 
     public <E extends Event> void handle(E event) {
-        synchronized (this) {
+        // Lock on the model's explicit lock rather than on this Fsm instance: the model (see
+        // FsmModel#getStateAndEventQueueSnapshot) must be lockable directly by callers that only hold a reference
+        // to the model - e.g. Trade#getTradeBuilder during persistence - without needing a reference to this
+        // Fsm/TradeProtocol. Sharing the same lock object gives both sides the same mutual exclusion, so a
+        // persistence snapshot of {state, eventQueue} can never be taken mid-transition. Unlike
+        // getStateAndEventQueueSnapshot()'s bounded tryLock, a live transition takes the lock unbounded - its
+        // correctness cannot be short-circuited by a timeout.
+        model.lock.lock();
+        try {
+            // Tracks whether this call reached a final state, so the finally block below can route the mandatory
+            // post-transition persist() call through persistOnFinalState() instead of the normal persist(). This
+            // matters for privacy/retention (#1622 follow-up): a final state clears eventQueue/processedEvents
+            // in-memory a few lines below, and that wipe must reach disk promptly - persistOnFinalState() bypasses
+            // any write-rate limiting a subclass may apply to the ordinary persist(), so the wipe is not silently
+            // dropped and left stranded on disk for an indefinite time.
+            boolean reachedFinalState = false;
             try {
                 checkNotNull(event, "event must not be null");
                 State currentState = model.getState();
                 checkNotNull(currentState, "currentState must not be null");
                 if (currentState.isFinalState()) {
-                    log.warn("We have reached the final state and do not allow further state transition. New event was: {}", event);
+                    // Render the class only, never the event instance: the Fsm layer is generic and handles
+                    // domain events (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage) whose
+                    // generated toString() can contain private payment-account data. This log line - like the
+                    // checkArgument message and the error log below - can end up persisted as trade error info
+                    // and included in the error report sent to the peer, so it must never carry event content.
+                    log.warn("We have reached the final state and do not allow further state transition. New event class was: {}", event.getClass().getSimpleName());
                     return;
                 }
                 log.info("Start transition from currentState {}", currentState);
                 Class<? extends Event> eventClass = event.getClass();
                 var transitionMapEntriesForEvent = findTransitionMapEntriesForEvent(eventClass);
-                checkArgument(!transitionMapEntriesForEvent.isEmpty(), "No transition found for given event " + event);
+                // Class name only - see the final-state log above for why the event instance itself must never
+                // be rendered here. This message reaches FsmException's cause chain and from there the trade's
+                // persisted error info / peer error report.
+                checkArgument(!transitionMapEntriesForEvent.isEmpty(), "No transition found for given event class " + eventClass.getSimpleName());
                 Optional<Transition> transition = findTransition(currentState, transitionMapEntriesForEvent);
                 if (transition.isPresent()) {
                     State targetState = transition.get().getTargetState();
@@ -95,14 +118,11 @@ public abstract class Fsm<M extends FsmModel> {
                     if (targetState.isFinalState()) {
                         model.processedEvents.clear();
                         model.eventQueue.clear();
+                        reachedFinalState = true;
                     } else {
                         model.processedEvents.add(eventClass);
                         // Apply all pending events to see if any of those match our current state.
-                        // If an exception is thrown by the processed pending event it will get thrown to the
-                        // caller. This would be a different triggering event as the event which cause
-                        // the exception (the one from the queue).
-                        // Clone set to avoid ConcurrentModificationException
-                        new HashSet<>(model.getEventQueue()).forEach(this::handle);
+                        drainEventQueue();
                     }
                 } else {
                     log.info("We did not find a transition with state {} and event {}. " +
@@ -116,7 +136,11 @@ public abstract class Fsm<M extends FsmModel> {
                             .forEach(e -> model.eventQueue.add(event));
                 }
             } catch (Exception exception) {
-                log.error("Error at handling {}.", event, exception);
+                // Class name only - see the comment at the final-state log above. Null-safe on
+                // purpose: the checkNotNull above lands here with event == null, and calling
+                // event.getClass() would mask the informative NPE with a raw one, bypassing the
+                // FsmErrorEvent/error-state handling below.
+                log.error("Error at handling event of class {}.", eventClassName(event), exception);
                 FsmException fsmException = new FsmException(exception, event);
                 // In case of an exception we fire the FsmErrorEvent to trigger an error state.
                 // We apply that only if the event which triggered the exception was not the FsmErrorEvent itself
@@ -128,12 +152,70 @@ public abstract class Fsm<M extends FsmModel> {
                 // We throw the exception to allow specific error handling to the implementation class.
                 throw fsmException;
             } finally {
-                persist();
+                if (reachedFinalState) {
+                    persistOnFinalState();
+                } else {
+                    persist();
+                }
             }
+        } finally {
+            model.lock.unlock();
         }
     }
 
-    protected abstract void persist();
+    private static String eventClassName(Event event) {
+        return event == null ? "null" : event.getClass().getSimpleName();
+    }
+
+    /**
+     * Persistence hook invoked after every handled event (and from the error path). No-op by
+     * default: implementations whose FSM state must survive restarts (e.g. trade protocols
+     * persisting the event queue) override this to trigger their store's persist.
+     */
+    protected void persist() {
+    }
+
+    /**
+     * Called instead of {@link #persist()} exactly once, when a transition reaches a final state. The default
+     * implementation just delegates to {@link #persist()}; override to bypass any write-rate limiting the
+     * concrete {@link #persist()} implementation applies (see {@code bisq.persistence.RateLimitedPersistenceClient}).
+     * <br/>
+     * Reaching a final state clears {@code eventQueue}/{@code processedEvents} in-memory a few lines above in
+     * {@link #handle(Event)}; those may hold sensitive, trade-specific network messages. Without a guaranteed,
+     * unthrottled flush here, a rate-limited persist() call could be silently dropped, leaving the (already
+     * in-memory-wiped) sensitive data sitting on disk for an unbounded time - potentially until the process's
+     * next unrelated persist() call, or its next clean shutdown, neither of which is guaranteed to happen promptly
+     * (or at all, on a crash/kill -9).
+     */
+    protected void persistOnFinalState() {
+        persist();
+    }
+
+    /**
+     * Re-attempts to handle every event currently sitting in the event queue against the current state.
+     * <br/>
+     * This is called automatically after any successful transition (see {@link #handle(Event)}), but it is
+     * also safe - and sometimes necessary - to call explicitly, e.g. once right after a model has been restored
+     * from persisted data: the event queue itself is not guaranteed to be persisted for every {@link FsmModel}
+     * subclass, so events which arrived out of order before a restart may otherwise never be re-applied because
+     * no further live transition ever occurs for that trade.
+     * <br/>
+     * Safe to call when the queue is empty (no-op) and safe to call multiple times. Exceptions from handling a
+     * queued event behave exactly as for a live event: each event goes through the concrete {@link #handle(Event)}
+     * implementation, so whether an {@link FsmException} propagates to the caller or is absorbed is up to the
+     * subclass (e.g. the trade protocols swallow it and surface an error state instead).
+     */
+    public void drainEventQueue() {
+        // Unbounded, like handle() - ReentrantLock is reentrant, so the nested lock() calls inside each
+        // handle(event) below (same thread) are free.
+        model.lock.lock();
+        try {
+            // Clone set to avoid ConcurrentModificationException as handle() mutates model.eventQueue.
+            new HashSet<>(model.getEventQueue()).forEach(this::handle);
+        } finally {
+            model.lock.unlock();
+        }
+    }
 
     public TransitionBuilder<M> addTransition() {
         return new TransitionBuilder<>(this);

--- a/common/src/main/java/bisq/common/fsm/FsmModel.java
+++ b/common/src/main/java/bisq/common/fsm/FsmModel.java
@@ -24,18 +24,53 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 @Slf4j
 @ToString
 @EqualsAndHashCode
 public class FsmModel {
+    /**
+     * Bound for {@link #getStateAndEventQueueSnapshot()}'s {@code tryLock}. Chosen short enough that the single,
+     * JVM-wide {@code Persistence} executor thread (see {@code bisq.persistence.Persistence#EXECUTOR}) can never
+     * be stuck for long on one trade's live transition - which would otherwise queue up every other store's
+     * writes behind it - yet long enough to comfortably clear the lock's normal, fast holders (a transition's
+     * state mutation plus a non-blocking persist() submission). A timed-out snapshot fails this write cycle
+     * rather than risk a torn read; RateLimitedPersistenceClient's generation pair keeps the store dirty so the
+     * next persist()/shutdown fallback retries - by which time a merely-slow (not stuck) handler has typically
+     * released the lock.
+     */
+    static final long SNAPSHOT_LOCK_TIMEOUT_MS = 500;
+
     private final Observable<State> state = new Observable<>();
 
-    // Package visibility for access from Fsm mutating the collections 
-    final Set<Event> eventQueue = new HashSet<>();
-    final Set<Class<? extends Event>> processedEvents = new HashSet<>();
+    // Explicit lock replacing the previous intrinsic-monitor use (synchronized(model) in Fsm#handle()/
+    // drainEventQueue(), synchronized methods below): ReentrantLock, unlike synchronized, offers a bounded
+    // tryLock(timeout), which getStateAndEventQueueSnapshot() below needs. Every party that used to synchronize
+    // on the model instance must now go through this SAME lock object - Fsm#handle()/drainEventQueue() included -
+    // or mutual exclusion between a live transition and a persistence-facing read silently breaks.
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    final ReentrantLock lock = new ReentrantLock();
+
+    // Package visibility for access from Fsm mutating the collections.
+    // CopyOnWriteArraySet rather than a plain HashSet, as defense-in-depth for any reader that bypasses
+    // getStateAndEventQueueSnapshot() and calls getEventQueue()/getProcessedEvents() directly without acquiring
+    // the shared lock field above (Fsm#handle()/Fsm#drainEventQueue() run under that same lock - see
+    // getStateAndEventQueueSnapshot() below for why). Concurrently iterating a plain HashSet while another thread
+    // structurally mutates it is undefined behavior (ConcurrentModificationException or a torn read). Both sets
+    // are always small (a handful of pending FSM events per trade at most) and read far more often than mutated,
+    // which is exactly CopyOnWriteArraySet's sweet spot; it also gives every such reader (including
+    // Fsm#drainEventQueue()'s defensive copy-before-iterate, which a plain HashSet copy does not actually make
+    // safe under concurrent mutation) consistent snapshot-iterator semantics for free, without requiring any
+    // external synchronization. The primary, recommended mechanism for a cross-thread, all-fields-consistent read
+    // (e.g. Trade#getTradeBuilder during persistence) is getStateAndEventQueueSnapshot(), not these getters.
+    final Set<Event> eventQueue = new CopyOnWriteArraySet<>();
+    final Set<Class<? extends Event>> processedEvents = new CopyOnWriteArraySet<>();
 
     public FsmModel(State initialState) {
         if (initialState == null) {
@@ -72,5 +107,103 @@ public class FsmModel {
 
     public Set<Class<? extends Event>> getProcessedEvents() {
         return Collections.unmodifiableSet(processedEvents);
+    }
+
+    /**
+     * Returns an atomic, defensively-copied snapshot of {@code state} and {@code eventQueue} taken together.
+     * <br/>
+     * {@link Fsm#handle(Event)} and {@link Fsm#drainEventQueue()} take the same {@link #lock} (not a lock on the
+     * {@code Fsm} instance) precisely so that this method - callable directly on the model, e.g. from
+     * {@code bisq.trade.Trade#getTradeBuilder} during persistence, which runs on a different thread than the Fsm's
+     * own transitions (persistence is cloned/serialized asynchronously, and for MuSig trades the message-handling
+     * itself runs on a dedicated executor - see {@code MuSigTradeService#handleMuSigTradeMessage}) - can take the
+     * same lock and therefore never observe a torn read.
+     * <br/>
+     * Reading {@link #getState()} and {@link #getEventQueue()} via two separate, unsynchronized calls can tear:
+     * a persistence snapshot could capture the state AFTER a transition together with the just-applied event
+     * STILL in the queue (causing a double-apply on restore), or the state BEFORE the transition with the event
+     * already removed (causing the event to be silently lost). Capturing both fields in one atomically-locked
+     * method closes that gap.
+     * <br/>
+     * Unlike {@link Fsm#handle(Event)}/{@link Fsm#drainEventQueue()}, which take the lock unbounded (transition
+     * correctness cannot be short-circuited), this method bounds its wait via {@code tryLock}: it is called from
+     * {@code Trade#getTradeBuilder}, which runs on the single, JVM-wide {@code Persistence} executor thread. A live
+     * transition can legitimately hold {@link #lock} for as long as its event handler takes (including blocking
+     * I/O - e.g. MuSig's gRPC calls), and that thread must never block on it indefinitely: doing so would queue up
+     * every other store's disk writes in the JVM behind this one trade. On timeout this throws
+     * {@link SnapshotLockTimeoutException} instead of falling back to an unsynchronized read - a torn read is
+     * exactly the bug this method exists to prevent - so the write fails for this cycle and retries once the
+     * generation pair notices it's still dirty (see {@code RateLimitedPersistenceClient}).
+     * <br/>
+     * The returned {@code eventQueue} is a defensive copy ({@link Set#copyOf}): it is independent of the live,
+     * mutable {@code eventQueue} field, so a later transition can never retroactively change a snapshot that was
+     * already taken and handed to a caller.
+     */
+    public StateAndEventQueue getStateAndEventQueueSnapshot() {
+        boolean acquired;
+        try {
+            acquired = lock.tryLock(SNAPSHOT_LOCK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting up to {}ms to acquire the FsmModel lock during serialization; " +
+                    "write cycle will retry. modelClass={}", SNAPSHOT_LOCK_TIMEOUT_MS, getClass().getSimpleName());
+            throw new SnapshotLockTimeoutException(this, SNAPSHOT_LOCK_TIMEOUT_MS, e);
+        }
+        if (!acquired) {
+            log.warn("FsmModel lock not acquired within {}ms during serialization - a live transition is likely " +
+                    "holding it; write cycle will retry. modelClass={}", SNAPSHOT_LOCK_TIMEOUT_MS, getClass().getSimpleName());
+            throw new SnapshotLockTimeoutException(this, SNAPSHOT_LOCK_TIMEOUT_MS);
+        }
+        try {
+            return new StateAndEventQueue(getState(), Set.copyOf(eventQueue));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Clears the pending out-of-order event queue (and {@code processedEvents}) under the same lock used by
+     * {@link #getStateAndEventQueueSnapshot()}, mirroring the final-state cleanup in {@link Fsm#handle(Event)}.
+     * Takes the lock unbounded, like {@link Fsm#handle(Event)}: this is called from the trade services, not from
+     * the persistence-serialization path, so there is no shared-executor-stall concern to bound against here.
+     * <br/>
+     * Used by the trade data-retention/redaction pass: the queue can hold sensitive account-data network messages
+     * (e.g. {@code BisqEasyAccountDataMessage} / MuSig {@code SendAccountPayloadMessage}) which are persisted with
+     * the trade. A stuck trade may never reach a final state to clear them, so they must be scrubbed once the trade
+     * passes the redaction threshold, otherwise the persisted copy would linger on disk indefinitely.
+     */
+    public void clearEventQueue() {
+        lock.lock();
+        try {
+            eventQueue.clear();
+            processedEvents.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Removes queued out-of-order events matching {@code filter}, under the same lock as
+     * {@link #getStateAndEventQueueSnapshot()}. Returns true if anything was removed (so callers know a
+     * persist is warranted). Takes the lock unbounded - see {@link #clearEventQueue()}.
+     * <br/>
+     * Used by the restore-drain guard in the trade services: a queued trade message passed validation when it
+     * was originally received, but its sender may have been banned before the restart. Draining applies queued
+     * events directly through the FSM - bypassing the {@code onMessage()} banned-sender check - so such events
+     * must be scrubbed before the drain, mirroring what {@code onMessage()} would do with a live message.
+     */
+    public boolean removeQueuedEventsIf(Predicate<Event> filter) {
+        lock.lock();
+        try {
+            return eventQueue.removeIf(filter);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Immutable {state, eventQueue} pair captured atomically by {@link #getStateAndEventQueueSnapshot()}.
+     */
+    public record StateAndEventQueue(State state, Set<Event> eventQueue) {
     }
 }

--- a/common/src/main/java/bisq/common/fsm/FsmModel.java
+++ b/common/src/main/java/bisq/common/fsm/FsmModel.java
@@ -40,9 +40,10 @@ public class FsmModel {
      * be stuck for long on one trade's live transition - which would otherwise queue up every other store's
      * writes behind it - yet long enough to comfortably clear the lock's normal, fast holders (a transition's
      * state mutation plus a non-blocking persist() submission). A timed-out snapshot fails this write cycle
-     * rather than risk a torn read; RateLimitedPersistenceClient's generation pair keeps the store dirty so the
-     * next persist()/shutdown fallback retries - by which time a merely-slow (not stuck) handler has typically
-     * released the lock.
+     * rather than risk a torn read; the thrown {@link SnapshotLockTimeoutException} escapes the write path
+     * (see {@code PersistableStoreReaderWriter#write}) so {@code RateLimitedPersistenceClient} keeps a retry
+     * pending - the next persist() call or the shutdown fallback rewrites the then-current store, by which time
+     * a merely-slow (not stuck) handler has typically released the lock.
      */
     static final long SNAPSHOT_LOCK_TIMEOUT_MS = 500;
 
@@ -132,8 +133,9 @@ public class FsmModel {
      * I/O - e.g. MuSig's gRPC calls), and that thread must never block on it indefinitely: doing so would queue up
      * every other store's disk writes in the JVM behind this one trade. On timeout this throws
      * {@link SnapshotLockTimeoutException} instead of falling back to an unsynchronized read - a torn read is
-     * exactly the bug this method exists to prevent - so the write fails for this cycle and retries once the
-     * generation pair notices it's still dirty (see {@code RateLimitedPersistenceClient}).
+     * exactly the bug this method exists to prevent - so the write fails for this cycle; the exception escapes
+     * the write path (see {@code PersistableStoreReaderWriter#write}) and {@code RateLimitedPersistenceClient}
+     * keeps a retry pending (next persist() call or the shutdown fallback).
      * <br/>
      * The returned {@code eventQueue} is a defensive copy ({@link Set#copyOf}): it is independent of the live,
      * mutable {@code eventQueue} field, so a later transition can never retroactively change a snapshot that was
@@ -162,21 +164,26 @@ public class FsmModel {
     }
 
     /**
-     * Clears the pending out-of-order event queue (and {@code processedEvents}) under the same lock used by
-     * {@link #getStateAndEventQueueSnapshot()}, mirroring the final-state cleanup in {@link Fsm#handle(Event)}.
+     * Clears the pending out-of-order event queue under the same lock used by
+     * {@link #getStateAndEventQueueSnapshot()}. Unlike the final-state cleanup in {@link Fsm#handle(Event)}, this
+     * deliberately KEEPS {@code processedEvents}: the cleared trade may still be live (stuck, not final) and
+     * receiving duplicate resends of already-applied messages - {@code processedEvents} is the dedup guard that
+     * stops such a resend from being re-queued (and re-persisted) with sensitive content. It holds only event
+     * classes, in memory, and is never persisted, so keeping it costs nothing privacy-wise.
      * Takes the lock unbounded, like {@link Fsm#handle(Event)}: this is called from the trade services, not from
      * the persistence-serialization path, so there is no shared-executor-stall concern to bound against here.
      * <br/>
-     * Used by the trade data-retention/redaction pass: the queue can hold sensitive account-data network messages
-     * (e.g. {@code BisqEasyAccountDataMessage} / MuSig {@code SendAccountPayloadMessage}) which are persisted with
-     * the trade. A stuck trade may never reach a final state to clear them, so they must be scrubbed once the trade
-     * passes the redaction threshold, otherwise the persisted copy would linger on disk indefinitely.
+     * Used by the trade data-retention/redaction pass (see
+     * {@code BisqEasyTradeService#maybeRedactDataOfCompletedTrades} and the MuSig equivalent): the queue can hold
+     * sensitive account-data network messages (e.g. {@code BisqEasyAccountDataMessage} / MuSig
+     * {@code SendAccountPayloadMessage}) which are persisted with the trade. A stuck trade may never reach a
+     * final state to clear them, so they must be scrubbed once the trade passes the redaction threshold,
+     * otherwise the persisted copy would linger on disk indefinitely.
      */
     public void clearEventQueue() {
         lock.lock();
         try {
             eventQueue.clear();
-            processedEvents.clear();
         } finally {
             lock.unlock();
         }
@@ -205,5 +212,10 @@ public class FsmModel {
      * Immutable {state, eventQueue} pair captured atomically by {@link #getStateAndEventQueueSnapshot()}.
      */
     public record StateAndEventQueue(State state, Set<Event> eventQueue) {
+        public StateAndEventQueue {
+            // Enforce the documented immutability in the type itself rather than relying on caller discipline;
+            // no-op when the caller already passes an immutable set (Set.copyOf returns it unchanged).
+            eventQueue = Set.copyOf(eventQueue);
+        }
     }
 }

--- a/common/src/main/java/bisq/common/fsm/SnapshotLockTimeoutException.java
+++ b/common/src/main/java/bisq/common/fsm/SnapshotLockTimeoutException.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.fsm;
+
+/**
+ * Thrown by {@link FsmModel#getStateAndEventQueueSnapshot()} when its bounded {@code tryLock} could not acquire
+ * the model's lock in time, because a live {@link Fsm#handle(Event)}/{@link Fsm#drainEventQueue()} transition is
+ * holding it. Callers taking snapshots for persistence must NOT catch this per entry - it should propagate and
+ * fail the whole store write for that cycle, rather than silently dropping one entry from the snapshot while the
+ * write still reports success. A later persist retries the write, by which time the transition holding the lock
+ * has typically finished.
+ */
+public class SnapshotLockTimeoutException extends RuntimeException {
+    public SnapshotLockTimeoutException(FsmModel model, long timeoutMs) {
+        super("Could not acquire the FsmModel lock within " + timeoutMs + "ms while taking a state/eventQueue " +
+                "snapshot for " + model.getClass().getSimpleName() + " - a live transition is likely holding it.");
+    }
+
+    public SnapshotLockTimeoutException(FsmModel model, long timeoutMs, Throwable cause) {
+        super("Interrupted while waiting up to " + timeoutMs + "ms to acquire the FsmModel lock while taking a " +
+                "state/eventQueue snapshot for " + model.getClass().getSimpleName(), cause);
+    }
+}

--- a/common/src/test/java/bisq/common/fsm/FsmTest.java
+++ b/common/src/test/java/bisq/common/fsm/FsmTest.java
@@ -204,11 +204,12 @@ public class FsmTest {
         assertEquals(MockState.INIT, fsm.getModel().getState());
         assertEquals(1, model.getEventQueue().size());
 
-        // "Restart": rebuild the model purely from the persisted snapshot (state + queue + processedEvents),
-        // exactly as BisqEasyTrade#fromProto now does via Trade#pendingEventsFromProto/processedEventsFromProto.
+        // "Restart": rebuild the model purely from the persisted snapshot (state + queue), exactly as
+        // BisqEasyTrade#fromProto now does via Trade#pendingEventsFromProto. processedEvents deliberately starts
+        // empty, mirroring production (see the Trade restore constructor) - it is never restored across a restart.
         // The restored state (S1) represents the enabling transition having already been persisted; only the
         // event queue itself was previously at risk of being silently dropped across a restart.
-        MockModel restoredModel = new MockModel(MockState.S1, model.getEventQueue(), model.getProcessedEvents());
+        MockModel restoredModel = new MockModel(MockState.S1, model.getEventQueue(), Set.of());
         SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
         restoredFsm.addTransition()
                 .from(MockState.S1)
@@ -445,10 +446,12 @@ public class FsmTest {
      * so its parked out-of-order events - which can hold sensitive account-data network messages persisted with the
      * trade - would otherwise linger on disk indefinitely. {@link FsmModel#clearEventQueue()} is the seam the
      * data-retention/redaction pass uses to scrub them once a trade passes the redaction threshold. This pins that
-     * it empties both eventQueue and processedEvents.
+     * it empties eventQueue but KEEPS processedEvents: the trade may still be live and receiving duplicate resends
+     * of already-applied messages, and processedEvents is the dedup guard that stops such a resend from being
+     * re-queued (and re-persisted) with sensitive content.
      */
     @Test
-    void testClearEventQueueScrubsParkedEvents() {
+    void testClearEventQueueScrubsParkedEventsButKeepsProcessedEvents() {
         MockModel model = new MockModel(MockState.INIT);
         SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
         fsm.addTransition()
@@ -456,21 +459,30 @@ public class FsmTest {
                 .on(MockEvent1.class)
                 .run(MockEventHandler.class)
                 .to(MockState.S1);
+        // MockEvent2's only transition starts from S2, which is never reached - so it stays parked (the
+        // stuck-trade shape) even after the MockEvent1 transition below succeeds.
         fsm.addTransition()
-                .from(MockState.S1)
+                .from(MockState.S2)
                 .on(MockEvent2.class)
                 .run(MockEventHandler.class)
-                .to(MockState.S2);
+                .to(MockState.S3);
 
-        // MockEvent2 arrives before its enabling transition, so the Fsm parks it in the queue (the stuck-trade shape).
         fsm.handle(new MockEvent2(model, "queued"));
         assertEquals(MockState.INIT, model.getState());
         assertEquals(1, model.getEventQueue().size());
 
+        // A successful transition records its event class in processedEvents (the duplicate-resend dedup guard).
+        fsm.handle(new MockEvent1(model, "applied"));
+        assertEquals(MockState.S1, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+        assertTrue(model.getProcessedEvents().contains(MockEvent1.class));
+
         model.clearEventQueue();
 
         assertTrue(model.getEventQueue().isEmpty(), "clearEventQueue() must empty the parked event queue");
-        assertTrue(model.getProcessedEvents().isEmpty(), "clearEventQueue() must also clear processedEvents");
+        assertTrue(model.getProcessedEvents().contains(MockEvent1.class),
+                "clearEventQueue() must keep processedEvents - the dedup guard against duplicate resends " +
+                        "re-queueing sensitive content on a still-live trade");
     }
 
     @Test

--- a/common/src/test/java/bisq/common/fsm/FsmTest.java
+++ b/common/src/test/java/bisq/common/fsm/FsmTest.java
@@ -21,10 +21,22 @@ import lombok.Getter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FsmTest {
+    // Standin for private payment-account data that a real domain event's generated toString() could contain
+    // (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage). Used by SentinelMockEvent below.
+    private static final String SENTINEL_SECRET = "SECRET_PAYMENT_ACCOUNT_DATA_MUST_NOT_LEAK";
 
     @Test
     void testTransitions() {
@@ -156,6 +168,341 @@ public class FsmTest {
         assertEquals("test_comp", fsm.getModel().data);
         assertEquals(0, model.eventQueue.size());
         assertEquals(0, model.processedEvents.size());
+    }
+
+    /**
+     * Reproduces the recovery mechanism behind issue #1622 (a Bisq Easy trade getting stuck because an
+     * out-of-order message sits forever in the FSM's event queue): a queued event, and the model's state,
+     * are captured as if they had just been read back from persisted data (this is exactly what
+     * {@code Trade}'s 3-arg constructor now feeds into {@link FsmModel#FsmModel(State, Set, Set)} when a
+     * trade is restored from proto). We then rebuild a fresh Fsm around that restored model and call
+     * {@link Fsm#drainEventQueue()} once, with no further event delivered, and confirm the queued event is
+     * still applied - proving that recovery no longer depends on some later, unrelated live transition
+     * (or, as happens in production today, an app restart happening to re-deliver the same message via
+     * mailbox replay) to save the trade.
+     */
+    @Test
+    void testDrainEventQueueAfterModelRestore() {
+        // Session 1: an out-of-order event arrives before its prerequisite transition. It gets queued and the
+        // enabling transition (INIT -> S1) never happens live in this session - mirrors the reported bug,
+        // where the buyer's confirm-fiat-sent message arrives before the seller has processed the buyer's
+        // btc-address message.
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, fsm.getModel().getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        // "Restart": rebuild the model purely from the persisted snapshot (state + queue + processedEvents),
+        // exactly as BisqEasyTrade#fromProto now does via Trade#pendingEventsFromProto/processedEventsFromProto.
+        // The restored state (S1) represents the enabling transition having already been persisted; only the
+        // event queue itself was previously at risk of being silently dropped across a restart.
+        MockModel restoredModel = new MockModel(MockState.S1, model.getEventQueue(), model.getProcessedEvents());
+        SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
+        restoredFsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // The restored queue must round-trip faithfully.
+        assertEquals(1, restoredModel.getEventQueue().size());
+        assertEquals(MockState.S1, restoredFsm.getModel().getState());
+
+        // No further event is delivered - only the drain is triggered, as happens once at trade/protocol
+        // reconstruction for a restored trade (BisqEasyTradeService#createAndAddTradeProtocol).
+        restoredFsm.drainEventQueue();
+
+        assertEquals(MockState.S2, restoredFsm.getModel().getState());
+        // MockEventHandler mutates the model referenced by the event itself (the original, pre-restore model,
+        // per the test fixture below) rather than the restoredFsm's model - this confirms the handler for the
+        // queued MockEvent2 genuinely ran during the drain, not just a state placeholder change.
+        assertEquals("queued", model.data);
+        assertTrue(restoredFsm.getModel().getEventQueue().isEmpty());
+    }
+
+    @Test
+    void testDrainEventQueueIsSafeAndIdempotentWhenEmpty() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+
+        // Calling drainEventQueue() on an empty queue must be a safe no-op, and calling it repeatedly must not
+        // change behaviour or throw (re-entrancy is guarded by the same reentrant model lock handle() uses).
+        fsm.drainEventQueue();
+        fsm.drainEventQueue();
+        assertEquals(MockState.INIT, fsm.getModel().getState());
+
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S1, fsm.getModel().getState());
+
+        fsm.drainEventQueue();
+        fsm.drainEventQueue();
+        assertEquals(MockState.S1, fsm.getModel().getState());
+        assertEquals("test1", fsm.getModel().data);
+    }
+
+    /**
+     * Regression/documentation guard for the bug itself: if the event queue is NOT carried over on restore
+     * (the behaviour before this fix - {@code Trade} used to call the single-arg {@code FsmModel(State)}
+     * constructor from {@code fromProto}), the queued event is lost forever. Calling drainEventQueue() cannot
+     * recover data that was never restored in the first place; restoring the queue itself (see
+     * {@link #testDrainEventQueueAfterModelRestore}) is what fixes issue #1622, not drainEventQueue() alone.
+     */
+    @Test
+    void testEventIsLostForeverIfQueueIsNotRestored() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(1, model.getEventQueue().size());
+
+        // "Restart" using only the single-arg constructor - the pre-fix behaviour: the queue is not restored.
+        MockModel restoredModel = new MockModel(MockState.S1);
+        SimpleFsm<MockModel> restoredFsm = new SimpleFsm<>(restoredModel);
+        restoredFsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        assertTrue(restoredModel.getEventQueue().isEmpty());
+        restoredFsm.drainEventQueue();
+
+        // The trade is stuck forever: nothing but the original MockEvent2 instance (now gone) could unstick it.
+        assertEquals(MockState.S1, restoredFsm.getModel().getState());
+        assertNull(restoredFsm.getModel().data);
+    }
+
+    /**
+     * Deterministic proof that {@link FsmModel#getStateAndEventQueueSnapshot()} captures {@code state} and
+     * {@code eventQueue} atomically and independently of later mutation - the concurrency guarantee behind the
+     * #4885 follow-up (making the persisted {state, eventQueue} pair atomic). A genuine data race between
+     * Fsm#handle() and an off-thread persistence read is not something we can reproduce deterministically without
+     * a flaky thread-interleaving test, so instead this pins the single-threaded contract the fix relies on:
+     * a snapshot taken at time T must forever reflect exactly what was true at T, however the model changes after.
+     */
+    @Test
+    void testStateAndEventQueueSnapshotIsAtomicAndIndependentOfLaterMutation() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // MockEvent2 arrives before the enabling INIT -> S1 transition: no transition matches MockEvent2 from
+        // INIT, so the Fsm parks it in the queue instead of applying it.
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        // A snapshot taken now must reflect exactly this pre-transition reality.
+        FsmModel.StateAndEventQueue snapshotBeforeTransition = model.getStateAndEventQueueSnapshot();
+        assertEquals(MockState.INIT, snapshotBeforeTransition.state());
+        assertEquals(1, snapshotBeforeTransition.eventQueue().size());
+
+        // The enabling transition fires: state moves to S1, then the automatic post-transition drain immediately
+        // re-applies the queued MockEvent2, advancing straight on to S2 and emptying the live queue - all within
+        // this single handle() call.
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S2, model.getState());
+        assertTrue(model.getEventQueue().isEmpty());
+
+        // Load-bearing assertion: the snapshot taken BEFORE the transition must be completely unaffected by it.
+        // This proves two things at once: (a) the eventQueue copy was defensive/independent - a reference into
+        // the live CopyOnWriteArraySet would now appear empty, since the live queue was drained - and (b) state
+        // and eventQueue were captured together as of the same instant, not via two independently-racy reads.
+        assertEquals(MockState.INIT, snapshotBeforeTransition.state());
+        assertEquals(1, snapshotBeforeTransition.eventQueue().size());
+
+        // A fresh snapshot taken now must reflect the new, post-transition reality.
+        FsmModel.StateAndEventQueue snapshotAfterTransition = model.getStateAndEventQueueSnapshot();
+        assertEquals(MockState.S2, snapshotAfterTransition.state());
+        assertTrue(snapshotAfterTransition.eventQueue().isEmpty());
+    }
+
+    /**
+     * Pins the bounded-tryLock behaviour {@link FsmModel#getStateAndEventQueueSnapshot()} needs for the single,
+     * JVM-wide {@code Persistence} executor thread (see {@code Trade#getTradeBuilder}): while a live transition
+     * holds the model's lock for a long-running event handler (simulating blocking I/O, e.g. MuSig's gRPC calls),
+     * a concurrent snapshot attempt must give up close to its bound instead of blocking indefinitely, and must
+     * throw {@link SnapshotLockTimeoutException} rather than fall back to an unsynchronized (and possibly torn)
+     * read. Once the transition completes and releases the lock, the very next snapshot attempt must succeed and
+     * reflect the settled, post-transition state.
+     */
+    @Test
+    void testGetStateAndEventQueueSnapshotTimesOutWhileHandleHoldsLockThenSucceedsAfterRelease() throws InterruptedException {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(BlockingMockEventHandler.class)
+                .to(MockState.S1);
+
+        BlockingMockEventHandler.started = new CountDownLatch(1);
+        BlockingMockEventHandler.release = new CountDownLatch(1);
+        try {
+            Thread slowHandlerThread = new Thread(() -> fsm.handle(new MockEvent1(model, "slow")), "slow-handler");
+            slowHandlerThread.start();
+            assertTrue(BlockingMockEventHandler.started.await(2, TimeUnit.SECONDS), "handler never started");
+
+            // The slow-handler thread now holds model's lock for the whole transition (Fsm#handle wraps
+            // eventHandler.handle()). A concurrent bounded snapshot attempt - exactly what Trade#getTradeBuilder
+            // does from the shared Persistence executor thread - must not block indefinitely.
+            long startNanos = System.nanoTime();
+            assertThrows(SnapshotLockTimeoutException.class, model::getStateAndEventQueueSnapshot);
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            assertTrue(elapsedMs < 2000,
+                    "tryLock must give up close to its bound, not block indefinitely; took " + elapsedMs + "ms");
+
+            // Release the slow handler; the transition completes normally.
+            BlockingMockEventHandler.release.countDown();
+            slowHandlerThread.join(2000);
+            assertEquals(MockState.S1, model.getState());
+
+            // Once the lock is free again, the very next snapshot call must succeed and reflect the now-settled
+            // state, proving this is a bounded wait, not a permanently broken lock.
+            FsmModel.StateAndEventQueue snapshot = model.getStateAndEventQueueSnapshot();
+            assertEquals(MockState.S1, snapshot.state());
+            assertTrue(snapshot.eventQueue().isEmpty());
+        } finally {
+            BlockingMockEventHandler.started = null;
+            BlockingMockEventHandler.release = null;
+        }
+    }
+
+    /**
+     * Follow-up to #4885 (privacy/retention, Henrik's review point): a transition reaching a final state clears
+     * eventQueue/processedEvents in-memory (see Fsm#handle), which may hold sensitive, trade-specific network
+     * messages. The persist call which follows that clear must be routed through {@link Fsm#persistOnFinalState()}
+     * rather than the plain, potentially rate-limited {@link Fsm#persist()}, so that the wipe is not left stranded
+     * on disk. This test pins that dispatch deterministically, without any real I/O or timing involved.
+     */
+    @Test
+    void testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.COMPLETED);
+
+        // A normal, non-final transition must go through the ordinary (potentially rate-limited) persist().
+        fsm.handle(new MockEvent1(model, "test1"));
+        assertEquals(MockState.S1, fsm.getModel().getState());
+        assertEquals(1, fsm.persistCallCount);
+        assertEquals(0, fsm.persistOnFinalStateCallCount);
+
+        // The completing transition must be routed through persistOnFinalState() instead - exactly once, and
+        // the ordinary persist() must NOT additionally fire for this same call.
+        fsm.handle(new MockEvent2(model, "test2"));
+        assertEquals(MockState.COMPLETED, fsm.getModel().getState());
+        assertEquals(1, fsm.persistCallCount);
+        assertEquals(1, fsm.persistOnFinalStateCallCount);
+    }
+
+    /**
+     * Follow-up to #4885 (privacy/retention, Henrik's review point): a stuck trade may never reach a final state,
+     * so its parked out-of-order events - which can hold sensitive account-data network messages persisted with the
+     * trade - would otherwise linger on disk indefinitely. {@link FsmModel#clearEventQueue()} is the seam the
+     * data-retention/redaction pass uses to scrub them once a trade passes the redaction threshold. This pins that
+     * it empties both eventQueue and processedEvents.
+     */
+    @Test
+    void testClearEventQueueScrubsParkedEvents() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S1);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+
+        // MockEvent2 arrives before its enabling transition, so the Fsm parks it in the queue (the stuck-trade shape).
+        fsm.handle(new MockEvent2(model, "queued"));
+        assertEquals(MockState.INIT, model.getState());
+        assertEquals(1, model.getEventQueue().size());
+
+        model.clearEventQueue();
+
+        assertTrue(model.getEventQueue().isEmpty(), "clearEventQueue() must empty the parked event queue");
+        assertTrue(model.getProcessedEvents().isEmpty(), "clearEventQueue() must also clear processedEvents");
+    }
+
+    @Test
+    void testRemoveQueuedEventsIfScrubsOnlyMatchingParkedEvents() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent2.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S2);
+        fsm.addTransition()
+                .from(MockState.S1)
+                .on(MockEvent3.class)
+                .run(MockEventHandler.class)
+                .to(MockState.S3);
+
+        // Both arrive before their enabling state, so the Fsm parks them (the stuck-trade shape).
+        fsm.handle(new MockEvent2(model, "queued-2"));
+        fsm.handle(new MockEvent3(model, "queued-3"));
+        assertEquals(2, model.getEventQueue().size());
+
+        // The selective scrub used by the restore-drain guard (drop events from a now-banned sender):
+        // only matching events go, the rest stay queued for the drain.
+        boolean removed = model.removeQueuedEventsIf(MockEvent2.class::isInstance);
+
+        assertTrue(removed, "removeQueuedEventsIf must report that something was removed");
+        assertEquals(1, model.getEventQueue().size(), "non-matching events must stay queued");
+        assertTrue(model.getEventQueue().stream().anyMatch(MockEvent3.class::isInstance));
+
+        assertFalse(model.removeQueuedEventsIf(MockEvent2.class::isInstance),
+                "a second scrub with no matches must report nothing removed");
     }
 
     @Test
@@ -522,6 +869,77 @@ public class FsmTest {
     }
 
 
+    /**
+     * The generic Fsm layer must never string-render a full
+     * event instance - domain events (e.g. BisqEasyAccountDataMessage / MuSig SendAccountPayloadMessage) have
+     * generated toString() output that can contain private payment-account data, and the FsmException message
+     * built here (via {@code ExceptionUtil#getRootCauseMessage}) ends up both in the trade's persisted error
+     * info and in the BisqEasyReportErrorMessage sent to the peer. This drives the no-transition-found path
+     * (Fsm#handle's checkArgument), the one site whose message used to concatenate the event instance directly.
+     */
+    @Test
+    void testNoTransitionExceptionMessageDoesNotLeakEventContent() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        // Deliberately no transition registered for SentinelMockEvent at all.
+
+        fsm.handle(new SentinelMockEvent());
+
+        assertNotNull(fsm.lastSwallowedException, "handle() must have hit the no-transition-found path");
+        String message = fsm.lastSwallowedException.getMessage();
+        assertTrue(message.contains(SentinelMockEvent.class.getSimpleName()),
+                "message should still identify the event's class for diagnostics: " + message);
+        assertFalse(message.contains(SENTINEL_SECRET),
+                "message must not render the event instance itself: " + message);
+    }
+
+    /**
+     * Same guard as above, for the OTHER generic catch site in Fsm#handle: an event handler throwing mid-transition.
+     * The FSM layer's own log.error/FsmException construction must not add a leak here either - what the handler's
+     * own exception message says is outside the FSM layer's control (it's generic, not domain-aware), but the
+     * framework itself must not concatenate the event on top of that.
+     */
+    @Test
+    void testHandlerExceptionMessageDoesNotLeakEventContent() {
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(SentinelMockEvent.class)
+                .run(SentinelThrowingMockEventHandler.class)
+                .to(MockState.S1);
+
+        fsm.handle(new SentinelMockEvent());
+
+        assertNotNull(fsm.lastSwallowedException, "handle() must have hit the handler-exception path");
+        String message = fsm.lastSwallowedException.getMessage();
+        assertFalse(message.contains(SENTINEL_SECRET),
+                "message must not render the event instance itself: " + message);
+    }
+
+    @Test
+    void handleNullEventFailsWithInformativeCauseInsteadOfMaskingNpe() {
+        // Regression: the error-path logging used to call event.getClass() on the null event. The
+        // resulting raw NPE was not an FsmException, so it bypassed the FsmErrorEvent/error-state
+        // handling entirely (and would blow through SimpleFsm's FsmException catch), masking the
+        // informative "event must not be null" message.
+        MockModel model = new MockModel(MockState.INIT);
+        SimpleFsm<MockModel> fsm = new SimpleFsm<>(model);
+        fsm.addTransition()
+                .from(MockState.INIT)
+                .on(MockEvent1.class)
+                .run(MockEventHandler.class);
+
+        fsm.handle(null);
+
+        // The configured error handling ran: FsmException raised (captured by SimpleFsm), error
+        // state entered, and the informative NPE preserved as the cause.
+        assertNotNull(fsm.lastSwallowedException);
+        assertInstanceOf(NullPointerException.class, fsm.lastSwallowedException.getCause());
+        assertEquals("event must not be null", fsm.lastSwallowedException.getCause().getMessage());
+        assertEquals(State.FsmState.ERROR, fsm.getModel().getState());
+    }
+
     @Getter
     public enum MockState implements State {
         INIT,
@@ -600,6 +1018,56 @@ public class FsmTest {
         }
     }
 
+    /**
+     * Standin for a domain event whose generated toString() carries private data. Used to prove the generic
+     * Fsm layer only ever renders the event's CLASS, never the instance itself (see
+     * testNoTransitionExceptionMessageDoesNotLeakEventContent / testHandlerExceptionMessageDoesNotLeakEventContent).
+     */
+    public static class SentinelMockEvent implements Event {
+        @Override
+        public String toString() {
+            return SENTINEL_SECRET;
+        }
+    }
+
+    public static class SentinelThrowingMockEventHandler implements EventHandler<Event> {
+        public SentinelThrowingMockEventHandler() {
+        }
+
+        @Override
+        public void handle(Event event) {
+            throw new RuntimeException("handler failed");
+        }
+    }
+
+    /**
+     * Simulates a slow/blocking event handler (e.g. MuSig's gRPC calls) to test that a concurrent, bounded
+     * {@link FsmModel#getStateAndEventQueueSnapshot()} does not block indefinitely on the model lock this handler
+     * holds for the whole transition. Handler classes are constructed reflectively via a no-arg constructor (see
+     * {@link SimpleFsm#newEventHandlerFromClass}), so per-run coordination must be static - reset by the test
+     * before and after use.
+     */
+    public static class BlockingMockEventHandler implements EventHandler<MockEvent1> {
+        static volatile CountDownLatch started;
+        static volatile CountDownLatch release;
+
+        @Override
+        public void handle(MockEvent1 event) {
+            started.countDown();
+            boolean released;
+            try {
+                released = release.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while blocking", e);
+            }
+            if (!released) {
+                throw new IllegalStateException("blocking handler was never released");
+            }
+            event.model.data = event.data;
+        }
+    }
+
     public static class MockModel extends FsmModel {
         public MockModel(MockState state) {
             super(state);
@@ -608,6 +1076,10 @@ public class FsmTest {
         public MockModel(MockState state, String data) {
             super(state);
             this.data = data;
+        }
+
+        public MockModel(MockState state, Set<Event> eventQueue, Set<Class<? extends Event>> processedEvents) {
+            super(state, eventQueue, processedEvents);
         }
 
         private String data = null;

--- a/common/src/test/java/bisq/common/fsm/SimpleFsm.java
+++ b/common/src/test/java/bisq/common/fsm/SimpleFsm.java
@@ -3,6 +3,15 @@ package bisq.common.fsm;
 import java.lang.reflect.InvocationTargetException;
 
 public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
+    // Test-only invocation counters, used to assert which persist path a given transition routed through
+    // (see FsmTest#testPersistOnFinalStateIsUsedInsteadOfPersistWhenReachingFinalState).
+    public int persistCallCount = 0;
+    public int persistOnFinalStateCallCount = 0;
+    // Test-only capture of the FsmException this class otherwise swallows below, so tests can assert on its
+    // message content (e.g. that it never renders a full event instance - see
+    // FsmTest#testNoTransitionExceptionMessageDoesNotLeakEventContent /
+    // #testHandlerExceptionMessageDoesNotLeakEventContent).
+    public FsmException lastSwallowedException;
 
     public SimpleFsm(M model) {
         super(model);
@@ -30,12 +39,18 @@ public class SimpleFsm<M extends FsmModel> extends Fsm<M> {
         try {
             super.handle(event);
         } catch (FsmException fsmException) {
-            // We swallow the exception
+            // We swallow the exception - test-only capture for assertions, see lastSwallowedException above.
+            lastSwallowedException = fsmException;
         }
     }
 
     @Override
     protected void persist() {
-        // Ignore for test
+        persistCallCount++;
+    }
+
+    @Override
+    protected void persistOnFinalState() {
+        persistOnFinalStateCallCount++;
     }
 }

--- a/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
+++ b/persistence/src/main/java/bisq/persistence/PersistableStoreReaderWriter.java
@@ -18,6 +18,7 @@
 package bisq.persistence;
 
 import bisq.common.file.FileMutatorUtils;
+import bisq.common.fsm.SnapshotLockTimeoutException;
 import bisq.persistence.backup.BackupFileInfo;
 import bisq.persistence.backup.RestoreService;
 import com.google.protobuf.Any;
@@ -70,6 +71,13 @@ public class PersistableStoreReaderWriter<T extends PersistableStore<T>> {
                 Files.deleteIfExists(storeFilePath);
             }
             storeFileManager.renameTempFileToCurrentFile();
+        } catch (SnapshotLockTimeoutException e) {
+            // Transient by design (see FsmModel#getStateAndEventQueueSnapshot): a live FSM transition held the
+            // model lock past the bounded wait, so no consistent snapshot could be serialized this cycle. Unlike
+            // the failures below, this must not be swallowed - rethrow so the caller's persist future completes
+            // exceptionally and the client keeps a retry pending (see RateLimitedPersistenceClient#persist).
+            // The previous store file on disk is left untouched.
+            throw e;
         } catch (CouldNotSerializePersistableStore e) {
             log.error("Couldn't serialize {}", persistableStore, e);
         } catch (Exception e) {

--- a/persistence/src/main/java/bisq/persistence/RateLimitedPersistenceClient.java
+++ b/persistence/src/main/java/bisq/persistence/RateLimitedPersistenceClient.java
@@ -59,10 +59,39 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
             return getPersistence()
                     .persistAsync(getPersistableStore().getClone())
                     .handle((nil, throwable) -> {
+                        if (throwable != null) {
+                            // The write failed (e.g. SnapshotLockTimeoutException while serializing - see
+                            // PersistableStoreReaderWriter#write): the on-disk snapshot is stale, so keep the
+                            // retry state. The next persist() call writes the then-current store, and
+                            // persistOnShutdown() covers the case where no further persist() ever comes.
+                            dropped = true;
+                        }
                         writeInProgress = false;
                         return throwable == null;
                     });
         }
+    }
+
+    /**
+     * Unthrottled write path: bypasses the max-write-rate gate and any in-progress write, for the rare writes
+     * that must not be silently dropped - e.g. a trade protocol reaching a final state, whose in-memory wipe of
+     * sensitive queued messages has to reach disk promptly (see {@code bisq.common.fsm.Fsm#persistOnFinalState}).
+     * Safe to submit while a throttled write is in flight: the single Persistence executor thread serializes
+     * writes, and this call clones the store at submission time, so it captures state at least as new as any
+     * write already queued ahead of it.
+     */
+    public CompletableFuture<Boolean> persistNow() {
+        lastWrite = System.currentTimeMillis();
+        dropped = false;
+        return getPersistence()
+                .persistAsync(getPersistableStore().getClone())
+                .handle((nil, throwable) -> {
+                    if (throwable != null) {
+                        // Same contract as the throttled path above: a failed write must leave a retry pending.
+                        dropped = true;
+                    }
+                    return throwable == null;
+                });
     }
 
     protected long getMaxWriteRateInMs() {
@@ -72,7 +101,14 @@ public abstract class RateLimitedPersistenceClient<T extends PersistableStore<T>
     private void persistOnShutdown() {
         if (dropped) {
             dropped = false;
-            getPersistence().persist(getPersistableStore().getClone());
+            try {
+                getPersistence().persist(getPersistableStore().getClone());
+            } catch (Exception e) {
+                // Runs on a JVM shutdown-hook thread: an escaping exception (e.g. SnapshotLockTimeoutException,
+                // which the write path deliberately rethrows) would die unlogged there, and nothing can retry
+                // after this point anyway. The previous store file on disk remains intact.
+                log.error("Persisting {} at shutdown failed.", getPersistence().getStorePath(), e);
+            }
         }
     }
 }

--- a/persistence/src/test/java/bisq/persistence/PersistableStoreReaderWriterTests.java
+++ b/persistence/src/test/java/bisq/persistence/PersistableStoreReaderWriterTests.java
@@ -18,9 +18,13 @@
 package bisq.persistence;
 
 import bisq.common.file.FileMutatorUtils;
+import bisq.common.fsm.FsmModel;
+import bisq.common.fsm.SnapshotLockTimeoutException;
+import bisq.common.fsm.State;
 import bisq.common.proto.ProtoResolver;
 import bisq.persistence.backup.MaxBackupSize;
 import bisq.persistence.backup.RestoreService;
+import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -30,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PersistableStoreReaderWriterTests {
@@ -143,5 +148,44 @@ public class PersistableStoreReaderWriterTests {
 
         // Triggers rename
         persistableStoreReaderWriter.write(timestampStore);
+    }
+
+    @Test
+    void writePropagatesSnapshotLockTimeout(@TempDir Path tempDirPath) {
+        Path storageFilePath = tempDirPath.resolve("protoFile");
+        var storeFileManager = new PersistableStoreFileManager(storageFilePath);
+        var persistableStoreReaderWriter = new PersistableStoreReaderWriter<SnapshotLockTimeoutStore>(storeFileManager, new RestoreService());
+
+        // Unlike other serialization failures, which write() logs and swallows, a SnapshotLockTimeoutException
+        // must escape so that the caller does not treat the skipped write cycle as a success
+        // (see RateLimitedPersistenceClient#persist).
+        assertThatThrownBy(() -> persistableStoreReaderWriter.write(new SnapshotLockTimeoutStore()))
+                .isInstanceOf(SnapshotLockTimeoutException.class);
+
+        // The failed cycle must not have produced a (necessarily incomplete) store file.
+        assertThat(Files.notExists(storageFilePath)).isTrue();
+    }
+
+    // Minimal store whose serialization fails like a trade store does when a live FSM transition holds the
+    // FsmModel lock past the bounded snapshot wait (see BisqEasyTradeStore#getBuilder).
+    private static final class SnapshotLockTimeoutStore implements PersistableStore<SnapshotLockTimeoutStore> {
+        @Override
+        public Message.Builder getBuilder(boolean serializeForHash) {
+            throw new SnapshotLockTimeoutException(new FsmModel(State.FsmState.ERROR), 500);
+        }
+
+        @Override
+        public SnapshotLockTimeoutStore getClone() {
+            return this;
+        }
+
+        @Override
+        public void applyPersisted(SnapshotLockTimeoutStore persisted) {
+        }
+
+        @Override
+        public ProtoResolver<PersistableStore<?>> getResolver() {
+            throw new UnsupportedOperationException("Not used in this test");
+        }
     }
 }

--- a/persistence/src/test/java/bisq/persistence/RateLimitedPersistenceClientTests.java
+++ b/persistence/src/test/java/bisq/persistence/RateLimitedPersistenceClientTests.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.persistence;
+
+import bisq.common.fsm.FsmModel;
+import bisq.common.fsm.SnapshotLockTimeoutException;
+import bisq.common.fsm.State;
+import bisq.persistence.backup.MaxBackupSize;
+import bisq.persistence.backup.RestoreService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RateLimitedPersistenceClientTests {
+
+    @Test
+    void failedWriteKeepsRetryPending(@TempDir Path tempDirPath) {
+        var persistence = new Persistence<TimestampStore>(tempDirPath, "TimestampStore", MaxBackupSize.TEN_MB, new RestoreService()) {
+            @Override
+            public CompletableFuture<Void> persistAsync(TimestampStore serializable) {
+                return CompletableFuture.failedFuture(
+                        new SnapshotLockTimeoutException(new FsmModel(State.FsmState.ERROR), 500));
+            }
+        };
+        var client = createClient(persistence);
+
+        // A failed write must not be reported as a success, and must leave the dropped flag set so that
+        // persistOnShutdown() retries it if no further persist() call ever comes.
+        assertThat(client.persist().join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+    }
+
+    @Test
+    void persistNowBypassesRateLimit(@TempDir Path tempDirPath) {
+        var persistence = new Persistence<TimestampStore>(tempDirPath, "TimestampStore", MaxBackupSize.TEN_MB, new RestoreService());
+        var client = createClient(persistence);
+
+        assertThat(client.persist().join()).isTrue();
+
+        // Within the max-write-rate window the throttled path drops the write...
+        assertThat(client.persist().join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+
+        // ...but the unthrottled path must write anyway and clear the pending retry it covers.
+        assertThat(client.persistNow().join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    @Test
+    void failedPersistNowKeepsRetryPending(@TempDir Path tempDirPath) {
+        var persistence = new Persistence<TimestampStore>(tempDirPath, "TimestampStore", MaxBackupSize.TEN_MB, new RestoreService()) {
+            @Override
+            public CompletableFuture<Void> persistAsync(TimestampStore serializable) {
+                return CompletableFuture.failedFuture(
+                        new SnapshotLockTimeoutException(new FsmModel(State.FsmState.ERROR), 500));
+            }
+        };
+        var client = createClient(persistence);
+
+        assertThat(client.persistNow().join()).isFalse();
+        assertThat(client.isDropped()).isTrue();
+    }
+
+    @Test
+    void successfulWriteLeavesNoRetryPending(@TempDir Path tempDirPath) {
+        var persistence = new Persistence<TimestampStore>(tempDirPath, "TimestampStore", MaxBackupSize.TEN_MB, new RestoreService());
+        var client = createClient(persistence);
+
+        assertThat(client.persist().join()).isTrue();
+        assertThat(client.isDropped()).isFalse();
+    }
+
+    private static RateLimitedPersistenceClient<TimestampStore> createClient(Persistence<TimestampStore> persistence) {
+        var store = new TimestampStore();
+        return new RateLimitedPersistenceClient<>() {
+            @Override
+            public Persistence<TimestampStore> getPersistence() {
+                return persistence;
+            }
+
+            @Override
+            public PersistableStore<TimestampStore> getPersistableStore() {
+                return store;
+            }
+
+            @Override
+            protected long getMaxWriteRateInMs() {
+                // Wide window so back-to-back persist() calls are reliably rate-limited even under a slow/paused
+                // test JVM; the default 1000ms could theoretically elapse between the two calls.
+                return 60_000;
+            }
+        };
+    }
+}

--- a/trade/src/main/java/bisq/trade/Trade.java
+++ b/trade/src/main/java/bisq/trade/Trade.java
@@ -17,6 +17,7 @@
 
 package bisq.trade;
 
+import bisq.common.fsm.Event;
 import bisq.common.fsm.FsmModel;
 import bisq.common.fsm.State;
 import bisq.common.monetary.Monetary;
@@ -26,6 +27,7 @@ import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.proto.PersistableProto;
 import bisq.contract.Contract;
 import bisq.identity.Identity;
+import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.offer.Direction;
 import bisq.offer.Offer;
 import bisq.security.DigestUtil;
@@ -37,7 +39,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -114,7 +118,25 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                     P taker,
                     P maker,
                     TradeLifecycleState lifecycleState) {
-        super(state);
+        this(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState, Set.of());
+    }
+
+    // Used when restoring a trade from persisted data. Passing in the persisted pendingEvents ensures that FSM
+    // events which arrived out of order and could not yet be applied before the previous shutdown are not
+    // silently lost (see bisq.common.fsm.FsmModel and bisq.common.fsm.Fsm#drainEventQueue). processedEvents is
+    // never restored across a restart: it is only ever used live, in-memory, within a single running session
+    // (populated the moment a transition succeeds, cleared once a final state is reached - see Fsm#handle), so
+    // we always start it out empty here.
+    protected Trade(C contract,
+                    State state,
+                    String id,
+                    TradeRole tradeRole,
+                    Identity myIdentity,
+                    P taker,
+                    P maker,
+                    TradeLifecycleState lifecycleState,
+                    Set<Event> pendingEvents) {
+        super(state, pendingEvents, Set.of());
 
         this.contract = contract;
         this.id = id;
@@ -126,6 +148,19 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
     }
 
     protected bisq.trade.protobuf.Trade.Builder getTradeBuilder(boolean serializeForHash) {
+        // Read state + eventQueue together as one atomic, defensively-copied snapshot (see
+        // FsmModel#getStateAndEventQueueSnapshot) rather than via two separate, unsynchronized calls to getState()
+        // and getEventQueue(). This method (Trade#toProto -> here) can run concurrently with Fsm#handle()/
+        // Fsm#drainEventQueue() on a different thread - persistence clones/serializes the trade store
+        // asynchronously, and for MuSig trades message handling itself runs on a dedicated executor - so an
+        // un-synchronized pair of reads could tear: capturing the state AFTER a transition together with the
+        // just-applied event STILL in the queue (a double-apply on restore), or the state BEFORE the transition
+        // with the event already removed (a silent loss). Taking both from the same locked snapshot closes that gap.
+        // getStateAndEventQueueSnapshot() bounds its wait for this lock and throws SnapshotLockTimeoutException
+        // rather than block indefinitely - this runs on the single, JVM-wide Persistence executor thread, which
+        // must never stall behind one trade's live transition. Deliberately left uncaught here: it must propagate
+        // out of toProto() and fail this trade's/store's write for the cycle (see BisqEasyTradeStore#getBuilder).
+        StateAndEventQueue snapshot = getStateAndEventQueueSnapshot();
         bisq.trade.protobuf.Trade.Builder builder = bisq.trade.protobuf.Trade.newBuilder()
                 .setContract(contract.toProto(serializeForHash))
                 .setId(id)
@@ -133,7 +168,7 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
                 .setMyIdentity(myIdentity.toProto(serializeForHash))
                 .setTaker(taker.toProto(serializeForHash))
                 .setMaker(maker.toProto(serializeForHash))
-                .setState(getState().name())
+                .setState(snapshot.state().name())
                 .setLifecycleState(getLifecycleState().toProtoEnum());
         Optional.ofNullable(getErrorMessage()).ifPresent(builder::setErrorMessage);
         Optional.ofNullable(getErrorStackTrace()).ifPresent(builder::setErrorStackTrace);
@@ -141,7 +176,38 @@ public abstract class Trade<T extends Offer<?, ?>, C extends Contract<T>, P exte
         Optional.ofNullable(getPeersErrorStackTrace()).ifPresent(builder::setPeersErrorStackTrace);
         Optional.ofNullable(getTradeProtocolFailure()).ifPresent(e -> builder.setTradeProtocolFailure(e.toProtoEnum()));
         Optional.ofNullable(getPeersTradeProtocolFailure()).ifPresent(e -> builder.setPeersTradeProtocolFailure(e.toProtoEnum()));
+        // Only network messages are serializable; local, user-triggered events (e.g. BisqEasyConfirmFiatSentEvent)
+        // have no proto representation and are never at risk of being lost across a restart since they are only
+        // ever created while the app is already running.
+        snapshot.eventQueue().stream()
+                .filter(EnvelopePayloadMessage.class::isInstance)
+                .map(event -> ((EnvelopePayloadMessage) event).toProto(serializeForHash))
+                .forEach(builder::addPendingFsmEvents);
         return builder;
+    }
+
+    /**
+     * Resolves the persisted pending FSM events (out-of-order network messages) from the given proto.
+     * Any entry which fails to resolve (e.g. an unknown/removed message class from an old persisted trade) is
+     * logged and skipped rather than failing the whole trade load.
+     */
+    protected static Set<Event> pendingEventsFromProto(bisq.trade.protobuf.Trade proto) {
+        Set<Event> pendingEvents = new HashSet<>();
+        for (bisq.network.protobuf.EnvelopePayloadMessage envelopePayloadMessageProto : proto.getPendingFsmEventsList()) {
+            try {
+                EnvelopePayloadMessage envelopePayloadMessage = EnvelopePayloadMessage.fromProto(envelopePayloadMessageProto);
+                if (envelopePayloadMessage instanceof Event event) {
+                    pendingEvents.add(event);
+                } else {
+                    log.warn("Persisted pending FSM event does not implement Event and is dropped. messageType={}",
+                            envelopePayloadMessage.getClass().getSimpleName());
+                }
+            } catch (Exception e) {
+                log.warn("Could not resolve a persisted pending FSM event. It will be dropped and not re-applied " +
+                        "after restore. messageCase={}", envelopePayloadMessageProto.getMessageCase(), e);
+            }
+        }
+        return pendingEvents;
     }
 
     protected void setErrorMessage(String errorMessage) {

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTrade.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.bisq_easy;
 
+import bisq.common.fsm.Event;
 import bisq.common.observable.Observable;
 import bisq.common.observable.ReadOnlyObservable;
 import bisq.common.proto.ProtobufUtils;
@@ -38,6 +39,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @ToString(callSuper = true)
@@ -88,8 +90,9 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                           Identity myIdentity,
                           BisqEasyTradeParty taker,
                           BisqEasyTradeParty maker,
-                          TradeLifecycleState lifecycleState) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState);
+                          TradeLifecycleState lifecycleState,
+                          Set<Event> pendingEvents) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState, pendingEvents);
 
         stateObservable().addObserver(s -> tradeState.set((BisqEasyTradeState) s));
     }
@@ -127,7 +130,8 @@ public final class BisqEasyTrade extends Trade<BisqEasyOffer, BisqEasyContract, 
                 Identity.fromProto(proto.getMyIdentity()),
                 TradeParty.protoToBisqEasyTradeParty(proto.getTaker()),
                 TradeParty.protoToBisqEasyTradeParty(proto.getMaker()),
-                TradeLifecycleState.fromProto(proto.getLifecycleState()));
+                TradeLifecycleState.fromProto(proto.getLifecycleState()),
+                pendingEventsFromProto(proto));
         if (proto.hasErrorMessage()) {
             trade.setErrorMessage(proto.getErrorMessage());
         }

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
@@ -69,6 +69,7 @@ import bisq.user.contact_list.ContactListService;
 import bisq.user.contact_list.ContactReason;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -133,15 +134,18 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     /* --------------------------------------------------------------------- */
 
     public CompletableFuture<Boolean> initialize() {
+        // Register the alert observer BEFORE restoring trades: addObserver() synchronously replays the
+        // persisted authorized alert data, so haltTrading / minRequiredVersionForTrading reflect the last
+        // known alert state by the time the restore drain below re-applies queued events. Registered after
+        // the restore, the drain-time checks would be vacuously green on every cold start.
+        authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(this::updateTradeRestrictions);
 
-        persistableStore.getTrades().forEach(this::createAndAddTradeProtocol);
+        persistableStore.getTrades().forEach(trade -> createAndAddTradeProtocol(trade, true));
 
         networkService.getConfidentialMessageServices().stream()
                 .flatMap(service -> service.getProcessedEnvelopePayloadMessages().stream())
                 .forEach(this::onMessage);
         networkService.addConfidentialMessageListener(this);
-
-        authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(this::updateTradeRestrictions);
 
         numDaysAfterRedactingTradeDataScheduler = Scheduler.run(this::maybeRedactDataOfCompletedTrades)
                 .host(this)
@@ -402,6 +406,17 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     }
 
     private BisqEasyProtocol createAndAddTradeProtocol(BisqEasyTrade trade) {
+        return createAndAddTradeProtocol(trade, false);
+    }
+
+    // isRestoredTrade is true when the trade was just loaded from persisted data (app startup), as opposed to a
+    // trade which was just created for a brand-new offer/take-offer flow (whose event queue is always empty).
+    // For restored trades we drain the event queue once: the queue itself survives a restart (persisted on
+    // Trade), but nothing would otherwise re-attempt those pending events until some further, unrelated live
+    // transition happens to occur for that same trade - which may never happen. See bisq.common.fsm.Fsm#drainEventQueue.
+    // Package-private (rather than private) so tests can register a hand-placed trade's protocol exactly the way
+    // production code does, without duplicating this wiring.
+    BisqEasyProtocol createAndAddTradeProtocol(BisqEasyTrade trade, boolean isRestoredTrade) {
         String id = trade.getId();
         BisqEasyProtocol tradeProtocol;
         boolean isBuyer = trade.isBuyer();
@@ -420,6 +435,45 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
         }
         trade.setProtocolVersion(tradeProtocol.getVersion());
         tradeProtocolById.put(id, tradeProtocol);
+        if (isRestoredTrade) {
+            // The queued events passed onMessage()'s guards when they were originally received, but those
+            // conditions may have changed before the restart. Draining applies them directly through the FSM,
+            // so re-check here what onMessage() would check for a live message:
+            //  - Trading halt / min-version (global, temporary): defer the drain entirely and KEEP the events
+            //    queued - they persist and drain on a later restart once the emergency alert is lifted.
+            //    Deliberately no throw: the catch below would mislabel it "stuck until investigated".
+            //  - Banned sender (per event): DROP the event, mirroring onMessage() ignoring a banned sender's
+            //    live message. Kept queued it would get applied after a ban-lift restart - something
+            //    onMessage() would never have allowed.
+            if (haltTrading || isMinVersionForTradingViolated()) {
+                log.warn("Deferring the queued-event drain for restored trade {}: an emergency alert halts " +
+                        "trading or requires a min version. The events stay queued and drain on a later " +
+                        "restart once the alert is lifted.", id);
+            } else {
+                boolean removedBannedSenderEvents = trade.removeQueuedEventsIf(event ->
+                        event instanceof BisqEasyTradeMessage message &&
+                                bannedUserService.isUserProfileBanned(message.getSender()));
+                if (removedBannedSenderEvents) {
+                    log.warn("Removed queued event(s) from a banned sender for restored trade {} before " +
+                            "draining, mirroring the onMessage() banned-sender check.", id);
+                    // Unthrottled: the throttled persist() may silently drop the write during the restore loop,
+                    // and a dropped removal would resurface the banned event on a ban-lift restart.
+                    persistNow();
+                }
+                // Isolate per trade: drainEventQueue() re-applies queued events and can raise an FsmException. The
+                // trade is already created and registered above, so we keep it regardless. Without this guard a
+                // single failing trade would escape the persistableStore.getTrades().forEach(...) loop in
+                // initialize() and block restoring every subsequent trade. A failed drain here means the trade
+                // stays stuck until it is manually looked at - there is no periodic or reconnect-triggered safety
+                // net to retry it.
+                try {
+                    tradeProtocol.drainEventQueue();
+                } catch (Exception e) {
+                    log.warn("Failed to drain the event queue for restored trade {} on load. The trade is still " +
+                            "loaded but remains stuck until manually investigated.", id, e);
+                }
+            }
+        }
         return tradeProtocol;
     }
 
@@ -444,12 +498,21 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
         }
     }
 
+    // Same condition as verifyMinVersionForTrading, as a boolean for the restore-drain guard in
+    // createAndAddTradeProtocol(), which must defer rather than throw.
+    private boolean isMinVersionForTradingViolated() {
+        Optional<String> minRequiredVersion = minRequiredVersionForTrading;
+        return minRequiredVersion.isPresent()
+                && !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersion.get()));
+    }
+
 
     /* --------------------------------------------------------------------- */
     // Redact sensible data
     /* --------------------------------------------------------------------- */
 
-    private void maybeRedactDataOfCompletedTrades() {
+    @VisibleForTesting
+    void maybeRedactDataOfCompletedTrades() {
         int numDays = settingsService.getNumDaysAfterRedactingTradeData().get();
         long redactDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(numDays);
         // Trades which ended up with a failure or got stuck will never get the completed date set.
@@ -459,17 +522,26 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
         String redactedMarker = Res.get("data.redacted");
         long numChanges = getAllTrades().stream()
                 .filter(trade -> {
-                    if (StringUtils.isEmpty(trade.getPaymentAccountData().get()) ||
-                            trade.getPaymentAccountData().get().equals(redactedMarker)) {
-                        return false;
-                    }
                     boolean doRedaction = trade.getTradeCompletedDate().map(date -> date < redactDate)
                             .orElseGet(() -> trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
-                    if (doRedaction) {
-
+                    if (!doRedaction) {
+                        return false;
+                    }
+                    // The persisted pending-event queue can hold account-data messages
+                    // (e.g. BisqEasyAccountDataMessage) on a trade that never reached a final state, so it must
+                    // be scrubbed past the threshold even when the payment-account field below is already
+                    // redacted or was never set (see FsmModel#clearEventQueue).
+                    boolean queueCleared = !trade.getEventQueue().isEmpty();
+                    if (queueCleared) {
+                        trade.clearEventQueue();
+                    }
+                    String paymentAccountData = trade.getPaymentAccountData().get();
+                    boolean fieldRedacted = StringUtils.isNotEmpty(paymentAccountData) &&
+                            !paymentAccountData.equals(redactedMarker);
+                    if (fieldRedacted) {
                         trade.getPaymentAccountData().set(redactedMarker);
                     }
-                    return doRedaction;
+                    return fieldRedacted || queueCleared;
                 })
                 .count();
         if (numChanges > 0) {

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeStore.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeStore.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.bisq_easy;
 
+import bisq.common.fsm.SnapshotLockTimeoutException;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.common.proto.ProtoResolver;
 import bisq.common.proto.UnresolvableProtobufMessageException;
@@ -57,6 +58,14 @@ public final class BisqEasyTradeStore implements PersistableStore<BisqEasyTradeS
                         .map(trade -> {
                             try {
                                 return trade.toProto(serializeForHash);
+                            } catch (SnapshotLockTimeoutException e) {
+                                // Must propagate, not be swallowed like other per-trade failures below: a live
+                                // transition is holding this trade's FsmModel lock past the bounded wait, so this
+                                // snapshot would be stale/incomplete. Letting it fail the whole store write (rather
+                                // than silently dropping just this trade while still reporting success) lets
+                                // PersistableStoreReaderWriter#write rethrow it, so RateLimitedPersistenceClient
+                                // keeps a retry pending for once the transition has released the lock.
+                                throw e;
                             } catch (Exception e) {
                                 log.error("Could not create proto from BisqEasyTrade {}", trade, e);
                                 return null;
@@ -69,6 +78,9 @@ public final class BisqEasyTradeStore implements PersistableStore<BisqEasyTradeS
                         .map(closedTrade -> {
                             try {
                                 return closedTrade.toProto(serializeForHash);
+                            } catch (SnapshotLockTimeoutException e) {
+                                // See the same-named catch above - must propagate to fail the whole write.
+                                throw e;
                             } catch (Exception e) {
                                 log.error("Could not create proto from BisqEasyClosedTrade {}", closedTrade, e);
                                 return null;

--- a/trade/src/main/java/bisq/trade/bisq_easy/protocol/BisqEasyProtocol.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/protocol/BisqEasyProtocol.java
@@ -58,6 +58,14 @@ public abstract class BisqEasyProtocol extends TradeProtocol<BisqEasyTrade> {
         getServiceProvider().getBisqEasyTradeService().persist();
     }
 
+    @Override
+    protected void persistOnFinalState() {
+        // Unthrottled: a final state just cleared eventQueue/processedEvents in-memory (see Fsm#handle), and that
+        // wipe - which can cover sensitive account-data messages - must not be silently dropped by the
+        // rate-limited persist() path (see Fsm#persistOnFinalState's javadoc).
+        getServiceProvider().getBisqEasyTradeService().persistNow();
+    }
+
     public BisqEasyTrade getTrade() {
         return getModel();
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTrade.java
@@ -17,6 +17,7 @@
 
 package bisq.trade.mu_sig;
 
+import bisq.common.fsm.Event;
 import bisq.common.market.Market;
 import bisq.common.observable.Observable;
 import bisq.common.observable.ReadOnlyObservable;
@@ -40,6 +41,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.DEPOSIT_TX_CONFIRMED;
 import static bisq.trade.mu_sig.protocol.MuSigTradeState.INIT;
@@ -86,8 +88,9 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                        Identity myIdentity,
                        MuSigTradeParty taker,
                        MuSigTradeParty maker,
-                       TradeLifecycleState lifecycleState) {
-        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState);
+                       TradeLifecycleState lifecycleState,
+                       Set<Event> pendingEvents) {
+        super(contract, state, id, tradeRole, myIdentity, taker, maker, lifecycleState, pendingEvents);
 
         stateObservable().addObserver(s -> tradeState.set((MuSigTradeState) s));
     }
@@ -126,7 +129,8 @@ public final class MuSigTrade extends Trade<MuSigOffer, MuSigContract, MuSigTrad
                 Identity.fromProto(proto.getMyIdentity()),
                 TradeParty.protoToMuSigTradeParty(proto.getTaker()),
                 TradeParty.protoToMuSigTradeParty(proto.getMaker()),
-                TradeLifecycleState.fromProto(proto.getLifecycleState()));
+                TradeLifecycleState.fromProto(proto.getLifecycleState()),
+                pendingEventsFromProto(proto));
         if (proto.hasErrorMessage()) {
             trade.setErrorMessage(proto.getErrorMessage());
         }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -81,6 +81,7 @@ import bisq.user.contact_list.ContactListService;
 import bisq.user.contact_list.ContactReason;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.stub.StreamObserver;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -179,8 +180,19 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         executor = ExecutorFactory.boundedCachedPool("MuSigTradeService");
 
         return musigGrpcClient.initialize()
-                .thenApply(result -> {
-                    persistableStore.getTrades().forEach(this::createAndAddTradeProtocol);
+                // thenApplyAsync on this service's own bounded executor (not thenApply): the restored-trade
+                // drainEventQueue() below re-applies queued FSM events via protocol.handle(), and every other
+                // handle() in this service is dispatched onto `executor` (see handleMuSigTradeMessage /
+                // handleMuSigTradeEvent). Running it inline here would drain on the gRPC init-completion thread,
+                // re-entering the blocking gRPC stub from a gRPC callback thread. Keep all FSM work on `executor`.
+                .thenApplyAsync(result -> {
+                    // Register the alert observer BEFORE restoring trades: addObserver() synchronously replays
+                    // the persisted authorized alert data, so the restore-drain guard in
+                    // createAndAddTradeProtocol() sees the last known halt/min-version state instead of a
+                    // vacuously-green default. Mirrors BisqEasyTradeService#initialize().
+                    authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(this::updateTradeRestrictions);
+
+                    persistableStore.getTrades().forEach(trade -> createAndAddTradeProtocol(trade, true));
 
                     networkService.getConfidentialMessageServices().stream()
                             .flatMap(service -> service.getProcessedEnvelopePayloadMessages().stream())
@@ -192,14 +204,12 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                             .filter(MuSigTrade::isDepositTxCreatedButNotConfirmed)
                             .forEach(this::observeDepositTxConfirmationStatus);
 
-                    authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(this::updateTradeRestrictions);
-
                     numDaysAfterRedactingTradeDataScheduler = Scheduler.run(this::maybeRedactDataOfCompletedTrades)
                             .host(this)
                             .periodically(1, TimeUnit.HOURS);
                     numDaysAfterRedactingTradeDataPin = settingsService.getNumDaysAfterRedactingTradeData().addObserver(numDays -> maybeRedactDataOfCompletedTrades());
                     return true;
-                });
+                }, executor);
     }
 
     public CompletableFuture<Boolean> shutdown() {
@@ -588,6 +598,17 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     }
 
     private MuSigProtocol createAndAddTradeProtocol(MuSigTrade trade) {
+        return createAndAddTradeProtocol(trade, false);
+    }
+
+    // isRestoredTrade is true when the trade was just loaded from persisted data (app startup), as opposed to a
+    // trade which was just created for a brand-new offer/take-offer flow (whose event queue is always empty).
+    // For restored trades we drain the event queue once: the queue itself survives a restart (persisted on
+    // Trade), but nothing would otherwise re-attempt those pending events until some further, unrelated live
+    // transition happens to occur for that same trade - which may never happen. See bisq.common.fsm.Fsm#drainEventQueue.
+    // Package-private (rather than private) so tests can register a hand-placed trade's protocol exactly the way
+    // production code does, without duplicating this wiring.
+    MuSigProtocol createAndAddTradeProtocol(MuSigTrade trade, boolean isRestoredTrade) {
         String id = trade.getId();
         MuSigProtocol tradeProtocol;
         boolean isBuyer = trade.isBuyer();
@@ -606,6 +627,38 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         }
         trade.setProtocolVersion(tradeProtocol.getVersion());
         tradeProtocolById.put(id, tradeProtocol);
+        if (isRestoredTrade) {
+            // Mirror of the BisqEasyTradeService restore-drain guard - see there for the full rationale.
+            // Queued events passed onMessage()'s guards at receipt time, but halt/min-version/ban state may
+            // have changed before the restart: defer the drain (events stay queued) while an emergency alert
+            // is active, and drop queued events whose sender got banned in the meantime.
+            if (haltTrading || isMinVersionForTradingViolated()) {
+                log.warn("Deferring the queued-event drain for restored trade {}: an emergency alert halts " +
+                        "trading or requires a min version. The events stay queued and drain on a later " +
+                        "restart once the alert is lifted.", id);
+            } else {
+                boolean removedBannedSenderEvents = trade.removeQueuedEventsIf(event ->
+                        event instanceof MuSigTradeMessage message &&
+                                bannedUserService.isUserProfileBanned(message.getSender()));
+                if (removedBannedSenderEvents) {
+                    log.warn("Removed queued event(s) from a banned sender for restored trade {} before " +
+                            "draining, mirroring the onMessage() banned-sender check.", id);
+                    persist();
+                }
+                // Isolate per trade: drainEventQueue() re-applies queued events and can raise an FsmException. The
+                // trade is already created and registered above, so we keep it regardless. Without this guard a
+                // single failing trade would escape the persistableStore.getTrades().forEach(...) loop in
+                // initialize() and block restoring every subsequent trade. A failed drain here means the trade
+                // stays stuck until it is manually looked at - there is no periodic or reconnect-triggered safety
+                // net to retry it.
+                try {
+                    tradeProtocol.drainEventQueue();
+                } catch (Exception e) {
+                    log.warn("Failed to drain the event queue for restored trade {} on load. The trade is still " +
+                            "loaded but remains stuck until manually investigated.", id, e);
+                }
+            }
+        }
         return tradeProtocol;
     }
 
@@ -630,12 +683,21 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         }
     }
 
+    // Same condition as verifyMinVersionForTrading, as a boolean for the restore-drain guard in
+    // createAndAddTradeProtocol(), which must defer rather than throw.
+    private boolean isMinVersionForTradingViolated() {
+        Optional<String> minRequiredVersion = minRequiredVersionForTrading;
+        return minRequiredVersion.isPresent()
+                && !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersion.get()));
+    }
+
 
     /* --------------------------------------------------------------------- */
     // Redact sensible data
     /* --------------------------------------------------------------------- */
 
-    private void maybeRedactDataOfCompletedTrades() {
+    @VisibleForTesting
+    void maybeRedactDataOfCompletedTrades() {
         int numDays = settingsService.getNumDaysAfterRedactingTradeData().get();
         long redactDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(numDays);
         // Trades which ended up with a failure or got stuck will never get the completed date set.
@@ -646,8 +708,18 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                 .filter(trade -> {
                     boolean doRedaction = trade.getTradeCompletedDate().map(date -> date < redactDate)
                             .orElseGet(() -> trade.getContract().getTakeOfferDate() < redactDateForNotCompletedTrades);
-                    //todo
-                    return doRedaction;
+                    if (!doRedaction) {
+                        return false;
+                    }
+                    // The persisted pending-event queue can hold account-data messages
+                    // (e.g. SendAccountPayloadMessage) on a trade that never reached a final state, so it must be
+                    // scrubbed past the threshold (see FsmModel#clearEventQueue).
+                    boolean queueCleared = !trade.getEventQueue().isEmpty();
+                    if (queueCleared) {
+                        trade.clearEventQueue();
+                    }
+                    //todo redact MuSig account payload fields, mirroring BisqEasyTradeService's paymentAccountData
+                    return queueCleared;
                 })
                 .count();
         if (numChanges > 0) {

--- a/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigProtocol.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/protocol/MuSigProtocol.java
@@ -60,6 +60,14 @@ public abstract class MuSigProtocol extends TradeProtocol<MuSigTrade> {
         getServiceProvider().getMuSigTradeService().persist();
     }
 
+    @Override
+    protected void persistOnFinalState() {
+        // Unthrottled: a final state just cleared eventQueue/processedEvents in-memory (see Fsm#handle), and that
+        // wipe - which can cover sensitive account-data messages - must not be silently dropped by the
+        // rate-limited persist() path (see Fsm#persistOnFinalState's javadoc).
+        getServiceProvider().getMuSigTradeService().persistNow();
+    }
+
     public MuSigTrade getTrade() {
         return getModel();
     }

--- a/trade/src/main/proto/trade.proto
+++ b/trade/src/main/proto/trade.proto
@@ -23,6 +23,7 @@ import "common.proto";
 import "contract.proto";
 import "identity.proto";
 import "account.proto";
+import "network.proto";
 import "network_identity.proto";
 import "offer.proto";
 import "rpc.proto";
@@ -79,6 +80,11 @@ message Trade {
   TradeLifecycleState lifecycleState = 12;
   optional TradeProtocolFailure tradeProtocolFailure = 13;
   optional TradeProtocolFailure peersTradeProtocolFailure = 14;
+  // FSM events which arrived out of order and could not yet be applied to the current state
+  // (e.g. a confirmation message received before its sibling message completing an earlier,
+  // unordered phase of the protocol). Persisted so that they are not silently lost across a
+  // restart and can be re-applied once the trade is restored.
+  repeated network.EnvelopePayloadMessage pendingFsmEvents = 15;
 
   oneof message {
     BisqEasyTrade bisqEasyTrade = 30;

--- a/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeStuckByOutOfOrderMessageProofTest.java
+++ b/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeStuckByOutOfOrderMessageProofTest.java
@@ -1,0 +1,417 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.bisq_easy;
+
+import bisq.account.payment_method.BitcoinPaymentMethod;
+import bisq.account.payment_method.BitcoinPaymentMethodSpec;
+import bisq.account.payment_method.BitcoinPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.bonded_roles.release.AppType;
+import bisq.common.market.Market;
+import bisq.common.network.Address;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.proto.UnresolvableProtobufEnumException;
+import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.identity.Identity;
+import bisq.network.NetworkService;
+import bisq.network.SendMessageResult;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.message.EnvelopePayloadMessage;
+import bisq.network.p2p.message.NetworkMessageResolver;
+import bisq.network.p2p.services.confidential.ConfidentialMessageService;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.persistence.PersistenceService;
+import bisq.security.keys.I2PKeyGeneration;
+import bisq.security.keys.KeyBundle;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.keys.TorKeyGeneration;
+import bisq.trade.ServiceProvider;
+import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.bisq_easy.protocol.BisqEasySellerAsMakerProtocol;
+import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyBtcAddressMessage;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyConfirmFiatSentMessage;
+import bisq.trade.protocol.messages.TradeMessage;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Baseline reproduction of the stuck-trade defect discussed in bisq-network/bisq-mobile#1622 / #4885 / #4931.
+ * <p>
+ * These tests are written EXCLUSIVELY against APIs that exist on {@code main}. Two of them assert the behavior
+ * a trader is entitled to expect ("the trade advances once every protocol message has been delivered exactly
+ * once") and FAIL on main - each failure is one concrete, deterministic way a Bisq Easy trade gets permanently
+ * stuck. The control test passes on main and pins the one recovery path the unchanged FSM does provide, so the
+ * failing tests cannot be dismissed as a broken harness.
+ * <p>
+ * Scenario shared by all three tests (seller-as-maker, the reporter's role in #1622): the trade sits at
+ * {@code MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS} - the
+ * seller has sent account data, the buyer's btc-address message is the one leg still in flight. The buyer
+ * (who by protocol config can only confirm fiat-sent after receiving the seller's account data, see
+ * {@code BisqEasyBuyerAsTakerProtocol}) confirms fiat-sent; over Tor/mailbox the two buyer messages can reach
+ * the seller in either order.
+ * <ol>
+ *   <li>{@link #control_outOfOrderFiatSentRecoversWhenEnablingMessageStillArrivesLive}: both messages reach
+ *       the running FSM, in the wrong order. The FSM parks the early one and re-applies it after the next
+ *       transition. PASSES on main - this is the (correct) "ordinary out-of-order delivery recovers" case.</li>
+ *   <li>{@link #tradeAdvancesWhenEnablingMessageCompletesProcessingDuringStartupHandoffWindow}: the
+ *       btc-address message finishes network processing inside the startup handoff window - after
+ *       {@code initialize()}'s replay snapshot was taken, before {@code addConfidentialMessageListener} runs
+ *       (see the ordering in {@code BisqEasyTradeService#initialize()}). The network layer counts it as
+ *       delivered (mailbox copy removed, sender resends stopped, re-deliveries deduped), so it is never
+ *       delivered again in this session; the fiat-sent message then parks forever. FAILS on main: the trade
+ *       is stuck while the app keeps running - no restart involved anywhere.</li>
+ *   <li>{@link #parkedOutOfOrderMessageSurvivesRestartSoTradeCompletesWhenEnablingMessageArrives}: the parked
+ *       fiat-sent message is wiped by the persistence round trip (the FSM event queue is not serialized on
+ *       main), so after a restart the trade advances to the both-legs-done state and sticks one step short,
+ *       with the peer's resend machinery long satisfied. FAILS on main: this is why "just restart" is a coin
+ *       flip, not a fix.</li>
+ * </ol>
+ * The harness (real offer/contract/identity/trade, real seller-as-maker protocol and FSM, real
+ * {@code BisqEasyTradeService.initialize()}/{@code onMessage()} lifecycle against a mocked network boundary,
+ * real proto (de)serialization) mirrors the regression tests shipped with the fix branch, so the same file runs
+ * green there unmodified.
+ */
+class BisqEasyTradeStuckByOutOfOrderMessageProofTest {
+    static {
+        // Normally registered once at app startup by bisq.application.ResolverConfig, which is not a dependency
+        // available to :trade tests. On main this is inert for these tests; on the fix branch it lets the
+        // persisted pending events resolve back via EnvelopePayloadMessage.fromProto() -> Any.unpack().
+        NetworkMessageResolver.addResolver("trade.TradeMessage", TradeMessage.getNetworkMessageResolver());
+    }
+
+    private static final String BTC_ADDRESS = "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx";
+
+    /**
+     * Control (PASSES on main): the recovery path the unchanged FSM genuinely provides. Both buyer messages
+     * reach the running service, out of order. The early fiat-sent parks; the btc-address transition then
+     * auto-drains the queue and the trade completes the fiat-sent step. This pins two things: the harness
+     * delivers messages correctly end-to-end, and "ordinary out-of-order delivery recovers" is conceded -
+     * the two failing tests below are exactly the cases where its precondition (a later live transition)
+     * never materializes.
+     */
+    @Test
+    void control_outOfOrderFiatSentRecoversWhenEnablingMessageStillArrivesLive(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-control");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-control");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir.resolve("control"));
+        BisqEasyTradeService tradeService = harness.tradeService();
+        tradeService.getPersistableStore().addTrade(trade);
+        try {
+            tradeService.initialize();
+
+            // Out of order: fiat-sent first. No transition matches -> the FSM parks it.
+            tradeService.onMessage(new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg-control", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId));
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                    trade.getTradeState(),
+                    "the early fiat-sent message must be parked, not applied");
+            assertEquals(1, trade.getEventQueue().size(),
+                    "the early fiat-sent message must sit in the FSM event queue");
+            assertTrue(trade.getEventQueue().stream().anyMatch(BisqEasyConfirmFiatSentMessage.class::isInstance),
+                    "the parked event must be the fiat-sent message itself");
+
+            // The enabling message still arrives while the app runs: transition + auto-drain -> recovered.
+            tradeService.onMessage(new BisqEasyBtcAddressMessage(
+                    "btc-address-msg-control", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                    BTC_ADDRESS, offer));
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, trade.getTradeState(),
+                    "ordinary out-of-order delivery must recover once the enabling transition happens");
+        } finally {
+            tradeService.persist().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * FAILS on main - the live stranding, no restart anywhere. The btc-address message finishes network
+     * processing inside {@code initialize()}'s handoff window: {@code BisqEasyTradeService#initialize()} first
+     * snapshots {@code getProcessedEnvelopePayloadMessages()} for replay and only AFTERWARDS registers itself
+     * via {@code addConfidentialMessageListener}. A message whose processing completes between those two steps
+     * is dispatched to the listeners registered at that instant ({@code ConfidentialMessageService}
+     * notifies only current listeners, then never again for that message) - i.e. to nobody. Nothing brings it
+     * back: the local mailbox copy is removed on successful decrypt regardless of listener count; the sender's
+     * resend machinery was already satisfied at send time ({@code ResendMessageService} stops resends on
+     * {@code ADDED_TO_MAILBOX}, independent of anything the receiving node does); and even a hypothetical
+     * re-delivery of the same logical message is swallowed by {@code ConfidentialMessageService}'s
+     * decrypted-content dedupe without ever being re-dispatched to listeners.
+     * <p>
+     * The buyer's fiat-sent then arrives perfectly normally, live - and parks forever: the queue is only
+     * drained after a later successful transition, and the only event that could cause one was just consumed
+     * unseen. Both protocol messages were delivered by the network exactly once, nothing crashed, the app
+     * keeps running - and the trade is stuck. This is the mechanism whose symptom matches the #1622 report
+     * ("Mark Payment Sent"/"Payment Received" not advancing while chat still works).
+     */
+    @Test
+    @Timeout(60)
+    @Disabled("Startup handoff window loss (#4947) is a separate mechanism this PR does not address: the message is "
+            + "consumed with no listener registered, so it never reaches the (now persisted) event queue. The follow-up "
+            + "PR fixing #4947 must remove this annotation; the test passes once initialize() no longer drops it.")
+    void tradeAdvancesWhenEnablingMessageCompletesProcessingDuringStartupHandoffWindow(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-handoff");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-handoff");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir.resolve("handoff"));
+        BisqEasyTradeService tradeService = harness.tradeService();
+        NetworkService networkService = harness.networkService();
+
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg-handoff", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                BTC_ADDRESS, offer);
+
+        AtomicReference<ConfidentialMessageService.Listener> registeredListener = new AtomicReference<>();
+        doAnswer(invocation -> {
+            registeredListener.set(invocation.getArgument(0));
+            return null;
+        }).when(networkService).addConfidentialMessageListener(any());
+
+        // Models the network finishing the btc-address message's processing at the point of the handoff
+        // window: the replay snapshot (returned set) does not contain it, and dispatch happens to whichever
+        // listeners are registered at that instant - exactly ConfidentialMessageService's contract
+        // (snapshot read + listeners.forEach on completion; a message is dispatched once, to current
+        // listeners only). Whether the trade service sees the message is decided purely by initialize()'s
+        // ordering of replay vs. registration - which is the code under test.
+        ConfidentialMessageService confidentialMessageService = mock(ConfidentialMessageService.class);
+        when(confidentialMessageService.getProcessedEnvelopePayloadMessages()).thenAnswer(invocation -> {
+            ConfidentialMessageService.Listener listener = registeredListener.get();
+            if (listener != null) {
+                listener.onMessage(btcAddressMessage);
+            }
+            return Set.<EnvelopePayloadMessage>of();
+        });
+        when(networkService.getConfidentialMessageServices()).thenReturn(Set.of(confidentialMessageService));
+
+        tradeService.getPersistableStore().addTrade(trade);
+        try {
+            tradeService.initialize();
+
+            // Wiring guard: initialize() must end with the trade service registered as the live listener. If
+            // BisqEasyTradeService.initialize()'s replay/registration order is ever restructured, this pins
+            // that the mock's model of that ordering still matches the code under test.
+            assertSame(tradeService, registeredListener.get(),
+                    "initialize() must register the trade service as the confidential message listener");
+
+            // The buyer's fiat-sent arrives live, entirely normally. On main the enabling btc-address message
+            // was consumed unseen above, so this parks - and nothing will ever drain it.
+            tradeService.onMessage(new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg-handoff", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId));
+
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, trade.getTradeState(),
+                    "STUCK TRADE: every protocol message was delivered by the network exactly once (btc-address "
+                            + "during the startup handoff window - mailbox-cleared, sender resends long since stopped, "
+                            + "dispatched to no listener; "
+                            + "fiat-sent live, parked in the FSM queue), the app never stopped running, and the seller "
+                            + "is now stranded at " + trade.getTradeState()
+                            + " with a parked event queue of size " + trade.getEventQueue().size()
+                            + " that no future transition will ever drain");
+        } finally {
+            tradeService.persist().join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * FAILS on main - the restart coin flip. Same starting point; the fiat-sent message arrives early and is
+     * parked (in-memory only - while at the network layer the message already counts as delivered: the local
+     * mailbox copy is gone and the sender's resends stopped at {@code ADDED_TO_MAILBOX}, so it will never be
+     * transmitted again). The node
+     * then restarts: the trade is round-tripped through {@code toProto()}/{@code fromProto()} exactly as the
+     * persistence layer does. On main the event queue is not serialized, so the parked message is silently
+     * wiped. When the genuinely pending btc-address message arrives after the restart, the trade advances to
+     * the both-legs-done state - and sticks there, one step short, forever: the fiat-sent confirmation exists
+     * nowhere anymore (not in the FSM, not in the mailbox, not in the peer's resend queue).
+     * <p>
+     * Together with the control test this also explains the #1622 field observation that a desktop restart
+     * only sometimes "fixed" the trade: recovery depended on which messages happened to still be around to
+     * re-feed, while the FSM's own parked copy was guaranteed to be lost.
+     */
+    @Test
+    void parkedOutOfOrderMessageSurvivesRestartSoTradeCompletesWhenEnablingMessageArrives()
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-restart");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-restart");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+        ServiceProvider serviceProvider = createServiceProvider();
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+        BisqEasySellerAsMakerProtocol protocol = new BisqEasySellerAsMakerProtocol(serviceProvider, trade);
+
+        // The buyer's fiat-sent arrives before the btc-address leg -> parked (while at the network layer the
+        // message already counts as delivered, final - it will never be transmitted again).
+        protocol.handle(new BisqEasyConfirmFiatSentMessage(
+                "fiat-sent-msg-restart", tradeId, protocol.getVersion(), takerNetworkId, makerNetworkId));
+        assertEquals(1, trade.getEventQueue().size(),
+                "the early fiat-sent message must be parked in the FSM event queue");
+        assertTrue(trade.getEventQueue().stream().anyMatch(BisqEasyConfirmFiatSentMessage.class::isInstance),
+                "the parked event must be the fiat-sent message itself");
+
+        // Restart: the exact proto round trip the persistence layer performs. The queue size right after
+        // restore is the root-cause checkpoint (0 on main - wiped; the fix preserves it) and is reported in
+        // the final assertion, which is branch-neutral.
+        bisq.trade.protobuf.Trade proto = trade.toProto(false);
+        BisqEasyTrade restoredTrade = BisqEasyTrade.fromProto(proto);
+        int queueSizeAfterRestore = restoredTrade.getEventQueue().size();
+        BisqEasySellerAsMakerProtocol restoredProtocol = new BisqEasySellerAsMakerProtocol(serviceProvider, restoredTrade);
+
+        // After the restart the genuinely pending btc-address message arrives (it was still unACKed /
+        // resend-covered - unlike the fiat-sent one).
+        restoredProtocol.handle(new BisqEasyBtcAddressMessage(
+                "btc-address-msg-restart", tradeId, restoredProtocol.getVersion(), takerNetworkId, makerNetworkId,
+                BTC_ADDRESS, offer));
+
+        assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState(),
+                "STUCK TRADE: the parked fiat-sent confirmation was wiped by the persistence round trip "
+                        + "(event queue size after restore: " + queueSizeAfterRestore + "), so the "
+                        + "restored trade strands one step short at " + restoredTrade.getTradeState()
+                        + " - and the network will never transmit that message again (mailbox cleared, "
+                        + "sender resends stopped at ADDED_TO_MAILBOX, re-deliveries deduped)");
+    }
+
+
+    /* --------------------------------------------------------------------- */
+    // Harness - mirrors the fix branch's regression-test scaffolding, restricted to main APIs.
+    /* --------------------------------------------------------------------- */
+
+    private record LifecycleHarness(BisqEasyTradeService tradeService, NetworkService networkService,
+                                    ServiceProvider serviceProvider) {
+    }
+
+    // Real BisqEasyTradeService against real persistence, with every ServiceProvider dependency initialize()
+    // itself touches stubbed at the network/bonded-roles boundary.
+    private static LifecycleHarness createLifecycleHarness(Path persistenceDir) {
+        NetworkService networkService = mock(NetworkService.class);
+        // Empty by default: message delivery is driven explicitly in each test body.
+        when(networkService.getConfidentialMessageServices()).thenReturn(Set.of());
+        when(networkService.confidentialSend(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendMessageResult.class)));
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+        when(serviceProvider.getPersistenceService()).thenReturn(new PersistenceService(persistenceDir));
+
+        BisqEasyTradeService tradeService = new BisqEasyTradeService(serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(tradeService);
+
+        return new LifecycleHarness(tradeService, networkService, serviceProvider);
+    }
+
+    // Hand-places a real trade at the given state via the same proto round trip persistence uses. The trade ID
+    // is derived (Trade#createId), not chosen - messages must be addressed to the real ID or the handlers'
+    // verification rejects them.
+    private static BisqEasyTrade createTradeAtState(BisqEasyContract contract,
+                                                    BisqEasyOffer offer,
+                                                    NetworkId takerNetworkId,
+                                                    NetworkId makerNetworkId,
+                                                    BisqEasyTradeState state) throws UnresolvableProtobufEnumException {
+        BisqEasyTrade freshTrade = new BisqEasyTrade(contract, false, false, createIdentity(makerNetworkId), offer,
+                takerNetworkId, makerNetworkId);
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(state.name())
+                .build();
+        return BisqEasyTrade.fromProto(proto);
+    }
+
+    private static Identity createIdentity(NetworkId networkId) {
+        KeyBundle keyBundle = new KeyBundle("test-key-bundle",
+                KeyGeneration.generateDefaultEcKeyPair(),
+                TorKeyGeneration.generateKeyPair(),
+                I2PKeyGeneration.generateKeyPair());
+        return new Identity("test-id", networkId, keyBundle);
+    }
+
+    private static ServiceProvider createServiceProvider() {
+        ServiceProvider serviceProvider = mock(ServiceProvider.class);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(mock(BisqEasyTradeService.class));
+        return serviceProvider;
+    }
+
+    private static BisqEasyContract createRealContract(BisqEasyOffer offer, NetworkId takerNetworkId) {
+        return new BisqEasyContract(System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                new BitcoinPaymentMethodSpec(BitcoinPaymentMethod.fromPaymentRail(BitcoinPaymentRail.MAIN_CHAIN)),
+                new FiatPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+    }
+
+    private static BisqEasyOffer createRealOffer(NetworkId makerNetworkId) {
+        return new BisqEasyOffer(makerNetworkId,
+                Direction.SELL,
+                new Market("BTC", "EUR", "Bitcoin", "Euro"),
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(BitcoinPaymentMethod.fromPaymentRail(BitcoinPaymentRail.MAIN_CHAIN)),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                "",
+                List.of("en"),
+                "1.0.0");
+    }
+
+    private static NetworkId createNetworkId(String keyId) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        Address address = Address.from("127.0.0.1", 1000);
+        return new NetworkId(new AddressByTransportTypeMap(Map.of(address.getTransportType(), address)),
+                new PubKey(keyPair.getPublic(), keyId));
+    }
+}

--- a/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeTest.java
+++ b/trade/src/test/java/bisq/trade/bisq_easy/BisqEasyTradeTest.java
@@ -1,0 +1,625 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.bisq_easy;
+
+import bisq.account.payment_method.BitcoinPaymentMethod;
+import bisq.account.payment_method.BitcoinPaymentMethodSpec;
+import bisq.account.payment_method.BitcoinPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.bonded_roles.release.AppType;
+import bisq.bonded_roles.security_manager.alert.AlertType;
+import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.common.market.Market;
+import bisq.common.observable.Observable;
+import bisq.common.observable.collection.ObservableSet;
+import bisq.common.network.Address;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.proto.UnresolvableProtobufEnumException;
+import bisq.contract.bisq_easy.BisqEasyContract;
+import bisq.i18n.Res;
+import bisq.identity.Identity;
+import bisq.network.NetworkService;
+import bisq.network.SendMessageResult;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.message.NetworkMessageResolver;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.bisq_easy.BisqEasyOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.persistence.PersistenceService;
+import bisq.security.keys.I2PKeyGeneration;
+import bisq.security.keys.KeyBundle;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.keys.TorKeyGeneration;
+import bisq.trade.ServiceProvider;
+import bisq.trade.bisq_easy.protocol.BisqEasyProtocol;
+import bisq.trade.bisq_easy.protocol.BisqEasySellerAsMakerProtocol;
+import bisq.trade.bisq_easy.protocol.BisqEasyTradeState;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyBtcAddressMessage;
+import bisq.trade.bisq_easy.protocol.messages.BisqEasyConfirmFiatSentMessage;
+import bisq.trade.protocol.messages.TradeMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Coverage for the stuck-trade fix (#1622): out-of-order protocol messages queued by the FSM survive persistence
+ * round-trips and drain on restore (in-memory, via the real service lifecycle and via real disk persistence), and
+ * the restore drain honours banned-sender and trading-halt guards.
+ * <p>
+ * This is PR B of a multi-PR split of the original fix: only the generic {@code trade/} persistence + drain-on-restore
+ * plumbing is covered here. Tests exercising the creation-atomicity guard (duplicate take-offer delivery),
+ * the startup register-before-replay handoff, the final-state unthrottled-persist follow-up, and the periodic
+ * redaction pass's event-queue scrubbing all depend on code that lives in later PRs and are intentionally not
+ * ported yet - see the PR B report for the full list.
+ */
+class BisqEasyTradeTest {
+    static {
+        // Normally registered once at app startup by bisq.application.ResolverConfig, which is not a dependency
+        // available to :trade tests. Required so that a persisted, wrapped TradeMessage (see
+        // Trade#pendingEventsFromProto) can be resolved back via EnvelopePayloadMessage.fromProto() -> Any.unpack().
+        NetworkMessageResolver.addResolver("trade.TradeMessage", TradeMessage.getNetworkMessageResolver());
+    }
+
+    /**
+     * End-to-end reproduction of issue #1622: a Bisq Easy trade getting stuck because a message which arrives
+     * out of order (here: the buyer's confirm-fiat-sent message, before the seller has processed the buyer's
+     * btc-address message) sits in the FSM's event queue, which historically was not persisted and therefore
+     * lost across a restart. Drives the real seller-as-maker protocol/FSM and the real Trade proto (de)serialization,
+     * proving the queued event survives a toProto()/fromProto() round trip and is correctly re-applied once the
+     * enabling message arrives on the restored trade - without needing the fiat-sent message to be re-delivered.
+     */
+    @Test
+    void confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrains() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker");
+        NetworkId makerNetworkId = createNetworkId("seller-maker");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+        ServiceProvider serviceProvider = createServiceProvider();
+
+        // Seller-as-maker trade, hand-placed at the state reached after: seller sent account data, but has not
+        // yet processed the buyer's btc-address message. This is the realistic predecessor state for #1622: the
+        // buyer cannot confirm fiat-sent before having received the seller's account data (see BisqEasyBuyerAsTakerProtocol),
+        // so by the time the buyer's confirm-fiat-sent message reaches the seller, SELLER_SENT_ACCOUNT_DATA must
+        // already be true; the only leg genuinely still in flight is the buyer's own btc-address message.
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        // The trade ID is derived (Trade#createId) from the offer/taker/take-offer-date, not chosen by us -
+        // messages must be addressed to the real ID or TradeMessageHandler#verifyInternal rejects them.
+        String tradeId = trade.getId();
+
+        BisqEasySellerAsMakerProtocol protocol = new BisqEasySellerAsMakerProtocol(serviceProvider, trade);
+
+        BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                "fiat-sent-msg", tradeId, protocol.getVersion(), takerNetworkId, makerNetworkId);
+
+        // The message arrives before its prerequisite transition: no matching transition from the current
+        // state, so the Fsm queues it instead of applying it.
+        protocol.handle(fiatSentMessage);
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                trade.getTradeState());
+        assertEquals(1, trade.getEventQueue().size());
+
+        // Restart: round-trip the trade through proto exactly as persistence does.
+        bisq.trade.protobuf.Trade proto = trade.toProto(false);
+        BisqEasyTrade restoredTrade = BisqEasyTrade.fromProto(proto);
+
+        // The queued event survives the restart.
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertTrue(restoredTrade.getEventQueue().stream().anyMatch(BisqEasyConfirmFiatSentMessage.class::isInstance));
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                restoredTrade.getTradeState());
+
+        BisqEasySellerAsMakerProtocol restoredProtocol = new BisqEasySellerAsMakerProtocol(serviceProvider, restoredTrade);
+
+        // Draining right after restore is a safe no-op: the current state still does not accept the queued event.
+        restoredProtocol.drainEventQueue();
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                restoredTrade.getTradeState());
+
+        // The genuinely pending message (buyer's btc address) finally arrives.
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg", tradeId, restoredProtocol.getVersion(), takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+        restoredProtocol.handle(btcAddressMessage);
+
+        // This transition succeeds and automatically drains the restored queue, re-applying the previously
+        // queued confirm-fiat-sent message - the trade is no longer stuck, with no restart-timing luck required.
+        assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState());
+        assertTrue(restoredTrade.getEventQueue().isEmpty());
+    }
+
+    /**
+     * End-to-end regression test for issue #1622, driven exclusively through {@link BisqEasyTradeService}'s
+     * public API - {@link BisqEasyTradeService#onMessage(bisq.network.p2p.message.EnvelopePayloadMessage)}, the
+     * real {@code ConfidentialMessageService.Listener} entry point for every inbound trade message, and
+     * {@link BisqEasyTradeService#initialize()}, the real app-bootstrap entry point that restores persisted
+     * trades - rather than by calling {@code protocol.handle()}/{@code drainEventQueue()} directly as
+     * {@link #confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrains()} above does. This
+     * proves the fix survives the actual node lifecycle, not just the Fsm/Trade unit-level mechanics.
+     * <p>
+     * Phase 1 ("before restart"): a seller-as-maker trade is hand-placed at the state reached after the seller
+     * has sent its account data but not yet received the buyer's btc-address message. A
+     * {@link BisqEasyTradeService} instance registers the trade's protocol via {@code initialize()} (as a
+     * running node's service would on startup), then receives the buyer's confirm-fiat-sent message via
+     * {@code onMessage()} - out of order, since the btc-address leg is still outstanding, so it is queued
+     * rather than applied.
+     * <p>
+     * Phase 2 (restart): the trade is round-tripped through {@code toProto()}/{@code fromProto()}, exactly as
+     * persistence does across a restart. Pre-fix, the queued event is silently dropped here.
+     * <p>
+     * Phase 3 ("after restart"): a brand-new {@link BisqEasyTradeService} instance (a fresh service/Fsm, as a
+     * genuine restart produces - not the same instance from phase 1) registers the restored trade's protocol
+     * via {@code initialize()}, then the genuinely still-pending btc-address message arrives via
+     * {@code onMessage()}. On the fix, {@code initialize()}'s restore drain plus the Fsm's own post-transition
+     * auto-drain re-applies the previously queued confirm-fiat-sent message once the btc-address transition
+     * succeeds, so the trade reaches {@code SELLER_RECEIVED_FIAT_SENT_CONFIRMATION} without the peer needing to
+     * resend anything. Pre-fix, the trade gets stuck one step short, at
+     * {@code MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS}.
+     */
+    @Test
+    void confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrainsViaRealServiceLifecycle(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-lifecycle");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-lifecycle");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        // Phase 1: "before restart" - a running node's service instance registers the trade's protocol exactly
+        // as a real node does on startup (initialize()), then a real inbound message is routed through the
+        // real ConfidentialMessageService.Listener entry point (onMessage()), never via protocol.handle().
+        LifecycleHarness harnessA = createLifecycleHarness(tempDir.resolve("before-restart"));
+        BisqEasyTradeService tradeServiceA = harnessA.tradeService();
+        try {
+            tradeServiceA.getPersistableStore().addTrade(trade);
+            tradeServiceA.initialize();
+
+            BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId);
+            tradeServiceA.onMessage(fiatSentMessage);
+
+            // Diagnostic only: confirms the message really did get queued rather than applied (pre-existing,
+            // unchanged-by-the-fix queuing behavior) - not itself the regression signal.
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                    trade.getTradeState());
+        } finally {
+            // Drain the shared persistence executor before this test's @TempDir is cleaned: the service's
+            // persist() calls are fire-and-forget async writes, and a write landing after cleanup makes
+            // JUnit's temp-dir deletion fail (flaky "Failed to close extension context"). Persistence#persistAsync's
+            // future queues behind every earlier write on the FIFO executor, so joining it = quiescence. (This
+            // bypasses RateLimitedPersistenceClient's throttle directly rather than via a persistNow()-style
+            // unthrottled hook, which does not exist yet on this branch - see the PR B report.)
+            tradeServiceA.getPersistence().persistAsync(tradeServiceA.getPersistableStore().getClone()).join();
+            tradeServiceA.shutdown();
+        }
+
+        // Phase 2: restart - the exact persistence round trip.
+        bisq.trade.protobuf.Trade proto = trade.toProto(false);
+        BisqEasyTrade restoredTrade = BisqEasyTrade.fromProto(proto);
+
+        // Phase 3: "after restart" - a brand-new service/Fsm (never harnessA/tradeServiceA - a real restart
+        // produces a brand-new process/service), registers the restored trade via initialize() (the real
+        // app-bootstrap entry point), then the genuinely still-pending btc-address message arrives via
+        // onMessage().
+        LifecycleHarness harnessB = createLifecycleHarness(tempDir.resolve("after-restart"));
+        BisqEasyTradeService tradeServiceB = harnessB.tradeService();
+        tradeServiceB.getPersistableStore().addTrade(restoredTrade);
+        tradeServiceB.initialize();
+
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+        try {
+            tradeServiceB.onMessage(btcAddressMessage);
+
+            // The load-bearing assertion: on the fix, the previously queued confirm-fiat-sent message survived
+            // the restart and was re-applied once the btc-address transition unblocked it - the trade is no
+            // longer stuck, without the peer needing to resend anything. Pre-fix this fails, with the trade
+            // stuck one step short at ..._SELLER_RECEIVED_BTC_ADDRESS.
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState());
+        } finally {
+            tradeServiceB.getPersistence().persistAsync(tradeServiceB.getPersistableStore().getClone()).join();
+            tradeServiceB.shutdown();
+        }
+    }
+
+    /**
+     * Strengthens the real-service-lifecycle exercising the
+     * ACTUAL on-disk persistence round trip - {@link BisqEasyTradeService#persist()} (real
+     * {@code RateLimitedPersistenceClient#persist()} -> {@code Persistence#persistAsync()/write()}), then
+     * {@link BisqEasyTradeService#readPersisted()} (real {@code Persistence#read()}) - rather than a manual
+     * {@code trade.toProto()}/{@code BisqEasyTrade.fromProto()} call. The previous version of this test (see
+     * above) only proved the FSM/Trade proto (de)serialization survives a round trip, not that the actual
+     * persistence write/read path a running node relies on does. This also exercises the atomic
+     * {state, eventQueue} snapshot (see {@code FsmModel#getStateAndEventQueueSnapshot} /
+     * {@code Trade#getTradeBuilder}): a real, asynchronously-scheduled {@code persistAsync()} write is exactly
+     * the kind of cross-thread read a torn, unsynchronized snapshot could have corrupted.
+     */
+    @Test
+    void confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRealDiskPersistenceRoundTripAndDrains(@TempDir Path persistenceDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-disk");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-disk");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        String tradeId = trade.getId();
+
+        // Phase 1 ("before restart"): same setup as the lifecycle test above, but bound to a real, on-disk
+        // persistence directory that is deliberately reused (not a fresh subdirectory per phase) for the
+        // "after restart" service below - a real restart reads the SAME data directory a previous run wrote to.
+        LifecycleHarness harnessA = createLifecycleHarness(persistenceDir);
+        BisqEasyTradeService tradeServiceA = harnessA.tradeService();
+        try {
+            tradeServiceA.getPersistableStore().addTrade(trade);
+            tradeServiceA.initialize();
+
+            BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                    "fiat-sent-msg-disk", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId);
+            tradeServiceA.onMessage(fiatSentMessage);
+            assertEquals(1, trade.getEventQueue().size());
+
+            // Force a real write to disk and block until it has landed. Note: onMessage() above already triggered a
+            // persist() internally (Fsm#handle()'s finally always persists after every transition, including queuing
+            // an out-of-order event) - but RateLimitedPersistenceClient#persist() throttles to at most one write per
+            // second, so a second, explicit call to persist() here could easily land inside that same throttling
+            // window and be silently dropped without writing anything. Rather than racing that throttle, we go
+            // around it via the lower-level Persistence#persistAsync() directly: it runs on the same
+            // single-threaded write executor as every persist() call, so waiting for THIS write to complete
+            // guarantees any earlier-submitted write (like the automatic one above) has already landed too (FIFO).
+            tradeServiceA.getPersistence().persistAsync(tradeServiceA.getPersistableStore().getClone()).join();
+        } finally {
+            tradeServiceA.getPersistence().persistAsync(tradeServiceA.getPersistableStore().getClone()).join();
+            tradeServiceA.shutdown();
+        }
+
+        // Phase 2 (restart): a brand-new service instance bound to the SAME persistence directory, reading back
+        // via the real PersistenceClient#readPersisted() path - what PersistenceService#readAllPersisted() calls
+        // for every registered client at real app bootstrap - instead of a manual toProto()/fromProto() round trip.
+        LifecycleHarness harnessB = createLifecycleHarness(persistenceDir);
+        BisqEasyTradeService tradeServiceB = harnessB.tradeService();
+        assertTrue(tradeServiceB.readPersisted().isPresent());
+
+        BisqEasyTrade restoredTrade = tradeServiceB.findTrade(tradeId).orElseThrow();
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS,
+                restoredTrade.getTradeState());
+
+        // Phase 3 ("after restart"): initialize() registers the restored trade's protocol and attempts a drain
+        // (a no-op here, since the still-missing btc-address leg has not arrived yet), then the genuinely
+        // pending message arrives via the real onMessage() entry point.
+        tradeServiceB.initialize();
+
+        BisqEasyBtcAddressMessage btcAddressMessage = new BisqEasyBtcAddressMessage(
+                "btc-address-msg-disk", tradeId, BisqEasyProtocol.VERSION, takerNetworkId, makerNetworkId,
+                "bc1qxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzxyzx", offer);
+        try {
+            tradeServiceB.onMessage(btcAddressMessage);
+
+            // The load-bearing assertion: on the fix, the previously queued confirm-fiat-sent message survived a
+            // REAL disk write + read and was re-applied once the btc-address transition unblocked it. Pre-fix
+            // this fails, with the trade stuck one step short at ..._SELLER_RECEIVED_BTC_ADDRESS.
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState());
+        } finally {
+            tradeServiceB.getPersistence().persistAsync(tradeServiceB.getPersistableStore().getClone()).join();
+            tradeServiceB.shutdown();
+        }
+    }
+
+    /**
+     * A queued event passed onMessage()'s guards when it was originally
+     * received, but its sender may have been BANNED before the restart. The restore drain applies queued events
+     * directly through the FSM - bypassing onMessage()'s banned-sender check - so the guard in
+     * {@link BisqEasyTradeService#createAndAddTradeProtocol} must scrub such events before draining, mirroring
+     * what onMessage() would do with the same message arriving live. The trade is placed at a state that
+     * ACCEPTS the queued message, so an unguarded drain WOULD have applied it - the assertion that the state
+     * did NOT advance is what separates "dropped" from "vacuously not applied".
+     */
+    @Test
+    void restoreDrainDropsQueuedEventsFromNowBannedSender(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-banned");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-banned");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade restoredTrade =
+                createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(contract, offer, takerNetworkId, makerNetworkId);
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir);
+        // The sender of the queued message got banned between original receipt and the restart.
+        when(harness.serviceProvider().getUserService().getBannedUserService()
+                .isUserProfileBanned(any(NetworkId.class))).thenReturn(true);
+        BisqEasyTradeService tradeService = harness.tradeService();
+        try {
+            tradeService.getPersistableStore().addTrade(restoredTrade);
+            tradeService.initialize();
+
+            // Dropped, not applied: queue empty AND state unchanged. (A drain would have advanced the state to
+            // SELLER_RECEIVED_FIAT_SENT_CONFIRMATION - see the control phase of the halt test below.)
+            assertTrue(restoredTrade.getEventQueue().isEmpty(),
+                    "queued events from a banned sender must be scrubbed before the restore drain");
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                    restoredTrade.getTradeState(),
+                    "a banned sender's queued message must not be applied");
+        } finally {
+            tradeService.getPersistence().persistAsync(tradeService.getPersistableStore().getClone()).join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * With an EMERGENCY halt-trading alert active (persisted alert data is
+     * replayed synchronously when initialize() registers its observer - which happens BEFORE the restore),
+     * the restore drain must be DEFERRED: events stay queued rather than being applied or dropped, and drain on
+     * a later restart once the alert is lifted. Phase 2 is that later restart and doubles as the positive
+     * control proving the setup is real: without the alert, the same still-queued event drains and advances the
+     * trade.
+     */
+    @Test
+    void restoreDrainIsDeferredWhileTradingIsHaltedAndRunsOnceAlertIsLifted(@TempDir Path tempDir)
+            throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("buyer-taker-halt");
+        NetworkId makerNetworkId = createNetworkId("seller-maker-halt");
+        BisqEasyOffer offer = createRealOffer(makerNetworkId);
+        BisqEasyContract contract = createRealContract(offer, takerNetworkId);
+
+        BisqEasyTrade restoredTrade =
+                createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(contract, offer, takerNetworkId, makerNetworkId);
+
+        // Phase 1: restart while a halt-trading emergency alert is in effect.
+        LifecycleHarness haltedHarness = createLifecycleHarness(tempDir.resolve("halted"));
+        AuthorizedAlertData haltAlert = mock(AuthorizedAlertData.class);
+        when(haltAlert.getAlertType()).thenReturn(AlertType.EMERGENCY);
+        when(haltAlert.getAppType()).thenReturn(AppType.DESKTOP);
+        when(haltAlert.isHaltTrading()).thenReturn(true);
+        when(haltedHarness.serviceProvider().getBondedRolesService().getAlertService().getAuthorizedAlertDataSet())
+                .thenReturn(new ObservableSet<>(Set.of(haltAlert)));
+        BisqEasyTradeService haltedTradeService = haltedHarness.tradeService();
+        try {
+            haltedTradeService.getPersistableStore().addTrade(restoredTrade);
+            haltedTradeService.initialize();
+
+            // Deferred: kept queued (not dropped) and not applied.
+            assertEquals(1, restoredTrade.getEventQueue().size(),
+                    "the queued event must survive a halted restart untouched");
+            assertEquals(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS,
+                    restoredTrade.getTradeState(),
+                    "no queued event may be applied while trading is halted");
+        } finally {
+            haltedTradeService.getPersistence().persistAsync(haltedTradeService.getPersistableStore().getClone()).join();
+            haltedTradeService.shutdown();
+        }
+
+        // Phase 2: a later restart with the alert lifted - the still-queued event now drains and the trade
+        // advances. This is also the positive control for both guard tests: it proves the chosen state really
+        // does accept the queued message, so phase 1's non-application was the guard, not a vacuous no-op.
+        LifecycleHarness liftedHarness = createLifecycleHarness(tempDir.resolve("lifted"));
+        BisqEasyTradeService liftedTradeService = liftedHarness.tradeService();
+        try {
+            liftedTradeService.getPersistableStore().addTrade(restoredTrade);
+            liftedTradeService.initialize();
+
+            assertEquals(BisqEasyTradeState.SELLER_RECEIVED_FIAT_SENT_CONFIRMATION, restoredTrade.getTradeState(),
+                    "once the alert is lifted the deferred event must drain on the next restart");
+            assertTrue(restoredTrade.getEventQueue().isEmpty());
+        } finally {
+            liftedTradeService.getPersistence().persistAsync(liftedTradeService.getPersistableStore().getClone()).join();
+            liftedTradeService.shutdown();
+        }
+    }
+
+    /**
+     * The data-retention pass must scrub the persisted pending-event queue - which can hold account-data
+     * messages - once a trade passes the redaction threshold. That includes trades whose payment-account field
+     * is empty or already redacted, which a field-only check would skip entirely. Trades still inside the
+     * threshold keep their queue untouched.
+     */
+    @Test
+    void redactionPassClearsPendingEventQueueOfOldTrades(@TempDir Path tempDir) throws UnresolvableProtobufEnumException {
+        Res.setAndApplyLanguageTag("en");
+        long oldTakeOfferDate = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(91);
+
+        NetworkId takerA = createNetworkId("buyer-taker-redact-a");
+        NetworkId makerA = createNetworkId("seller-maker-redact-a");
+        BisqEasyOffer offerA = createRealOffer(makerA);
+        BisqEasyTrade oldTradeWithAccountData = createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(
+                createRealContract(offerA, takerA, oldTakeOfferDate), offerA, takerA, makerA);
+        oldTradeWithAccountData.getPaymentAccountData().set("Sparkasse - IBAN DE02 1234");
+
+        NetworkId takerB = createNetworkId("buyer-taker-redact-b");
+        NetworkId makerB = createNetworkId("seller-maker-redact-b");
+        BisqEasyOffer offerB = createRealOffer(makerB);
+        // Payment-account field never set: the queue is the ONLY place holding sensitive data. The previous
+        // field-only filter skipped exactly this trade.
+        BisqEasyTrade oldTradeQueueOnly = createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(
+                createRealContract(offerB, takerB, oldTakeOfferDate), offerB, takerB, makerB);
+
+        NetworkId takerC = createNetworkId("buyer-taker-redact-c");
+        NetworkId makerC = createNetworkId("seller-maker-redact-c");
+        BisqEasyOffer offerC = createRealOffer(makerC);
+        BisqEasyTrade recentTrade = createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(
+                createRealContract(offerC, takerC), offerC, takerC, makerC);
+
+        LifecycleHarness harness = createLifecycleHarness(tempDir);
+        when(harness.serviceProvider().getSettingsService().getNumDaysAfterRedactingTradeData())
+                .thenReturn(new Observable<>(90));
+        BisqEasyTradeService tradeService = harness.tradeService();
+        try {
+            tradeService.getPersistableStore().addTrade(oldTradeWithAccountData);
+            tradeService.getPersistableStore().addTrade(oldTradeQueueOnly);
+            tradeService.getPersistableStore().addTrade(recentTrade);
+
+            tradeService.maybeRedactDataOfCompletedTrades();
+
+            assertTrue(oldTradeWithAccountData.getEventQueue().isEmpty(),
+                    "queued events of a trade past the redaction threshold must be scrubbed");
+            assertEquals(Res.get("data.redacted"), oldTradeWithAccountData.getPaymentAccountData().get(),
+                    "payment account data past the redaction threshold must be redacted");
+            assertTrue(oldTradeQueueOnly.getEventQueue().isEmpty(),
+                    "the queue must be scrubbed even when the payment-account field is empty");
+            assertEquals(1, recentTrade.getEventQueue().size(),
+                    "a trade inside the redaction threshold must keep its queued events");
+        } finally {
+            tradeService.getPersistence().persistAsync(tradeService.getPersistableStore().getClone()).join();
+            tradeService.shutdown();
+        }
+    }
+
+    /**
+     * Builds the restored-trade shape both guard tests need: a queued confirm-fiat-sent message, with the trade
+     * state advanced (as part of the persistence round trip, as if the btc-address transition completed right
+     * before shutdown without a drain) to the state that ACCEPTS the queued message - so the restore drain,
+     * unless guarded, applies it immediately.
+     */
+    private static BisqEasyTrade createRestoredTradeWithQueuedFiatSentMessageAtAcceptingState(BisqEasyContract contract,
+                                                                                              BisqEasyOffer offer,
+                                                                                              NetworkId takerNetworkId,
+                                                                                              NetworkId makerNetworkId)
+            throws UnresolvableProtobufEnumException {
+        BisqEasyTrade trade = createTradeAtState(contract, offer, takerNetworkId, makerNetworkId,
+                BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_DID_NOT_RECEIVED_BTC_ADDRESS);
+        BisqEasySellerAsMakerProtocol protocol = new BisqEasySellerAsMakerProtocol(createServiceProvider(), trade);
+        BisqEasyConfirmFiatSentMessage fiatSentMessage = new BisqEasyConfirmFiatSentMessage(
+                "fiat-sent-msg-guard", trade.getId(), protocol.getVersion(), takerNetworkId, makerNetworkId);
+        // No transition from the current state accepts it -> parked in the event queue.
+        protocol.handle(fiatSentMessage);
+        assertEquals(1, trade.getEventQueue().size());
+
+        bisq.trade.protobuf.Trade proto = trade.toProto(false).toBuilder()
+                .setState(BisqEasyTradeState.MAKER_SENT_TAKE_OFFER_RESPONSE__SELLER_SENT_ACCOUNT_DATA__SELLER_RECEIVED_BTC_ADDRESS.name())
+                .build();
+        return BisqEasyTrade.fromProto(proto);
+    }
+
+    private record LifecycleHarness(BisqEasyTradeService tradeService, NetworkService networkService,
+                                    ServiceProvider serviceProvider) {
+    }
+
+    // Builds a BisqEasyTradeService harness suitable for exercising the real initialize()/onMessage() lifecycle,
+    // stubbing every ServiceProvider dependency initialize() itself touches: getConfidentialMessageServices(),
+    // the alert/settings observers, and the periodic redaction scheduler.
+    // Each call is given its own persistence directory: a real restart produces a brand-new service/Fsm, and
+    // reusing one directory (or one service instance) across "before" and "after" phases would let the two
+    // phases silently share state that only a real proto round trip should carry across.
+    private static LifecycleHarness createLifecycleHarness(Path persistenceDir) {
+        NetworkService networkService = mock(NetworkService.class);
+        // Empty: message delivery is driven explicitly via onMessage() in the test body rather than letting
+        // initialize()'s own startup replay (of whatever this would return) do it implicitly.
+        when(networkService.getConfidentialMessageServices()).thenReturn(Set.of());
+        when(networkService.confidentialSend(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(mock(SendMessageResult.class)));
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+        when(serviceProvider.getPersistenceService()).thenReturn(new PersistenceService(persistenceDir));
+
+        BisqEasyTradeService tradeService = new BisqEasyTradeService(serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(tradeService);
+
+        return new LifecycleHarness(tradeService, networkService, serviceProvider);
+    }
+
+    private static BisqEasyTrade createTradeAtState(BisqEasyContract contract,
+                                                     BisqEasyOffer offer,
+                                                     NetworkId takerNetworkId,
+                                                     NetworkId makerNetworkId,
+                                                     BisqEasyTradeState state) throws UnresolvableProtobufEnumException {
+        BisqEasyTrade freshTrade = new BisqEasyTrade(contract, false, false, createIdentity(makerNetworkId), offer,
+                takerNetworkId, makerNetworkId);
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(state.name())
+                .build();
+        return BisqEasyTrade.fromProto(proto);
+    }
+
+    private static Identity createIdentity(NetworkId networkId) {
+        KeyBundle keyBundle = new KeyBundle("test-key-bundle",
+                KeyGeneration.generateDefaultEcKeyPair(),
+                TorKeyGeneration.generateKeyPair(),
+                I2PKeyGeneration.generateKeyPair());
+        return new Identity("test-id", networkId, keyBundle);
+    }
+
+    private static ServiceProvider createServiceProvider() {
+        ServiceProvider serviceProvider = mock(ServiceProvider.class);
+        when(serviceProvider.getBisqEasyTradeService()).thenReturn(mock(BisqEasyTradeService.class));
+        return serviceProvider;
+    }
+
+    private static BisqEasyContract createRealContract(BisqEasyOffer offer, NetworkId takerNetworkId) {
+        return createRealContract(offer, takerNetworkId, System.currentTimeMillis());
+    }
+
+    private static BisqEasyContract createRealContract(BisqEasyOffer offer, NetworkId takerNetworkId, long takeOfferDate) {
+        return new BisqEasyContract(takeOfferDate,
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                new BitcoinPaymentMethodSpec(BitcoinPaymentMethod.fromPaymentRail(BitcoinPaymentRail.MAIN_CHAIN)),
+                new FiatPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+    }
+
+    private static BisqEasyOffer createRealOffer(NetworkId makerNetworkId) {
+        return new BisqEasyOffer(makerNetworkId,
+                Direction.SELL,
+                new Market("BTC", "EUR", "Bitcoin", "Euro"),
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(BitcoinPaymentMethod.fromPaymentRail(BitcoinPaymentRail.MAIN_CHAIN)),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                "",
+                List.of("en"),
+                "1.0.0");
+    }
+
+    private static NetworkId createNetworkId(String keyId) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        Address address = Address.from("127.0.0.1", 1000);
+        return new NetworkId(new AddressByTransportTypeMap(Map.of(address.getTransportType(), address)),
+                new PubKey(keyPair.getPublic(), keyId));
+    }
+}

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceRestoreDrainTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceRestoreDrainTest.java
@@ -1,0 +1,389 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.account.accounts.fiat.UserDefinedFiatAccountPayload;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.bonded_roles.release.AppType;
+import bisq.common.market.Market;
+import bisq.common.network.Address;
+import bisq.common.observable.Observable;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.proto.UnresolvableProtobufEnumException;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.identity.Identity;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.network.p2p.message.NetworkMessageResolver;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.security.keys.I2PKeyGeneration;
+import bisq.security.keys.KeyBundle;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.security.keys.TorKeyGeneration;
+import bisq.trade.ServiceProvider;
+import bisq.trade.mu_sig.messages.network.SendAccountPayloadMessage;
+import bisq.trade.mu_sig.protocol.MuSigProtocol;
+import bisq.trade.mu_sig.protocol.MuSigTradeState;
+import bisq.trade.protocol.messages.TradeMessage;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * MuSig parity: the generic {@code Trade}/{@code FsmModel}
+ * persistence fix (persisted pendingFsmEvents + Fsm#drainEventQueue) applies to every {@code Trade} subclass,
+ * including {@link MuSigTrade} - but only {@code BisqEasyTradeService} actually drained restored trades on load.
+ * {@link MuSigTradeService} persisted the queue (via the same generic Trade machinery) without ever draining it,
+ * so a MuSig trade with an out-of-order message parked at shutdown would stay stuck forever after a restart,
+ * even though the data needed to self-heal was sitting right there in the persisted proto.
+ * <br/>
+ * A full onMessage()/initialize()-driven lifecycle test analogous to
+ * {@code BisqEasyTradeTest#confirmFiatSentMessageQueuedWhileBtcAddressPendingSurvivesRestoreAndDrainsViaRealServiceLifecycle}
+ * is impractical for MuSig: essentially every message handler in the setup phase (SetupTradeMessage_B/C/D and
+ * their handlers) calls out to {@code MusigGrpcClient}'s real blocking gRPC stub (nonce shares, partial
+ * signatures, deposit tx signing), which would require standing up (or deeply mocking) a MuSig gRPC server - out
+ * of proportion for this regression test. {@link SendAccountPayloadMessage}'s handler is the one early-phase
+ * message handler that does NOT touch gRPC (its only side effect,
+ * {@code MuSigTradeService#observeDepositTxConfirmationStatus}, is itself a dev-time no-op - see the
+ * {@code if (true) return;} guard at the top of that method), which makes a genuine out-of-order-message
+ * restore-and-drain scenario reproducible here without any gRPC involvement.
+ * <p>
+ * This is PR B of a multi-PR split of the original fix - see {@code BisqEasyTradeTest}'s class javadoc for what
+ * is intentionally not ported yet (the creation-atomicity/id-derivation test for MuSig's mirror of that guard is
+ * excluded here for the same reason).
+ */
+class MuSigTradeServiceRestoreDrainTest {
+    static {
+        // Normally registered once at app startup by bisq.application.ResolverConfig, which is not a dependency
+        // available to :trade tests. Required so a persisted, wrapped TradeMessage (see Trade#pendingEventsFromProto)
+        // can be resolved back via EnvelopePayloadMessage.fromProto() -> Any.unpack() - shared by both BisqEasy and
+        // MuSig trade messages (see TradeMessage#fromProto's MessageCase switch).
+        NetworkMessageResolver.addResolver("trade.TradeMessage", TradeMessage.getNetworkMessageResolver());
+    }
+
+    /**
+     * End-to-end reproduction of the MuSig restore-drain gap: a buyer-as-taker trade is hand-placed at
+     * {@code TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX} with a {@link SendAccountPayloadMessage} already queued in
+     * its persisted {@code pendingFsmEvents} (as if it had arrived out of order and survived a restart via the
+     * generic Trade persistence fix, but before this fix was applied to MuSigTradeService). The trade is then
+     * registered via {@link MuSigTradeService#createAndAddTradeProtocol(MuSigTrade, boolean)} with
+     * {@code isRestoredTrade=true} - the exact call {@code initialize()} now makes for every persisted trade at
+     * app startup - and the queued message must be re-applied immediately, without any further live message ever
+     * arriving.
+     */
+    @Test
+    void restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        // Buyer-as-taker trade, hand-placed at the state reached right after publishing the deposit tx - the
+        // predecessor state for SendAccountPayloadMessage (see MuSigBuyerAsTakerProtocol#configTransitions) -
+        // with the message already parked in the persisted pendingFsmEvents, exactly mirroring
+        // BisqEasyTradeTest's out-of-order simulation via toProto()/fromProto().
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer, takerNetworkId, makerNetworkId);
+        String tradeId = freshTrade.getId();
+
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg", tradeId, MuSigProtocol.VERSION, makerNetworkId, takerNetworkId,
+                new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertEquals(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX, restoredTrade.getTradeState());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        NetworkService networkService = mock(NetworkService.class);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getMuSigTradeService()).thenReturn(tradeService);
+
+        // The real, package-private restore-time entry point - mirrors exactly what initialize() now calls for
+        // every persisted trade (see MuSigTradeService#initialize(): "persistableStore.getTrades().forEach(trade
+        // -> createAndAddTradeProtocol(trade, true))"). isRestoredTrade=true must drain the queue once,
+        // immediately, without waiting for some later, unrelated live transition to happen to occur for this trade.
+        tradeService.createAndAddTradeProtocol(restoredTrade, true);
+
+        // The load-bearing assertion: on the fix, the parked SendAccountPayloadMessage was re-applied purely by
+        // virtue of being restored and registered - the trade advanced from TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX
+        // to TAKER_RECEIVED_ACCOUNT_PAYLOAD with no further message ever delivered. Pre-fix (isRestoredTrade drain
+        // wiring absent, as MuSigTradeService#initialize() used to call the plain 1-arg createAndAddTradeProtocol),
+        // this trade would stay stuck at TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX forever, exactly like #1622 before
+        // BisqEasyTradeService got its drain-on-restore fix.
+        assertEquals(MuSigTradeState.TAKER_RECEIVED_ACCOUNT_PAYLOAD, restoredTrade.getTradeState());
+        assertTrue(restoredTrade.getEventQueue().isEmpty());
+    }
+
+    /**
+     * Isolation guard mirroring {@code BisqEasyTradeService#createAndAddTradeProtocol}'s per-trade try/catch:
+     * a trade restored with a queued event that no longer matches ANY transition in its (possibly since-changed)
+     * protocol config must not prevent the trade from being registered - drainEventQueue() re-queues an
+     * unmatched event rather than applying it, so this also pins that a mismatched queued event is simply left
+     * parked (not lost, not thrown) rather than blocking restore.
+     */
+    @Test
+    void restoredTradeWithQueuedMessageThatStillDoesNotMatchIsLeftParkedWithoutBlockingRestore() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker-mismatch");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker-mismatch");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id-mismatch",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer, takerNetworkId, makerNetworkId);
+        String tradeId = freshTrade.getId();
+
+        // SendAccountPayloadMessage only matches a transition from TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX. Parking
+        // it while the trade is still at the earlier TAKER_INITIALIZED_TRADE state means it genuinely does not
+        // match on restore - drainEventQueue() must re-queue it (a safe no-op), not throw or lose it.
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg-mismatch", tradeId, MuSigProtocol.VERSION, makerNetworkId, takerNetworkId,
+                new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_INITIALIZED_TRADE.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        NetworkService networkService = mock(NetworkService.class);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getMuSigTradeService()).thenReturn(tradeService);
+
+        // Must not throw, and the trade must still get registered/returned even though the drain could not
+        // apply anything.
+        tradeService.createAndAddTradeProtocol(restoredTrade, true);
+
+        assertEquals(MuSigTradeState.TAKER_INITIALIZED_TRADE, restoredTrade.getTradeState());
+        assertEquals(1, restoredTrade.getEventQueue().size());
+        assertTrue(tradeService.findProtocol(tradeId).isPresent());
+    }
+
+    /**
+     * MuSig mirror of {@code BisqEasyTradeTest#restoreDrainDropsQueuedEventsFromNowBannedSender}:
+     * the queued message passed onMessage()'s banned-sender check when originally received, but
+     * the sender got banned before the restart. The restore drain bypasses onMessage(), so the guard in
+     * {@link MuSigTradeService#createAndAddTradeProtocol} must scrub the banned sender's queued events before
+     * draining. Same trade shape as {@link #restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore} - a state
+     * that ACCEPTS the queued message - so the state NOT advancing proves the drop, not a vacuous no-op.
+     */
+    @Test
+    void restoreDrainDropsQueuedEventsFromNowBannedSender() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker-banned");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker-banned");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id-banned",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis(),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer, takerNetworkId, makerNetworkId);
+        String tradeId = freshTrade.getId();
+
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg-banned", tradeId, MuSigProtocol.VERSION, makerNetworkId, takerNetworkId,
+                new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        NetworkService networkService = mock(NetworkService.class);
+        when(serviceProvider.getNetworkService()).thenReturn(networkService);
+        // The sender of the queued message got banned between original receipt and the restart.
+        when(serviceProvider.getUserService().getBannedUserService()
+                .isUserProfileBanned(any(NetworkId.class))).thenReturn(true);
+
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getMuSigTradeService()).thenReturn(tradeService);
+
+        tradeService.createAndAddTradeProtocol(restoredTrade, true);
+
+        // Dropped, not applied: pre-guard this exact shape advanced to TAKER_RECEIVED_ACCOUNT_PAYLOAD (see
+        // restoredTradeWithQueuedMessageDrainsAndAdvancesOnRestore above).
+        assertTrue(restoredTrade.getEventQueue().isEmpty(),
+                "queued events from a banned sender must be scrubbed before the restore drain");
+        assertEquals(MuSigTradeState.TAKER_SIGNED_AND_PUBLISHED_DEPOSIT_TX, restoredTrade.getTradeState(),
+                "a banned sender's queued message must not be applied");
+    }
+
+    /**
+     * MuSig mirror of {@code BisqEasyTradeTest#redactionPassClearsPendingEventQueueOfOldTrades}: the
+     * data-retention pass must scrub the persisted pending-event queue - which can hold a
+     * {@link SendAccountPayloadMessage} with the peer's account payload - once the trade passes the redaction
+     * threshold, while a trade inside the threshold keeps its queue.
+     */
+    @Test
+    void redactionPassClearsPendingEventQueueOfOldTrades() throws UnresolvableProtobufEnumException {
+        NetworkId takerNetworkId = createNetworkId("musig-buyer-taker-redact");
+        NetworkId makerNetworkId = createNetworkId("musig-seller-maker-redact");
+
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        MuSigOffer offer = new MuSigOffer(
+                "musig-offer-id-redact",
+                makerNetworkId,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(100_000),
+                new MarketPriceSpec(),
+                List.of(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK)),
+                List.of(),
+                "1.0.0");
+        // Take-offer date past the not-completed-trades redaction threshold (45-90 days, here 90 with
+        // numDays=90) - the trade never reaches a final state, so only this date gates the redaction.
+        MuSigContract contract = new MuSigContract(
+                System.currentTimeMillis() - TimeUnit.DAYS.toMillis(91),
+                offer,
+                takerNetworkId,
+                100_000,
+                3_500_000,
+                PaymentMethodSpecUtil.createPaymentMethodSpec(FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.NATIONAL_BANK), "USD"),
+                Optional.empty(),
+                new MarketPriceSpec(),
+                0);
+
+        MuSigTrade freshTrade = new MuSigTrade(contract, true, true, createIdentity(takerNetworkId), offer,
+                takerNetworkId, makerNetworkId);
+        SendAccountPayloadMessage sendAccountPayloadMessage = new SendAccountPayloadMessage(
+                "send-account-payload-msg-redact", freshTrade.getId(), MuSigProtocol.VERSION, makerNetworkId,
+                takerNetworkId, new UserDefinedFiatAccountPayload("test-id", "test-account-data"));
+        bisq.trade.protobuf.Trade proto = freshTrade.toProto(false).toBuilder()
+                .setState(MuSigTradeState.TAKER_INITIALIZED_TRADE.name())
+                .addPendingFsmEvents(sendAccountPayloadMessage.toProto(false))
+                .build();
+        MuSigTrade restoredTrade = MuSigTrade.fromProto(proto);
+        assertEquals(1, restoredTrade.getEventQueue().size());
+
+        ServiceProvider serviceProvider = mock(ServiceProvider.class, RETURNS_DEEP_STUBS);
+        when(serviceProvider.getNetworkService()).thenReturn(mock(NetworkService.class));
+        MuSigTradeService tradeService = new MuSigTradeService(
+                new MuSigTradeService.Config("localhost", 0), serviceProvider, AppType.DESKTOP);
+        when(serviceProvider.getSettingsService().getNumDaysAfterRedactingTradeData())
+                .thenReturn(new Observable<>(90));
+        tradeService.getPersistableStore().addTrade(restoredTrade);
+
+        tradeService.maybeRedactDataOfCompletedTrades();
+
+        assertTrue(restoredTrade.getEventQueue().isEmpty(),
+                "queued events of a trade past the redaction threshold must be scrubbed");
+    }
+
+    private static Identity createIdentity(NetworkId networkId) {
+        KeyBundle keyBundle = new KeyBundle("test-key-bundle",
+                KeyGeneration.generateDefaultEcKeyPair(),
+                TorKeyGeneration.generateKeyPair(),
+                I2PKeyGeneration.generateKeyPair());
+        return new Identity("test-id", networkId, keyBundle);
+    }
+
+    private static NetworkId createNetworkId(String keyId) {
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        Address address = Address.from("127.0.0.1", 1000);
+        return new NetworkId(new AddressByTransportTypeMap(Map.of(address.getTransportType(), address)),
+                new PubKey(keyPair.getPublic(), keyId));
+    }
+}


### PR DESCRIPTION
 - ~~resolves https://github.com/bisq-network/bisq-mobile/issues/1622~~ -> this will be added to PR "C"
 - resolves #4946
 - depends on #4921 
 - ported #4933 (with the unresolved one disabled for now until PR C lands) into this solution
 - code extracted from already working PR #4885 as per PR splitting description (this is labelled as "PR B" dependent on "PR A")
 - added comments are meaningful but if reviewers don't agree happy to review and trim/erase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Restored trades retain pending messages and automatically process them when required information becomes available.
- Trade state and queued messages are saved consistently, including at final state.
- Added safer management of queued trade events.

## Bug Fixes
- Removed queued messages from banned senders.
- Deferred processing during emergency halts or version restrictions, with automatic recovery afterward.
- Isolated trade restoration failures so one trade does not block others.
- Improved recovery for out-of-order messages.
- Improved persistence reliability after temporary save failures.
- Prevented incomplete data from replacing valid saved state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->