### PR TITLE
Validate MuSig take offer requests on the maker side

### DIFF
--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -44,6 +44,18 @@ public class StringUtils {
     public static final String DOT_ELLIPSIS = "...";
     public static final String UNICODE_ELLIPSIS = "…";
 
+    // Strips every character that could forge or reorder a log line before truncating, so an
+    // attacker-controlled value (e.g. a peer-supplied id) cannot inject a fake record. \p{Cntrl}
+    // alone misses the C1 controls (U+0085 NEL) and the format/bidi category (U+202E), so the
+    // class is spelled out: \p{Cc} all controls, \p{Cf} format/bidi, U+2028/U+2029 the line and
+    // paragraph separators.
+    public static String sanitizeForLog(String value) {
+        if (value == null) {
+            return "";
+        }
+        return truncate(value.replaceAll("[\\p{Cc}\\p{Cf}\\u2028\\u2029]", "?"), 60);
+    }
+
     public static String truncate(Object value) {
         return truncate(value.toString());
     }

--- a/common/src/test/java/bisq/common/util/StringUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/StringUtilsTest.java
@@ -165,4 +165,14 @@ public class StringUtilsTest {
         String expected = "user@example.com";
         assertEquals(expected, StringUtils.cleanUserInput(input));
     }
+
+    @Test
+    void sanitizeForLogStripsControlFormatAndBidiCharacters() {
+        // \p{Cntrl} misses U+0085 (NEL, a C1 control) and the format/bidi category (U+202E,
+        // U+200B); each stripped character becomes '?'. A crafted id must not carry a line
+        // break or a reordering control into a log line.
+        String injected = "x\u0085WARN forged\u2028line reversed\u202Etext\u0007bell\u200Bzwsp";
+        assertEquals("x?WARN forged?line reversed?text?bell?zwsp", StringUtils.sanitizeForLog(injected));
+        assertEquals("", StringUtils.sanitizeForLog(null));
+    }
 }

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
@@ -18,7 +18,6 @@
 package bisq.mu_sig;
 
 import bisq.account.payment_method.PaymentRail;
-import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannel;
 import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookChannelService;

--- a/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
+++ b/mu-sig/src/main/java/bisq/mu_sig/MuSigTradeAmountLimits.java
@@ -29,6 +29,7 @@ import bisq.common.monetary.Fiat;
 import bisq.common.monetary.Monetary;
 import bisq.common.util.MathUtils;
 import bisq.offer.Direction;
+import bisq.offer.mu_sig.MuSigTradeAmountLimitsPolicy;
 import bisq.offer.amount.OfferAmountUtil;
 import bisq.offer.amount.spec.FixedAmountSpec;
 import bisq.offer.bisq_easy.BisqEasyOffer;
@@ -53,17 +54,13 @@ import static bisq.bonded_roles.market_price.MarketBasedAmountConversion.usdToFi
 
 @Slf4j
 public class MuSigTradeAmountLimits {
-    public static final Fiat MIN_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10, "USD");
-
-
-    /* --------------------------------------------------------------------- */
-    // MaxTradeLimit
-    /* --------------------------------------------------------------------- */
-
-    public static final Fiat MAX_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10000, "USD");
+    // The absolute and rail-dependent limits are the shared policy in the offer module, so the
+    // maker-side trade protocol validation applies the same numbers as the offer-side consumers.
+    public static final Fiat MIN_USD_TRADE_AMOUNT = MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT;
+    public static final Fiat MAX_USD_TRADE_AMOUNT = MuSigTradeAmountLimitsPolicy.MAX_USD_TRADE_AMOUNT;
 
     public static Fiat getMaxTradeLimitInUsd(PaymentRail paymentRail) {
-        return getMaxTradeLimitInUsd(paymentRail, MAX_USD_TRADE_AMOUNT);
+        return MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(paymentRail);
     }
 
     public static String getFormattedMaxTradeLimitInUsd(PaymentRail paymentRail) {
@@ -72,27 +69,7 @@ public class MuSigTradeAmountLimits {
     }
 
     public static Fiat getMaxTradeLimitInUsd(PaymentRail paymentRail, Fiat maxTradeLimitByProtocol) {
-        if (paymentRail instanceof FiatPaymentRail fiatPaymentRail) {
-            switch (fiatPaymentRail.getChargebackRisk()) {
-                case VERY_LOW -> {
-                    return maxTradeLimitByProtocol;
-                }
-                case LOW -> {
-                    return maxTradeLimitByProtocol.multiply(0.8);
-                }
-                case MEDIUM -> {
-                    return maxTradeLimitByProtocol.multiply(0.65);
-                }
-                case MODERATE -> {
-                    return maxTradeLimitByProtocol.multiply(0.5);
-                }
-                default -> {
-                    return maxTradeLimitByProtocol.multiply(0d);
-                }
-            }
-        } else {
-            return maxTradeLimitByProtocol;
-        }
+        return MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(paymentRail, maxTradeLimitByProtocol);
     }
 
 

--- a/offer/src/main/java/bisq/offer/mu_sig/MuSigTradeAmountLimitsPolicy.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MuSigTradeAmountLimitsPolicy.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.mu_sig;
+
+import bisq.account.payment_method.PaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.monetary.Fiat;
+
+/**
+ * The absolute and payment-rail-dependent MuSig trade amount limits. Lives in the offer module
+ * so both the offer-side consumers and the maker-side trade protocol validation can share one
+ * policy without a dependency cycle; the mu-sig module's MuSigTradeAmountLimits delegates here.
+ */
+public class MuSigTradeAmountLimitsPolicy {
+    public static final Fiat MIN_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10, "USD");
+    public static final Fiat MAX_USD_TRADE_AMOUNT = Fiat.fromFaceValue(10000, "USD");
+
+    public static Fiat getMaxTradeLimitInUsd(PaymentRail paymentRail) {
+        return getMaxTradeLimitInUsd(paymentRail, MAX_USD_TRADE_AMOUNT);
+    }
+
+    public static Fiat getMaxTradeLimitInUsd(PaymentRail paymentRail, Fiat maxTradeLimitByProtocol) {
+        if (paymentRail instanceof FiatPaymentRail fiatPaymentRail) {
+            switch (fiatPaymentRail.getChargebackRisk()) {
+                case VERY_LOW -> {
+                    return maxTradeLimitByProtocol;
+                }
+                case LOW -> {
+                    return maxTradeLimitByProtocol.multiply(0.8);
+                }
+                case MEDIUM -> {
+                    return maxTradeLimitByProtocol.multiply(0.65);
+                }
+                case MODERATE -> {
+                    return maxTradeLimitByProtocol.multiply(0.5);
+                }
+                default -> {
+                    return maxTradeLimitByProtocol.multiply(0d);
+                }
+            }
+        } else {
+            return maxTradeLimitByProtocol;
+        }
+    }
+}

--- a/offer/src/main/java/bisq/offer/mu_sig/MyMuSigOffersService.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MyMuSigOffersService.java
@@ -82,4 +82,12 @@ public class MyMuSigOffersService extends RateLimitedPersistenceClient<MyMuSigOf
                 .filter(offer -> offer.getId().equals(offerId))
                 .findAny();
     }
+
+    // Deactivated offers stay retained in getOffers(); a caller establishing that an offer is
+    // currently takeable must use this lookup, not findOffer.
+    public Optional<MuSigOffer> findActivatedOffer(String offerId) {
+        return getActivatedOffers().stream()
+                .filter(offer -> offer.getId().equals(offerId))
+                .findAny();
+    }
 }

--- a/offer/src/main/java/bisq/offer/mu_sig/MyMuSigOffersService.java
+++ b/offer/src/main/java/bisq/offer/mu_sig/MyMuSigOffersService.java
@@ -45,22 +45,22 @@ public class MyMuSigOffersService extends RateLimitedPersistenceClient<MyMuSigOf
     // API
     /* --------------------------------------------------------------------- */
 
-    public void addOffer(MuSigOffer offer) {
+    public synchronized void addOffer(MuSigOffer offer) {
         persistableStore.addOffer(offer);
         persist();
     }
 
-    public void removeOffer(MuSigOffer offer) {
+    public synchronized void removeOffer(MuSigOffer offer) {
         persistableStore.removeOffer(offer);
         persist();
     }
 
-    public void activateOffer(MuSigOffer offer) {
+    public synchronized void activateOffer(MuSigOffer offer) {
         persistableStore.activateOffer(offer);
         persist();
     }
 
-    public void deactivateOffer(MuSigOffer offer) {
+    public synchronized void deactivateOffer(MuSigOffer offer) {
         persistableStore.deactivateOffer(offer);
         persist();
     }
@@ -69,7 +69,7 @@ public class MyMuSigOffersService extends RateLimitedPersistenceClient<MyMuSigOf
         return persistableStore.getOffers();
     }
 
-    public Set<MuSigOffer> getActivatedOffers() {
+    public synchronized Set<MuSigOffer> getActivatedOffers() {
         return persistableStore.getActivatedOffers();
     }
 
@@ -83,9 +83,9 @@ public class MyMuSigOffersService extends RateLimitedPersistenceClient<MyMuSigOf
                 .findAny();
     }
 
-    // Deactivated offers stay retained in getOffers(); a caller establishing that an offer is
-    // currently takeable must use this lookup, not findOffer.
-    public Optional<MuSigOffer> findActivatedOffer(String offerId) {
+    // A claim authorizes one take without consuming the offer; active MuSig offers support
+    // multiple trades until the maker deactivates or removes them.
+    public synchronized Optional<MuSigOffer> claimActivatedOffer(String offerId) {
         return getActivatedOffers().stream()
                 .filter(offer -> offer.getId().equals(offerId))
                 .findAny();

--- a/offer/src/test/java/bisq/offer/mu_sig/MuSigTradeAmountLimitsPolicyTest.java
+++ b/offer/src/test/java/bisq/offer/mu_sig/MuSigTradeAmountLimitsPolicyTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.mu_sig;
+
+import bisq.account.payment_method.BitcoinPaymentRail;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.monetary.Fiat;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MuSigTradeAmountLimitsPolicyTest {
+    @Test
+    void railDependentLimitsFollowTheChargebackRiskTiers() {
+        assertThat(MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(FiatPaymentRail.ADVANCED_CASH))
+                .isEqualTo(Fiat.fromFaceValue(10000, "USD"));
+        assertThat(MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(FiatPaymentRail.ALI_PAY))
+                .isEqualTo(Fiat.fromFaceValue(8000, "USD"));
+        assertThat(MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(FiatPaymentRail.MONEY_GRAM))
+                .isEqualTo(Fiat.fromFaceValue(6500, "USD"));
+        assertThat(MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(FiatPaymentRail.WISE))
+                .isEqualTo(Fiat.fromFaceValue(5000, "USD"));
+    }
+
+    @Test
+    void nonFiatRailsGetTheProtocolLimit() {
+        assertThat(MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(BitcoinPaymentRail.MAIN_CHAIN))
+                .isEqualTo(MuSigTradeAmountLimitsPolicy.MAX_USD_TRADE_AMOUNT);
+    }
+}

--- a/offer/src/test/java/bisq/offer/mu_sig/MyMuSigOffersServiceTest.java
+++ b/offer/src/test/java/bisq/offer/mu_sig/MyMuSigOffersServiceTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.offer.mu_sig;
+
+import bisq.persistence.DbSubDirectory;
+import bisq.persistence.Persistence;
+import bisq.persistence.PersistenceService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MyMuSigOffersServiceTest {
+    @Test
+    void claimingDoesNotConsumeTheActivatedOffer() {
+        MyMuSigOffersService service = createService();
+        MuSigOffer offer = mock(MuSigOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        service.addOffer(offer);
+
+        assertThat(service.claimActivatedOffer("offer-id").orElseThrow()).isSameAs(offer);
+        assertThat(service.claimActivatedOffer("offer-id").orElseThrow()).isSameAs(offer);
+    }
+
+    @Test
+    void removedOfferCannotBeClaimed() {
+        MyMuSigOffersService service = createService();
+        MuSigOffer offer = mock(MuSigOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        service.addOffer(offer);
+
+        service.removeOffer(offer);
+
+        assertThat(service.claimActivatedOffer("offer-id")).isEmpty();
+    }
+
+    @Test
+    void deactivationThatWinsTheStateLockPreventsClaim() throws Exception {
+        MyMuSigOffersService service = createService();
+        MuSigOffer offer = mock(MuSigOffer.class);
+        when(offer.getId()).thenReturn("offer-id");
+        service.addOffer(offer);
+
+        CountDownLatch claimThreadStarted = new CountDownLatch(1);
+        AtomicReference<Optional<MuSigOffer>> result = new AtomicReference<>();
+        Thread claimThread = new Thread(() -> {
+            claimThreadStarted.countDown();
+            result.set(service.claimActivatedOffer("offer-id"));
+        });
+
+        synchronized (service) {
+            claimThread.start();
+            assertThat(claimThreadStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            awaitBlocked(claimThread);
+            service.deactivateOffer(offer);
+        }
+
+        claimThread.join(TimeUnit.SECONDS.toMillis(5));
+        assertThat(claimThread.isAlive()).isFalse();
+        assertThat(result.get()).isEmpty();
+    }
+
+    private static MyMuSigOffersService createService() {
+        PersistenceService persistenceService = mock(PersistenceService.class);
+        @SuppressWarnings("unchecked")
+        Persistence<MyMuSigOffersStore> persistence = mock(Persistence.class);
+        when(persistence.persistAsync(any(MyMuSigOffersStore.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(persistenceService.getOrCreatePersistence(any(), eq(DbSubDirectory.PRIVATE),
+                any(MyMuSigOffersStore.class)))
+                .thenReturn(persistence);
+        return new MyMuSigOffersService(persistenceService);
+    }
+
+    private static void awaitBlocked(Thread thread) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (thread.isAlive() && thread.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertThat(thread.getState()).isEqualTo(Thread.State.BLOCKED);
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -389,18 +389,25 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             // must not leave a trade, a protocol entry or a contact-list entry behind. The
             // handler keeps its own check as defense in depth.
             log.warn("Dropping a take offer request from an ignored taker. tradeId={}",
-                    StringUtils.truncate(message.getTradeId().replaceAll("[\\p{Cntrl}\\u2028\\u2029]", "?"), 60));
+                    StringUtils.sanitizeForLog(message.getTradeId()));
             return;
         }
         try {
             // The request is validated before any trade is created or persisted; a rejected
             // request must not leave a failed trade, a protocol entry or a contact-list entry.
             MuSigTakeOfferRequestValidator.validateIdentity(serviceProvider.getContractService(), message);
+            MuSigTakeOfferRequestValidator.validateTakerProfileKnown(userProfileService, message);
             MuSigTakeOfferRequestValidator.validateOffer(
                     serviceProvider.getOfferService().getMuSigOfferService().getMyMuSigOffersService(), message);
+            MuSigTakeOfferRequestValidator.validateEconomics(
+                    serviceProvider.getBondedRolesService().getMarketPriceService(),
+                    settingsService,
+                    muSigTraderMediationService,
+                    muSigTraderArbitrationService,
+                    message);
         } catch (TradeProtocolException e) {
             log.warn("Dropping an invalid MuSig take offer request. tradeId={}",
-                    StringUtils.truncate(message.getTradeId().replaceAll("[\\p{Cntrl}\\u2028\\u2029]", "?"), 60));
+                    StringUtils.sanitizeForLog(message.getTradeId()));
             return;
         }
         MuSigContract muSigContract = message.getContract();

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -397,19 +397,20 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             return;
         }
         try {
+            MuSigOffer claimedOffer;
             try {
                 // The request is validated before any trade is created or persisted; a rejected
                 // request must not leave a failed trade, a protocol entry or a contact-list entry.
                 MuSigTakeOfferRequestValidator.validateIdentity(serviceProvider.getContractService(), message);
                 MuSigTakeOfferRequestValidator.validateTakerProfileKnown(userProfileService, message);
-                MuSigTakeOfferRequestValidator.validateOffer(
-                        serviceProvider.getOfferService().getMuSigOfferService().getMyMuSigOffersService(), message);
                 MuSigTakeOfferRequestValidator.validateEconomics(
                         serviceProvider.getBondedRolesService().getMarketPriceService(),
                         settingsService,
                         muSigTraderMediationService,
                         muSigTraderArbitrationService,
                         message);
+                claimedOffer = MuSigTakeOfferRequestValidator.validateOffer(
+                        serviceProvider.getOfferService().getMuSigOfferService().getMyMuSigOffersService(), message);
             } catch (TradeProtocolException e) {
                 throw e;
             } catch (RuntimeException e) {
@@ -421,7 +422,11 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                         e);
             }
             MuSigContract muSigContract = message.getContract();
-            makerCreatesProtocol(muSigContract, message.getTradeId(), message.getSender(), message.getReceiver())
+            makerCreatesProtocol(muSigContract,
+                    claimedOffer,
+                    message.getTradeId(),
+                    message.getSender(),
+                    message.getReceiver())
                     .ifPresent(protocol -> handleMuSigTradeMessage(message, protocol));
         } catch (TradeProtocolException e) {
             log.warn("Dropping an invalid MuSig take offer request. tradeId={}",
@@ -718,15 +723,20 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     // The maker has added the salted account id to the AccountOptions.
     // We will use the payment method chosen by the taker to determine which account we had assigned to that offer.
     public Optional<Account<? extends PaymentMethod<?>, ?>> findMyAccount(MuSigTrade trade) {
+        return findMyAccount(trade, trade.getOffer());
+    }
+
+    private Optional<Account<? extends PaymentMethod<?>, ?>> findMyAccount(MuSigTrade trade,
+                                                                           MuSigOffer claimedOffer) {
         MuSigContract contract = trade.getContract();
-        MuSigOffer offer = contract.getOffer();
         PaymentMethod<?> selectedPaymentMethod = contract.getNonBtcSidePaymentMethodSpec().getPaymentMethod();
         Set<Account<? extends PaymentMethod<?>, ?>> matchingAccounts = serviceProvider.getAccountService().getAccounts(selectedPaymentMethod);
-        Set<AccountOption> accountOptions = OfferOptionUtil.findAccountOptions(offer.getOfferOptions());
+        Set<AccountOption> accountOptions = OfferOptionUtil.findAccountOptions(claimedOffer.getOfferOptions());
         return accountOptions.stream()
                 .filter(accountOption -> accountOption.getPaymentMethod().equals(selectedPaymentMethod))
                 .map(AccountOption::getSaltedAccountId)
-                .flatMap(saltedAccountId -> OfferOptionUtil.findAccountFromSaltedAccountId(matchingAccounts, saltedAccountId, offer.getId()).stream())
+                .flatMap(saltedAccountId -> OfferOptionUtil.findAccountFromSaltedAccountId(
+                        matchingAccounts, saltedAccountId, claimedOffer.getId()).stream())
                 .findAny();
     }
 
@@ -734,7 +744,11 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     // TradeProtocol factory
     /* --------------------------------------------------------------------- */
 
-    private Optional<MuSigProtocol> makerCreatesProtocol(MuSigContract contract, String tradeId, NetworkId sender, NetworkId receiver) {
+    private Optional<MuSigProtocol> makerCreatesProtocol(MuSigContract contract,
+                                                         MuSigOffer claimedOffer,
+                                                         String tradeId,
+                                                         NetworkId sender,
+                                                         NetworkId receiver) {
         // The handler performs its FSM-level verification after protocol creation. tradeId is the
         // validated message trade id.
         synchronized (tradeCreationLock) {
@@ -746,11 +760,10 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                         StringUtils.sanitizeForLog(tradeId));
                 return Optional.empty();
             }
-            MuSigOffer offer = contract.getOffer();
-            boolean isBuyer = offer.getDirection().isBuy();
+            boolean isBuyer = claimedOffer.getDirection().isBuy();
             // The maker's own identity/account can be gone while the offer is still active; reject
             // before creating partial state.
-            Optional<Identity> myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId());
+            Optional<Identity> myIdentity = identityService.findAnyIdentityByNetworkId(claimedOffer.getMakerNetworkId());
             if (myIdentity.isEmpty()) {
                 log.warn("Rejecting a take offer request: no local identity backs the offer's maker. tradeId={}",
                         StringUtils.sanitizeForLog(tradeId));
@@ -765,9 +778,10 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                 throw new TradeProtocolException("The maker can no longer take this offer.",
                         TradeProtocolFailure.OFFER_NOT_AVAILABLE);
             }
-            MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity.get(), offer, sender, receiver);
+            MuSigTrade trade = new MuSigTrade(
+                    contract, isBuyer, false, myIdentity.get(), claimedOffer, sender, receiver);
 
-            Optional<Account<? extends PaymentMethod<?>, ?>> myAccount = findMyAccount(trade);
+            Optional<Account<? extends PaymentMethod<?>, ?>> myAccount = findMyAccount(trade, claimedOffer);
             if (myAccount.isEmpty()) {
                 log.warn("Rejecting a take offer request: no maker account backs the offer's payment method anymore. tradeId={}",
                         StringUtils.sanitizeForLog(tradeId));

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -384,13 +384,23 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     /* --------------------------------------------------------------------- */
 
     private void handleMuSigTakeOfferMessage(SetupTradeMessage_A message) {
+        if (userProfileService.isChatUserIgnored(message.getSender().getId())) {
+            // Checked before anything is created or persisted: a request from an ignored taker
+            // must not leave a trade, a protocol entry or a contact-list entry behind. The
+            // handler keeps its own check as defense in depth.
+            log.warn("Dropping a take offer request from an ignored taker. tradeId={}",
+                    StringUtils.truncate(message.getTradeId().replaceAll("[\\p{Cntrl}\\u2028\\u2029]", "?"), 60));
+            return;
+        }
         try {
             // The request is validated before any trade is created or persisted; a rejected
             // request must not leave a failed trade, a protocol entry or a contact-list entry.
             MuSigTakeOfferRequestValidator.validateIdentity(serviceProvider.getContractService(), message);
+            MuSigTakeOfferRequestValidator.validateOffer(
+                    serviceProvider.getOfferService().getMuSigOfferService().getMyMuSigOffersService(), message);
         } catch (TradeProtocolException e) {
             log.warn("Dropping an invalid MuSig take offer request. tradeId={}",
-                    StringUtils.truncate(message.getTradeId().replaceAll("\\p{Cntrl}", "?"), 60));
+                    StringUtils.truncate(message.getTradeId().replaceAll("[\\p{Cntrl}\\u2028\\u2029]", "?"), 60));
             return;
         }
         MuSigContract muSigContract = message.getContract();

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -48,7 +48,6 @@ import bisq.network.NetworkService;
 import bisq.network.identity.NetworkId;
 import bisq.network.p2p.message.EnvelopePayloadMessage;
 import bisq.network.p2p.services.confidential.ConfidentialMessageService;
-import bisq.offer.Direction;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.offer.options.AccountOption;
 import bisq.offer.options.OfferOptionUtil;
@@ -163,6 +162,9 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     private final Map<String, Scheduler> closeTradeTimeoutSchedulerByTradeId = new ConcurrentHashMap<>();
     private final Map<String, CompletableFuture<Void>> observeDepositTxConfirmationStatusFutureByTradeId = new ConcurrentHashMap<>();
     private final Object disputeStateLock = new Object();
+    // Serializes maker-side trade creation so two concurrent take requests for the same trade id
+    // cannot race a second trade or protocol into the registries.
+    private final Object tradeCreationLock = new Object();
 
     private ExecutorService executor;
 
@@ -411,8 +413,8 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             return;
         }
         MuSigContract muSigContract = message.getContract();
-        MuSigProtocol protocol = makerCreatesProtocol(muSigContract, message.getSender(), message.getReceiver());
-        handleMuSigTradeMessage(message, protocol);
+        makerCreatesProtocol(muSigContract, message.getTradeId(), message.getSender(), message.getReceiver())
+                .ifPresent(protocol -> handleMuSigTradeMessage(message, protocol));
     }
 
     private void handleMuSigTradeMessage(MuSigTradeMessage message) {
@@ -683,27 +685,37 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     // TradeProtocol factory
     /* --------------------------------------------------------------------- */
 
-    private MuSigProtocol makerCreatesProtocol(MuSigContract contract, NetworkId sender, NetworkId receiver) {
+    private Optional<MuSigProtocol> makerCreatesProtocol(MuSigContract contract, String tradeId, NetworkId sender, NetworkId receiver) {
         // We only create the data required for the protocol creation.
-        // Verification will happen in the MuSigTakeOfferRequestHandler
-        MuSigOffer offer = contract.getOffer();
-        Direction makersDirection = offer.getDirection();
-        boolean isBuyer = makersDirection.isBuy();
-        Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
-        MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
+        // Verification will happen in the MuSigTakeOfferRequestHandler.
+        // tradeId is the validated message trade id (== the id derived from the contract).
+        synchronized (tradeCreationLock) {
+            // A duplicate or concurrent request for the same trade id must not race a second trade
+            // or protocol into the registries; drop it cleanly instead of throwing on the network
+            // notify thread. The duplicate check runs before the identity/account lookups so a
+            // duplicate that arrives after the account or identity was removed still drops cleanly
+            // rather than throwing. Resuming a persisted INIT trade on a resend is a separate
+            // concern (see the take-offer follow-ups).
+            if (findProtocol(tradeId).isPresent() || tradeExists(tradeId)) {
+                log.warn("Dropping a duplicate MuSig take offer request for an existing trade. tradeId={}",
+                        StringUtils.sanitizeForLog(tradeId));
+                return Optional.empty();
+            }
+            MuSigOffer offer = contract.getOffer();
+            boolean isBuyer = offer.getDirection().isBuy();
+            Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
+            MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
 
-        AccountPayload<? extends PaymentMethod<?>> accountPayload = findMyAccount(trade).orElseThrow().getAccountPayload();
-        trade.getMyself().setAccountPayload(accountPayload);
+            AccountPayload<? extends PaymentMethod<?>> accountPayload = findMyAccount(trade).orElseThrow().getAccountPayload();
+            trade.getMyself().setAccountPayload(accountPayload);
 
-        String tradeId = trade.getId();
-        checkArgument(findProtocol(tradeId).isEmpty(), "We received the MuSigTakeOfferRequest for an already existing protocol");
-        checkArgument(!tradeExists(tradeId), "A trade with that ID exists already");
-        persistableStore.addTrade(trade);
-        persist();
-
-        maybeAddPeerToContactList(sender.getId(), myIdentity.getId());
-
-        return createAndAddTradeProtocol(trade);
+            persistableStore.addTrade(trade);
+            persist();
+            // The peer is added to the contact list only after the handler has verified and
+            // processed the request (SetupTradeMessage_A_Handler.commit), so a rejected or failed
+            // take leaves no contact-list entry.
+            return Optional.of(createAndAddTradeProtocol(trade));
+        }
     }
 
     private MuSigProtocol createAndAddTradeProtocol(MuSigTrade trade) {
@@ -771,7 +783,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     // Misc
     /* --------------------------------------------------------------------- */
 
-    private void maybeAddPeerToContactList(String peersProfileId, String myProfileId) {
+    public void maybeAddPeerToContactList(String peersProfileId, String myProfileId) {
         if (settingsService.getDoAutoAddToContactList()) {
             Optional<UserProfile> peersProfile = userProfileService.findUserProfile(peersProfileId);
             Optional<UserProfile> myProfile = userProfileService.findUserProfile(myProfileId);

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -62,6 +62,7 @@ import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.trade.ServiceProvider;
 import bisq.trade.exceptions.TradeProtocolException;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService;
 import bisq.trade.mu_sig.events.MuSigTradeEvent;
@@ -72,6 +73,7 @@ import bisq.trade.mu_sig.events.taker.MuSigTakeOfferEvent;
 import bisq.trade.mu_sig.grpc.MusigGrpcClient;
 import bisq.trade.mu_sig.mediation.MuSigTraderMediationService;
 import bisq.trade.mu_sig.messages.grpc.TxConfirmationStatus;
+import bisq.trade.mu_sig.messages.network.MuSigReportErrorMessage;
 import bisq.trade.mu_sig.messages.network.MuSigTradeMessage;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
 import bisq.trade.mu_sig.messages.network.handler.maker.MuSigTakeOfferRequestValidator;
@@ -395,26 +397,73 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             return;
         }
         try {
-            // The request is validated before any trade is created or persisted; a rejected
-            // request must not leave a failed trade, a protocol entry or a contact-list entry.
-            MuSigTakeOfferRequestValidator.validateIdentity(serviceProvider.getContractService(), message);
-            MuSigTakeOfferRequestValidator.validateTakerProfileKnown(userProfileService, message);
-            MuSigTakeOfferRequestValidator.validateOffer(
-                    serviceProvider.getOfferService().getMuSigOfferService().getMyMuSigOffersService(), message);
-            MuSigTakeOfferRequestValidator.validateEconomics(
-                    serviceProvider.getBondedRolesService().getMarketPriceService(),
-                    settingsService,
-                    muSigTraderMediationService,
-                    muSigTraderArbitrationService,
-                    message);
+            try {
+                // The request is validated before any trade is created or persisted; a rejected
+                // request must not leave a failed trade, a protocol entry or a contact-list entry.
+                MuSigTakeOfferRequestValidator.validateIdentity(serviceProvider.getContractService(), message);
+                MuSigTakeOfferRequestValidator.validateTakerProfileKnown(userProfileService, message);
+                MuSigTakeOfferRequestValidator.validateOffer(
+                        serviceProvider.getOfferService().getMuSigOfferService().getMyMuSigOffersService(), message);
+                MuSigTakeOfferRequestValidator.validateEconomics(
+                        serviceProvider.getBondedRolesService().getMarketPriceService(),
+                        settingsService,
+                        muSigTraderMediationService,
+                        muSigTraderArbitrationService,
+                        message);
+            } catch (TradeProtocolException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                log.warn("Unexpected failure while validating a MuSig take offer request. tradeId={}",
+                        StringUtils.sanitizeForLog(message.getTradeId()), e);
+                throw new TradeProtocolException(
+                        "The maker has rejected the take offer request because the offer is not available anymore.",
+                        TradeProtocolFailure.OFFER_NOT_AVAILABLE,
+                        e);
+            }
+            MuSigContract muSigContract = message.getContract();
+            makerCreatesProtocol(muSigContract, message.getTradeId(), message.getSender(), message.getReceiver())
+                    .ifPresent(protocol -> handleMuSigTradeMessage(message, protocol));
         } catch (TradeProtocolException e) {
             log.warn("Dropping an invalid MuSig take offer request. tradeId={}",
                     StringUtils.sanitizeForLog(message.getTradeId()));
+            reportTakeOfferRejection(networkService, identityService, message, e);
             return;
         }
-        MuSigContract muSigContract = message.getContract();
-        makerCreatesProtocol(muSigContract, message.getTradeId(), message.getSender(), message.getReceiver())
-                .ifPresent(protocol -> handleMuSigTradeMessage(message, protocol));
+    }
+
+    static void reportTakeOfferRejection(NetworkService networkService,
+                                         IdentityService identityService,
+                                         SetupTradeMessage_A message,
+                                         TradeProtocolException exception) {
+        try {
+            Optional<Identity> receivingIdentity = identityService.findAnyIdentityByNetworkId(message.getReceiver());
+            if (receivingIdentity.isEmpty()) {
+                log.warn("Cannot report a MuSig take offer rejection because the receiving identity is unavailable. tradeId={}",
+                        StringUtils.sanitizeForLog(message.getTradeId()));
+                return;
+            }
+            Identity identity = receivingIdentity.orElseThrow();
+            String errorMessage = Optional.ofNullable(exception.getMessage())
+                    .orElse(exception.getTradeProtocolFailure().name());
+            MuSigReportErrorMessage error = new MuSigReportErrorMessage(
+                    StringUtils.createUid(),
+                    message.getTradeId(),
+                    MuSigProtocol.VERSION,
+                    identity.getNetworkId(),
+                    message.getSender(),
+                    StringUtils.truncate(errorMessage, MuSigReportErrorMessage.MAX_LENGTH_ERROR_MESSAGE),
+                    "",
+                    exception.getTradeProtocolFailure());
+            networkService.confidentialSend(error, message.getSender(), identity.getNetworkIdWithKeyPair())
+                    .exceptionally(throwable -> {
+                        log.warn("Sending a MuSig take offer rejection failed. tradeId={}",
+                                StringUtils.sanitizeForLog(message.getTradeId()), throwable);
+                        return null;
+                    });
+        } catch (RuntimeException e) {
+            log.warn("Creating or sending a MuSig take offer rejection failed. tradeId={}",
+                    StringUtils.sanitizeForLog(message.getTradeId()), e);
+        }
     }
 
     private void handleMuSigTradeMessage(MuSigTradeMessage message) {
@@ -686,16 +735,12 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     /* --------------------------------------------------------------------- */
 
     private Optional<MuSigProtocol> makerCreatesProtocol(MuSigContract contract, String tradeId, NetworkId sender, NetworkId receiver) {
-        // We only create the data required for the protocol creation.
-        // Verification will happen in the MuSigTakeOfferRequestHandler.
-        // tradeId is the validated message trade id (== the id derived from the contract).
+        // The handler performs its FSM-level verification after protocol creation. tradeId is the
+        // validated message trade id.
         synchronized (tradeCreationLock) {
-            // A duplicate or concurrent request for the same trade id must not race a second trade
-            // or protocol into the registries; drop it cleanly instead of throwing on the network
-            // notify thread. The duplicate check runs before the identity/account lookups so a
-            // duplicate that arrives after the account or identity was removed still drops cleanly
-            // rather than throwing. Resuming a persisted INIT trade on a resend is a separate
-            // concern (see the take-offer follow-ups).
+            // Serialize creation and drop a duplicate cleanly instead of racing or throwing. The
+            // check runs before the identity/account lookups so a late removal also drops cleanly.
+            // Resuming a persisted INIT trade on a resend is a follow-up.
             if (findProtocol(tradeId).isPresent() || tradeExists(tradeId)) {
                 log.warn("Dropping a duplicate MuSig take offer request for an existing trade. tradeId={}",
                         StringUtils.sanitizeForLog(tradeId));
@@ -703,39 +748,37 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             }
             MuSigOffer offer = contract.getOffer();
             boolean isBuyer = offer.getDirection().isBuy();
-            // The maker's own identity and payment account can be removed while the offer is still
-            // active; drop the request cleanly instead of throwing NoSuchElementException on the
-            // network notify thread. No trade is created in that case.
+            // The maker's own identity/account can be gone while the offer is still active; reject
+            // before creating partial state.
             Optional<Identity> myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId());
             if (myIdentity.isEmpty()) {
-                log.warn("Dropping a take offer request: no local identity backs the offer's maker. tradeId={}",
+                log.warn("Rejecting a take offer request: no local identity backs the offer's maker. tradeId={}",
                         StringUtils.sanitizeForLog(tradeId));
-                return Optional.empty();
+                throw new TradeProtocolException("The maker can no longer take this offer.",
+                        TradeProtocolFailure.OFFER_NOT_AVAILABLE);
             }
-            // findAnyIdentityByNetworkId also returns retired identities, but the handler needs an
-            // active user identity (SetupTradeMessage_A_Handler resolves it with orElseThrow); if
-            // the maker retired its user identity while the offer stayed active, drop cleanly here
-            // rather than persist a trade whose handler would then fail.
+            // findAnyIdentityByNetworkId includes retired identities, but the handler needs an
+            // active user identity, so require one here.
             if (serviceProvider.getUserService().getUserIdentityService().findUserIdentity(myIdentity.get().getId()).isEmpty()) {
-                log.warn("Dropping a take offer request: the offer's maker is no longer an active user identity. tradeId={}",
+                log.warn("Rejecting a take offer request: the offer's maker is no longer an active user identity. tradeId={}",
                         StringUtils.sanitizeForLog(tradeId));
-                return Optional.empty();
+                throw new TradeProtocolException("The maker can no longer take this offer.",
+                        TradeProtocolFailure.OFFER_NOT_AVAILABLE);
             }
             MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity.get(), offer, sender, receiver);
 
             Optional<Account<? extends PaymentMethod<?>, ?>> myAccount = findMyAccount(trade);
             if (myAccount.isEmpty()) {
-                log.warn("Dropping a take offer request: no maker account backs the offer's payment method anymore. tradeId={}",
+                log.warn("Rejecting a take offer request: no maker account backs the offer's payment method anymore. tradeId={}",
                         StringUtils.sanitizeForLog(tradeId));
-                return Optional.empty();
+                throw new TradeProtocolException("The maker can no longer take this offer.",
+                        TradeProtocolFailure.OFFER_NOT_AVAILABLE);
             }
             trade.getMyself().setAccountPayload(myAccount.get().getAccountPayload());
 
             persistableStore.addTrade(trade);
             persist();
-            // The peer is added to the contact list only after the handler has verified and
-            // processed the request (SetupTradeMessage_A_Handler.commit), so a rejected or failed
-            // take leaves no contact-list entry.
+            // The contact-list add is done by the handler after it verifies and processes the request.
             return Optional.of(createAndAddTradeProtocol(trade));
         }
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -38,6 +38,7 @@ import bisq.common.observable.map.HashMapObserver;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.common.platform.Version;
 import bisq.common.threading.ExecutorFactory;
+import bisq.common.util.StringUtils;
 import bisq.common.timer.Scheduler;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.i18n.Res;
@@ -61,6 +62,7 @@ import bisq.support.dispute.mu_sig.MuSigDisputeCasePaymentDetailsRequest;
 import bisq.support.mediation.mu_sig.MuSigMediationResultAcceptanceMessage;
 import bisq.support.mediation.mu_sig.MuSigMediationStateChangeMessage;
 import bisq.trade.ServiceProvider;
+import bisq.trade.exceptions.TradeProtocolException;
 import bisq.trade.exceptions.TradingNotAllowedException;
 import bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService;
 import bisq.trade.mu_sig.events.MuSigTradeEvent;
@@ -73,6 +75,7 @@ import bisq.trade.mu_sig.mediation.MuSigTraderMediationService;
 import bisq.trade.mu_sig.messages.grpc.TxConfirmationStatus;
 import bisq.trade.mu_sig.messages.network.MuSigTradeMessage;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
+import bisq.trade.mu_sig.messages.network.handler.maker.MuSigTakeOfferRequestValidator;
 import bisq.trade.mu_sig.protocol.MuSigBuyerAsMakerProtocol;
 import bisq.trade.mu_sig.protocol.MuSigBuyerAsTakerProtocol;
 import bisq.trade.mu_sig.protocol.MuSigProtocol;
@@ -381,6 +384,15 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     /* --------------------------------------------------------------------- */
 
     private void handleMuSigTakeOfferMessage(SetupTradeMessage_A message) {
+        try {
+            // The request is validated before any trade is created or persisted; a rejected
+            // request must not leave a failed trade, a protocol entry or a contact-list entry.
+            MuSigTakeOfferRequestValidator.validateIdentity(serviceProvider.getContractService(), message);
+        } catch (TradeProtocolException e) {
+            log.warn("Dropping an invalid MuSig take offer request. tradeId={}",
+                    StringUtils.truncate(message.getTradeId().replaceAll("\\p{Cntrl}", "?"), 60));
+            return;
+        }
         MuSigContract muSigContract = message.getContract();
         MuSigProtocol protocol = makerCreatesProtocol(muSigContract, message.getSender(), message.getReceiver());
         handleMuSigTradeMessage(message, protocol);

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -703,11 +703,33 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
             }
             MuSigOffer offer = contract.getOffer();
             boolean isBuyer = offer.getDirection().isBuy();
-            Identity myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId()).orElseThrow();
-            MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity, offer, sender, receiver);
+            // The maker's own identity and payment account can be removed while the offer is still
+            // active; drop the request cleanly instead of throwing NoSuchElementException on the
+            // network notify thread. No trade is created in that case.
+            Optional<Identity> myIdentity = identityService.findAnyIdentityByNetworkId(offer.getMakerNetworkId());
+            if (myIdentity.isEmpty()) {
+                log.warn("Dropping a take offer request: no local identity backs the offer's maker. tradeId={}",
+                        StringUtils.sanitizeForLog(tradeId));
+                return Optional.empty();
+            }
+            // findAnyIdentityByNetworkId also returns retired identities, but the handler needs an
+            // active user identity (SetupTradeMessage_A_Handler resolves it with orElseThrow); if
+            // the maker retired its user identity while the offer stayed active, drop cleanly here
+            // rather than persist a trade whose handler would then fail.
+            if (serviceProvider.getUserService().getUserIdentityService().findUserIdentity(myIdentity.get().getId()).isEmpty()) {
+                log.warn("Dropping a take offer request: the offer's maker is no longer an active user identity. tradeId={}",
+                        StringUtils.sanitizeForLog(tradeId));
+                return Optional.empty();
+            }
+            MuSigTrade trade = new MuSigTrade(contract, isBuyer, false, myIdentity.get(), offer, sender, receiver);
 
-            AccountPayload<? extends PaymentMethod<?>> accountPayload = findMyAccount(trade).orElseThrow().getAccountPayload();
-            trade.getMyself().setAccountPayload(accountPayload);
+            Optional<Account<? extends PaymentMethod<?>, ?>> myAccount = findMyAccount(trade);
+            if (myAccount.isEmpty()) {
+                log.warn("Dropping a take offer request: no maker account backs the offer's payment method anymore. tradeId={}",
+                        StringUtils.sanitizeForLog(tradeId));
+                return Optional.empty();
+            }
+            trade.getMyself().setAccountPayload(myAccount.get().getAccountPayload());
 
             persistableStore.addTrade(trade);
             persist();

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -357,13 +357,23 @@ public final class MuSigTakeOfferRequestValidator {
         if (usdAtomic.compareTo(java.math.BigDecimal.valueOf(MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT.getValue())) < 0) {
             throw reject("The trade amount lies below the absolute minimum. usd=" + usdAtomic.toPlainString());
         }
+        // The payment-rail cap limits the fiat obligation, which is the non-Bitcoin side. The
+        // two-sided price tolerance lets that side sit up to the tolerance above the Bitcoin value,
+        // so valuing the cap on the Bitcoin side alone would let the fiat obligation exceed the cap
+        // by the tolerance. When the fiat side is quoted in USD it is directly comparable in the
+        // same atomic scale, so cap on the larger of the Bitcoin-derived value and the actual USD
+        // obligation. (Non-USD fiat still needs a fiat/USD conversion - a disclosed follow-up.)
+        java.math.BigDecimal obligationUsd = usdAtomic;
+        if (market.isBaseCurrencyBitcoin() && "USD".equals(market.getQuoteCurrencyCode())) {
+            obligationUsd = obligationUsd.max(java.math.BigDecimal.valueOf(quoteSideAmount));
+        }
         PaymentMethodSpec<?> nonBtcSideSpec = market.isBaseCurrencyBitcoin()
                 ? contract.getQuoteSidePaymentMethodSpec()
                 : contract.getBaseSidePaymentMethodSpec();
         Fiat railLimit = MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(
                 nonBtcSideSpec.getPaymentMethod().getPaymentRail());
-        if (usdAtomic.compareTo(java.math.BigDecimal.valueOf(railLimit.getValue())) > 0) {
-            throw reject("The trade amount exceeds the payment rail's limit. usd=" + usdAtomic.toPlainString()
+        if (obligationUsd.compareTo(java.math.BigDecimal.valueOf(railLimit.getValue())) > 0) {
+            throw reject("The trade amount exceeds the payment rail's limit. usd=" + obligationUsd.toPlainString()
                     + ", limit=" + railLimit.getValue());
         }
     }
@@ -410,7 +420,14 @@ public final class MuSigTakeOfferRequestValidator {
     // value, so it is compared explicitly; the remaining version fields stay excluded so a benign
     // profile-version skew does not reject a genuine agent.
     private static boolean sameDisputeAgent(Optional<UserProfile> mine, Optional<UserProfile> theirs) {
+        // UserProfile.equals omits version, applicationVersion and avatarVersion, yet all three are
+        // part of the contract the maker co-signs (the version field even selects which fields
+        // serializeForHash clears). Compare equals plus those three fields - i.e. the whole profile
+        // - so a taker cannot forge dispute-agent profile metadata into the signed contract while
+        // this check still accepts it.
         return mine.equals(theirs)
+                && mine.map(UserProfile::getVersion).equals(theirs.map(UserProfile::getVersion))
+                && mine.map(UserProfile::getApplicationVersion).equals(theirs.map(UserProfile::getApplicationVersion))
                 && mine.map(UserProfile::getAvatarVersion).equals(theirs.map(UserProfile::getAvatarVersion));
     }
 

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -18,15 +18,39 @@
 package bisq.trade.mu_sig.messages.network.handler.maker;
 
 import bisq.common.util.StringUtils;
+import bisq.bonded_roles.market_price.MarketPrice;
+import bisq.bonded_roles.market_price.MarketPriceService;
+import bisq.common.application.DevMode;
+import bisq.common.market.Market;
+import bisq.common.market.MarketRepository;
+import bisq.common.monetary.Coin;
+import bisq.common.monetary.Fiat;
+import bisq.common.monetary.Monetary;
+import bisq.common.monetary.PriceQuote;
+import bisq.account.protocol_type.TradeProtocolType;
 import bisq.contract.ContractService;
 import bisq.contract.ContractSignatureData;
+import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.network.identity.NetworkId;
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.offer.amount.spec.AmountSpecUtil;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.mu_sig.MuSigTradeAmountLimitsPolicy;
+import bisq.offer.price.PriceUtil;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.offer.price.spec.FloatPriceSpec;
+import bisq.offer.price.spec.MarketPriceSpec;
+import bisq.offer.price.spec.PriceSpec;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
 import bisq.offer.mu_sig.MyMuSigOffersService;
 import bisq.trade.exceptions.TradeProtocolFailure;
+import bisq.settings.SettingsService;
 import bisq.trade.Trade;
 import bisq.trade.exceptions.TradeProtocolException;
+import bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService;
+import bisq.trade.mu_sig.mediation.MuSigTraderMediationService;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,12 +59,19 @@ import java.security.PublicKey;
 import java.util.Optional;
 
 /**
- * Validates an incoming take offer request before any trade is created or persisted. Every
- * rejection carries the same generic wire reason while the log keeps the specific cause, so a
- * crafted request learns nothing from the failure mode.
+ * Validates an incoming take offer request before any trade is created or persisted.
+ * Structural and identity rejections carry the same generic wire reason while the log keeps
+ * the specific cause, so a crafted request learns nothing from the failure mode; price
+ * deviations and dispute-agent mismatches carry their specific reasons, as those are
+ * legitimate conditions an honest taker can act on.
  */
 @Slf4j
 public final class MuSigTakeOfferRequestValidator {
+    // 21,000,000 BTC in satoshis. A Bitcoin-side amount cannot exceed the total supply; the cap
+    // also keeps the USD-limit conversion below the range where PriceQuote's long arithmetic
+    // wraps, which a taker could otherwise exploit to make an enormous amount read as tiny.
+    private static final long MAX_BITCOIN_SUPPLY_SATS = 2_100_000_000_000_000L;
+
     private MuSigTakeOfferRequestValidator() {
     }
 
@@ -52,14 +83,14 @@ public final class MuSigTakeOfferRequestValidator {
         NetworkId takerNetworkId = contract.getTaker().getNetworkId();
         if (!message.getSender().equals(takerNetworkId)) {
             throw reject("The authenticated message sender does not match the taker in the contract. senderId="
-                    + sanitizeForLog(message.getSender().getId()) + ", contract takerId=" + sanitizeForLog(takerNetworkId.getId()));
+                    + StringUtils.sanitizeForLog(message.getSender().getId()) + ", contract takerId=" + StringUtils.sanitizeForLog(takerNetworkId.getId()));
         }
         if (!message.getReceiver().equals(contract.getOffer().getMakerNetworkId())) {
             // On a node owning several identities the confidential layer only binds the message
             // to the receiving identity; without this check a request naming maker A in the
             // contract but sent to identity B would build a trade mixing both identities.
             throw reject("The message receiver does not match the offer's maker network id. receiverId="
-                    + sanitizeForLog(message.getReceiver().getId()) + ", offer makerId=" + sanitizeForLog(contract.getOffer().getMakerNetworkId().getId()));
+                    + StringUtils.sanitizeForLog(message.getReceiver().getId()) + ", offer makerId=" + StringUtils.sanitizeForLog(contract.getOffer().getMakerNetworkId().getId()));
         }
         String expectedTradeId = Trade.createId(contract.getOffer().getId(),
                 takerNetworkId.getId(),
@@ -70,7 +101,7 @@ public final class MuSigTakeOfferRequestValidator {
             // a permanent failed trade per crafted message. The attacker-chosen id is
             // sanitized before logging - control characters would allow forged log entries.
             throw reject("The message trade id does not match the id derived from the contract. messageTradeId="
-                    + sanitizeForLog(message.getTradeId()) + ", expected=" + expectedTradeId);
+                    + StringUtils.sanitizeForLog(message.getTradeId()) + ", expected=" + expectedTradeId);
         }
         PublicKey takerPublicKey = takerNetworkId.getPubKey().getPublicKey();
         if (!contractService.arePublicKeysMatching(message.getSenderPublicKey(), takerPublicKey)) {
@@ -93,6 +124,14 @@ public final class MuSigTakeOfferRequestValidator {
         }
     }
 
+    public static void validateTakerProfileKnown(UserProfileService userProfileService, SetupTradeMessage_A message) {
+        // The handler resolves the taker's profile with orElseThrow after the trade exists; a
+        // sender that never published a profile must be rejected before anything is persisted.
+        if (userProfileService.findUserProfile(message.getSender().getId()).isEmpty()) {
+            throw reject("The taker's user profile is not known");
+        }
+    }
+
     public static void validateOffer(MyMuSigOffersService myMuSigOffersService, SetupTradeMessage_A message) {
         MuSigOffer embeddedOffer = message.getContract().getOffer();
         // Only the activated set establishes takeability: deactivated offers stay retained in
@@ -103,19 +142,285 @@ public final class MuSigTakeOfferRequestValidator {
         Optional<MuSigOffer> myOffer = myMuSigOffersService.findActivatedOffer(embeddedOffer.getId());
         if (myOffer.isEmpty()) {
             throw reject("The offer is not one of the maker's activated offers. offerId="
-                    + sanitizeForLog(embeddedOffer.getId()));
+                    + StringUtils.sanitizeForLog(embeddedOffer.getId()));
         }
         if (!myOffer.get().equals(embeddedOffer)) {
             // The id belongs to a genuine offer but the embedded terms differ: the maker's own
             // retained offer is the authority, not the taker-supplied copy.
             throw reject("The embedded offer does not equal the maker's own offer with that id. offerId="
-                    + sanitizeForLog(embeddedOffer.getId()));
+                    + StringUtils.sanitizeForLog(embeddedOffer.getId()));
+        }
+        if (!myOffer.get().toProto(true).equals(embeddedOffer.toProto(true))) {
+            // Offer.equals (Lombok) ignores fields that are still part of the contract hash -
+            // notably the Market currency names, which are excluded from equals but not from the
+            // hash. A taker could keep every code and economic field yet alter only a display
+            // name; equals passes, but the maker would co-sign a contract committing to the
+            // forged name. Comparing the serialize-for-hash form includes those fields while
+            // still ignoring the deliberately hash-excluded version fields.
+            throw reject("The embedded offer differs from the maker's own offer in a hash-relevant field. offerId="
+                    + StringUtils.sanitizeForLog(embeddedOffer.getId()));
+        }
+        // Contract.verify only validates the date, so the taker-authored protocol-type and
+        // party-role discriminators reach the maker unchecked. A contract declaring BISQ_EASY,
+        // or one whose taker role is MAKER, would be double-signed and persisted with those
+        // wrong values into the dispute-visible record; pin them to the canonical MuSig form.
+        MuSigContract contract = message.getContract();
+        if (contract.getProtocolType() != TradeProtocolType.MU_SIG) {
+            throw reject("The contract's protocol type is not MuSig. protocolType=" + contract.getProtocolType());
+        }
+        if (contract.getMaker().getRole() != Role.MAKER || contract.getTaker().getRole() != Role.TAKER) {
+            throw reject("The contract's party roles are not canonical. makerRole=" + contract.getMaker().getRole()
+                    + ", takerRole=" + contract.getTaker().getRole());
         }
     }
 
-    private static String sanitizeForLog(String value) {
-        return StringUtils.truncate(value.replaceAll("[\\p{Cntrl}\\u2028\\u2029]", "?"), 60);
+    public static void validateEconomics(MarketPriceService marketPriceService,
+                                         SettingsService settingsService,
+                                         MuSigTraderMediationService mediationService,
+                                         MuSigTraderArbitrationService arbitrationService,
+                                         SetupTradeMessage_A message) {
+        MuSigContract contract = message.getContract();
+        MuSigOffer offer = contract.getOffer();
+        Market market = offer.getMarket();
+        // The take date is taker-chosen and only bounded by a Bisq-1-launch..now+2h range in
+        // Contract.verify, so a taker could date a take before the offer existed. That date is part
+        // of the trade id and drives the UI's remaining-trade-time, so a back-dated take would show
+        // as already expired. It cannot precede the offer it takes.
+        if (contract.getTakeOfferDate() < offer.getDate()) {
+            throw reject("The take offer date predates the offer. takeOfferDate=" + contract.getTakeOfferDate()
+                    + ", offerDate=" + offer.getDate());
+        }
+        long baseSideAmount = contract.getBaseSideAmount();
+        long quoteSideAmount = contract.getQuoteSideAmount();
+        // The wire encoding is a signed sint64; every comparison below assumes positive values.
+        if (baseSideAmount <= 0 || quoteSideAmount <= 0) {
+            throw reject("Non-positive contract amounts. base=" + baseSideAmount + ", quote=" + quoteSideAmount);
+        }
+        if (!contract.getPriceSpec().equals(offer.getPriceSpec())) {
+            // The taker constructs the contract with the offer's own price spec; anything else
+            // is taker-authored pricing.
+            throw reject("The contract price spec does not equal the offer's price spec");
+        }
+        if (contract.getTaker().getSaltedAccountPayloadHash().map(hash -> hash.length == 0).orElse(true)) {
+            // The commitment is optional on the wire and Party.verify only validates it when
+            // present; without this check its absence is discovered only after the maker has
+            // signed the deposit transaction.
+            throw reject("The contract carries no taker account payload commitment");
+        }
+        if (!offer.getBaseSidePaymentMethodSpecs().contains(contract.getBaseSidePaymentMethodSpec())
+                || !offer.getQuoteSidePaymentMethodSpecs().contains(contract.getQuoteSidePaymentMethodSpec())) {
+            throw reject("The contract payment method specs are not part of the offer");
+        }
+        boolean specIsBaseSide = validateAmountSpecMembership(offer, baseSideAmount, quoteSideAmount);
+        validatePriceTolerance(marketPriceService, settingsService, offer, specIsBaseSide, baseSideAmount, quoteSideAmount);
+        validateUsdLimits(marketPriceService, contract, market, baseSideAmount, quoteSideAmount);
+        validateDisputeAgents(mediationService, arbitrationService, contract, offer);
     }
+
+    // The side the offer's amount spec pins is validated exactly against the spec; returns
+    // whether that side is the base side, so the tolerance check knows which side is derived.
+    private static boolean validateAmountSpecMembership(MuSigOffer offer, long baseSideAmount, long quoteSideAmount) {
+        Optional<Monetary> baseMin = AmountSpecUtil.findBaseSideMinOrFixedAmountFromSpec(
+                offer.getAmountSpec(), offer.getMarket().getBaseCurrencyCode());
+        Optional<Monetary> baseMax = AmountSpecUtil.findBaseSideMaxOrFixedAmountFromSpec(
+                offer.getAmountSpec(), offer.getMarket().getBaseCurrencyCode());
+        if (baseMin.isPresent() && baseMax.isPresent()) {
+            if (baseSideAmount < baseMin.get().getValue() || baseSideAmount > baseMax.get().getValue()) {
+                throw reject("The contract base amount lies outside the offer's amount spec. base="
+                        + baseSideAmount + ", spec min=" + baseMin.get().getValue() + ", max=" + baseMax.get().getValue());
+            }
+            return true;
+        }
+        Optional<Monetary> quoteMin = AmountSpecUtil.findQuoteSideMinOrFixedAmountFromSpec(
+                offer.getAmountSpec(), offer.getMarket().getQuoteCurrencyCode());
+        Optional<Monetary> quoteMax = AmountSpecUtil.findQuoteSideMaxOrFixedAmountFromSpec(
+                offer.getAmountSpec(), offer.getMarket().getQuoteCurrencyCode());
+        if (quoteMin.isPresent() && quoteMax.isPresent()) {
+            if (quoteSideAmount < quoteMin.get().getValue() || quoteSideAmount > quoteMax.get().getValue()) {
+                throw reject("The contract quote amount lies outside the offer's amount spec. quote="
+                        + quoteSideAmount + ", spec min=" + quoteMin.get().getValue() + ", max=" + quoteMax.get().getValue());
+            }
+            return false;
+        }
+        throw reject("The offer's amount spec pins neither side");
+    }
+
+    // The side not pinned by the amount spec must be consistent with the offer's price spec
+    // resolved at the maker's current market price, within the maker's configured tolerance.
+    // Whether a deviation is adverse depends on whether the maker gives or receives the derived
+    // asset. Offer.direction is the maker's raw BASE-currency direction (getDisplayDirection is
+    // the one that mirrors it for BTC-quote markets), so it is exactly whether the maker buys the
+    // base side - no market-dependent flip.
+    private static void validatePriceTolerance(MarketPriceService marketPriceService,
+                                               SettingsService settingsService,
+                                               MuSigOffer offer,
+                                               boolean specIsBaseSide,
+                                               long baseSideAmount,
+                                               long quoteSideAmount) {
+        Market market = offer.getMarket();
+        PriceSpec priceSpec = offer.getPriceSpec();
+        PriceQuote quote;
+        if (priceSpec instanceof FixPriceSpec) {
+            // A fixed-price offer carries its own price; no market lookup or freshness check.
+            quote = ((FixPriceSpec) priceSpec).getPriceQuote();
+        } else {
+            // Market- and float-price offers resolve against the live market price. Read ONE
+            // MarketPrice snapshot and derive both the freshness decision and the quote from it:
+            // the service replaces map entries concurrently, so a second lookup could pass
+            // freshness on a different object than the quote came from. It also keeps the previous
+            // map after a failed refresh and delegates freshness to callers, so a >12h-stale quote
+            // must be rejected rather than trusted.
+            Optional<MarketPrice> marketPrice = marketPriceService.findMarketPrice(market);
+            if (marketPrice.isEmpty() || !marketPrice.get().isValidDate()) {
+                throw reject("No fresh market price is available to validate the contract amounts. market=" + market);
+            }
+            PriceQuote marketQuote = marketPrice.get().getPriceQuote();
+            if (priceSpec instanceof FloatPriceSpec) {
+                quote = PriceUtil.fromMarketPriceMarkup(marketQuote, ((FloatPriceSpec) priceSpec).getPercentage());
+            } else if (priceSpec instanceof MarketPriceSpec) {
+                quote = marketQuote;
+            } else {
+                throw reject("Unsupported price spec for validation. priceSpec=" + priceSpec);
+            }
+        }
+        if (quote.getValue() <= 0) {
+            // A zero or negative price cannot validate amounts: it would zero the cross-multiplication
+            // denominator (or numerator) and fail the tolerance check open.
+            throw reject("The resolved price is not positive; cannot validate the contract amounts. value="
+                    + quote.getValue());
+        }
+        double tolerance = settingsService.getMaxTradePriceDeviation().get();
+        // The free side must match the offer's price within tolerance in BOTH directions. Bounding
+        // only the adverse side would let an unboundedly favorable side through: for a BTC/fiat
+        // maker who receives the fiat side, a taker could inflate the fiat amount far above the
+        // Bitcoin value, passing a one-sided check while the rail limit - valued on the Bitcoin
+        // side - stays under its cap, so the maker co-signs a fiat trade well above the rail limit.
+        // The expected free-side amount is the rational numerator/denominator; PriceQuote's
+        // toQuoteSideMonetary/toBaseSideMonetary truncate that to a long and wrap on overflow, so
+        // compare by cross-multiplication (both denominators are positive) - exact, no division.
+        java.math.BigDecimal numerator;
+        java.math.BigDecimal denominator;
+        long actual;
+        if (specIsBaseSide) {
+            // Mirror toQuoteSideMonetary: base.value * price.value / 10^base.precision.
+            Monetary base = Monetary.from(baseSideAmount, market.getBaseCurrencyCode());
+            numerator = java.math.BigDecimal.valueOf(base.getValue())
+                    .multiply(java.math.BigDecimal.valueOf(quote.getValue()));
+            denominator = java.math.BigDecimal.TEN.pow(base.getPrecision());
+            actual = quoteSideAmount;
+        } else {
+            // Mirror toBaseSideMonetary: quote.value * 10^(price base precision) / price.value.
+            numerator = java.math.BigDecimal.valueOf(quoteSideAmount)
+                    .multiply(java.math.BigDecimal.TEN.pow(quote.getBaseSideMonetary().getPrecision()));
+            denominator = java.math.BigDecimal.valueOf(quote.getValue());
+            actual = baseSideAmount;
+        }
+        // lower*expected <= actual <= upper*expected  <=>  (cross-multiplying by the positive
+        // denominator)  numerator*(1-tol) <= actual*denominator <= numerator*(1+tol).
+        java.math.BigDecimal actualTimesDenominator = java.math.BigDecimal.valueOf(actual).multiply(denominator);
+        java.math.BigDecimal lowerBound = numerator.multiply(java.math.BigDecimal.ONE.subtract(java.math.BigDecimal.valueOf(tolerance)));
+        java.math.BigDecimal upperBound = numerator.multiply(java.math.BigDecimal.ONE.add(java.math.BigDecimal.valueOf(tolerance)));
+        if (actualTimesDenominator.compareTo(lowerBound) < 0 || actualTimesDenominator.compareTo(upperBound) > 0) {
+            throw rejectPriceDeviation("The contract amounts deviate from the offer price beyond the tolerance. actual="
+                    + actual + ", expected≈" + expectedForLog(numerator, denominator));
+        }
+    }
+
+    // The decision uses exact cross-multiplication; this rounded quotient is only for the log line.
+    private static String expectedForLog(java.math.BigDecimal numerator, java.math.BigDecimal denominator) {
+        return numerator.divide(denominator, java.math.MathContext.DECIMAL64).toPlainString();
+    }
+
+    private static void validateUsdLimits(MarketPriceService marketPriceService,
+                                          MuSigContract contract,
+                                          Market market,
+                                          long baseSideAmount,
+                                          long quoteSideAmount) {
+        long btcSideValue = market.isBaseCurrencyBitcoin() ? baseSideAmount : quoteSideAmount;
+        if (btcSideValue > MAX_BITCOIN_SUPPLY_SATS) {
+            throw reject("The Bitcoin-side amount exceeds the total supply. sats=" + btcSideValue);
+        }
+        Coin btcAmount = Coin.asBtcFromValue(btcSideValue);
+        Optional<MarketPrice> btcUsdMarketPrice = marketPriceService.findMarketPrice(MarketRepository.getUSDBitcoinMarket());
+        if (btcUsdMarketPrice.isEmpty() || !btcUsdMarketPrice.get().isValidDate()) {
+            // A stale BTC/USD price (kept from a failed refresh) would misvalue the trade against
+            // the absolute and rail limits, so require a fresh one before enforcing them.
+            throw reject("No fresh BTC/USD price is available to validate the absolute trade limits");
+        }
+        // Compute the USD value with exact arithmetic and compare in BigDecimal: the supply cap
+        // alone does not prevent PriceQuote's toQuoteSideMonetary from wrapping its longValue at
+        // an extreme BTC/USD price, which would make an enormous amount read as a tiny one. The
+        // result is a USD Fiat atomic value, so it compares directly with the policy limits.
+        java.math.BigDecimal usdAtomic = java.math.BigDecimal.valueOf(btcAmount.getValue())
+                .multiply(java.math.BigDecimal.valueOf(btcUsdMarketPrice.get().getPriceQuote().getValue()))
+                .movePointLeft(btcAmount.getPrecision());
+        if (usdAtomic.compareTo(java.math.BigDecimal.valueOf(MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT.getValue())) < 0) {
+            throw reject("The trade amount lies below the absolute minimum. usd=" + usdAtomic.toPlainString());
+        }
+        PaymentMethodSpec<?> nonBtcSideSpec = market.isBaseCurrencyBitcoin()
+                ? contract.getQuoteSidePaymentMethodSpec()
+                : contract.getBaseSidePaymentMethodSpec();
+        Fiat railLimit = MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(
+                nonBtcSideSpec.getPaymentMethod().getPaymentRail());
+        if (usdAtomic.compareTo(java.math.BigDecimal.valueOf(railLimit.getValue())) > 0) {
+            throw reject("The trade amount exceeds the payment rail's limit. usd=" + usdAtomic.toPlainString()
+                    + ", limit=" + railLimit.getValue());
+        }
+    }
+
+    // The dispute agents are contract terms the taker must not choose: the maker re-runs the
+    // same deterministic selections and requires agreement.
+    private static void validateDisputeAgents(MuSigTraderMediationService mediationService,
+                                              MuSigTraderArbitrationService arbitrationService,
+                                              MuSigContract contract,
+                                              MuSigOffer offer) {
+        if (!DevMode.isDevMode() && (contract.getMediator().isEmpty() || contract.getArbitrator().isEmpty())) {
+            // The taker's own creation path rejects missing dispute agents outside dev mode;
+            // the maker enforces the same invariant, else a crafted contract could create a
+            // trade whose mediation and arbitration requests have no recipient.
+            throw reject("The contract names no mediator or no arbitrator");
+        }
+        String makersUserProfileId = offer.getMakersUserProfileId();
+        String takersUserProfileId = contract.getTaker().getNetworkId().getId();
+        Optional<UserProfile> myMediator = mediationService.selectMediator(makersUserProfileId,
+                takersUserProfileId,
+                offer.getId());
+        if (!sameDisputeAgent(myMediator, contract.getMediator())) {
+            log.warn("Rejecting the MuSig take offer request before trade creation: mediators do not match. mine={}, contract={}",
+                    myMediator.map(p -> StringUtils.sanitizeForLog(p.getNickName())), contract.getMediator().map(p -> StringUtils.sanitizeForLog(p.getNickName())));
+            throw new TradeProtocolException("The maker has rejected the take offer request because the mediators do not match.",
+                    TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+        }
+        Optional<UserProfile> myArbitrator = arbitrationService.selectArbitrator(makersUserProfileId,
+                takersUserProfileId,
+                offer.getId(),
+                myMediator.map(UserProfile::getId));
+        if (!sameDisputeAgent(myArbitrator, contract.getArbitrator())) {
+            log.warn("Rejecting the MuSig take offer request before trade creation: arbitrators do not match. mine={}, contract={}",
+                    myArbitrator.map(p -> StringUtils.sanitizeForLog(p.getNickName())), contract.getArbitrator().map(p -> StringUtils.sanitizeForLog(p.getNickName())));
+            throw new TradeProtocolException("The maker has rejected the take offer request because the arbitrators do not match.",
+                    TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+        }
+    }
+
+    // The dispute-agent profile is retained in the signed contract and shown as the assigned
+    // agent, so it must equal the maker's own selected profile, not merely share its network id.
+    // UserProfile.equals covers nickname, proof of work, network id, terms and statement but not
+    // avatarVersion, which is attacker-controlled and breaks avatar rendering for an unsupported
+    // value, so it is compared explicitly; the remaining version fields stay excluded so a benign
+    // profile-version skew does not reject a genuine agent.
+    private static boolean sameDisputeAgent(Optional<UserProfile> mine, Optional<UserProfile> theirs) {
+        return mine.equals(theirs)
+                && mine.map(UserProfile::getAvatarVersion).equals(theirs.map(UserProfile::getAvatarVersion));
+    }
+
+    private static TradeProtocolException rejectPriceDeviation(String logMessage) {
+        log.warn("Rejecting the MuSig take offer request before trade creation: {}", logMessage);
+        return new TradeProtocolException(
+                "The maker has rejected the take offer request because the amounts deviate too much from the current market price.",
+                TradeProtocolFailure.PRICE_DEVIATION);
+    }
+
 
     private static TradeProtocolException reject(String logMessage) {
         log.warn("Rejecting the MuSig take offer request before trade creation: {}", logMessage);

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -22,6 +22,8 @@ import bisq.contract.ContractService;
 import bisq.contract.ContractSignatureData;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.network.identity.NetworkId;
+import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.mu_sig.MyMuSigOffersService;
 import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.Trade;
 import bisq.trade.exceptions.TradeProtocolException;
@@ -30,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.util.Optional;
 
 /**
  * Validates an incoming take offer request before any trade is created or persisted. Every
@@ -48,15 +51,15 @@ public final class MuSigTakeOfferRequestValidator {
         }
         NetworkId takerNetworkId = contract.getTaker().getNetworkId();
         if (!message.getSender().equals(takerNetworkId)) {
-            throw reject("The authenticated message sender does not match the taker in the contract. sender="
-                    + message.getSender() + ", contract taker=" + takerNetworkId);
+            throw reject("The authenticated message sender does not match the taker in the contract. senderId="
+                    + sanitizeForLog(message.getSender().getId()) + ", contract takerId=" + sanitizeForLog(takerNetworkId.getId()));
         }
         if (!message.getReceiver().equals(contract.getOffer().getMakerNetworkId())) {
             // On a node owning several identities the confidential layer only binds the message
             // to the receiving identity; without this check a request naming maker A in the
             // contract but sent to identity B would build a trade mixing both identities.
-            throw reject("The message receiver does not match the offer's maker network id. receiver="
-                    + message.getReceiver() + ", offer maker=" + contract.getOffer().getMakerNetworkId());
+            throw reject("The message receiver does not match the offer's maker network id. receiverId="
+                    + sanitizeForLog(message.getReceiver().getId()) + ", offer makerId=" + sanitizeForLog(contract.getOffer().getMakerNetworkId().getId()));
         }
         String expectedTradeId = Trade.createId(contract.getOffer().getId(),
                 takerNetworkId.getId(),
@@ -90,8 +93,28 @@ public final class MuSigTakeOfferRequestValidator {
         }
     }
 
+    public static void validateOffer(MyMuSigOffersService myMuSigOffersService, SetupTradeMessage_A message) {
+        MuSigOffer embeddedOffer = message.getContract().getOffer();
+        // Only the activated set establishes takeability: deactivated offers stay retained in
+        // the store, and the public offerbook is not authoritative for the maker's own offers.
+        // Deliberately NO fallback to existing trades for the same offer - accepting a request
+        // because the offer was taken before would let a cached copy of a removed offer be
+        // replayed indefinitely.
+        Optional<MuSigOffer> myOffer = myMuSigOffersService.findActivatedOffer(embeddedOffer.getId());
+        if (myOffer.isEmpty()) {
+            throw reject("The offer is not one of the maker's activated offers. offerId="
+                    + sanitizeForLog(embeddedOffer.getId()));
+        }
+        if (!myOffer.get().equals(embeddedOffer)) {
+            // The id belongs to a genuine offer but the embedded terms differ: the maker's own
+            // retained offer is the authority, not the taker-supplied copy.
+            throw reject("The embedded offer does not equal the maker's own offer with that id. offerId="
+                    + sanitizeForLog(embeddedOffer.getId()));
+        }
+    }
+
     private static String sanitizeForLog(String value) {
-        return StringUtils.truncate(value.replaceAll("\\p{Cntrl}", "?"), 60);
+        return StringUtils.truncate(value.replaceAll("[\\p{Cntrl}\\u2028\\u2029]", "?"), 60);
     }
 
     private static TradeProtocolException reject(String logMessage) {

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network.handler.maker;
+
+import bisq.common.util.StringUtils;
+import bisq.contract.ContractService;
+import bisq.contract.ContractSignatureData;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.network.identity.NetworkId;
+import bisq.trade.exceptions.TradeProtocolFailure;
+import bisq.trade.Trade;
+import bisq.trade.exceptions.TradeProtocolException;
+import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.GeneralSecurityException;
+import java.security.PublicKey;
+
+/**
+ * Validates an incoming take offer request before any trade is created or persisted. Every
+ * rejection carries the same generic wire reason while the log keeps the specific cause, so a
+ * crafted request learns nothing from the failure mode.
+ */
+@Slf4j
+public final class MuSigTakeOfferRequestValidator {
+    private MuSigTakeOfferRequestValidator() {
+    }
+
+    public static void validateIdentity(ContractService contractService, SetupTradeMessage_A message) {
+        MuSigContract contract = message.getContract();
+        if (contract == null || contract.getOffer() == null) {
+            throw reject("The request carries no contract or no offer");
+        }
+        NetworkId takerNetworkId = contract.getTaker().getNetworkId();
+        if (!message.getSender().equals(takerNetworkId)) {
+            throw reject("The authenticated message sender does not match the taker in the contract. sender="
+                    + message.getSender() + ", contract taker=" + takerNetworkId);
+        }
+        if (!message.getReceiver().equals(contract.getOffer().getMakerNetworkId())) {
+            // On a node owning several identities the confidential layer only binds the message
+            // to the receiving identity; without this check a request naming maker A in the
+            // contract but sent to identity B would build a trade mixing both identities.
+            throw reject("The message receiver does not match the offer's maker network id. receiver="
+                    + message.getReceiver() + ", offer maker=" + contract.getOffer().getMakerNetworkId());
+        }
+        String expectedTradeId = Trade.createId(contract.getOffer().getId(),
+                takerNetworkId.getId(),
+                contract.getTakeOfferDate());
+        if (!message.getTradeId().equals(expectedTradeId)) {
+            // The trade id the maker will derive from the contract must be the id the message
+            // claims; a mismatch would only be rejected after the trade was persisted, leaving
+            // a permanent failed trade per crafted message. The attacker-chosen id is
+            // sanitized before logging - control characters would allow forged log entries.
+            throw reject("The message trade id does not match the id derived from the contract. messageTradeId="
+                    + sanitizeForLog(message.getTradeId()) + ", expected=" + expectedTradeId);
+        }
+        PublicKey takerPublicKey = takerNetworkId.getPubKey().getPublicKey();
+        if (!contractService.arePublicKeysMatching(message.getSenderPublicKey(), takerPublicKey)) {
+            throw reject("The message sender public key does not match the taker's public key");
+        }
+        ContractSignatureData signatureData = message.getContractSignatureData();
+        if (signatureData == null || !contractService.arePublicKeysMatching(signatureData, takerPublicKey)) {
+            throw reject("The contract signature public key does not match the taker's public key");
+        }
+        boolean signatureValid;
+        try {
+            signatureValid = contractService.verifyContractSignature(contract, signatureData);
+        } catch (GeneralSecurityException | RuntimeException e) {
+            // verifyContractSignature also throws on a hash mismatch between the signature data
+            // and the contract; any failure mode of a crafted signature must reject, not crash.
+            throw reject("The taker's contract signature could not be verified: " + e.getMessage());
+        }
+        if (!signatureValid) {
+            throw reject("The taker's contract signature does not verify");
+        }
+    }
+
+    private static String sanitizeForLog(String value) {
+        return StringUtils.truncate(value.replaceAll("\\p{Cntrl}", "?"), 60);
+    }
+
+    private static TradeProtocolException reject(String logMessage) {
+        log.warn("Rejecting the MuSig take offer request before trade creation: {}", logMessage);
+        return new TradeProtocolException(
+                "The maker has rejected the take offer request because the offer is not available anymore.",
+                TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+}

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -17,7 +17,8 @@
 
 package bisq.trade.mu_sig.messages.network.handler.maker;
 
-import bisq.common.util.StringUtils;
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.account.protocol_type.TradeProtocolType;
 import bisq.bonded_roles.market_price.MarketPrice;
 import bisq.bonded_roles.market_price.MarketPriceService;
 import bisq.common.application.DevMode;
@@ -27,36 +28,40 @@ import bisq.common.monetary.Coin;
 import bisq.common.monetary.Fiat;
 import bisq.common.monetary.Monetary;
 import bisq.common.monetary.PriceQuote;
-import bisq.account.protocol_type.TradeProtocolType;
+import bisq.common.util.StringUtils;
 import bisq.contract.ContractService;
 import bisq.contract.ContractSignatureData;
 import bisq.contract.Role;
 import bisq.contract.mu_sig.MuSigContract;
 import bisq.network.identity.NetworkId;
-import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.offer.amount.spec.AmountSpecUtil;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.offer.mu_sig.MuSigTradeAmountLimitsPolicy;
+import bisq.offer.mu_sig.MyMuSigOffersService;
 import bisq.offer.price.PriceUtil;
 import bisq.offer.price.spec.FixPriceSpec;
 import bisq.offer.price.spec.FloatPriceSpec;
 import bisq.offer.price.spec.MarketPriceSpec;
 import bisq.offer.price.spec.PriceSpec;
-import bisq.user.profile.UserProfile;
-import bisq.user.profile.UserProfileService;
-import bisq.offer.mu_sig.MyMuSigOffersService;
-import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.settings.SettingsService;
 import bisq.trade.Trade;
 import bisq.trade.exceptions.TradeProtocolException;
+import bisq.trade.exceptions.TradeProtocolFailure;
 import bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService;
 import bisq.trade.mu_sig.mediation.MuSigTraderMediationService;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
+import bisq.user.profile.UserProfile;
+import bisq.user.profile.UserProfileService;
 import lombok.extern.slf4j.Slf4j;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
 import java.util.Optional;
+
+import static bisq.common.validation.NetworkDataValidation.TWO_HOURS;
 
 /**
  * Validates an incoming take offer request before any trade is created or persisted.
@@ -67,9 +72,7 @@ import java.util.Optional;
  */
 @Slf4j
 public final class MuSigTakeOfferRequestValidator {
-    // 21,000,000 BTC in satoshis. A Bitcoin-side amount cannot exceed the total supply; the cap
-    // also keeps the USD-limit conversion below the range where PriceQuote's long arithmetic
-    // wraps, which a taker could otherwise exploit to make an enormous amount read as tiny.
+    // Also keeps the USD-limit conversion below the range where PriceQuote's long arithmetic wraps.
     private static final long MAX_BITCOIN_SUPPLY_SATS = 2_100_000_000_000_000L;
 
     private MuSigTakeOfferRequestValidator() {
@@ -86,9 +89,7 @@ public final class MuSigTakeOfferRequestValidator {
                     + StringUtils.sanitizeForLog(message.getSender().getId()) + ", contract takerId=" + StringUtils.sanitizeForLog(takerNetworkId.getId()));
         }
         if (!message.getReceiver().equals(contract.getOffer().getMakerNetworkId())) {
-            // On a node owning several identities the confidential layer only binds the message
-            // to the receiving identity; without this check a request naming maker A in the
-            // contract but sent to identity B would build a trade mixing both identities.
+            // On a multi-identity node the confidential layer only binds the receiving identity.
             throw reject("The message receiver does not match the offer's maker network id. receiverId="
                     + StringUtils.sanitizeForLog(message.getReceiver().getId()) + ", offer makerId=" + StringUtils.sanitizeForLog(contract.getOffer().getMakerNetworkId().getId()));
         }
@@ -96,10 +97,6 @@ public final class MuSigTakeOfferRequestValidator {
                 takerNetworkId.getId(),
                 contract.getTakeOfferDate());
         if (!message.getTradeId().equals(expectedTradeId)) {
-            // The trade id the maker will derive from the contract must be the id the message
-            // claims; a mismatch would only be rejected after the trade was persisted, leaving
-            // a permanent failed trade per crafted message. The attacker-chosen id is
-            // sanitized before logging - control characters would allow forged log entries.
             throw reject("The message trade id does not match the id derived from the contract. messageTradeId="
                     + StringUtils.sanitizeForLog(message.getTradeId()) + ", expected=" + expectedTradeId);
         }
@@ -115,8 +112,7 @@ public final class MuSigTakeOfferRequestValidator {
         try {
             signatureValid = contractService.verifyContractSignature(contract, signatureData);
         } catch (GeneralSecurityException | RuntimeException e) {
-            // verifyContractSignature also throws on a hash mismatch between the signature data
-            // and the contract; any failure mode of a crafted signature must reject, not crash.
+            // Any failure mode of a crafted signature must reject, not crash.
             throw reject("The taker's contract signature could not be verified: " + e.getMessage());
         }
         if (!signatureValid) {
@@ -125,8 +121,7 @@ public final class MuSigTakeOfferRequestValidator {
     }
 
     public static void validateTakerProfileKnown(UserProfileService userProfileService, SetupTradeMessage_A message) {
-        // The handler resolves the taker's profile with orElseThrow after the trade exists; a
-        // sender that never published a profile must be rejected before anything is persisted.
+        // The handler resolves the profile with orElseThrow after the trade exists.
         if (userProfileService.findUserProfile(message.getSender().getId()).isEmpty()) {
             throw reject("The taker's user profile is not known");
         }
@@ -134,36 +129,24 @@ public final class MuSigTakeOfferRequestValidator {
 
     public static void validateOffer(MyMuSigOffersService myMuSigOffersService, SetupTradeMessage_A message) {
         MuSigOffer embeddedOffer = message.getContract().getOffer();
-        // Only the activated set establishes takeability: deactivated offers stay retained in
-        // the store, and the public offerbook is not authoritative for the maker's own offers.
-        // Deliberately NO fallback to existing trades for the same offer - accepting a request
-        // because the offer was taken before would let a cached copy of a removed offer be
-        // replayed indefinitely.
+        // Only the activated set establishes takeability. No fallback to existing trades: that
+        // would let a cached copy of a removed offer be replayed.
         Optional<MuSigOffer> myOffer = myMuSigOffersService.findActivatedOffer(embeddedOffer.getId());
         if (myOffer.isEmpty()) {
             throw reject("The offer is not one of the maker's activated offers. offerId="
                     + StringUtils.sanitizeForLog(embeddedOffer.getId()));
         }
         if (!myOffer.get().equals(embeddedOffer)) {
-            // The id belongs to a genuine offer but the embedded terms differ: the maker's own
-            // retained offer is the authority, not the taker-supplied copy.
             throw reject("The embedded offer does not equal the maker's own offer with that id. offerId="
                     + StringUtils.sanitizeForLog(embeddedOffer.getId()));
         }
         if (!myOffer.get().toProto(true).equals(embeddedOffer.toProto(true))) {
-            // Offer.equals (Lombok) ignores fields that are still part of the contract hash -
-            // notably the Market currency names, which are excluded from equals but not from the
-            // hash. A taker could keep every code and economic field yet alter only a display
-            // name; equals passes, but the maker would co-sign a contract committing to the
-            // forged name. Comparing the serialize-for-hash form includes those fields while
-            // still ignoring the deliberately hash-excluded version fields.
+            // Offer.equals ignores fields that are still hash-relevant (e.g. the Market currency
+            // names); the serialize-for-hash form covers them while ignoring the excluded version fields.
             throw reject("The embedded offer differs from the maker's own offer in a hash-relevant field. offerId="
                     + StringUtils.sanitizeForLog(embeddedOffer.getId()));
         }
-        // Contract.verify only validates the date, so the taker-authored protocol-type and
-        // party-role discriminators reach the maker unchecked. A contract declaring BISQ_EASY,
-        // or one whose taker role is MAKER, would be double-signed and persisted with those
-        // wrong values into the dispute-visible record; pin them to the canonical MuSig form.
+        // Contract.verify only checks the date, so pin the taker-authored discriminators.
         MuSigContract contract = message.getContract();
         if (contract.getProtocolType() != TradeProtocolType.MU_SIG) {
             throw reject("The contract's protocol type is not MuSig. protocolType=" + contract.getProtocolType());
@@ -182,29 +165,23 @@ public final class MuSigTakeOfferRequestValidator {
         MuSigContract contract = message.getContract();
         MuSigOffer offer = contract.getOffer();
         Market market = offer.getMarket();
-        // The take date is taker-chosen and only bounded by a Bisq-1-launch..now+2h range in
-        // Contract.verify, so a taker could date a take before the offer existed. That date is part
-        // of the trade id and drives the UI's remaining-trade-time, so a back-dated take would show
-        // as already expired. It cannot precede the offer it takes.
-        if (contract.getTakeOfferDate() < offer.getDate()) {
-            throw reject("The take offer date predates the offer. takeOfferDate=" + contract.getTakeOfferDate()
+        // The taker-chosen take date drives the trade id and UI time; allow the same clock-skew
+        // window as generic network dates, but not an older backdate.
+        if (contract.getTakeOfferDate() + TWO_HOURS < offer.getDate()) {
+            throw reject("The take offer date predates the offer beyond the clock-skew window. takeOfferDate=" + contract.getTakeOfferDate()
                     + ", offerDate=" + offer.getDate());
         }
         long baseSideAmount = contract.getBaseSideAmount();
         long quoteSideAmount = contract.getQuoteSideAmount();
-        // The wire encoding is a signed sint64; every comparison below assumes positive values.
         if (baseSideAmount <= 0 || quoteSideAmount <= 0) {
             throw reject("Non-positive contract amounts. base=" + baseSideAmount + ", quote=" + quoteSideAmount);
         }
         if (!contract.getPriceSpec().equals(offer.getPriceSpec())) {
-            // The taker constructs the contract with the offer's own price spec; anything else
-            // is taker-authored pricing.
             throw reject("The contract price spec does not equal the offer's price spec");
         }
         if (contract.getTaker().getSaltedAccountPayloadHash().map(hash -> hash.length == 0).orElse(true)) {
-            // The commitment is optional on the wire and Party.verify only validates it when
-            // present; without this check its absence is discovered only after the maker has
-            // signed the deposit transaction.
+            // Optional on the wire and only validated when present; its absence would otherwise
+            // surface after the maker signs the deposit transaction.
             throw reject("The contract carries no taker account payload commitment");
         }
         if (!offer.getBaseSidePaymentMethodSpecs().contains(contract.getBaseSidePaymentMethodSpec())
@@ -217,17 +194,20 @@ public final class MuSigTakeOfferRequestValidator {
         validateDisputeAgents(mediationService, arbitrationService, contract, offer);
     }
 
-    // The side the offer's amount spec pins is validated exactly against the spec; returns
-    // whether that side is the base side, so the tolerance check knows which side is derived.
+    // Returns whether the spec pins the base side, so the tolerance check knows which side is derived.
     private static boolean validateAmountSpecMembership(MuSigOffer offer, long baseSideAmount, long quoteSideAmount) {
         Optional<Monetary> baseMin = AmountSpecUtil.findBaseSideMinOrFixedAmountFromSpec(
                 offer.getAmountSpec(), offer.getMarket().getBaseCurrencyCode());
         Optional<Monetary> baseMax = AmountSpecUtil.findBaseSideMaxOrFixedAmountFromSpec(
                 offer.getAmountSpec(), offer.getMarket().getBaseCurrencyCode());
         if (baseMin.isPresent() && baseMax.isPresent()) {
-            if (baseSideAmount < baseMin.get().getValue() || baseSideAmount > baseMax.get().getValue()) {
+            long min = baseMin.get().getValue();
+            long max = baseMax.get().getValue();
+            if ((baseSideAmount < min || baseSideAmount > max)
+                    && !isWithinWholeFiatRoundingOfBaseBoundary(offer.getMarket(), baseSideAmount,
+                    quoteSideAmount, min, max)) {
                 throw reject("The contract base amount lies outside the offer's amount spec. base="
-                        + baseSideAmount + ", spec min=" + baseMin.get().getValue() + ", max=" + baseMax.get().getValue());
+                        + baseSideAmount + ", spec min=" + min + ", max=" + max);
             }
             return true;
         }
@@ -243,6 +223,33 @@ public final class MuSigTakeOfferRequestValidator {
             return false;
         }
         throw reject("The offer's amount spec pins neither side");
+    }
+
+    private static boolean isWithinWholeFiatRoundingOfBaseBoundary(Market market,
+                                                                    long baseSideAmount,
+                                                                    long quoteSideAmount,
+                                                                    long min,
+                                                                    long max) {
+        if (!market.isBtcFiatMarket()) {
+            return false;
+        }
+        long wholeFiatUnit = Fiat.fromFaceValue(1, market.getQuoteCurrencyCode()).getValue();
+        if (quoteSideAmount % wholeFiatUnit != 0) {
+            return false;
+        }
+        long maxQuoteRoundingDelta = wholeFiatUnit / 2 + 1;
+        if (quoteSideAmount <= maxQuoteRoundingDelta) {
+            return false;
+        }
+        long boundary = baseSideAmount < min ? min : max;
+        BigDecimal distance = BigDecimal.valueOf(baseSideAmount)
+                .subtract(BigDecimal.valueOf(boundary))
+                .abs();
+        BigDecimal maxRoundingDistance = BigDecimal.valueOf(boundary)
+                .multiply(BigDecimal.valueOf(maxQuoteRoundingDelta))
+                .divide(BigDecimal.valueOf(quoteSideAmount - maxQuoteRoundingDelta), 0, RoundingMode.CEILING)
+                .add(BigDecimal.ONE);
+        return distance.compareTo(maxRoundingDistance) <= 0;
     }
 
     // The side not pinned by the amount spec must be consistent with the offer's price spec
@@ -261,15 +268,10 @@ public final class MuSigTakeOfferRequestValidator {
         PriceSpec priceSpec = offer.getPriceSpec();
         PriceQuote quote;
         if (priceSpec instanceof FixPriceSpec) {
-            // A fixed-price offer carries its own price; no market lookup or freshness check.
             quote = ((FixPriceSpec) priceSpec).getPriceQuote();
         } else {
-            // Market- and float-price offers resolve against the live market price. Read ONE
-            // MarketPrice snapshot and derive both the freshness decision and the quote from it:
-            // the service replaces map entries concurrently, so a second lookup could pass
-            // freshness on a different object than the quote came from. It also keeps the previous
-            // map after a failed refresh and delegates freshness to callers, so a >12h-stale quote
-            // must be rejected rather than trusted.
+            // Read ONE MarketPrice snapshot for both the freshness decision and the quote (the map
+            // is replaced concurrently) and reject a stale quote (freshness is delegated to callers).
             Optional<MarketPrice> marketPrice = marketPriceService.findMarketPrice(market);
             if (marketPrice.isEmpty() || !marketPrice.get().isValidDate()) {
                 throw reject("No fresh market price is available to validate the contract amounts. market=" + market);
@@ -284,42 +286,36 @@ public final class MuSigTakeOfferRequestValidator {
             }
         }
         if (quote.getValue() <= 0) {
-            // A zero or negative price cannot validate amounts: it would zero the cross-multiplication
-            // denominator (or numerator) and fail the tolerance check open.
+            // A non-positive price would zero the cross-multiplication and fail the tolerance check open.
             throw reject("The resolved price is not positive; cannot validate the contract amounts. value="
                     + quote.getValue());
         }
         double tolerance = settingsService.getMaxTradePriceDeviation().get();
-        // The free side must match the offer's price within tolerance in BOTH directions. Bounding
-        // only the adverse side would let an unboundedly favorable side through: for a BTC/fiat
-        // maker who receives the fiat side, a taker could inflate the fiat amount far above the
-        // Bitcoin value, passing a one-sided check while the rail limit - valued on the Bitcoin
-        // side - stays under its cap, so the maker co-signs a fiat trade well above the rail limit.
-        // The expected free-side amount is the rational numerator/denominator; PriceQuote's
-        // toQuoteSideMonetary/toBaseSideMonetary truncate that to a long and wrap on overflow, so
-        // compare by cross-multiplication (both denominators are positive) - exact, no division.
-        java.math.BigDecimal numerator;
-        java.math.BigDecimal denominator;
+        // Bound the free side in BOTH directions: an unbounded favorable side would let the fiat
+        // obligation exceed the rail cap. Compare by cross-multiplication (positive denominators)
+        // rather than PriceQuote's monetary conversions, whose longValue wraps on overflow.
+        BigDecimal numerator;
+        BigDecimal denominator;
         long actual;
         if (specIsBaseSide) {
             // Mirror toQuoteSideMonetary: base.value * price.value / 10^base.precision.
             Monetary base = Monetary.from(baseSideAmount, market.getBaseCurrencyCode());
-            numerator = java.math.BigDecimal.valueOf(base.getValue())
-                    .multiply(java.math.BigDecimal.valueOf(quote.getValue()));
-            denominator = java.math.BigDecimal.TEN.pow(base.getPrecision());
+            numerator = BigDecimal.valueOf(base.getValue())
+                    .multiply(BigDecimal.valueOf(quote.getValue()));
+            denominator = BigDecimal.TEN.pow(base.getPrecision());
             actual = quoteSideAmount;
         } else {
             // Mirror toBaseSideMonetary: quote.value * 10^(price base precision) / price.value.
-            numerator = java.math.BigDecimal.valueOf(quoteSideAmount)
-                    .multiply(java.math.BigDecimal.TEN.pow(quote.getBaseSideMonetary().getPrecision()));
-            denominator = java.math.BigDecimal.valueOf(quote.getValue());
+            numerator = BigDecimal.valueOf(quoteSideAmount)
+                    .multiply(BigDecimal.TEN.pow(quote.getBaseSideMonetary().getPrecision()));
+            denominator = BigDecimal.valueOf(quote.getValue());
             actual = baseSideAmount;
         }
         // lower*expected <= actual <= upper*expected  <=>  (cross-multiplying by the positive
         // denominator)  numerator*(1-tol) <= actual*denominator <= numerator*(1+tol).
-        java.math.BigDecimal actualTimesDenominator = java.math.BigDecimal.valueOf(actual).multiply(denominator);
-        java.math.BigDecimal lowerBound = numerator.multiply(java.math.BigDecimal.ONE.subtract(java.math.BigDecimal.valueOf(tolerance)));
-        java.math.BigDecimal upperBound = numerator.multiply(java.math.BigDecimal.ONE.add(java.math.BigDecimal.valueOf(tolerance)));
+        BigDecimal actualTimesDenominator = BigDecimal.valueOf(actual).multiply(denominator);
+        BigDecimal lowerBound = numerator.multiply(BigDecimal.ONE.subtract(BigDecimal.valueOf(tolerance)));
+        BigDecimal upperBound = numerator.multiply(BigDecimal.ONE.add(BigDecimal.valueOf(tolerance)));
         if (actualTimesDenominator.compareTo(lowerBound) < 0 || actualTimesDenominator.compareTo(upperBound) > 0) {
             throw rejectPriceDeviation("The contract amounts deviate from the offer price beyond the tolerance. actual="
                     + actual + ", expected≈" + expectedForLog(numerator, denominator));
@@ -327,8 +323,8 @@ public final class MuSigTakeOfferRequestValidator {
     }
 
     // The decision uses exact cross-multiplication; this rounded quotient is only for the log line.
-    private static String expectedForLog(java.math.BigDecimal numerator, java.math.BigDecimal denominator) {
-        return numerator.divide(denominator, java.math.MathContext.DECIMAL64).toPlainString();
+    private static String expectedForLog(BigDecimal numerator, BigDecimal denominator) {
+        return numerator.divide(denominator, MathContext.DECIMAL64).toPlainString();
     }
 
     private static void validateUsdLimits(MarketPriceService marketPriceService,
@@ -347,32 +343,27 @@ public final class MuSigTakeOfferRequestValidator {
             // the absolute and rail limits, so require a fresh one before enforcing them.
             throw reject("No fresh BTC/USD price is available to validate the absolute trade limits");
         }
-        // Compute the USD value with exact arithmetic and compare in BigDecimal: the supply cap
-        // alone does not prevent PriceQuote's toQuoteSideMonetary from wrapping its longValue at
-        // an extreme BTC/USD price, which would make an enormous amount read as a tiny one. The
-        // result is a USD Fiat atomic value, so it compares directly with the policy limits.
-        java.math.BigDecimal usdAtomic = java.math.BigDecimal.valueOf(btcAmount.getValue())
-                .multiply(java.math.BigDecimal.valueOf(btcUsdMarketPrice.get().getPriceQuote().getValue()))
+        // Exact BigDecimal (PriceQuote's longValue would wrap at an extreme price); the result is
+        // a USD Fiat atomic value comparable to the policy limits.
+        BigDecimal usdAtomic = BigDecimal.valueOf(btcAmount.getValue())
+                .multiply(BigDecimal.valueOf(btcUsdMarketPrice.get().getPriceQuote().getValue()))
                 .movePointLeft(btcAmount.getPrecision());
-        if (usdAtomic.compareTo(java.math.BigDecimal.valueOf(MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT.getValue())) < 0) {
+        if (usdAtomic.compareTo(BigDecimal.valueOf(MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT.getValue())) < 0) {
             throw reject("The trade amount lies below the absolute minimum. usd=" + usdAtomic.toPlainString());
         }
-        // The payment-rail cap limits the fiat obligation, which is the non-Bitcoin side. The
-        // two-sided price tolerance lets that side sit up to the tolerance above the Bitcoin value,
-        // so valuing the cap on the Bitcoin side alone would let the fiat obligation exceed the cap
-        // by the tolerance. When the fiat side is quoted in USD it is directly comparable in the
-        // same atomic scale, so cap on the larger of the Bitcoin-derived value and the actual USD
-        // obligation. (Non-USD fiat still needs a fiat/USD conversion - a disclosed follow-up.)
-        java.math.BigDecimal obligationUsd = usdAtomic;
+        // The rail cap must bound the actual fiat obligation, which the tolerance lets sit above
+        // the Bitcoin value. For a USD quote that obligation is directly comparable, so cap on the
+        // larger of the two. (Non-USD fiat needs a fiat/USD conversion - a disclosed follow-up.)
+        BigDecimal obligationUsd = usdAtomic;
         if (market.isBaseCurrencyBitcoin() && "USD".equals(market.getQuoteCurrencyCode())) {
-            obligationUsd = obligationUsd.max(java.math.BigDecimal.valueOf(quoteSideAmount));
+            obligationUsd = obligationUsd.max(BigDecimal.valueOf(quoteSideAmount));
         }
         PaymentMethodSpec<?> nonBtcSideSpec = market.isBaseCurrencyBitcoin()
                 ? contract.getQuoteSidePaymentMethodSpec()
                 : contract.getBaseSidePaymentMethodSpec();
         Fiat railLimit = MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(
                 nonBtcSideSpec.getPaymentMethod().getPaymentRail());
-        if (obligationUsd.compareTo(java.math.BigDecimal.valueOf(railLimit.getValue())) > 0) {
+        if (obligationUsd.compareTo(BigDecimal.valueOf(railLimit.getValue())) > 0) {
             throw reject("The trade amount exceeds the payment rail's limit. usd=" + obligationUsd.toPlainString()
                     + ", limit=" + railLimit.getValue());
         }
@@ -413,18 +404,10 @@ public final class MuSigTakeOfferRequestValidator {
         }
     }
 
-    // The dispute-agent profile is retained in the signed contract and shown as the assigned
-    // agent, so it must equal the maker's own selected profile, not merely share its network id.
-    // UserProfile.equals covers nickname, proof of work, network id, terms and statement but not
-    // avatarVersion, which is attacker-controlled and breaks avatar rendering for an unsupported
-    // value, so it is compared explicitly; the remaining version fields stay excluded so a benign
-    // profile-version skew does not reject a genuine agent.
+    // The maker co-signs the taker's copy of the dispute-agent profile, so compare the whole
+    // profile: equals plus the three version fields it omits (the version field even selects which
+    // fields serializeForHash clears), else a taker could forge that metadata into the contract.
     private static boolean sameDisputeAgent(Optional<UserProfile> mine, Optional<UserProfile> theirs) {
-        // UserProfile.equals omits version, applicationVersion and avatarVersion, yet all three are
-        // part of the contract the maker co-signs (the version field even selects which fields
-        // serializeForHash clears). Compare equals plus those three fields - i.e. the whole profile
-        // - so a taker cannot forge dispute-agent profile metadata into the signed contract while
-        // this check still accepts it.
         return mine.equals(theirs)
                 && mine.map(UserProfile::getVersion).equals(theirs.map(UserProfile::getVersion))
                 && mine.map(UserProfile::getApplicationVersion).equals(theirs.map(UserProfile::getApplicationVersion))

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -127,11 +127,11 @@ public final class MuSigTakeOfferRequestValidator {
         }
     }
 
-    public static void validateOffer(MyMuSigOffersService myMuSigOffersService, SetupTradeMessage_A message) {
+    public static MuSigOffer validateOffer(MyMuSigOffersService myMuSigOffersService, SetupTradeMessage_A message) {
         MuSigOffer embeddedOffer = message.getContract().getOffer();
         // Only the activated set establishes takeability. No fallback to existing trades: that
         // would let a cached copy of a removed offer be replayed.
-        Optional<MuSigOffer> myOffer = myMuSigOffersService.findActivatedOffer(embeddedOffer.getId());
+        Optional<MuSigOffer> myOffer = myMuSigOffersService.claimActivatedOffer(embeddedOffer.getId());
         if (myOffer.isEmpty()) {
             throw reject("The offer is not one of the maker's activated offers. offerId="
                     + StringUtils.sanitizeForLog(embeddedOffer.getId()));
@@ -155,6 +155,7 @@ public final class MuSigTakeOfferRequestValidator {
             throw reject("The contract's party roles are not canonical. makerRole=" + contract.getMaker().getRole()
                     + ", takerRole=" + contract.getTaker().getRole());
         }
+        return myOffer.get();
     }
 
     public static void validateEconomics(MarketPriceService marketPriceService,

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
@@ -138,9 +138,7 @@ public final class SetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerA
                 trade.getContract().getMediator(),
                 trade.getContract().getArbitrator());
 
-        // Add the taker to the contact list only now that the request has been verified and
-        // processed. Best-effort and last: this auxiliary action must not turn an accepted trade
-        // into a failed one, so a failure here is logged and swallowed.
+        // Best-effort and last, so this auxiliary action cannot turn an accepted trade into a failed one.
         try {
             serviceProvider.getMuSigTradeService().maybeAddPeerToContactList(
                     trade.getPeer().getNetworkId().getId(),

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/SetupTradeMessage_A_Handler.java
@@ -137,6 +137,18 @@ public final class SetupTradeMessage_A_Handler extends MuSigTradeMessageHandlerA
                 peersUserProfile,
                 trade.getContract().getMediator(),
                 trade.getContract().getArbitrator());
+
+        // Add the taker to the contact list only now that the request has been verified and
+        // processed. Best-effort and last: this auxiliary action must not turn an accepted trade
+        // into a failed one, so a failure here is logged and swallowed.
+        try {
+            serviceProvider.getMuSigTradeService().maybeAddPeerToContactList(
+                    trade.getPeer().getNetworkId().getId(),
+                    trade.getMyIdentity().getId());
+        } catch (RuntimeException e) {
+            log.warn("Adding the peer to the contact list failed for tradeId={}. The trade is unaffected.",
+                    StringUtils.sanitizeForLog(trade.getId()), e);
+        }
     }
 
     @Override

--- a/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/MuSigTradeServiceTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig;
+
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.ClearnetAddress;
+import bisq.common.network.TransportType;
+import bisq.identity.Identity;
+import bisq.identity.IdentityService;
+import bisq.network.NetworkService;
+import bisq.network.identity.NetworkId;
+import bisq.network.identity.NetworkIdWithKeyPair;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.trade.exceptions.TradeProtocolException;
+import bisq.trade.exceptions.TradeProtocolFailure;
+import bisq.trade.mu_sig.messages.network.MuSigReportErrorMessage;
+import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
+import bisq.trade.mu_sig.protocol.MuSigProtocol;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.KeyPair;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MuSigTradeServiceTest {
+    @Test
+    void takeOfferRejectionIsReportedFromTheReceivingIdentity() {
+        NetworkService networkService = mock(NetworkService.class);
+        IdentityService identityService = mock(IdentityService.class);
+        SetupTradeMessage_A request = mock(SetupTradeMessage_A.class);
+        Identity makerIdentity = mock(Identity.class);
+        NetworkIdWithKeyPair makerNetworkIdWithKeyPair = mock(NetworkIdWithKeyPair.class);
+        NetworkId makerNetworkId = createNetworkId("maker", 9997);
+        NetworkId takerNetworkId = createNetworkId("taker", 9999);
+        when(request.getTradeId()).thenReturn("trade-id");
+        when(request.getReceiver()).thenReturn(makerNetworkId);
+        when(request.getSender()).thenReturn(takerNetworkId);
+        when(identityService.findAnyIdentityByNetworkId(makerNetworkId)).thenReturn(Optional.of(makerIdentity));
+        when(makerIdentity.getNetworkId()).thenReturn(makerNetworkId);
+        when(makerIdentity.getNetworkIdWithKeyPair()).thenReturn(makerNetworkIdWithKeyPair);
+        when(networkService.confidentialSend(any(), eq(takerNetworkId), same(makerNetworkIdWithKeyPair)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        TradeProtocolException rejection = new TradeProtocolException("x".repeat(600),
+                TradeProtocolFailure.PRICE_DEVIATION);
+
+        MuSigTradeService.reportTakeOfferRejection(networkService, identityService, request, rejection);
+
+        ArgumentCaptor<MuSigReportErrorMessage> captor = ArgumentCaptor.forClass(MuSigReportErrorMessage.class);
+        verify(networkService).confidentialSend(captor.capture(), eq(takerNetworkId), same(makerNetworkIdWithKeyPair));
+        MuSigReportErrorMessage report = captor.getValue();
+        assertThat(report.getTradeId()).isEqualTo("trade-id");
+        assertThat(report.getProtocolVersion()).isEqualTo(MuSigProtocol.VERSION);
+        assertThat(report.getSender()).isEqualTo(makerNetworkId);
+        assertThat(report.getReceiver()).isEqualTo(takerNetworkId);
+        assertThat(report.getTradeProtocolFailure()).isEqualTo(TradeProtocolFailure.PRICE_DEVIATION);
+        assertThat(report.getErrorMessage()).hasSize(MuSigReportErrorMessage.MAX_LENGTH_ERROR_MESSAGE);
+        assertThat(report.getStackTrace()).isEmpty();
+    }
+
+    @Test
+    void takeOfferRejectionIsNotSentWithoutTheReceivingIdentity() {
+        NetworkService networkService = mock(NetworkService.class);
+        IdentityService identityService = mock(IdentityService.class);
+        SetupTradeMessage_A request = mock(SetupTradeMessage_A.class);
+        NetworkId makerNetworkId = createNetworkId("maker", 9997);
+        when(request.getTradeId()).thenReturn("trade-id");
+        when(request.getReceiver()).thenReturn(makerNetworkId);
+        when(identityService.findAnyIdentityByNetworkId(makerNetworkId)).thenReturn(Optional.empty());
+
+        MuSigTradeService.reportTakeOfferRejection(networkService, identityService, request,
+                new TradeProtocolException(TradeProtocolFailure.OFFER_NOT_AVAILABLE));
+
+        verify(networkService, never()).confidentialSend(any(), any(), any());
+    }
+
+    @Test
+    void takeOfferRejectionSendFailuresDoNotEscape() {
+        NetworkService networkService = mock(NetworkService.class);
+        IdentityService identityService = mock(IdentityService.class);
+        SetupTradeMessage_A request = mock(SetupTradeMessage_A.class);
+        Identity makerIdentity = mock(Identity.class);
+        NetworkIdWithKeyPair makerNetworkIdWithKeyPair = mock(NetworkIdWithKeyPair.class);
+        NetworkId makerNetworkId = createNetworkId("maker", 9997);
+        NetworkId takerNetworkId = createNetworkId("taker", 9999);
+        when(request.getTradeId()).thenReturn("trade-id");
+        when(request.getReceiver()).thenReturn(makerNetworkId);
+        when(request.getSender()).thenReturn(takerNetworkId);
+        when(identityService.findAnyIdentityByNetworkId(makerNetworkId)).thenReturn(Optional.of(makerIdentity));
+        when(makerIdentity.getNetworkId()).thenReturn(makerNetworkId);
+        when(makerIdentity.getNetworkIdWithKeyPair()).thenReturn(makerNetworkIdWithKeyPair);
+        when(networkService.confidentialSend(any(), eq(takerNetworkId), same(makerNetworkIdWithKeyPair)))
+                .thenThrow(new IllegalStateException("synchronous send failure"))
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("asynchronous send failure")));
+
+        assertThatCode(() -> MuSigTradeService.reportTakeOfferRejection(networkService, identityService, request,
+                new TradeProtocolException(TradeProtocolFailure.OFFER_NOT_AVAILABLE)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> MuSigTradeService.reportTakeOfferRejection(networkService, identityService, request,
+                new TradeProtocolException(TradeProtocolFailure.OFFER_NOT_AVAILABLE)))
+                .doesNotThrowAnyException();
+    }
+
+    private static NetworkId createNetworkId(String keyIdSuffix, int port) {
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(Map.of(
+                TransportType.CLEAR, new ClearnetAddress("127.0.0.1", port)));
+        KeyPair keyPair = KeyGeneration.generateDefaultEcKeyPair();
+        return new NetworkId(addresses, new PubKey(keyPair.getPublic(), "test-key-" + keyIdSuffix));
+    }
+}

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -180,21 +180,22 @@ class MuSigTakeOfferRequestValidatorTest {
         MuSigContract contract = createContract();
         SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
-                .thenReturn(Optional.of(contract.getOffer()));
+        MuSigOffer claimedOffer = MuSigOffer.fromProto(contract.getOffer().toProto(false));
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id"))
+                .thenReturn(Optional.of(claimedOffer));
 
-        assertThatCode(() -> MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
-                .doesNotThrowAnyException();
+        assertThat(MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
+                .isSameAs(claimedOffer);
     }
 
     @Test
     void unknownOrDeactivatedOfferIsRejected() throws GeneralSecurityException {
         MuSigContract contract = createContract();
         SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
-        // findActivatedOffer covers both cases: an unknown offer and a retained-but-deactivated
+        // claimActivatedOffer covers both cases: an unknown offer and a retained-but-deactivated
         // offer are equally absent from the activated set.
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id")).thenReturn(Optional.empty());
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id")).thenReturn(Optional.empty());
 
         assertOfferRejected(myOffers, message);
     }
@@ -207,7 +208,7 @@ class MuSigTakeOfferRequestValidatorTest {
         // of a genuine activated offer.
         MuSigOffer myRealOffer = createOffer(new BaseSideFixedAmountSpec(999_999L));
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id"))
                 .thenReturn(Optional.of(myRealOffer));
 
         assertOfferRejected(myOffers, message);
@@ -225,7 +226,7 @@ class MuSigTakeOfferRequestValidatorTest {
         MuSigContract forged = MuSigContract.fromProto(forgedProto);
         SetupTradeMessage_A message = createMessage(forged, TAKER_NETWORK_ID, sign(genuine, TAKER_KEY_PAIR));
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id"))
                 .thenReturn(Optional.of(forged.getOffer()));
 
         assertOfferRejected(myOffers, message);
@@ -244,7 +245,7 @@ class MuSigTakeOfferRequestValidatorTest {
         MuSigContract forged = MuSigContract.fromProto(forgedProto);
         SetupTradeMessage_A message = createMessage(forged, TAKER_NETWORK_ID, sign(genuine, TAKER_KEY_PAIR));
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id"))
                 .thenReturn(Optional.of(forged.getOffer()));
 
         assertOfferRejected(myOffers, message);
@@ -266,7 +267,7 @@ class MuSigTakeOfferRequestValidatorTest {
                 Optional.empty(), Optional.empty());
         SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id")).thenReturn(Optional.of(makersOffer));
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id")).thenReturn(Optional.of(makersOffer));
 
         assertOfferRejected(myOffers, message);
     }
@@ -284,7 +285,7 @@ class MuSigTakeOfferRequestValidatorTest {
                 otherVersion.getPriceSpec(), Optional.empty(), Optional.empty());
         SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
         MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
-        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id")).thenReturn(Optional.of(makersOffer));
+        org.mockito.Mockito.when(myOffers.claimActivatedOffer("test-id")).thenReturn(Optional.of(makersOffer));
 
         assertThatCode(() -> MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
                 .doesNotThrowAnyException();

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -23,6 +23,7 @@ import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.common.market.Market;
 import bisq.common.monetary.Coin;
+import bisq.common.monetary.Fiat;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.network.AddressByTransportTypeMap;
 import bisq.common.network.ClearnetAddress;
@@ -33,6 +34,7 @@ import bisq.contract.mu_sig.MuSigContract;
 import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.amount.spec.BaseSideRangeAmountSpec;
 import bisq.offer.mu_sig.MuSigOffer;
 import bisq.offer.mu_sig.MyMuSigOffersService;
 import bisq.offer.price.spec.FixPriceSpec;
@@ -41,9 +43,9 @@ import bisq.security.keys.PubKey;
 import bisq.trade.Trade;
 import bisq.trade.exceptions.TradeProtocolException;
 import bisq.trade.exceptions.TradeProtocolFailure;
-import bisq.user.profile.UserProfile;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.PubKeyShares;
+import bisq.user.profile.UserProfile;
 import org.junit.jupiter.api.Test;
 
 import java.security.GeneralSecurityException;
@@ -52,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static bisq.common.validation.NetworkDataValidation.TWO_HOURS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -357,6 +361,61 @@ class MuSigTakeOfferRequestValidatorTest {
     }
 
     @Test
+    void wholeFiatRoundingAtBaseRangeBoundsIsAccepted() {
+        PriceQuote price = PriceQuote.fromFiatPrice(50_131, "USD");
+        MuSigOffer offer = createOffer(new BaseSideRangeAmountSpec(1_000_000L, 2_000_000L), price);
+
+        long roundedMinQuote = price.toQuoteSideMonetary(Coin.asBtcFromValue(1_000_000L)).round(0).getValue();
+        long derivedMinBase = price.toBaseSideMonetary(Fiat.fromValue(roundedMinQuote, "USD")).getValue();
+        long roundedMaxQuote = price.toQuoteSideMonetary(Coin.asBtcFromValue(2_000_000L)).round(0).getValue();
+        long derivedMaxBase = price.toBaseSideMonetary(Fiat.fromValue(roundedMaxQuote, "USD")).getValue();
+
+        assertThat(derivedMinBase).isEqualTo(999_382L);
+        assertThat(derivedMaxBase).isEqualTo(2_000_758L);
+        assertEconomicsAccepted(createContract(offer, derivedMinBase, roundedMinQuote, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile)));
+        assertEconomicsAccepted(createContract(offer, derivedMaxBase, roundedMaxQuote, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile)));
+    }
+
+    @Test
+    void wholeFiatRoundingAtBaseFixedAmountIsAccepted() {
+        PriceQuote price = PriceQuote.fromFiatPrice(50_131, "USD");
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L), price);
+        long roundedQuote = price.toQuoteSideMonetary(Coin.asBtcFromValue(2_000_000L)).round(0).getValue();
+        long derivedBase = price.toBaseSideMonetary(Fiat.fromValue(roundedQuote, "USD")).getValue();
+
+        assertThat(derivedBase).isEqualTo(2_000_758L);
+        assertEconomicsAccepted(createContract(offer, derivedBase, roundedQuote, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile)));
+    }
+
+    @Test
+    void baseRangeAmountBeyondWholeFiatRoundingIsRejected() {
+        PriceQuote price = PriceQuote.fromFiatPrice(50_131, "USD");
+        MuSigOffer offer = createOffer(new BaseSideRangeAmountSpec(1_000_000L, 2_000_000L), price);
+        long outsideBase = 2_002_000L;
+        long roundedQuote = price.toQuoteSideMonetary(Coin.asBtcFromValue(outsideBase)).round(0).getValue();
+        MuSigContract contract = createContract(offer, outsideBase, roundedQuote, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void baseAmountOutsideSpecWithoutWholeFiatQuoteIsRejected() {
+        PriceQuote price = PriceQuote.fromFiatPrice(50_131, "USD");
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L), price);
+        long outsideBase = 2_000_001L;
+        long unroundedQuote = price.toQuoteSideMonetary(Coin.asBtcFromValue(outsideBase)).getValue();
+        MuSigContract contract = createContract(offer, outsideBase, unroundedQuote, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertThat(unroundedQuote % Fiat.fromFaceValue(1, "USD").getValue()).isNotZero();
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
     void quoteAmountBeyondPriceToleranceIsRejected() {
         // Maker gives the quote side (maker buys BTC): a quote 10% above the resolved price is
         // adverse and beyond the 5% tolerance; 4% above is tolerated.
@@ -443,11 +502,9 @@ class MuSigTakeOfferRequestValidatorTest {
     }
 
     @Test
-    void takeDatePredatingTheOfferIsRejected() {
-        // The take date is taker-chosen; a take dated before the offer existed drives the UI's
-        // remaining trade time and would show as already expired. It must not precede the offer.
+    void takeDateEarlierThanTheClockSkewWindowIsRejected() {
         MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
-        MuSigContract contract = new MuSigContract(offer.getDate() - 1,
+        MuSigContract contract = new MuSigContract(offer.getDate() - TWO_HOURS - 1,
                 offer,
                 TAKER_NETWORK_ID,
                 2_000_000L,
@@ -460,6 +517,24 @@ class MuSigTakeOfferRequestValidatorTest {
                 0);
 
         assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void takeDateWithinTheClockSkewWindowIsAccepted() {
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = new MuSigContract(offer.getDate() - TWO_HOURS + 1,
+                offer,
+                TAKER_NETWORK_ID,
+                2_000_000L,
+                10_000_000L,
+                offer.getQuoteSidePaymentMethodSpecs().get(0),
+                new byte[20],
+                Optional.of(mediatorProfile),
+                Optional.of(arbitratorProfile),
+                offer.getPriceSpec(),
+                0);
+
+        assertEconomicsAccepted(contract);
     }
 
     @Test
@@ -650,13 +725,17 @@ class MuSigTakeOfferRequestValidatorTest {
     }
 
     @Test
-    void mediatorWithForgedProfileMetadataIsRejected() {
-        // Same network id as the maker's selection, but a forged nickname: the full-profile
-        // comparison rejects it so the maker never signs an altered dispute-agent profile.
-        NetworkId mediatorNetworkId = mediatorProfile.getNetworkId();
-        UserProfile forged = org.mockito.Mockito.mock(UserProfile.class);
-        org.mockito.Mockito.when(forged.getNetworkId()).thenReturn(mediatorNetworkId);
-        org.mockito.Mockito.when(forged.getUserName()).thenReturn("forged");
+    void mediatorWithForgedNicknameIsRejected() {
+        bisq.security.pow.ProofOfWork proofOfWork = org.mockito.Mockito.mock(bisq.security.pow.ProofOfWork.class);
+        org.mockito.Mockito.when(proofOfWork.getSolution()).thenReturn(new byte[72]);
+        NetworkId agentNetworkId = createNetworkId("dispute-agent", 9988, null);
+        UserProfile genuine = new UserProfile(0, "agent", proofOfWork, 0, agentNetworkId, "", "", "");
+        UserProfile forged = new UserProfile(0, "forged", proofOfWork, 0, agentNetworkId, "", "", "");
+        org.mockito.Mockito.when(mediationService.selectMediator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(genuine));
         MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
         MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
                 Optional.of(forged), Optional.of(arbitratorProfile));
@@ -768,11 +847,6 @@ class MuSigTakeOfferRequestValidatorTest {
         MuSigOffer offer = createOffer(amountSpec);
         return createContract(offer, baseSideAmount, quoteSideAmount, offer.getPriceSpec(),
                 Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
-    }
-
-    private MuSigContract altcoinContract(long baseSideAmount, long quoteSideAmount) {
-        // Raw BUY: the maker buys XMR (the base) and gives BTC (the quote).
-        return altcoinContract(Direction.BUY, baseSideAmount, quoteSideAmount);
     }
 
     private MuSigContract altcoinContract(Direction direction, long baseSideAmount, long quoteSideAmount) {
@@ -913,6 +987,10 @@ class MuSigTakeOfferRequestValidatorTest {
     }
 
     private static MuSigOffer createOffer(bisq.offer.amount.spec.AmountSpec amountSpec) {
+        return createOffer(amountSpec, PriceQuote.fromFiatPrice(50_000, "USD"));
+    }
+
+    private static MuSigOffer createOffer(bisq.offer.amount.spec.AmountSpec amountSpec, PriceQuote price) {
         Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
         PaymentMethodSpec<?> nonBtcPaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
                 FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER),
@@ -922,7 +1000,7 @@ class MuSigTakeOfferRequestValidatorTest {
                 Direction.BUY,
                 market,
                 amountSpec,
-                new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")),
+                new FixPriceSpec(price),
                 List.of(nonBtcPaymentMethodSpec.getPaymentMethod()),
                 List.of(),
                 "1.0.0");

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -33,6 +33,7 @@ import bisq.network.identity.NetworkId;
 import bisq.offer.Direction;
 import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
 import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.mu_sig.MyMuSigOffersService;
 import bisq.offer.price.spec.FixPriceSpec;
 import bisq.security.keys.KeyGeneration;
 import bisq.security.keys.PubKey;
@@ -128,6 +129,52 @@ class MuSigTakeOfferRequestValidatorTest {
         assertRejected(message);
     }
 
+    @Test
+    void activatedOwnOfferPasses() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+                .thenReturn(Optional.of(contract.getOffer()));
+
+        assertThatCode(() -> MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void unknownOrDeactivatedOfferIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+        // findActivatedOffer covers both cases: an unknown offer and a retained-but-deactivated
+        // offer are equally absent from the activated set.
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id")).thenReturn(Optional.empty());
+
+        assertOfferRejected(myOffers, message);
+    }
+
+    @Test
+    void embeddedOfferDifferingFromOwnOfferIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+        // Same id, different terms: the taker altered the embedded offer while keeping the id
+        // of a genuine activated offer.
+        MuSigOffer myRealOffer = createOffer(new BaseSideFixedAmountSpec(999_999L));
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+                .thenReturn(Optional.of(myRealOffer));
+
+        assertOfferRejected(myOffers, message);
+    }
+
+    private void assertOfferRejected(MyMuSigOffersService myOffers, SetupTradeMessage_A message) {
+        assertThatThrownBy(() -> MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
+                .isInstanceOf(TradeProtocolException.class)
+                .satisfies(e -> org.assertj.core.api.Assertions.assertThat(
+                                ((TradeProtocolException) e).getTradeProtocolFailure())
+                        .isEqualTo(TradeProtocolFailure.OFFER_NOT_AVAILABLE));
+    }
+
     private void assertRejected(SetupTradeMessage_A message) {
         assertThatThrownBy(() -> MuSigTakeOfferRequestValidator.validateIdentity(contractService, message))
                 .isInstanceOf(TradeProtocolException.class)
@@ -173,15 +220,7 @@ class MuSigTakeOfferRequestValidatorTest {
         PaymentMethodSpec<?> nonBtcPaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
                 FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER),
                 "USD");
-        MuSigOffer offer = new MuSigOffer("test-id",
-                OFFER_MAKER_NETWORK_ID,
-                Direction.BUY,
-                market,
-                new BaseSideFixedAmountSpec(111L),
-                new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")),
-                List.of(nonBtcPaymentMethodSpec.getPaymentMethod()),
-                List.of(),
-                "1.0.0");
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(111L));
         return new MuSigContract(1_700_000_000_000L,
                 offer,
                 TAKER_NETWORK_ID,
@@ -193,6 +232,22 @@ class MuSigTakeOfferRequestValidatorTest {
                 Optional.empty(),
                 offer.getPriceSpec(),
                 0);
+    }
+
+    private static MuSigOffer createOffer(bisq.offer.amount.spec.AmountSpec amountSpec) {
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        PaymentMethodSpec<?> nonBtcPaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER),
+                "USD");
+        return new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.BUY,
+                market,
+                amountSpec,
+                new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")),
+                List.of(nonBtcPaymentMethodSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
     }
 
     private static NetworkId createNetworkId(String keyIdSuffix, int port, KeyPair keyPair) {

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -22,6 +22,7 @@ import bisq.account.payment_method.PaymentMethodSpecUtil;
 import bisq.account.payment_method.fiat.FiatPaymentMethod;
 import bisq.account.payment_method.fiat.FiatPaymentRail;
 import bisq.common.market.Market;
+import bisq.common.monetary.Coin;
 import bisq.common.monetary.PriceQuote;
 import bisq.common.network.AddressByTransportTypeMap;
 import bisq.common.network.ClearnetAddress;
@@ -40,6 +41,7 @@ import bisq.security.keys.PubKey;
 import bisq.trade.Trade;
 import bisq.trade.exceptions.TradeProtocolException;
 import bisq.trade.exceptions.TradeProtocolFailure;
+import bisq.user.profile.UserProfile;
 import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
 import bisq.trade.mu_sig.messages.network.mu_sig_data.PubKeyShares;
 import org.junit.jupiter.api.Test;
@@ -60,6 +62,46 @@ class MuSigTakeOfferRequestValidatorTest {
     private static final NetworkId OTHER_NETWORK_ID = createNetworkId("other", 9996, null);
 
     private final ContractService contractService = new ContractService(null);
+    private final bisq.bonded_roles.market_price.MarketPriceService marketPriceService =
+            org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPriceService.class);
+    private final bisq.settings.SettingsService settingsService =
+            org.mockito.Mockito.mock(bisq.settings.SettingsService.class);
+    private final bisq.trade.mu_sig.mediation.MuSigTraderMediationService mediationService =
+            org.mockito.Mockito.mock(bisq.trade.mu_sig.mediation.MuSigTraderMediationService.class);
+    private final bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService arbitrationService =
+            org.mockito.Mockito.mock(bisq.trade.mu_sig.arbitration.MuSigTraderArbitrationService.class);
+
+    private final UserProfile mediatorProfile = org.mockito.Mockito.mock(UserProfile.class);
+    private final UserProfile arbitratorProfile = org.mockito.Mockito.mock(UserProfile.class);
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUpEconomicsMocks() {
+        org.mockito.Mockito.when(mediatorProfile.getNetworkId()).thenReturn(createNetworkId("mediator", 9990, null));
+        org.mockito.Mockito.when(mediatorProfile.getUserName()).thenReturn("mediator");
+        org.mockito.Mockito.when(arbitratorProfile.getNetworkId()).thenReturn(createNetworkId("arbitrator", 9989, null));
+        org.mockito.Mockito.when(arbitratorProfile.getUserName()).thenReturn("arbitrator");
+        org.mockito.Mockito.when(settingsService.getMaxTradePriceDeviation())
+                .thenReturn(new bisq.common.observable.Observable<>(0.05));
+        // A fresh BTC/USD market price for the absolute USD limit conversions and for resolving
+        // market-price offers; findMarketPrice carries the timestamp the freshness check reads.
+        bisq.bonded_roles.market_price.MarketPrice freshPrice =
+                org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);
+        org.mockito.Mockito.when(freshPrice.isValidDate()).thenReturn(true);
+        org.mockito.Mockito.when(freshPrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(50_000, "USD"));
+        org.mockito.Mockito.when(marketPriceService.findMarketPrice(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.of(freshPrice));
+        org.mockito.Mockito.when(mediationService.selectMediator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(mediatorProfile));
+        org.mockito.Mockito.when(arbitrationService.selectArbitrator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.of(arbitratorProfile));
+    }
 
     @Test
     void validRequestPasses() throws GeneralSecurityException {
@@ -167,6 +209,602 @@ class MuSigTakeOfferRequestValidatorTest {
         assertOfferRejected(myOffers, message);
     }
 
+    @Test
+    void contractWithForgedProtocolTypeIsRejected() throws GeneralSecurityException {
+        // Contract.verify checks only the date, so a taker can serialize a MuSigContract that
+        // declares BISQ_EASY; MuSigContract.fromProto keeps the forged value. The maker must not
+        // double-sign it. The wire mutation is reproduced by round-tripping through proto.
+        MuSigContract genuine = createContract();
+        bisq.contract.protobuf.Contract forgedProto = genuine.toProto(false).toBuilder()
+                .setTradeProtocolType(bisq.account.protocol_type.TradeProtocolType.BISQ_EASY.toProtoEnum())
+                .build();
+        MuSigContract forged = MuSigContract.fromProto(forgedProto);
+        SetupTradeMessage_A message = createMessage(forged, TAKER_NETWORK_ID, sign(genuine, TAKER_KEY_PAIR));
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+                .thenReturn(Optional.of(forged.getOffer()));
+
+        assertOfferRejected(myOffers, message);
+    }
+
+    @Test
+    void contractWithForgedTakerRoleIsRejected() throws GeneralSecurityException {
+        // A taker can serialize its own Party with role MAKER; verification never checks it.
+        MuSigContract genuine = createContract();
+        bisq.contract.protobuf.Contract proto = genuine.toProto(false);
+        bisq.contract.protobuf.Contract forgedProto = proto.toBuilder()
+                .setTwoPartyContract(proto.getTwoPartyContract().toBuilder()
+                        .setTaker(proto.getTwoPartyContract().getTaker().toBuilder()
+                                .setRole(bisq.contract.protobuf.Role.ROLE_MAKER)))
+                .build();
+        MuSigContract forged = MuSigContract.fromProto(forgedProto);
+        SetupTradeMessage_A message = createMessage(forged, TAKER_NETWORK_ID, sign(genuine, TAKER_KEY_PAIR));
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id"))
+                .thenReturn(Optional.of(forged.getOffer()));
+
+        assertOfferRejected(myOffers, message);
+    }
+
+    @Test
+    void embeddedOfferWithAForgedCurrencyNameIsRejected() throws GeneralSecurityException {
+        // Market.equals excludes the currency names, but they are part of the contract hash (not
+        // @ExcludeForHash). Starting from the maker's own offer, the taker forges only the base
+        // currency name; equals still passes (names excluded, same date and economic fields),
+        // yet the maker would co-sign a contract committing to the forged name. The
+        // serialize-for-hash comparison rejects it.
+        MuSigOffer makersOffer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        bisq.offer.protobuf.Offer forgedProto = makersOffer.toProto(false).toBuilder()
+                .setMarket(makersOffer.toProto(false).getMarket().toBuilder().setBaseCurrencyName("Forged"))
+                .build();
+        MuSigOffer forged = MuSigOffer.fromProto(forgedProto);
+        MuSigContract contract = createContract(forged, 2_000_000L, 10_000_000L, forged.getPriceSpec(),
+                Optional.empty(), Optional.empty());
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id")).thenReturn(Optional.of(makersOffer));
+
+        assertOfferRejected(myOffers, message);
+    }
+
+    @Test
+    void embeddedOfferDifferingOnlyInTradeProtocolVersionIsAccepted() throws GeneralSecurityException {
+        // tradeProtocolVersion is excluded from both equals and the hash (@ExcludeForHash), so a
+        // peer whose copy carries a different version must still pass the hash-relevant comparison.
+        MuSigOffer makersOffer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        bisq.offer.protobuf.Offer otherVersionProto = makersOffer.toProto(false).toBuilder()
+                .setTradeProtocolVersion("9.9.9")
+                .build();
+        MuSigOffer otherVersion = MuSigOffer.fromProto(otherVersionProto);
+        MuSigContract contract = createContract(otherVersion, 2_000_000L, 10_000_000L,
+                otherVersion.getPriceSpec(), Optional.empty(), Optional.empty());
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+        MyMuSigOffersService myOffers = org.mockito.Mockito.mock(MyMuSigOffersService.class);
+        org.mockito.Mockito.when(myOffers.findActivatedOffer("test-id")).thenReturn(Optional.of(makersOffer));
+
+        assertThatCode(() -> MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void unknownTakerProfileIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+        bisq.user.profile.UserProfileService userProfileService =
+                org.mockito.Mockito.mock(bisq.user.profile.UserProfileService.class);
+        org.mockito.Mockito.when(userProfileService.findUserProfile(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> MuSigTakeOfferRequestValidator.validateTakerProfileKnown(userProfileService, message))
+                .isInstanceOf(TradeProtocolException.class);
+    }
+
+    @Test
+    void missingAccountPayloadCommitmentIsRejected() {
+        // An ABSENT commitment survives deserialization because Party.verify validates the
+        // hash only when present; the case is built through the actual wire path by clearing
+        // the field from a valid contract's proto. Dev mode isolates the commitment check from
+        // the dispute-agent presence check, which would otherwise also reject this contract.
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract valid = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
+                Optional.empty(), Optional.empty());
+        bisq.contract.protobuf.Contract proto = valid.toProto(true);
+        bisq.contract.protobuf.Contract mutated = proto.toBuilder()
+                .setTwoPartyContract(proto.getTwoPartyContract().toBuilder()
+                        .setTaker(proto.getTwoPartyContract().getTaker().toBuilder()
+                                .clearSaltedAccountPayloadHash()))
+                .build();
+        MuSigContract contract = MuSigContract.fromProto(mutated);
+
+        bisq.common.application.DevMode.setDevMode(true);
+        try {
+            assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+        } finally {
+            bisq.common.application.DevMode.setDevMode(false);
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    // Economics
+    /* ------------------------------------------------------------------ */
+
+    @Test
+    void consistentEconomicsPass() {
+        // 0.02 BTC at $50,000 fixed: quote 1,000 USD; base pinned by the fixed spec.
+        MuSigContract contract = fiatContract(2_000_000L, 10_000_000L);
+        assertEconomicsAccepted(contract);
+    }
+
+    @Test
+    void nonPositiveAmountsAreRejected() {
+        assertEconomicsRejected(fiatContract(2_000_000L, -1L), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+        assertEconomicsRejected(fiatContract(0L, 10_000_000L), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void priceSpecDifferingFromOfferIsRejected() {
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L,
+                new FixPriceSpec(PriceQuote.fromFiatPrice(45_000, "USD")),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void baseAmountOffTheFixedSpecIsRejected() {
+        // The base side is pinned exactly by the offer's fixed amount spec.
+        assertEconomicsRejected(fiatContract(1_900_000L, 10_000_000L), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void quoteAmountBeyondPriceToleranceIsRejected() {
+        // Maker gives the quote side (maker buys BTC): a quote 10% above the resolved price is
+        // adverse and beyond the 5% tolerance; 4% above is tolerated.
+        assertEconomicsRejected(fiatContract(2_000_000L, 11_000_000L), TradeProtocolFailure.PRICE_DEVIATION);
+        assertEconomicsAccepted(fiatContract(2_000_000L, 10_400_000L));
+    }
+
+    @Test
+    void altcoinBuyOfferRejectsTooMuchBitcoinGiven() {
+        // Offer.direction is the raw BASE-currency direction. XMR/BTC raw BUY means the maker buys
+        // XMR (the base) and GIVES BTC (the quote), so giving too much BTC is adverse. 4 XMR at
+        // 0.005 BTC/XMR: expected quote 2,000,000 sats, 5% tolerance -> upper bound 2,100,000.
+        assertEconomicsRejected(altcoinContract(Direction.BUY, 4_000_000_000_000L, 2_300_000L),
+                TradeProtocolFailure.PRICE_DEVIATION);
+        assertEconomicsAccepted(altcoinContract(Direction.BUY, 4_000_000_000_000L, 2_050_000L));
+    }
+
+    @Test
+    void altcoinSellOfferRejectsTooLittleBitcoinReceived() {
+        // XMR/BTC raw SELL means the maker sells XMR and RECEIVES BTC, so receiving too little BTC
+        // is adverse - the mirror bound of the BUY case. Expected quote 2,000,000 sats, 5%
+        // tolerance -> lower bound 1,900,000.
+        assertEconomicsRejected(altcoinContract(Direction.SELL, 4_000_000_000_000L, 1_700_000L),
+                TradeProtocolFailure.PRICE_DEVIATION);
+        assertEconomicsAccepted(altcoinContract(Direction.SELL, 4_000_000_000_000L, 1_950_000L));
+    }
+
+    @Test
+    void paymentSpecNotOfferedIsRejected() {
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        PaymentMethodSpec<?> foreignSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.WISE), "USD");
+        MuSigContract contract = new MuSigContract(offer.getDate(),
+                offer,
+                TAKER_NETWORK_ID,
+                2_000_000L,
+                10_000_000L,
+                foreignSpec,
+                new byte[20],
+                Optional.of(mediatorProfile),
+                Optional.of(arbitratorProfile),
+                offer.getPriceSpec(),
+                0);
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void overSupplyBitcoinAmountIsRejected() {
+        // A Bitcoin-side amount above the total supply is rejected before the USD conversion, even
+        // when the quote is consistent with the price (so the two-sided tolerance passes first).
+        long baseSats = 2_100_000_000_000_001L; // MAX_BITCOIN_SUPPLY_SATS + 1
+        PriceQuote price = PriceQuote.fromFiatPrice(50_000, "USD");
+        long consistentQuote = price.toQuoteSideMonetary(Coin.asBtcFromValue(baseSats)).getValue();
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        PaymentMethodSpec<?> paymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD");
+        MuSigOffer offer = new MuSigOffer("test-id", OFFER_MAKER_NETWORK_ID, Direction.BUY, market,
+                new BaseSideFixedAmountSpec(baseSats), new FixPriceSpec(price),
+                List.of(paymentMethodSpec.getPaymentMethod()), List.of(), "1.0.0");
+        MuSigContract contract = createContract(offer, baseSats, consistentQuote, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void favorableFiatAmountBeyondToleranceIsRejected() {
+        // A one-sided tolerance would let an unboundedly favorable side through, defeating the rail
+        // cap: a BTC/USD SELL maker receives the USD side, so a taker could inflate the quote far
+        // above the Bitcoin value; the rail check - valued on the 0.1 BTC = $5,000 - passes its
+        // $5,000 ACH cap, and the maker would co-sign a $100,000 ACH contract. Two-sided tolerance
+        // rejects the inflated quote (20x, far beyond the 5% band).
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        PaymentMethodSpec<?> paymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD");
+        MuSigOffer offer = new MuSigOffer("test-id", OFFER_MAKER_NETWORK_ID, Direction.SELL, market,
+                new BaseSideFixedAmountSpec(10_000_000L), new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")),
+                List.of(paymentMethodSpec.getPaymentMethod()), List.of(), "1.0.0");
+        // base 0.1 BTC, quote 1,000,000,000 = $100,000 (expected $5,000).
+        MuSigContract contract = createContract(offer, 10_000_000L, 1_000_000_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.PRICE_DEVIATION);
+    }
+
+    @Test
+    void takeDatePredatingTheOfferIsRejected() {
+        // The take date is taker-chosen; a take dated before the offer existed drives the UI's
+        // remaining trade time and would show as already expired. It must not precede the offer.
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = new MuSigContract(offer.getDate() - 1,
+                offer,
+                TAKER_NETWORK_ID,
+                2_000_000L,
+                10_000_000L,
+                offer.getQuoteSidePaymentMethodSpecs().get(0),
+                new byte[20],
+                Optional.of(mediatorProfile),
+                Optional.of(arbitratorProfile),
+                offer.getPriceSpec(),
+                0);
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void staleBtcUsdPriceIsRejected() {
+        // A fixed-price offer passes the tolerance check, but the absolute USD limits are valued
+        // with the BTC/USD market price. A >12h-stale quote (kept after a failed refresh) must be
+        // rejected rather than trusted.
+        bisq.bonded_roles.market_price.MarketPrice stalePrice =
+                org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);
+        org.mockito.Mockito.when(stalePrice.isValidDate()).thenReturn(false);
+        org.mockito.Mockito.when(stalePrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(50_000, "USD"));
+        org.mockito.Mockito.when(marketPriceService.findMarketPrice(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.of(stalePrice));
+
+        assertEconomicsRejected(fiatContract(2_000_000L, 10_000_000L), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void staleMarketPriceOfferIsRejected() {
+        // A market-price offer resolves against the live market price; a stale quote for its own
+        // market must be rejected before the amounts are validated against an outdated price.
+        bisq.bonded_roles.market_price.MarketPrice stalePrice =
+                org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);
+        org.mockito.Mockito.when(stalePrice.isValidDate()).thenReturn(false);
+        org.mockito.Mockito.when(stalePrice.getPriceQuote()).thenReturn(PriceQuote.fromFiatPrice(50_000, "USD"));
+        org.mockito.Mockito.when(marketPriceService.findMarketPrice(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.of(stalePrice));
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        PaymentMethodSpec<?> nonBtcPaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER), "USD");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.SELL,
+                market,
+                new BaseSideFixedAmountSpec(2_000_000L),
+                new bisq.offer.price.spec.MarketPriceSpec(),
+                List.of(nonBtcPaymentMethodSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void zeroValuedResolvedPriceIsRejected() {
+        // Nothing upstream rejects a zero price. For a market-price offer whose fresh quote is
+        // zero, the cross-multiplication denominator would be zero and the tolerance check would
+        // fail open, accepting any amount. The BTC/USD price stays fresh and non-zero so the USD
+        // limits do not reject first - only the non-positive guard catches it.
+        Market xmrBtc = new Market("XMR", "BTC", "Monero", "Bitcoin");
+        bisq.bonded_roles.market_price.MarketPrice zeroPrice =
+                org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);
+        org.mockito.Mockito.when(zeroPrice.isValidDate()).thenReturn(true);
+        org.mockito.Mockito.when(zeroPrice.getPriceQuote()).thenReturn(PriceQuote.fromPrice(0L, "XMR", "BTC"));
+        org.mockito.Mockito.when(marketPriceService.findMarketPrice(xmrBtc)).thenReturn(Optional.of(zeroPrice));
+        PaymentMethodSpec<?> cryptoSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                bisq.account.payment_method.crypto.CryptoPaymentMethod.fromCustomName("XMR", "XMR"), "XMR");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.SELL,
+                xmrBtc,
+                new bisq.offer.amount.spec.QuoteSideFixedAmountSpec(100_000L),
+                new bisq.offer.price.spec.MarketPriceSpec(),
+                List.of(cryptoSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = createContract(offer, 5_000_000_000_000L, 100_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void marketPriceOfferReadsASingleFreshnessSnapshot() {
+        // The freshness check and the validated quote must come from ONE MarketPrice lookup - a
+        // second lookup could pass freshness on a different object than the quote came from (the
+        // map is replaced concurrently). Verify the market-based path reads the offer market's
+        // price exactly once.
+        Market xmrBtc = new Market("XMR", "BTC", "Monero", "Bitcoin");
+        bisq.bonded_roles.market_price.MarketPrice freshXmrPrice =
+                org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);
+        org.mockito.Mockito.when(freshXmrPrice.isValidDate()).thenReturn(true);
+        org.mockito.Mockito.when(freshXmrPrice.getPriceQuote()).thenReturn(PriceQuote.fromPrice(0.005, "XMR", "BTC"));
+        org.mockito.Mockito.when(marketPriceService.findMarketPrice(xmrBtc)).thenReturn(Optional.of(freshXmrPrice));
+        PaymentMethodSpec<?> cryptoSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                bisq.account.payment_method.crypto.CryptoPaymentMethod.fromCustomName("XMR", "XMR"), "XMR");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.SELL,
+                xmrBtc,
+                new BaseSideFixedAmountSpec(4_000_000_000_000L),
+                new bisq.offer.price.spec.MarketPriceSpec(),
+                List.of(cryptoSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        // 4 XMR at 0.005 BTC/XMR = 2,000,000 sats, exactly the expected quote.
+        MuSigContract contract = createContract(offer, 4_000_000_000_000L, 2_000_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+        assertEconomicsAccepted(contract);
+
+        org.mockito.Mockito.verify(marketPriceService, org.mockito.Mockito.times(1)).findMarketPrice(xmrBtc);
+    }
+
+    @Test
+    void quotePinnedAmountThatWouldWrapThePriceConversionIsRejected() {
+        // XMR/BTC BUY offer (the maker buys XMR and receives it, so too little XMR is adverse),
+        // quote (BTC) side pinned at 0.1 BTC (10,000,000 sats). At an extreme resolved price of
+        // 1 sat/XMR the expected base amount is 10^7 * 10^12 = 10^19, which overflows a long and
+        // wraps negative in PriceQuote.toBaseSideMonetary. The wrapped value makes the tolerance
+        // comparison "1 < negative" pass a 1-piconero base against a 10^19 expectation; the exact
+        // BigDecimal comparison rejects it.
+        Market market = new Market("XMR", "BTC", "Monero", "Bitcoin");
+        PaymentMethodSpec<?> cryptoSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                bisq.account.payment_method.crypto.CryptoPaymentMethod.fromCustomName("XMR", "XMR"), "XMR");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.BUY,
+                market,
+                new bisq.offer.amount.spec.QuoteSideFixedAmountSpec(10_000_000L),
+                new FixPriceSpec(PriceQuote.fromPrice(1L, "XMR", "BTC")),
+                List.of(cryptoSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        MuSigContract contract = createContract(offer, 1L, 10_000_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.PRICE_DEVIATION);
+    }
+
+    @Test
+    void quotePinnedAmountJustOverTheExactToleranceIsRejected() {
+        // XMR/BTC SELL (the maker sells XMR and gives it, so too much XMR is adverse), quote (BTC)
+        // side pinned at 1,000,000 sats, price 7 sats/XMR, 5% tolerance. Exact expected base =
+        // 1,000,000 * 10^12 / 7 piconero; the exact 5% upper bound is exactly 150,000,000,000,000,000
+        // piconero. A base 20 piconero above it must be rejected - a rounded (DECIMAL64) bound would
+        // widen to 150,000,000,000,000,045 and wrongly accept it.
+        Market market = new Market("XMR", "BTC", "Monero", "Bitcoin");
+        PaymentMethodSpec<?> cryptoSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                bisq.account.payment_method.crypto.CryptoPaymentMethod.fromCustomName("XMR", "XMR"), "XMR");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.SELL,
+                market,
+                new bisq.offer.amount.spec.QuoteSideFixedAmountSpec(1_000_000L),
+                new FixPriceSpec(PriceQuote.fromPrice(7L, "XMR", "BTC")),
+                List.of(cryptoSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        MuSigContract overLimit = createContract(offer, 150_000_000_000_000_020L, 1_000_000L,
+                offer.getPriceSpec(), Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+        assertEconomicsRejected(overLimit, TradeProtocolFailure.PRICE_DEVIATION);
+
+        // Exactly at the bound is within tolerance and accepted.
+        MuSigContract atLimit = createContract(offer, 150_000_000_000_000_000L, 1_000_000L,
+                offer.getPriceSpec(), Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+        assertEconomicsAccepted(atLimit);
+    }
+
+    @Test
+    void amountBeyondTheRailLimitIsRejected() {
+        // 0.18 BTC at $50,000 is $9,000; ACH transfer's chargeback tier caps at $5,000.
+        assertEconomicsRejected(fiatContract(18_000_000L, 90_000_000L, new BaseSideFixedAmountSpec(18_000_000L)),
+                TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void amountBelowTheAbsoluteMinimumIsRejected() {
+        // 0.0001 BTC at $50,000 is $5, below the $10 absolute minimum.
+        assertEconomicsRejected(fiatContract(10_000L, 50_000L, new BaseSideFixedAmountSpec(10_000L)),
+                TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void mediatorNotMatchingOwnSelectionIsRejected() {
+        MuSigContract contract = fiatContract(2_000_000L, 10_000_000L);
+        UserProfile myMediator = org.mockito.Mockito.mock(UserProfile.class);
+        org.mockito.Mockito.when(myMediator.getNetworkId()).thenReturn(OTHER_NETWORK_ID);
+        org.mockito.Mockito.when(myMediator.getUserName()).thenReturn("other");
+        org.mockito.Mockito.when(mediationService.selectMediator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(myMediator));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+    }
+
+    @Test
+    void mediatorWithForgedProfileMetadataIsRejected() {
+        // Same network id as the maker's selection, but a forged nickname: the full-profile
+        // comparison rejects it so the maker never signs an altered dispute-agent profile.
+        NetworkId mediatorNetworkId = mediatorProfile.getNetworkId();
+        UserProfile forged = org.mockito.Mockito.mock(UserProfile.class);
+        org.mockito.Mockito.when(forged.getNetworkId()).thenReturn(mediatorNetworkId);
+        org.mockito.Mockito.when(forged.getUserName()).thenReturn("forged");
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
+                Optional.of(forged), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+    }
+
+    @Test
+    void mediatorWithForgedAvatarVersionIsRejected() {
+        // Two profiles equal in every field UserProfile.equals covers but differing in
+        // avatarVersion, which equals ignores; an unsupported value breaks avatar rendering, so
+        // the maker's selection and the contract's copy must also agree on it. Real profiles are
+        // used (a shared proof of work) so equals actually returns true and the check falls
+        // through to the avatarVersion comparison.
+        bisq.security.pow.ProofOfWork proofOfWork = org.mockito.Mockito.mock(bisq.security.pow.ProofOfWork.class);
+        org.mockito.Mockito.when(proofOfWork.getSolution()).thenReturn(new byte[72]);
+        NetworkId agentNetworkId = createNetworkId("dispute-agent", 9988, null);
+        UserProfile genuine = new UserProfile(0, "agent", proofOfWork, 0, agentNetworkId, "", "", "");
+        UserProfile forged = new UserProfile(0, "agent", proofOfWork, Integer.MAX_VALUE, agentNetworkId, "", "", "");
+        org.mockito.Mockito.when(mediationService.selectMediator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(genuine));
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
+                Optional.of(forged), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+    }
+
+    @Test
+    void arbitratorNotMatchingOwnSelectionIsRejected() {
+        MuSigContract contract = fiatContract(2_000_000L, 10_000_000L);
+        UserProfile myArbitrator = org.mockito.Mockito.mock(UserProfile.class);
+        org.mockito.Mockito.when(myArbitrator.getNetworkId()).thenReturn(OTHER_NETWORK_ID);
+        org.mockito.Mockito.when(myArbitrator.getUserName()).thenReturn("other");
+        org.mockito.Mockito.when(arbitrationService.selectArbitrator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.of(myArbitrator));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+    }
+
+    @Test
+    void missingDisputeAgentsAreRejectedOutsideDevMode() {
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
+                Optional.empty(), Optional.empty());
+        org.mockito.Mockito.when(mediationService.selectMediator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.empty());
+        org.mockito.Mockito.when(arbitrationService.selectArbitrator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.empty());
+
+        // The selections agree with the contract, but a production trade without dispute
+        // agents would leave mediation and arbitration without a recipient.
+        assertEconomicsRejected(contract, TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    private MuSigContract fiatContract(long baseSideAmount, long quoteSideAmount) {
+        return fiatContract(baseSideAmount, quoteSideAmount, new BaseSideFixedAmountSpec(2_000_000L));
+    }
+
+    private MuSigContract fiatContract(long baseSideAmount, long quoteSideAmount, bisq.offer.amount.spec.AmountSpec amountSpec) {
+        MuSigOffer offer = createOffer(amountSpec);
+        return createContract(offer, baseSideAmount, quoteSideAmount, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+    }
+
+    private MuSigContract altcoinContract(long baseSideAmount, long quoteSideAmount) {
+        // Raw BUY: the maker buys XMR (the base) and gives BTC (the quote).
+        return altcoinContract(Direction.BUY, baseSideAmount, quoteSideAmount);
+    }
+
+    private MuSigContract altcoinContract(Direction direction, long baseSideAmount, long quoteSideAmount) {
+        Market market = new Market("XMR", "BTC", "Monero", "Bitcoin");
+        PaymentMethodSpec<?> cryptoSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                bisq.account.payment_method.crypto.CryptoPaymentMethod.fromCustomName("XMR", "XMR"), "XMR");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                direction,
+                market,
+                new BaseSideFixedAmountSpec(baseSideAmount),
+                new FixPriceSpec(PriceQuote.fromPrice(0.005, "XMR", "BTC")),
+                List.of(cryptoSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        return createContract(offer, baseSideAmount, quoteSideAmount, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile));
+    }
+
+    private MuSigContract createContract(MuSigOffer offer,
+                                         long baseSideAmount,
+                                         long quoteSideAmount,
+                                         bisq.offer.price.spec.PriceSpec priceSpec,
+                                         Optional<UserProfile> mediator,
+                                         Optional<UserProfile> arbitrator) {
+        PaymentMethodSpec<?> paymentMethodSpec = offer.getMarket().isBaseCurrencyBitcoin()
+                ? offer.getQuoteSidePaymentMethodSpecs().get(0)
+                : offer.getBaseSidePaymentMethodSpecs().get(0);
+        return new MuSigContract(offer.getDate(),
+                offer,
+                TAKER_NETWORK_ID,
+                baseSideAmount,
+                quoteSideAmount,
+                paymentMethodSpec,
+                new byte[20],
+                mediator,
+                arbitrator,
+                priceSpec,
+                0);
+    }
+
+    private void assertEconomicsAccepted(MuSigContract contract) {
+        assertThatCode(() -> MuSigTakeOfferRequestValidator.validateEconomics(marketPriceService,
+                settingsService, mediationService, arbitrationService, economicsMessage(contract)))
+                .doesNotThrowAnyException();
+    }
+
+    private void assertEconomicsRejected(MuSigContract contract, TradeProtocolFailure expectedFailure) {
+        assertThatThrownBy(() -> MuSigTakeOfferRequestValidator.validateEconomics(marketPriceService,
+                settingsService, mediationService, arbitrationService, economicsMessage(contract)))
+                .isInstanceOf(TradeProtocolException.class)
+                .satisfies(e -> org.assertj.core.api.Assertions.assertThat(
+                                ((TradeProtocolException) e).getTradeProtocolFailure())
+                        .isEqualTo(expectedFailure));
+    }
+
+    private SetupTradeMessage_A economicsMessage(MuSigContract contract) {
+        try {
+            // The economics checks never read the signature; a donor signature from the plain
+            // fixture contract avoids serializing the mocked dispute-agent profiles.
+            return createMessage(contract, TAKER_NETWORK_ID, sign(createContract(), TAKER_KEY_PAIR));
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private void assertOfferRejected(MyMuSigOffersService myOffers, SetupTradeMessage_A message) {
         assertThatThrownBy(() -> MuSigTakeOfferRequestValidator.validateOffer(myOffers, message))
                 .isInstanceOf(TradeProtocolException.class)
@@ -209,10 +847,16 @@ class MuSigTakeOfferRequestValidatorTest {
                 contract,
                 contractSignatureData,
                 PubKeyShares.fromProto(bisq.trade.protobuf.PubKeyShares.newBuilder()
-                        .setBuyerOutputPubKeyShare(com.google.protobuf.ByteString.copyFrom(new byte[33]))
-                        .setSellerOutputPubKeyShare(com.google.protobuf.ByteString.copyFrom(new byte[33]))
-                        .setMultisigScriptKey(com.google.protobuf.ByteString.copyFrom(new byte[33]))
+                        .setBuyerOutputPubKeyShare(com.google.protobuf.ByteString.copyFrom(compressedKey()))
+                        .setSellerOutputPubKeyShare(com.google.protobuf.ByteString.copyFrom(compressedKey()))
+                        .setMultisigScriptKey(com.google.protobuf.ByteString.copyFrom(compressedKey()))
                         .build()));
+    }
+
+    private static byte[] compressedKey() {
+        byte[] key = new byte[33];
+        key[0] = 0x02;
+        return key;
     }
 
     private static MuSigContract createContract() {
@@ -221,7 +865,7 @@ class MuSigTakeOfferRequestValidatorTest {
                 FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER),
                 "USD");
         MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(111L));
-        return new MuSigContract(1_700_000_000_000L,
+        return new MuSigContract(offer.getDate(),
                 offer,
                 TAKER_NETWORK_ID,
                 111L,

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -689,6 +689,40 @@ class MuSigTakeOfferRequestValidatorTest {
     }
 
     @Test
+    void mediatorWithForgedApplicationVersionIsRejected() {
+        // applicationVersion is excluded from UserProfile.equals but is hash-relevant for a
+        // version-1 profile, so the maker's selection and the contract's copy must agree on it,
+        // else a taker forges a different agent profile into the co-signed contract.
+        bisq.security.pow.ProofOfWork proofOfWork = org.mockito.Mockito.mock(bisq.security.pow.ProofOfWork.class);
+        org.mockito.Mockito.when(proofOfWork.getSolution()).thenReturn(new byte[72]);
+        NetworkId agentNetworkId = createNetworkId("dispute-agent", 9988, null);
+        UserProfile genuine = new UserProfile(1, "agent", proofOfWork, 0, agentNetworkId, "", "", "2.1.4");
+        UserProfile forged = new UserProfile(1, "agent", proofOfWork, 0, agentNetworkId, "", "", "9.9.9");
+        org.mockito.Mockito.when(mediationService.selectMediator(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(genuine));
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(2_000_000L));
+        MuSigContract contract = createContract(offer, 2_000_000L, 10_000_000L, offer.getPriceSpec(),
+                Optional.of(forged), Optional.of(arbitratorProfile));
+
+        assertEconomicsRejected(contract, TradeProtocolFailure.MEDIATORS_NOT_MATCHING);
+    }
+
+    @Test
+    void fiatObligationExceedingTheRailCapIsRejected() {
+        // The two-sided tolerance lets the USD quote sit up to 5% above the Bitcoin value, so the
+        // rail cap must be valued on the actual fiat obligation, not the Bitcoin side. 0.1 BTC at
+        // $50,000 is exactly the $5,000 ACH cap on the Bitcoin side, but a +5% quote is a $5,250
+        // ACH obligation above the cap.
+        assertEconomicsRejected(fiatContract(10_000_000L, 52_500_000L, new BaseSideFixedAmountSpec(10_000_000L)),
+                TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+        // The consistent $5,000 quote is at the cap and accepted.
+        assertEconomicsAccepted(fiatContract(10_000_000L, 50_000_000L, new BaseSideFixedAmountSpec(10_000_000L)));
+    }
+
+    @Test
     void arbitratorNotMatchingOwnSelectionIsRejected() {
         MuSigContract contract = fiatContract(2_000_000L, 10_000_000L);
         UserProfile myArbitrator = org.mockito.Mockito.mock(UserProfile.class);

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade.mu_sig.messages.network.handler.maker;
+
+import bisq.account.payment_method.PaymentMethodSpec;
+import bisq.account.payment_method.PaymentMethodSpecUtil;
+import bisq.account.payment_method.fiat.FiatPaymentMethod;
+import bisq.account.payment_method.fiat.FiatPaymentRail;
+import bisq.common.market.Market;
+import bisq.common.monetary.PriceQuote;
+import bisq.common.network.AddressByTransportTypeMap;
+import bisq.common.network.ClearnetAddress;
+import bisq.common.network.TransportType;
+import bisq.contract.ContractService;
+import bisq.contract.ContractSignatureData;
+import bisq.contract.mu_sig.MuSigContract;
+import bisq.network.identity.NetworkId;
+import bisq.offer.Direction;
+import bisq.offer.amount.spec.BaseSideFixedAmountSpec;
+import bisq.offer.mu_sig.MuSigOffer;
+import bisq.offer.price.spec.FixPriceSpec;
+import bisq.security.keys.KeyGeneration;
+import bisq.security.keys.PubKey;
+import bisq.trade.Trade;
+import bisq.trade.exceptions.TradeProtocolException;
+import bisq.trade.exceptions.TradeProtocolFailure;
+import bisq.trade.mu_sig.messages.network.SetupTradeMessage_A;
+import bisq.trade.mu_sig.messages.network.mu_sig_data.PubKeyShares;
+import org.junit.jupiter.api.Test;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MuSigTakeOfferRequestValidatorTest {
+    private static final KeyPair TAKER_KEY_PAIR = KeyGeneration.generateDefaultEcKeyPair();
+    private static final NetworkId OFFER_MAKER_NETWORK_ID = createNetworkId("offer-maker", 9997, null);
+    private static final NetworkId TAKER_NETWORK_ID = createNetworkId("taker", 9999, TAKER_KEY_PAIR);
+    private static final NetworkId OTHER_NETWORK_ID = createNetworkId("other", 9996, null);
+
+    private final ContractService contractService = new ContractService(null);
+
+    @Test
+    void validRequestPasses() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+
+        assertThatCode(() -> MuSigTakeOfferRequestValidator.validateIdentity(contractService, message))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void senderNotMatchingContractTakerIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, OTHER_NETWORK_ID, sign(contract, TAKER_KEY_PAIR));
+
+        assertRejected(message);
+    }
+
+    @Test
+    void signatureFromForeignKeyIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        KeyPair attackerKeyPair = KeyGeneration.generateDefaultEcKeyPair();
+        // The signature is internally consistent - hash and key match the signature - but the
+        // key is not the taker's; without the binding check the maker would accept it.
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, sign(contract, attackerKeyPair));
+
+        assertRejected(message);
+    }
+
+    @Test
+    void tamperedSignatureIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        ContractSignatureData signatureData = sign(contract, TAKER_KEY_PAIR);
+        byte[] tamperedSignature = signatureData.getSignature().clone();
+        // Flip a bit in the middle of the signature bits, not the DER framing: the verifier
+        // must return false on a well-formed but incorrect signature, not merely throw on a
+        // malformed encoding.
+        tamperedSignature[tamperedSignature.length / 2] ^= 0x01;
+        ContractSignatureData tampered = new ContractSignatureData(signatureData.getContractHash(),
+                tamperedSignature,
+                signatureData.getPublicKey());
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, tampered);
+
+        assertRejected(message);
+    }
+
+    @Test
+    void receiverNotMatchingOfferMakerIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, OTHER_NETWORK_ID,
+                sign(contract, TAKER_KEY_PAIR),
+                Trade.createId(contract.getOffer().getId(),
+                        contract.getTaker().getNetworkId().getId(),
+                        contract.getTakeOfferDate()));
+
+        assertRejected(message);
+    }
+
+    @Test
+    void tradeIdNotDerivedFromContractIsRejected() throws GeneralSecurityException {
+        MuSigContract contract = createContract();
+        // The contract itself is validly signed; only the claimed trade id differs from the id
+        // the maker derives, which would otherwise persist a failed trade per crafted message.
+        SetupTradeMessage_A message = createMessage(contract, TAKER_NETWORK_ID, OFFER_MAKER_NETWORK_ID,
+                sign(contract, TAKER_KEY_PAIR), "crafted-trade-id");
+
+        assertRejected(message);
+    }
+
+    private void assertRejected(SetupTradeMessage_A message) {
+        assertThatThrownBy(() -> MuSigTakeOfferRequestValidator.validateIdentity(contractService, message))
+                .isInstanceOf(TradeProtocolException.class)
+                .satisfies(e -> org.assertj.core.api.Assertions.assertThat(
+                                ((TradeProtocolException) e).getTradeProtocolFailure())
+                        .isEqualTo(TradeProtocolFailure.OFFER_NOT_AVAILABLE));
+    }
+
+    private ContractSignatureData sign(MuSigContract contract, KeyPair keyPair) throws GeneralSecurityException {
+        return contractService.signContract(contract, keyPair);
+    }
+
+    private static SetupTradeMessage_A createMessage(MuSigContract contract,
+                                                     NetworkId sender,
+                                                     ContractSignatureData contractSignatureData) {
+        return createMessage(contract, sender, OFFER_MAKER_NETWORK_ID, contractSignatureData,
+                Trade.createId(contract.getOffer().getId(),
+                        contract.getTaker().getNetworkId().getId(),
+                        contract.getTakeOfferDate()));
+    }
+
+    private static SetupTradeMessage_A createMessage(MuSigContract contract,
+                                                     NetworkId sender,
+                                                     NetworkId receiver,
+                                                     ContractSignatureData contractSignatureData,
+                                                     String tradeId) {
+        return new SetupTradeMessage_A("message-id",
+                tradeId,
+                "1.0.0",
+                sender,
+                receiver,
+                contract,
+                contractSignatureData,
+                PubKeyShares.fromProto(bisq.trade.protobuf.PubKeyShares.newBuilder()
+                        .setBuyerOutputPubKeyShare(com.google.protobuf.ByteString.copyFrom(new byte[33]))
+                        .setSellerOutputPubKeyShare(com.google.protobuf.ByteString.copyFrom(new byte[33]))
+                        .setMultisigScriptKey(com.google.protobuf.ByteString.copyFrom(new byte[33]))
+                        .build()));
+    }
+
+    private static MuSigContract createContract() {
+        Market market = new Market("BTC", "USD", "Bitcoin", "US Dollar");
+        PaymentMethodSpec<?> nonBtcPaymentMethodSpec = PaymentMethodSpecUtil.createPaymentMethodSpec(
+                FiatPaymentMethod.fromPaymentRail(FiatPaymentRail.ACH_TRANSFER),
+                "USD");
+        MuSigOffer offer = new MuSigOffer("test-id",
+                OFFER_MAKER_NETWORK_ID,
+                Direction.BUY,
+                market,
+                new BaseSideFixedAmountSpec(111L),
+                new FixPriceSpec(PriceQuote.fromFiatPrice(50_000, "USD")),
+                List.of(nonBtcPaymentMethodSpec.getPaymentMethod()),
+                List.of(),
+                "1.0.0");
+        return new MuSigContract(1_700_000_000_000L,
+                offer,
+                TAKER_NETWORK_ID,
+                111L,
+                222L,
+                nonBtcPaymentMethodSpec,
+                new byte[20],
+                Optional.empty(),
+                Optional.empty(),
+                offer.getPriceSpec(),
+                0);
+    }
+
+    private static NetworkId createNetworkId(String keyIdSuffix, int port, KeyPair keyPair) {
+        AddressByTransportTypeMap addresses = new AddressByTransportTypeMap(Map.of(
+                TransportType.CLEAR, new ClearnetAddress("127.0.0.1", port)));
+        KeyPair pair = keyPair != null ? keyPair : KeyGeneration.generateDefaultEcKeyPair();
+        PubKey pubKey = new PubKey(pair.getPublic(), "test-key-" + keyIdSuffix);
+        return new NetworkId(addresses, pubKey);
+    }
+}


### PR DESCRIPTION
Adds the maker-side take-offer validations the MuSig protocol was missing, so a
`SetupTradeMessage_A` is fully checked before any trade, protocol or contact-list
entry is created. This covers the validation gaps from the issue (items 1-3, and
the persist-before-verify concern); the trade fee / deposit hardcoding is left out
of scope and tracked separately.

The maker now validates the request in `MuSigTradeService.handleMuSigTakeOfferMessage`
before `makerCreatesProtocol`, and drops it on failure. The checks live in a new
`MuSigTakeOfferRequestValidator`:

- **Identity** — the message sender equals the contract's taker network id; the
  sender and contract-signature public keys are the taker's; the signature verifies;
  the receiver is the offer's maker; the message trade id equals the id derived from
  the contract.
- **Offer liveness** — the embedded offer must be one of the maker's currently
  activated offers and equal to the retained offer (compared by its serialize-for-hash
  form, which also covers the currency names that `equals` omits). No fallback to an
  existing trade, so a cached copy of a removed offer cannot be replayed. The contract's
  protocol type and party roles are pinned, and its take date cannot predate the offer.
- **Economics** — positive amounts; the contract price spec equals the offer's; a
  present taker account-payload commitment; payment-method-spec membership; the
  amount-spec-pinned side matches the offer exactly and the free side is within the
  configured price tolerance in both directions (an inflated favorable side cannot slip
  past the rail cap); absolute and payment-rail USD limits, valued with exact arithmetic
  against a single fresh market-price snapshot; and the deterministic mediator and
  arbitrator selections, compared over the whole profile.

Two follow-up commits address the creation path:

- Creation is serialized under a lock so two concurrent same-id requests cannot race a
  second trade/protocol into the registries or throw on the network thread, and the
  peer is added to the contact list only after the handler has verified and processed
  the request (best-effort, so it cannot fail the trade).
- A review pass tightened three residuals: the rail cap is valued on the actual USD
  obligation for USD-quoted markets, the dispute-agent comparison covers the profile's
  version metadata, and the maker identity/account lookups drop cleanly (requiring an
  active identity) instead of throwing.

### Commits

- Validate take offer identity before trade creation
- Reject takes of offers that are not live own offers
- Move MuSig trade limits policy to the offer module
- Validate take offer economics on the maker side
- Serialize maker-side take offer trade creation
- Harden take offer validation from review findings

### Testing

`MuSigTakeOfferRequestValidator` has unit tests covering each check and its bypass
attempts (identity/signature binding, offer liveness and equality, price tolerance in
both directions and both price regimes, USD/rail limits and overflow, dispute-agent
forgery, take date, currency-name and role forgery). `:trade`, `:mu-sig`, `:contract`
and `:common` suites pass. The `MuSigTradeService` / handler changes (the gate wiring,
the creation lock and the contact-add relocation) are verified by inspection, matching
how the equivalent Bisq Easy handler wiring is covered.

### Known limitations / follow-ups

These are pre-existing and bounded; I kept them out to keep the change focused:

- A taker can open more than one trade against a single offer by varying `takeOfferDate`
  (a different trade id each time). The creation lock only prevents same-id races. Bounding
  this needs a product decision — MuSig currently allows retaking an offer — so I did not
  want to enforce a one-take-per-offer rule here. **How would you like takes-per-offer
  bounded given retake is allowed?**
- The rail-cap obligation is valued exactly only for USD-quoted markets; other fiat and
  altcoin quotes keep the tolerance-bounded (~5%) approximation until a fiat/USD conversion
  is added.
- `MuSigContract.marketPrice`, the offer version strings and `protocolVersion` are
  taker-supplied and hash-relevant but not consumed by any calculation; they are persisted
  as-is rather than canonicalized.
- `takeOfferDate` is only required to be at or after the offer date; the generic date
  bound still allows up to ~2h in the future.
- `PubKeyShares.verify()` is still a TODO on main.

### Remarks

- The "Validate take offer economics" commit message says the dispute-agent selections are
  compared "by their full serialized form"; the final code compares the profile field by
  field (equals plus the three version fields), which is equivalent. The last commit
  implements that precisely.

Fixes #4927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for MuSig offer requests, including identities, offers, payment details, prices, limits, and dispute-agent assignments.
  * Added activated-offer lookup, payment-rail-specific trade limits, and sanitized logging.
  * Improved handling of invalid, duplicate, ignored, and concurrent trade requests.

* **Bug Fixes**
  * Prevented contact-list update failures from interrupting accepted trades.
  * Improved rejection reporting for invalid trade requests.

* **Tests**
  * Added coverage for validation, trade limits, offer handling, concurrency, and rejection reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->