### PR TITLE
feature/granular_based_api_sub_versioning_for_dockerized_distros

### DIFF
--- a/api/src/main/java/bisq/api/dto/settings/SettingsApiVersionDto.java
+++ b/api/src/main/java/bisq/api/dto/settings/SettingsApiVersionDto.java
@@ -17,5 +17,9 @@
 
 package bisq.api.dto.settings;
 
-public record SettingsApiVersionDto(String version) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+// imageVersion is only present on containerised distributions (see SettingsRestApi.resolveImageVersion)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SettingsApiVersionDto(String version, String imageVersion) {
 }

--- a/api/src/main/java/bisq/api/rest_api/endpoints/settings/SettingsRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/settings/SettingsRestApi.java
@@ -70,15 +70,25 @@ public class SettingsRestApi extends RestApiBase {
 
     @GET
     @Path("/version")
-    @Operation(description = "Get the current Bisq2 version")
+    @Operation(description = "Get the current Bisq2 version. Containerised distributions additionally report " +
+            "their granular image version (e.g. 2.1.11.2) as imageVersion via BISQ_IMAGE_VERSION.")
     public Response getVersion() {
         try {
             String version = ApplicationVersion.getVersion().toString();
-            return Response.ok(new SettingsApiVersionDto(version)).build();
+            String imageVersion = resolveImageVersion(System.getenv("BISQ_IMAGE_VERSION"));
+            return Response.ok(new SettingsApiVersionDto(version, imageVersion)).build();
         } catch (Exception e) {
             log.error("Error getting version", e);
             return buildErrorResponse("An unexpected error occurred: " + e.getMessage());
         }
+    }
+
+    // Clients key caches of static node config on the reported version, so a distribution that can be
+    // updated in place under the same core version (docker image rebuilds) reports the per-image release
+    // in a separate field. version itself must stay the plain core version: deployed clients parse it
+    // strictly as MAJOR.MINOR.PATCH and refuse the connection otherwise.
+    static String resolveImageVersion(String imageVersion) {
+        return imageVersion == null || imageVersion.isBlank() ? null : imageVersion.trim();
     }
 
     @PATCH

--- a/api/src/test/java/bisq/api/rest_api/endpoints/settings/SettingsRestApiVersionTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/settings/SettingsRestApiVersionTest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.settings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SettingsRestApiVersionTest {
+    @Test
+    void reportsNoImageVersionWhenNotSet() {
+        assertThat(SettingsRestApi.resolveImageVersion(null)).isNull();
+        assertThat(SettingsRestApi.resolveImageVersion("")).isNull();
+        assertThat(SettingsRestApi.resolveImageVersion("   ")).isNull();
+    }
+
+    @Test
+    void reportsGranularImageVersionWhenSet() {
+        assertThat(SettingsRestApi.resolveImageVersion("2.1.11.2")).isEqualTo("2.1.11.2");
+        assertThat(SettingsRestApi.resolveImageVersion(" 2.1.11.3-rc1 ")).isEqualTo("2.1.11.3-rc1");
+    }
+}

--- a/apps/api-app/docker/Dockerfile
+++ b/apps/api-app/docker/Dockerfile
@@ -76,6 +76,13 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # entrypoint's chown is a no-op. See entrypoint.sh.
 WORKDIR /opt/bisq2-api
 
+# Granular distribution version (e.g. 2.1.11.2) reported by the /settings/version endpoint as
+# imageVersion, alongside the unchanged core version. Paired clients key config caches on it, so
+# it must change with every image release even when the core version does not. Stamped by the
+# release workflow; empty (field omitted) for ad-hoc local builds.
+ARG IMAGE_VERSION=""
+ENV BISQ_IMAGE_VERSION=$IMAGE_VERSION
+
 # Single mount for all persistent state (identity, db, tor, pairing) so a host-level
 # backup of this one directory captures everything.
 ENV BISQ_DATA_DIR=/data


### PR DESCRIPTION
 - ade version api return system variable versioning config if available, otherwise default to current impl
 - setup docker file to allow IMAGE_VERSION argument and share as env var BISQ_IMAGE_VERSION so that IMAGE_VERSION is used on each platform setup
 - this allows for dockerised distrib to return granular versioning first hand (e.g. 2.1.11.3), making distribution of new features detection more robust

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version reporting now includes a release-specific image version when available, alongside the core application version.
  * Image version values are trimmed for consistent display, with blank or missing values omitted.
  * Container builds can provide a release version for runtime reporting.

* **Documentation**
  * Updated version endpoint documentation to describe the optional image version field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->