### PR TITLE
fix(api): decline malformed deflate offers

### DIFF
--- a/api/src/main/java/bisq/api/web_socket/compression/PerMessageDeflateFilter.java
+++ b/api/src/main/java/bisq/api/web_socket/compression/PerMessageDeflateFilter.java
@@ -39,9 +39,11 @@ import org.glassfish.grizzly.websockets.ProtocolError;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
@@ -148,23 +150,19 @@ public class PerMessageDeflateFilter extends BaseFilter {
         if (message instanceof HttpContent httpContent) {
             // The handshake response is the only point where we know the upgrade actually succeeded,
             // so compression is switched on exactly when we confirm the extension to the client.
-            if (!state.enabled
-                    && httpContent.getHttpHeader() instanceof HttpResponsePacket response
-                    && response.getStatus() != HttpStatus.SWITCHING_PROTOCOLS_101.getStatusCode()) {
-                // The upgrade this offer belonged to failed. Were the state left attached, a retry on
-                // the same connection that does not offer the extension would still be answered with
-                // it, and we would compress frames the client never agreed to decompress.
-                STATE.remove(ctx.getConnection());
-                return ctx.getInvokeAction();
-            }
-            if (!state.enabled
-                    && httpContent.getHttpHeader() instanceof HttpResponsePacket response
-                    && response.getStatus() == HttpStatus.SWITCHING_PROTOCOLS_101.getStatusCode()) {
-                // Replaces rather than appends: Grizzly may have written the extensions a
-                // WebSocketApplication declares, but it only echoes their names and cannot apply any of
-                // them, so permessage-deflate is the only one this response can honestly confirm.
-                response.setHeader(SEC_WEBSOCKET_EXTENSIONS, NEGOTIATED_EXTENSION);
-                state.enabled = true;
+            if (!state.enabled && httpContent.getHttpHeader() instanceof HttpResponsePacket response) {
+                if (response.getStatus() == HttpStatus.SWITCHING_PROTOCOLS_101.getStatusCode()) {
+                    // Replaces rather than appends: Grizzly may have written the extensions a
+                    // WebSocketApplication declares, but it only echoes their names and cannot apply any
+                    // of them, so permessage-deflate is the only one this response can honestly confirm.
+                    response.setHeader(SEC_WEBSOCKET_EXTENSIONS, NEGOTIATED_EXTENSION);
+                    state.enabled = true;
+                } else {
+                    // The upgrade this offer belonged to failed. Were the state left attached, a retry on
+                    // the same connection that does not offer the extension would still be answered with
+                    // it, and we would compress frames the client never agreed to decompress.
+                    STATE.remove(ctx.getConnection());
+                }
             }
             return ctx.getInvokeAction();
         }
@@ -222,27 +220,76 @@ public class PerMessageDeflateFilter extends BaseFilter {
     }
 
     static boolean acceptsOffer(String header) {
-        for (String offer : header.split(",")) {
-            String[] parts = offer.trim().split(";");
-            if (EXTENSION_NAME.equalsIgnoreCase(parts[0].trim()) && canHonour(parts)) {
-                return true;
-            }
-        }
-        return false;
+        return parseOffers(header).stream()
+                .flatMap(List::stream)
+                .anyMatch(offer -> EXTENSION_NAME.equalsIgnoreCase(offer.get(0)) && canHonour(offer));
     }
 
-    private static boolean canHonour(String[] offerParts) {
-        for (int i = 1; i < offerParts.length; i++) {
-            String parameter = offerParts[i].trim();
+    /**
+     * Splits a header into its offers and every offer into its parts, the extension name followed by its
+     * parameters. RFC 6455 lets a parameter value be a quoted string, in which a "," or a ";" is data
+     * rather than a separator, so a plain split would read one offer as several and could see an offer
+     * the client never made.
+     *
+     * @return the offers, each with its name in the first position, or empty if the header is malformed,
+     * which here means a quote that is never closed
+     */
+    private static Optional<List<List<String>>> parseOffers(String header) {
+        List<List<String>> offers = new ArrayList<>();
+        List<String> parts = new ArrayList<>();
+        StringBuilder part = new StringBuilder();
+        boolean quoted = false;
+        boolean escaped = false;
+        for (int i = 0; i < header.length(); i++) {
+            char character = header.charAt(i);
+            if (escaped) {
+                // A quoted pair stands for the character it escapes, but as no parameter we honour has a
+                // value that needs escaping, it is kept as written and left for the value checks to refuse
+                escaped = false;
+            } else if (quoted && character == '\\') {
+                escaped = true;
+            } else if (character == '"') {
+                quoted = !quoted;
+            } else if (!quoted && (character == ';' || character == ',')) {
+                parts.add(part.toString().trim());
+                part.setLength(0);
+                if (character == ',') {
+                    offers.add(parts);
+                    parts = new ArrayList<>();
+                }
+                continue;
+            }
+            part.append(character);
+        }
+        // An escape only ever starts inside a quoted string, so a header ending in one is unclosed as well
+        if (quoted) {
+            return Optional.empty();
+        }
+        parts.add(part.toString().trim());
+        offers.add(parts);
+        return Optional.of(offers);
+    }
+
+    private static boolean canHonour(List<String> offerParts) {
+        Set<String> seen = new HashSet<>();
+        for (int i = 1; i < offerParts.size(); i++) {
+            String parameter = offerParts.get(i);
             int separator = parameter.indexOf('=');
             String name = (separator < 0 ? parameter : parameter.substring(0, separator))
                     .trim().toLowerCase(Locale.ROOT);
             Optional<String> value = separator < 0
                     ? Optional.empty()
                     : Optional.of(unquote(parameter.substring(separator + 1).trim()));
+            // RFC 7692: an offer repeating a parameter must not be accepted
+            if (!seen.add(name)) {
+                return false;
+            }
             switch (name) {
                 case "client_no_context_takeover", "server_no_context_takeover" -> {
-                    // We apply both unconditionally
+                    // We apply both unconditionally, but RFC 7692 has them carry no value
+                    if (value.isPresent()) {
+                        return false;
+                    }
                 }
                 case "client_max_window_bits" -> {
                     // Limits the window the CLIENT compresses with, and RFC 7692 lets us ignore the
@@ -257,7 +304,7 @@ public class PerMessageDeflateFilter extends BaseFilter {
                     // Limits the window WE compress with, which java.util.zip cannot restrict, so only
                     // the largest can be honoured and RFC 7692 has us decline anything else. The offer
                     // has to carry a value, so one without is refused too.
-                    if (!value.filter("15"::equals).isPresent()) {
+                    if (value.filter("15"::equals).isEmpty()) {
                         return false;
                     }
                 }
@@ -497,6 +544,11 @@ public class PerMessageDeflateFilter extends BaseFilter {
 
         byte[] compressedFrame = buildFrame(frame.opcode(), compressed);
         compressedFrame[0] |= RSV1;
+        // Grizzly does not reclaim the buffer that ctx.setMessage() replaces, so a pooled MemoryManager
+        // would want a buffer.tryDispose() here. Nothing configures one, so the default HeapMemoryManager
+        // applies and disposing would be a no-op. Add the call along with any switch to a pooled manager,
+        // and only on this path: every earlier return hands back the very buffer that is about to be
+        // written.
         return Buffers.wrap(memoryManager, compressedFrame);
     }
 

--- a/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateFilterTest.java
+++ b/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateFilterTest.java
@@ -90,10 +90,77 @@ class PerMessageDeflateFilterTest {
         assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; client_max_window_bits=x")).isFalse();
     }
 
+    /**
+     * RFC 7692 defines both takeover parameters as flags, so an offer giving one a value is malformed.
+     */
+    @Test
+    void declinesANoContextTakeoverParameterCarryingAValue() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; client_no_context_takeover=1")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; server_no_context_takeover=true")).isFalse();
+    }
+
+    @Test
+    void declinesAnOfferRepeatingAParameter() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; client_no_context_takeover; client_no_context_takeover")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; server_max_window_bits=15; server_max_window_bits=15")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; Client_No_Context_Takeover; client_no_context_takeover")).isFalse();
+    }
+
+    /**
+     * A repetition only disqualifies the offer it appears in: a client is free to list the same
+     * parameter once in each of several alternative offers.
+     */
+    @Test
+    void countsRepetitionsPerOfferRatherThanPerHeader() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; client_no_context_takeover, permessage-deflate; client_no_context_takeover"))
+                .isTrue();
+    }
+
     @Test
     void declinesUnknownParameterAndUnknownExtension() {
         assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; unexpected=1")).isFalse();
         assertThat(PerMessageDeflateFilter.acceptsOffer("x-webkit-deflate-frame")).isFalse();
+    }
+
+    @Test
+    void acceptsAQuotedParameterValue() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; server_max_window_bits=\"15\"")).isTrue();
+    }
+
+    /**
+     * RFC 6455 lets a parameter value be a quoted string, so a separator inside one is data. Reading it
+     * as a separator would let the value of an unrelated extension pose as an offer of our own.
+     */
+    @Test
+    void treatsSeparatorsInsideAQuotedValueAsData() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("x-foo; bar=\"a, permessage-deflate ,b\"")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "x-foo; bar=\"a\\\", permessage-deflate ,b\"")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer(
+                "permessage-deflate; server_max_window_bits=\"15; client_max_window_bits\"")).isFalse();
+    }
+
+    /**
+     * RFC 6455 has a ";" introduce a parameter, so an offer ending in one, or holding an empty part
+     * between two of them, is malformed rather than an offer with a parameter left out.
+     */
+    @Test
+    void declinesAnOfferWithAnEmptyParameter() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate;")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate;; client_no_context_takeover")).isFalse();
+    }
+
+    @Test
+    void declinesAHeaderWithAnUnclosedQuote() {
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate; server_max_window_bits=\"15")).isFalse();
+        assertThat(PerMessageDeflateFilter.acceptsOffer("permessage-deflate, x-foo; bar=\"a")).isFalse();
     }
 
     @Test

--- a/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateIntegrationTest.java
+++ b/api/src/test/java/bisq/api/web_socket/compression/PerMessageDeflateIntegrationTest.java
@@ -95,8 +95,12 @@ class PerMessageDeflateIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        WebSocketEngine.getEngine().unregister(application);
-        server.shutdownNow();
+        if (application != null) {
+            WebSocketEngine.getEngine().unregister(application);
+        }
+        if (server != null) {
+            server.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
follow up on #4907 and #4903


-----

RFC 7692 requires a server to decline a permessage-deflate offer that repeats a parameter, or that gives a value to client_no_context_takeover or server_no_context_takeover, both of which are flags. Neither was checked, so such offers were accepted.

The header was also split on "," and ";" without regard for RFC 6455 quoted parameter values, in which those characters are data. That could read one offer as several, letting the value of an unrelated extension pose as a bare permessage-deflate offer the client never made, and we would then compress frames it never agreed to decompress. A single pass that tracks quoting replaces both splits and declines a header holding a quote that is never closed.

Declining leaves the connection uncompressed rather than failing the handshake, and no extension header is sent, so a client that offered something malformed falls back to plain frames.

Also carries the earlier follow-ups on this branch: the handshake response branches in handleWrite folded into one, a note on buffer disposal in deflateFrame, and a field order fix in ConnectionState.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket compression negotiation for quoted and malformed parameters.
  * Rejected duplicate, empty, and invalid extension parameters more reliably.
  * Ensured connection state is cleaned up when negotiation fails.
  * Correctly updates compression settings after successful upgrades.

* **Tests**
  * Expanded coverage for invalid offers, quoted values, duplicate parameters, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->