### PR TITLE
bugfix/android_api_33_bootstrap_tor_fails

### DIFF
--- a/common/src/main/java/bisq/common/facades/JdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/JdkFacade.java
@@ -18,6 +18,9 @@
 package bisq.common.facades;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -46,4 +49,10 @@ public interface JdkFacade {
     <T> void addFirst(List<T> list, T element);
 
     <T> T getFirst(List<T> list);
+
+    // CompletableFuture.exceptionallyCompose is JDK 12+; on Android it only exists from API 34
+    // and crashes older devices with NoSuchMethodError.
+
+    <T> CompletableFuture<T> exceptionallyCompose(CompletableFuture<T> future,
+                                                  Function<Throwable, ? extends CompletionStage<T>> fn);
 }

--- a/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
+++ b/common/src/main/java/bisq/common/facades/android/AndroidJdkFacade.java
@@ -21,6 +21,10 @@ import bisq.common.facades.JdkFacade;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class AndroidJdkFacade implements JdkFacade {
@@ -69,5 +73,47 @@ public class AndroidJdkFacade implements JdkFacade {
     @Override
     public <T> T getFirst(List<T> list) {
         return list.get(0);
+    }
+
+    @Override
+    public <T> CompletableFuture<T> exceptionallyCompose(CompletableFuture<T> future,
+                                                         Function<Throwable, ? extends CompletionStage<T>> fn) {
+        // CompletableFuture.exceptionallyCompose crashes Android below API 34.
+        // An explicit result future rather than handle().thenCompose(): cancelling the returned
+        // future must suppress the recovery function, as the native method does. With the chained
+        // form only the last stage gets cancelled, so fn would still run when the source fails
+        // later — in HttpRequestService that would continue the provider failover of a cancelled
+        // request. Like the native method, cancelling the result does not cancel the source, and a
+        // recovery already in flight is not interrupted.
+        CompletableFuture<T> result = new CompletableFuture<>();
+        future.whenComplete((value, throwable) -> {
+            if (result.isDone()) {
+                return;
+            }
+            if (throwable == null) {
+                result.complete(value);
+            } else {
+                try {
+                    fn.apply(throwable).whenComplete((recovered, recoveryThrowable) -> {
+                        if (recoveryThrowable == null) {
+                            result.complete(recovered);
+                        } else {
+                            // Wrapped like the native relay: observers see CompletionException, and a
+                            // cancelled recovery stage does not report the result as cancelled.
+                            result.completeExceptionally(asCompletionException(recoveryThrowable));
+                        }
+                    });
+                } catch (Throwable t) {
+                    result.completeExceptionally(asCompletionException(t));
+                }
+            }
+        });
+        return result;
+    }
+
+    private static CompletionException asCompletionException(Throwable throwable) {
+        return throwable instanceof CompletionException completionException
+                ? completionException
+                : new CompletionException(throwable);
     }
 }

--- a/common/src/test/java/bisq/common/facades/android/AndroidJdkFacadeTest.java
+++ b/common/src/test/java/bisq/common/facades/android/AndroidJdkFacadeTest.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.facades.android;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AndroidJdkFacadeTest {
+    private final AndroidJdkFacade facade = new AndroidJdkFacade(0);
+
+    // The fallback must mirror CompletableFuture.exceptionallyCompose, which is not available
+    // on Android below API 34.
+
+    @Test
+    void exceptionallyCompose_successfulFuture_doesNotInvokeHandler() {
+        AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.completedFuture("value"),
+                throwable -> {
+                    handlerInvoked.set(true);
+                    return CompletableFuture.completedFuture("recovered");
+                });
+
+        assertThat(result.join()).isEqualTo("value");
+        assertThat(handlerInvoked.get()).isFalse();
+    }
+
+    @Test
+    void exceptionallyCompose_failedFuture_composesRecovery() {
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.failedFuture(new IOException("boom")),
+                throwable -> CompletableFuture.completedFuture("recovered"));
+
+        assertThat(result.join()).isEqualTo("recovered");
+    }
+
+    @Test
+    void exceptionallyCompose_handlerReceivesWrappedExceptionLikeJdkImplementation() throws ExecutionException, InterruptedException {
+        IOException cause = new IOException("boom");
+        CompletableFuture<Throwable> observed = new CompletableFuture<>();
+
+        facade.exceptionallyCompose(
+                CompletableFuture.<String>supplyAsync(() -> {
+                    throw new CompletionException(cause);
+                }),
+                throwable -> {
+                    observed.complete(throwable);
+                    return CompletableFuture.completedFuture("recovered");
+                }).join();
+
+        assertThat(observed.get()).isInstanceOf(CompletionException.class).hasCause(cause);
+    }
+
+    @Test
+    void exceptionallyCompose_cancelledResult_suppressesRecoveryHandler() {
+        // Native exceptionallyCompose does not invoke the handler once its dependent future is
+        // cancelled; the fallback must match, or a cancelled HttpRequestService request would keep
+        // walking the provider failover chain.
+        CompletableFuture<String> source = new CompletableFuture<>();
+        AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+        CompletableFuture<String> result = facade.exceptionallyCompose(source, throwable -> {
+            handlerInvoked.set(true);
+            return CompletableFuture.completedFuture("recovered");
+        });
+
+        result.cancel(true);
+        source.completeExceptionally(new IOException("boom"));
+
+        assertThat(handlerInvoked.get()).isFalse();
+        assertThat(result.isCancelled()).isTrue();
+    }
+
+    @Test
+    void exceptionallyCompose_cancelledResult_staysCancelledOnSourceSuccess() {
+        CompletableFuture<String> source = new CompletableFuture<>();
+        CompletableFuture<String> result =
+                facade.exceptionallyCompose(source, throwable -> CompletableFuture.completedFuture("recovered"));
+
+        result.cancel(true);
+        source.complete("value");
+
+        assertThat(result.isCancelled()).isTrue();
+    }
+
+    @Test
+    void exceptionallyCompose_handlerReturningFailedFuture_propagatesFailure() {
+        IllegalStateException replacement = new IllegalStateException("replaced");
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.failedFuture(new IOException("boom")),
+                throwable -> CompletableFuture.failedFuture(replacement));
+
+        assertThatThrownBy(result::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(replacement);
+    }
+
+    // The native relay wraps a recovery failure in CompletionException before completing the
+    // dependent, so observers (whenComplete/handle) see the wrapper, not the raw cause, and a
+    // cancelled recovery stage surfaces as a failure rather than cancelling the result.
+
+    @Test
+    void exceptionallyCompose_failedRecovery_observersSeeCompletionExceptionLikeJdk() throws ExecutionException, InterruptedException {
+        IllegalStateException replacement = new IllegalStateException("replaced");
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.failedFuture(new IOException("boom")),
+                throwable -> CompletableFuture.failedFuture(replacement));
+
+        CompletableFuture<Throwable> observed = new CompletableFuture<>();
+        result.whenComplete((value, throwable) -> observed.complete(throwable));
+
+        assertThat(observed.get()).isInstanceOf(CompletionException.class).hasCause(replacement);
+    }
+
+    @Test
+    void exceptionallyCompose_cancelledRecovery_failsResultWithoutCancellingItLikeJdk() throws ExecutionException, InterruptedException {
+        CompletableFuture<String> recovery = new CompletableFuture<>();
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.failedFuture(new IOException("boom")),
+                throwable -> recovery);
+
+        recovery.cancel(true);
+
+        CompletableFuture<Throwable> observed = new CompletableFuture<>();
+        result.whenComplete((value, throwable) -> observed.complete(throwable));
+
+        assertThat(result.isCancelled()).isFalse();
+        assertThat(observed.get())
+                .isInstanceOf(CompletionException.class)
+                .cause()
+                .isInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    void exceptionallyCompose_throwingHandler_observersSeeCompletionExceptionLikeJdk() throws ExecutionException, InterruptedException {
+        RuntimeException handlerFailure = new RuntimeException("handler blew up");
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.failedFuture(new IOException("boom")),
+                throwable -> {
+                    throw handlerFailure;
+                });
+
+        CompletableFuture<Throwable> observed = new CompletableFuture<>();
+        result.whenComplete((value, throwable) -> observed.complete(throwable));
+
+        assertThat(observed.get()).isInstanceOf(CompletionException.class).hasCause(handlerFailure);
+    }
+
+    @Test
+    void exceptionallyCompose_recoveryFailingWithCompletionException_isNotDoubleWrappedLikeJdk() throws ExecutionException, InterruptedException {
+        RuntimeException cause = new RuntimeException("pre-wrapped");
+        CompletableFuture<String> result = facade.exceptionallyCompose(
+                CompletableFuture.failedFuture(new IOException("boom")),
+                throwable -> CompletableFuture.failedFuture(new CompletionException(cause)));
+
+        CompletableFuture<Throwable> observed = new CompletableFuture<>();
+        result.whenComplete((value, throwable) -> observed.complete(throwable));
+
+        assertThat(observed.get()).isInstanceOf(CompletionException.class).hasCause(cause);
+    }
+}

--- a/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
+++ b/java-se/src/main/java/bisq/java_se/facades/JavaSeJdkFacade.java
@@ -22,6 +22,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.lang.management.ManagementFactory;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -60,5 +63,11 @@ public class JavaSeJdkFacade implements JdkFacade {
     @Override
     public <T> T getFirst(List<T> list) {
         return list.getFirst();
+    }
+
+    @Override
+    public <T> CompletableFuture<T> exceptionallyCompose(CompletableFuture<T> future,
+                                                         Function<Throwable, ? extends CompletionStage<T>> fn) {
+        return future.exceptionallyCompose(fn);
     }
 }

--- a/network/network/src/main/java/bisq/network/http/HttpRequestService.java
+++ b/network/network/src/main/java/bisq/network/http/HttpRequestService.java
@@ -19,6 +19,7 @@ package bisq.network.http;
 
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
+import bisq.common.facades.FacadeProvider;
 import bisq.common.network.TransportType;
 import bisq.common.observable.Observable;
 import bisq.common.threading.ExecutorFactory;
@@ -186,20 +187,20 @@ public abstract class HttpRequestService<T, R> implements Service {
     }
 
     private CompletableFuture<R> requestWithFailover(T requestData, AtomicInteger recursionDepth) {
-        return request(requestData, recursionDepth)
-                .exceptionallyCompose(throwable -> {
-                    ProviderFailoverException providerFailoverException = null;
-                    if (throwable instanceof ProviderFailoverException e1) {
-                        providerFailoverException = e1;
-                    } else if (ExceptionUtil.getRootCause(throwable) instanceof ProviderFailoverException e2) {
-                        providerFailoverException = e2;
-                    }
-                    if (providerFailoverException != null) {
-                        return requestWithFailover(requestData, providerFailoverException.getRecursionDepth());
-                    }
+        // exceptionallyCompose goes via the JdkFacade as Android only provides it from API 34
+        return FacadeProvider.getJdkFacade().exceptionallyCompose(request(requestData, recursionDepth), throwable -> {
+            ProviderFailoverException providerFailoverException = null;
+            if (throwable instanceof ProviderFailoverException e1) {
+                providerFailoverException = e1;
+            } else if (ExceptionUtil.getRootCause(throwable) instanceof ProviderFailoverException e2) {
+                providerFailoverException = e2;
+            }
+            if (providerFailoverException != null) {
+                return requestWithFailover(requestData, providerFailoverException.getRecursionDepth());
+            }
 
-                    return CompletableFuture.failedFuture(throwable);
-                });
+            return CompletableFuture.failedFuture(throwable);
+        });
     }
 
     private CompletableFuture<R> request(T requestData, AtomicInteger recursionDepth) {
@@ -213,7 +214,7 @@ public abstract class HttpRequestService<T, R> implements Service {
         HttpRequestUrlProvider providerForThisRequest = checkNotNull(selectedProvider.get(), "Selected provider must not be null.");
         HttpRequest httpRequest = buildRequest(providerForThisRequest, requestData);
         try {
-            return CompletableFuture.supplyAsync(() -> {
+            CompletableFuture<R> requestFuture = CompletableFuture.supplyAsync(() -> {
                         // For POST the path is appended to the http-client baseUrl when the
                         // client is constructed, since BaseHttpClient.post(param, header) treats
                         // 'param' as the body. TODO: refactor BaseHttpClient.post to accept
@@ -303,24 +304,25 @@ public abstract class HttpRequestService<T, R> implements Service {
                             }
                         }
                     }, executorService)
-                    .orTimeout(conf.getTimeoutInSeconds(), SECONDS)
-                    .exceptionallyCompose(throwable -> {
-                        if (ExceptionUtil.getRootCause(throwable) instanceof TimeoutException) {
-                            log.warn("Request to provider {} timed out after {} seconds",
-                                    providerForThisRequest.getBaseUrl(), conf.getTimeoutInSeconds());
-                            if (!isServerErrorRetryAllowed(httpRequest)) {
-                                return CompletableFuture.failedFuture(new RuntimeException(
-                                        "Timeout. Non-idempotent POST — not retrying. Provider=" + providerForThisRequest.getBaseUrl(),
-                                        throwable));
-                            }
-                            boolean shouldRetry = shouldRetry(recursionDepth, providerForThisRequest, true);
-                            Exception exception = shouldRetry
-                                    ? new ProviderFailoverException("Timeout. Retrying with next provider " + selectedProvider.get().getBaseUrl(), recursionDepth)
-                                    : new RuntimeException("Timeout. We failed at all possible providers and give up. Provider=" + providerForThisRequest.getBaseUrl());
-                            return CompletableFuture.failedFuture(exception);
-                        }
-                        return CompletableFuture.failedFuture(throwable);
-                    });
+                    .orTimeout(conf.getTimeoutInSeconds(), SECONDS);
+            // exceptionallyCompose goes via the JdkFacade as Android only provides it from API 34
+            return FacadeProvider.getJdkFacade().exceptionallyCompose(requestFuture, throwable -> {
+                if (ExceptionUtil.getRootCause(throwable) instanceof TimeoutException) {
+                    log.warn("Request to provider {} timed out after {} seconds",
+                            providerForThisRequest.getBaseUrl(), conf.getTimeoutInSeconds());
+                    if (!isServerErrorRetryAllowed(httpRequest)) {
+                        return CompletableFuture.failedFuture(new RuntimeException(
+                                "Timeout. Non-idempotent POST — not retrying. Provider=" + providerForThisRequest.getBaseUrl(),
+                                throwable));
+                    }
+                    boolean shouldRetry = shouldRetry(recursionDepth, providerForThisRequest, true);
+                    Exception exception = shouldRetry
+                            ? new ProviderFailoverException("Timeout. Retrying with next provider " + selectedProvider.get().getBaseUrl(), recursionDepth)
+                            : new RuntimeException("Timeout. We failed at all possible providers and give up. Provider=" + providerForThisRequest.getBaseUrl());
+                    return CompletableFuture.failedFuture(exception);
+                }
+                return CompletableFuture.failedFuture(throwable);
+            });
         } catch (RejectedExecutionException e) {
             log.error("Executor rejected request task.", e);
             return CompletableFuture.failedFuture(e);


### PR DESCRIPTION
 - resolves https://github.com/bisq-network/bisq-mobile/issues/1741
 - used JdkFacade to separate Android-specific Java8 compatible code o avoid tor bootstraping issue in Android node API 33 + tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous error handling for HTTP requests across supported platforms.
  * Preserved request retry, failover, timeout, cancellation, and error propagation behavior.
  * Enhanced Android compatibility when recovering from failed operations.

* **Tests**
  * Added coverage for successful operations, failure recovery, wrapped exceptions, cancellation scenarios, and recovery-handler failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->