### PR TITLE
chore: sync #4929 to main — bugfix/android_sequenced_collection_crash_inventory_request_policy

### DIFF
--- a/common/src/main/java/bisq/common/facades/JdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/JdkFacade.java
@@ -17,6 +17,7 @@
 
 package bisq.common.facades;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -36,4 +37,13 @@ public interface JdkFacade {
     void redirectError(ProcessBuilder processBuilder);
 
     void redirectOutput(ProcessBuilder processBuilder);
+
+    // The JDK 21 SequencedCollection methods List.removeFirst()/addFirst()/getFirst() only exist on
+    // Android 15+ (API 35) and crash older devices with NoSuchMethodError.
+
+    <T> T removeFirst(List<T> list);
+
+    <T> void addFirst(List<T> list, T element);
+
+    <T> T getFirst(List<T> list);
 }

--- a/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
@@ -20,6 +20,7 @@ package bisq.common.facades.android;
 import bisq.common.facades.JdkFacade;
 
 import java.io.File;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class AndroidJdkFacade implements JdkFacade {
@@ -51,5 +52,22 @@ public class AndroidJdkFacade implements JdkFacade {
     public void redirectOutput(ProcessBuilder processBuilder) {
         // ProcessBuilder.Redirect.DISCARD not supported on Android
         processBuilder.redirectError(new File("/dev/null"));
+    }
+
+    @Override
+    public <T> T removeFirst(List<T> list) {
+        // List.removeFirst/addFirst crash Android below API 35
+        return list.remove(0);
+    }
+
+    @Override
+    public <T> void addFirst(List<T> list, T element) {
+        // List.removeFirst/addFirst crash Android below API 35
+        list.add(0, element);
+    }
+
+    @Override
+    public <T> T getFirst(List<T> list) {
+        return list.get(0);
     }
 }

--- a/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
+++ b/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
@@ -21,6 +21,7 @@ import bisq.common.facades.JdkFacade;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.management.ManagementFactory;
+import java.util.List;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -44,5 +45,20 @@ public class JavaSeJdkFacade implements JdkFacade {
     @Override
     public void redirectOutput(ProcessBuilder processBuilder) {
         processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+    }
+
+    @Override
+    public <T> T removeFirst(List<T> list) {
+        return list.removeFirst();
+    }
+
+    @Override
+    public <T> void addFirst(List<T> list, T element) {
+        list.addFirst(element);
+    }
+
+    @Override
+    public <T> T getFirst(List<T> list) {
+        return list.getFirst();
     }
 }

--- a/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
+++ b/network/network/src/main/java/bisq/network/p2p/node/authorization/AuthorizationService.java
@@ -139,7 +139,7 @@ public class AuthorizationService {
         return myPreferredAuthorizationTokenTypes.stream()
                 .filter(peersAuthorizationTokenTypes::contains)
                 .findFirst()
-                .orElseGet(peersAuthorizationTokenTypes::getFirst);
+                .orElseGet(() -> peersAuthorizationTokenTypes.get(0));
     }
 
     private static List<AuthorizationTokenType> toAuthorizationTypes(Collection<Feature> features) {

--- a/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestPolicy.java
+++ b/network/network/src/main/java/bisq/network/p2p/services/data/inventory/InventoryRequestPolicy.java
@@ -17,6 +17,7 @@
 
 package bisq.network.p2p.services.data.inventory;
 
+import bisq.common.facades.FacadeProvider;
 import bisq.common.network.Address;
 import bisq.common.util.CollectionUtil;
 import bisq.network.p2p.node.Connection;
@@ -132,11 +133,11 @@ class InventoryRequestPolicy {
                 .limit(config.getMaxSeedsForRequest())
                 .collect(Collectors.toCollection(ArrayList::new));
         if (!seeds.isEmpty()) {
-            Connection selectedSeed = seeds.removeFirst();
+            Connection selectedSeed = FacadeProvider.getJdkFacade().removeFirst(seeds);
             candidates.addAll(seeds);
 
             candidates = CollectionUtil.toShuffledList(candidates);
-            candidates.addFirst(selectedSeed); // ensure seed at front
+            FacadeProvider.getJdkFacade().addFirst(candidates, selectedSeed); // ensure seed at front
         }
 
         int limit = config.getMaxPendingRequestsAtPeriodicRequests();


### PR DESCRIPTION
Automated sync of #4929 from `for-mobile-based-on-2.1.11` to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for list operations across Android and Java environments.
  * Prevented unsupported modern list APIs from affecting Android devices.
  * Preserved reliable peer authorization fallback selection.
  * Maintained seed connection ordering while improving cross-platform handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->