### PR TITLE
Fix chat message edit eligibility

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItem.java
@@ -252,6 +252,17 @@ public final class ChatMessageListItem<M extends ChatMessage, C extends ChatChan
         return chatMessage.isMyMessage(userIdentityService);
     }
 
+    public boolean canEditMessage() {
+        return canEditMessage(isMyMessage(), isPublicChannel(), isBisqEasyPublicChatMessageWithOffer());
+    }
+
+    @VisibleForTesting
+    static boolean canEditMessage(boolean isMyMessage,
+                                  boolean isPublicChannel,
+                                  boolean isBisqEasyPublicChatMessageWithOffer) {
+        return isMyMessage && isPublicChannel && !isBisqEasyPublicChatMessageWithOffer;
+    }
+
     public boolean isPeerMessage() {
         return !isMyMessage();
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/ChatMessagesListController.java
@@ -331,7 +331,7 @@ public class ChatMessagesListController implements Controller {
     public void editMyLastMessage() {
         Optional<ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>>> messageListItem = model.getChatMessages()
                 .stream()
-                .filter(ChatMessageListItem::isMyMessage)
+                .filter(ChatMessageListItem::canEditMessage)
                 .max(Comparator.comparing((ChatMessageListItem<? extends ChatMessage, ? extends ChatChannel<? extends ChatMessage>> item) -> item.getChatMessage().getDate()));
         messageListItem.ifPresent(item -> item.getSetAsEditing().set(true));
     }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/list/message_box/MyTextMessageBox.java
@@ -19,7 +19,6 @@ package bisq.desktop.main.content.chat.message_container.list.message_box;
 
 import bisq.chat.ChatChannel;
 import bisq.chat.ChatMessage;
-import bisq.chat.bisq_easy.offerbook.BisqEasyOfferbookMessage;
 import bisq.common.util.StringUtils;
 import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.components.containers.Spacer;
@@ -174,10 +173,7 @@ public final class MyTextMessageBox extends BubbleMessageBox {
     protected void addActionsHandlers() {
         ChatMessage chatMessage = item.getChatMessage();
         boolean isPublicChannel = item.isPublicChannel();
-        boolean allowEditing = isPublicChannel;
-        if (chatMessage instanceof BisqEasyOfferbookMessage bisqEasyOfferbookMessage) {
-            allowEditing = allowEditing && bisqEasyOfferbookMessage.getBisqEasyOffer().isEmpty();
-        }
+        boolean allowEditing = item.canEditMessage();
 
         copy.setOnAction(e -> onCopyMessage(chatMessage));
         if (allowEditing) {

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItemTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/list/ChatMessageListItemTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.list;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatMessageListItemTest {
+    @Test
+    void ownedPublicTextMessageCanBeEdited() {
+        assertThat(ChatMessageListItem.canEditMessage(true, true, false)).isTrue();
+    }
+
+    @Test
+    void privateMessageCannotBeEdited() {
+        assertThat(ChatMessageListItem.canEditMessage(true, false, false)).isFalse();
+    }
+
+    @Test
+    void offerMessageCannotBeEdited() {
+        assertThat(ChatMessageListItem.canEditMessage(true, true, true)).isFalse();
+    }
+
+    @Test
+    void peerMessageCannotBeEdited() {
+        assertThat(ChatMessageListItem.canEditMessage(false, true, false)).isFalse();
+    }
+}


### PR DESCRIPTION
fixes #3884 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message editing eligibility.
  * Users can edit their own messages in public chats, except messages containing offers.
  * Prevented editing messages in private chats or messages sent by others.
* **Tests**
  * Added coverage for message-editing scenarios, including public, private, offer-related, and peer messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->