### PR TITLE
Select macOS update installers by architecture

### DIFF
--- a/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/ReleaseBinariesTaskFactory.kt
+++ b/build-logic/packaging/src/main/kotlin/bisq/gradle/packaging/ReleaseBinariesTaskFactory.kt
@@ -46,9 +46,13 @@ class ReleaseBinariesTaskFactory(private val project: Project) {
                         .replace("-1.x86_64", "")
                 val fileWithoutExtension = canonicalFileName.substring(0, canonicalFileName.length - 4)
                 val fileExtension = canonicalFileName.substring(canonicalFileName.length - 4, canonicalFileName.length)
-                val platformName = getPlatform().platformName
-                // E.g. Bisq-2.0.4-macos_arm64.dmg
-                "$fileWithoutExtension-$platformName$fileExtension"
+                val platform = getPlatform()
+                val platformName = platform.platformName
+                when (platform) {
+                    Platform.MACOS_X86_64 -> canonicalFileName.replaceFirst("Bisq-", "Bisq-x86_64-")
+                    Platform.MACOS_ARM_64 -> canonicalFileName.replaceFirst("Bisq-", "Bisq-aarch64-")
+                    else -> "$fileWithoutExtension-$platformName$fileExtension"
+                }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,8 +89,8 @@ val bisq2InstallerReleaseAssets = listOf(
     "Bisq-%s-linux_arm64.deb",
     "Bisq-%s-linux_x86_64.rpm",
     "Bisq-%s-linux_arm64.rpm",
-    "Bisq-%s-macos_x86_64.dmg",
-    "Bisq-%s-macos_arm64.dmg",
+    "Bisq-x86_64-%s.dmg",
+    "Bisq-aarch64-%s.dmg",
     "Bisq-%s-win_x86_64.exe",
     "Bisq-%s-win_x86_64.msi",
 )

--- a/docs/specifications/updater/installer-download-selection.md
+++ b/docs/specifications/updater/installer-download-selection.md
@@ -1,0 +1,12 @@
+# Installer Download Selection
+
+## Runtime Platform Binding
+
+An in-app launcher update must download the installer and detached signature for the operating system and architecture running the application. The selected filename must match the corresponding signed release asset.
+
+macOS release assets are architecture-specific:
+
+- Intel (`x86_64`) uses `Bisq-x86_64-<version>.dmg`.
+- Apple Silicon (`arm64`) uses `Bisq-aarch64-<version>.dmg`.
+
+The updater must not use the generic `Bisq-<version>.dmg` target on macOS because that name does not identify which architecture the image supports. Installer naming for platforms with a single published architecture remains unchanged.

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterUtils.java
@@ -20,6 +20,7 @@ package bisq.evolution.updater;
 import bisq.common.file.FileReaderUtils;
 import bisq.common.platform.Platform;
 import bisq.common.platform.PlatformUtils;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -45,7 +46,17 @@ public class UpdaterUtils {
     }
 
     public static String getInstallerFileName(String version) {
-        return "Bisq-" + version + PlatformUtils.getInstallerExtension();
+        return getInstallerFileName(version, Platform.getPlatform(), PlatformUtils.getInstallerExtension());
+    }
+
+    @VisibleForTesting
+    static String getInstallerFileName(String version, Platform platform, String installerExtension) {
+        String architecturePrefix = switch (platform) {
+            case MACOS_X86_64 -> "x86_64-";
+            case MACOS_ARM_64 -> "aarch64-";
+            default -> "";
+        };
+        return "Bisq-" + architecturePrefix + version + installerExtension;
     }
 
     public static String getJarFileName(String version) {

--- a/evolution/src/test/java/bisq/evolution/updater/UpdaterUtilsTest.java
+++ b/evolution/src/test/java/bisq/evolution/updater/UpdaterUtilsTest.java
@@ -18,6 +18,7 @@
 package bisq.evolution.updater;
 
 import bisq.common.file.FileMutatorUtils;
+import bisq.common.platform.Platform;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -29,6 +30,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UpdaterUtilsTest {
+
+    @Test
+    void getInstallerFileNameUsesIntelMacOsAsset() {
+        String fileName = UpdaterUtils.getInstallerFileName("2.1.12", Platform.MACOS_X86_64, ".dmg");
+
+        assertEquals("Bisq-x86_64-2.1.12.dmg", fileName);
+    }
+
+    @Test
+    void getInstallerFileNameUsesAppleSiliconMacOsAsset() {
+        String fileName = UpdaterUtils.getInstallerFileName("2.1.12", Platform.MACOS_ARM_64, ".dmg");
+
+        assertEquals("Bisq-aarch64-2.1.12.dmg", fileName);
+    }
+
+    @Test
+    void getInstallerFileNameRemainsGenericForOtherPlatforms() {
+        assertEquals("Bisq-2.1.12.deb",
+                UpdaterUtils.getInstallerFileName("2.1.12", Platform.LINUX_X86_64, ".deb"));
+        assertEquals("Bisq-2.1.12.exe",
+                UpdaterUtils.getInstallerFileName("2.1.12", Platform.WIN_X86_64, ".exe"));
+    }
 
     @Test
     void testReadVersionFromVersionFile(@TempDir Path tempDirPath) throws IOException {


### PR DESCRIPTION
Fixes https://github.com/bisq-network/bisq2/issues/4953

Launcher updates previously derived installer names from only the version and OS extension, so Intel and Apple Silicon macOS clients both requested the ambiguous generic DMG. Use the detected runtime platform to select Bisq-x86_64-<version>.dmg or Bisq-aarch64-<version>.dmg while preserving existing installer names on other platforms.\n\nAlign macOS release packaging and readiness expectations with the same artifact contract, document the invariant, and cover both architectures plus non-macOS compatibility. Detached signatures automatically follow the selected architecture-specific filename.