### PR TITLE
Fix trading-restriction alerts: structured errors for API clients + UNSPECIFIED wildcard matching

### DIFF
--- a/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/trades/TradeRestApi.java
@@ -50,6 +50,7 @@ import bisq.offer.price.spec.PriceSpec;
 import bisq.presentation.formatters.AmountFormatter;
 import bisq.support.SupportService;
 import bisq.support.mediation.bisq_easy.BisqEasyMediationRequestService;
+import bisq.trade.TradeRestrictedException;
 import bisq.trade.TradeService;
 import bisq.trade.bisq_easy.BisqEasyTrade;
 import bisq.trade.bisq_easy.BisqEasyTradeService;
@@ -79,7 +80,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -274,11 +277,26 @@ public class TradeRestApi extends RestApiBase {
             log.warn("Thread got interrupted at takeOffer method", e);
             Thread.currentThread().interrupt(); // Restore interrupted state
             asyncResponse.resume(buildErrorResponse("Thread was interrupted."));
+        } catch (TradeRestrictedException e) {
+            asyncResponse.resume(buildResponse(Response.Status.BAD_REQUEST, toTradeRestrictedErrorEntity(e)));
         } catch (IllegalArgumentException e) {
             asyncResponse.resume(buildResponse(Response.Status.BAD_REQUEST, "Invalid input: " + e.getMessage()));
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }
+    }
+
+    /**
+     * All values are strings so that clients decoding the error body as a flat string map keep
+     * working; the "error" text preserves the pre-structured wire format ("Invalid input: ..."),
+     * which released mobile clients match on.
+     */
+    static Map<String, String> toTradeRestrictedErrorEntity(TradeRestrictedException exception) {
+        Map<String, String> entity = new LinkedHashMap<>();
+        entity.put("error", "Invalid input: " + exception.getMessage());
+        entity.put("errorCode", exception.getRestriction().name());
+        exception.findMinRequiredVersion().ifPresent(minVersion -> entity.put("minRequiredVersion", minVersion));
+        return entity;
     }
 
     @PATCH
@@ -335,6 +353,8 @@ public class TradeRestApi extends RestApiBase {
                 case BTC_CONFIRMED -> handleBtcConfirmed(channel, trade, paymentRail, userName);
             }
             asyncResponse.resume(buildNoContentResponse());
+        } catch (TradeRestrictedException e) {
+            asyncResponse.resume(buildResponse(Response.Status.BAD_REQUEST, toTradeRestrictedErrorEntity(e)));
         } catch (Exception e) {
             asyncResponse.resume(buildErrorResponse("An unexpected error occurred: " + e.getMessage()));
         }

--- a/api/src/test/java/bisq/api/rest_api/endpoints/trades/TradeRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/trades/TradeRestApiTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.rest_api.endpoints.trades;
+
+import bisq.trade.TradeRestrictedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TradeRestApiTest {
+
+    @Test
+    void haltTradingErrorEntityKeepsLegacyErrorTextAndAddsErrorCode() {
+        Map<String, String> entity = TradeRestApi.toTradeRestrictedErrorEntity(TradeRestrictedException.haltTrading());
+
+        // Released mobile clients match on the "error" text; the prefix and fragments must not change
+        assertThat(entity.get("error"))
+                .startsWith("Invalid input: ")
+                .contains("Trading is on halt");
+        assertThat(entity.get("errorCode")).isEqualTo("HALT_TRADING");
+        assertThat(entity).doesNotContainKey("minRequiredVersion");
+    }
+
+    @Test
+    void minVersionErrorEntityCarriesVersionInTextAndField() {
+        Map<String, String> entity =
+                TradeRestApi.toTradeRestrictedErrorEntity(TradeRestrictedException.minVersionRequired("2.1.12"));
+
+        assertThat(entity.get("error"))
+                .startsWith("Invalid input: ")
+                .contains("version 2.1.12 installed")
+                .contains("min. version required for trading");
+        assertThat(entity.get("errorCode")).isEqualTo("MIN_VERSION_REQUIRED");
+        assertThat(entity.get("minRequiredVersion")).isEqualTo("2.1.12");
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/update/UpdaterController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/overlay/update/UpdaterController.java
@@ -20,11 +20,9 @@ package bisq.desktop.overlay.update;
 import bisq.bonded_roles.release.AppType;
 import bisq.bonded_roles.release.ReleaseNotification;
 import bisq.bonded_roles.security_manager.alert.AlertService;
-import bisq.bonded_roles.security_manager.alert.AlertType;
-import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.bonded_roles.security_manager.alert.AuthorizedAlertDataUtils;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.observable.Pin;
-import bisq.common.observable.collection.CollectionObserver;
 import bisq.common.platform.PlatformUtils;
 import bisq.common.platform.Version;
 import bisq.desktop.ServiceProvider;
@@ -110,44 +108,8 @@ public class UpdaterController implements Controller {
             });
         });
 
-        authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(new CollectionObserver<>() {
-            @Override
-            public void onAdded(AuthorizedAlertData authorizedAlertData) {
-                UIThread.run(() -> {
-                    if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY &&
-                            authorizedAlertData.isRequireVersionForTrading() &&
-                            authorizedAlertData.getAppType() == AppType.DESKTOP) {
-                        model.setRequireVersionForTrading(true);
-                        model.setMinRequiredVersionForTrading(authorizedAlertData.getMinVersion());
-                        updateIgnoreVersionState();
-                    }
-                });
-            }
-
-            @Override
-            public void onRemoved(Object element) {
-                UIThread.run(() -> {
-                    if (element instanceof AuthorizedAlertData authorizedAlertData) {
-                        if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY &&
-                                authorizedAlertData.isRequireVersionForTrading() &&
-                                authorizedAlertData.getAppType() == AppType.DESKTOP) {
-                            model.setRequireVersionForTrading(false);
-                            model.setMinRequiredVersionForTrading(Optional.empty());
-                            updateIgnoreVersionState();
-                        }
-                    }
-                });
-            }
-
-            @Override
-            public void onCleared() {
-                UIThread.run(() -> {
-                    model.setRequireVersionForTrading(false);
-                    model.setMinRequiredVersionForTrading(Optional.empty());
-                    updateIgnoreVersionState();
-                });
-            }
-        });
+        authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(() ->
+                UIThread.run(this::updateVersionForTradingRequirement));
 
         updateIgnoreVersionState();
         model.getFilteredList().setPredicate(
@@ -212,6 +174,14 @@ public class UpdaterController implements Controller {
         return model.isRequireVersionForTrading() &&
                 minRequiredVersionForTrading.isPresent() &&
                 new Version(minRequiredVersionForTrading.get()).above(ApplicationVersion.getVersion());
+    }
+
+    private void updateVersionForTradingRequirement() {
+        Optional<String> minRequiredVersionForTrading = AuthorizedAlertDataUtils.findMinRequiredVersionForTrading(
+                alertService.getAuthorizedAlertDataSet().stream(), AppType.DESKTOP);
+        model.setRequireVersionForTrading(minRequiredVersionForTrading.isPresent());
+        model.setMinRequiredVersionForTrading(minRequiredVersionForTrading);
+        updateIgnoreVersionState();
     }
 
     private void updateIgnoreVersionState() {

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AlertNotificationsService.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AlertNotificationsService.java
@@ -113,9 +113,7 @@ public class AlertNotificationsService implements Service {
     }
 
     private boolean matchesAppType(AuthorizedAlertData authorizedAlertData, AppType appType) {
-        return appType == AppType.UNSPECIFIED
-                || authorizedAlertData.getAppType() == AppType.UNSPECIFIED
-                || authorizedAlertData.getAppType() == appType;
+        return AuthorizedAlertDataUtils.appliesTo(authorizedAlertData, appType);
     }
 
     private boolean shouldProcessAlert(AuthorizedAlertData authorizedAlertData) {

--- a/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertDataUtils.java
+++ b/bonded-roles/src/main/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertDataUtils.java
@@ -34,6 +34,42 @@ public final class AuthorizedAlertDataUtils {
     }
 
     /**
+     * An alert applies to the given app type when both sides match, or when either side is
+     * {@link AppType#UNSPECIFIED} (wildcard). A security manager publishing a network-wide
+     * alert without an app type must restrict every app.
+     */
+    public static boolean appliesTo(AuthorizedAlertData alert, AppType appType) {
+        return appType == AppType.UNSPECIFIED
+                || alert.getAppType() == AppType.UNSPECIFIED
+                || alert.getAppType() == appType;
+    }
+
+    /**
+     * True while any applicable EMERGENCY alert has haltTrading set.
+     */
+    public static boolean isTradingHalted(Stream<AuthorizedAlertData> alerts, AppType appType) {
+        return alerts
+                .filter(alert -> alert.getAlertType() == AlertType.EMERGENCY)
+                .filter(alert -> appliesTo(alert, appType))
+                .anyMatch(AuthorizedAlertData::isHaltTrading);
+    }
+
+    /**
+     * The min. version required for trading from the most recent applicable EMERGENCY alert.
+     * Alerts with requireVersionForTrading but no minVersion are malformed and ignored, so they
+     * cannot shadow an older well-formed restriction.
+     */
+    public static Optional<String> findMinRequiredVersionForTrading(Stream<AuthorizedAlertData> alerts, AppType appType) {
+        return alerts
+                .filter(alert -> alert.getAlertType() == AlertType.EMERGENCY)
+                .filter(alert -> appliesTo(alert, appType))
+                .filter(AuthorizedAlertData::isRequireVersionForTrading)
+                .filter(alert -> alert.getMinVersion().isPresent())
+                .max(Comparator.comparingLong(AuthorizedAlertData::getDate))
+                .flatMap(AuthorizedAlertData::getMinVersion);
+    }
+
+    /**
      * Returns the single most important active trade-restricting alert for the given app type.
      *
      * <p>Selection policy:
@@ -49,7 +85,7 @@ public final class AuthorizedAlertDataUtils {
             Stream<AuthorizedAlertData> alerts, AppType appType) {
         List<AuthorizedAlertData> candidates = alerts
                 .filter(AuthorizedAlertData::isTradeRestrictingAlert)
-                .filter(alert -> alert.getAppType() == appType)
+                .filter(alert -> appliesTo(alert, appType))
                 .toList();
 
         Optional<AuthorizedAlertData> mostRecentHalt =

--- a/bonded-roles/src/test/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertDataUtilsTest.java
+++ b/bonded-roles/src/test/java/bisq/bonded_roles/security_manager/alert/AuthorizedAlertDataUtilsTest.java
@@ -143,6 +143,85 @@ class AuthorizedAlertDataUtilsTest {
         assertThat(result).hasValueSatisfying(alert -> assertThat(alert.getId()).isEqualTo("req-new"));
     }
 
+    @Test
+    void appliesToMatchesSameAppType() {
+        AuthorizedAlertData alert = createAlert("halt-1", AppType.DESKTOP, 10, AlertType.EMERGENCY, true, false);
+
+        assertThat(AuthorizedAlertDataUtils.appliesTo(alert, AppType.DESKTOP)).isTrue();
+        assertThat(AuthorizedAlertDataUtils.appliesTo(alert, AppType.MOBILE_CLIENT)).isFalse();
+    }
+
+    @Test
+    void appliesToTreatsUnspecifiedAlertAsWildcard() {
+        AuthorizedAlertData alert = createAlert("halt-1", AppType.UNSPECIFIED, 10, AlertType.EMERGENCY, true, false);
+
+        assertThat(AuthorizedAlertDataUtils.appliesTo(alert, AppType.DESKTOP)).isTrue();
+        assertThat(AuthorizedAlertDataUtils.appliesTo(alert, AppType.MOBILE_CLIENT)).isTrue();
+        assertThat(AuthorizedAlertDataUtils.appliesTo(alert, AppType.MOBILE_NODE)).isTrue();
+    }
+
+    @Test
+    void appliesToTreatsUnspecifiedQueryAsWildcard() {
+        AuthorizedAlertData alert = createAlert("halt-1", AppType.DESKTOP, 10, AlertType.EMERGENCY, true, false);
+
+        assertThat(AuthorizedAlertDataUtils.appliesTo(alert, AppType.UNSPECIFIED)).isTrue();
+    }
+
+    @Test
+    void findMostRecentTradeRestrictingAlertIncludesUnspecifiedAlerts() {
+        // A network-wide halt published without an app type must restrict every app
+        AuthorizedAlertData networkWideHalt = createAlert("halt-unspecified", AppType.UNSPECIFIED, 10, AlertType.EMERGENCY, true, false);
+
+        Optional<AuthorizedAlertData> result = AuthorizedAlertDataUtils.findMostRecentTradeRestrictingAlert(
+                Stream.of(networkWideHalt), AppType.MOBILE_CLIENT);
+
+        assertThat(result).contains(networkWideHalt);
+    }
+
+    @Test
+    void isTradingHaltedMatchesApplicableEmergencyHaltOnly() {
+        AuthorizedAlertData desktopHalt = createAlert("halt-desktop", AppType.DESKTOP, 10, AlertType.EMERGENCY, true, false);
+        AuthorizedAlertData mobileInfo = createAlert("info-mobile", AppType.MOBILE_CLIENT, 20, AlertType.INFO, true, false);
+
+        assertThat(AuthorizedAlertDataUtils.isTradingHalted(Stream.of(desktopHalt), AppType.DESKTOP)).isTrue();
+        assertThat(AuthorizedAlertDataUtils.isTradingHalted(Stream.of(desktopHalt), AppType.MOBILE_CLIENT)).isFalse();
+        // INFO alerts never halt trading, even with the flag set
+        assertThat(AuthorizedAlertDataUtils.isTradingHalted(Stream.of(mobileInfo), AppType.MOBILE_CLIENT)).isFalse();
+    }
+
+    @Test
+    void isTradingHaltedTreatsUnspecifiedAlertAsNetworkWide() {
+        AuthorizedAlertData networkWideHalt = createAlert("halt-unspecified", AppType.UNSPECIFIED, 10, AlertType.EMERGENCY, true, false);
+
+        assertThat(AuthorizedAlertDataUtils.isTradingHalted(Stream.of(networkWideHalt), AppType.DESKTOP)).isTrue();
+        assertThat(AuthorizedAlertDataUtils.isTradingHalted(Stream.of(networkWideHalt), AppType.MOBILE_CLIENT)).isTrue();
+    }
+
+    @Test
+    void findMinRequiredVersionForTradingPicksMostRecentApplicableAlert() {
+        AuthorizedAlertData reqOld = createAlert("req-old", AppType.DESKTOP, 10, AlertType.EMERGENCY, false, true, Optional.of("2.1.10"));
+        AuthorizedAlertData reqNew = createAlert("req-new", AppType.DESKTOP, 30, AlertType.EMERGENCY, false, true, Optional.of("2.1.12"));
+        AuthorizedAlertData otherApp = createAlert("req-mobile", AppType.MOBILE_CLIENT, 50, AlertType.EMERGENCY, false, true, Optional.of("9.9.9"));
+
+        Optional<String> result = AuthorizedAlertDataUtils.findMinRequiredVersionForTrading(
+                Stream.of(reqOld, reqNew, otherApp), AppType.DESKTOP);
+
+        assertThat(result).contains("2.1.12");
+    }
+
+    @Test
+    void findMinRequiredVersionForTradingIgnoresMalformedAlertWithoutMinVersion() {
+        // A newer alert with requireVersionForTrading but no minVersion must not shadow
+        // the older well-formed restriction
+        AuthorizedAlertData valid = createAlert("req-valid", AppType.DESKTOP, 10, AlertType.EMERGENCY, false, true, Optional.of("2.1.10"));
+        AuthorizedAlertData malformed = createAlert("req-malformed", AppType.DESKTOP, 30, AlertType.EMERGENCY, false, true, Optional.empty());
+
+        Optional<String> result = AuthorizedAlertDataUtils.findMinRequiredVersionForTrading(
+                Stream.of(valid, malformed), AppType.DESKTOP);
+
+        assertThat(result).contains("2.1.10");
+    }
+
     // ---- helpers ----
 
     private AuthorizedAlertData createAlert(String id, AppType appType, int relativeOffset, AlertType alertType,

--- a/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
+++ b/evolution/src/main/java/bisq/evolution/updater/UpdaterService.java
@@ -22,8 +22,7 @@ import bisq.bonded_roles.release.AppType;
 import bisq.bonded_roles.release.ReleaseNotification;
 import bisq.bonded_roles.release.ReleaseNotificationsService;
 import bisq.bonded_roles.security_manager.alert.AlertService;
-import bisq.bonded_roles.security_manager.alert.AlertType;
-import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.bonded_roles.security_manager.alert.AuthorizedAlertDataUtils;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.file.FileMutatorUtils;
@@ -128,38 +127,7 @@ public class UpdaterService implements Service {
             }
         }));
 
-        pins.add(alertService.getAuthorizedAlertDataSet().addObserver(new CollectionObserver<>() {
-            @Override
-            public void onAdded(AuthorizedAlertData authorizedAlertData) {
-                if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY &&
-                        authorizedAlertData.isRequireVersionForTrading() &&
-                        authorizedAlertData.getAppType() == appType) {
-                    requireVersionForTrading = true;
-                    minRequiredVersionForTrading = authorizedAlertData.getMinVersion();
-                    updateReleaseNotificationState();
-                }
-            }
-
-            @Override
-            public void onRemoved(Object element) {
-                if (element instanceof AuthorizedAlertData authorizedAlertData) {
-                    if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY &&
-                            authorizedAlertData.isRequireVersionForTrading() &&
-                            authorizedAlertData.getAppType() == appType) {
-                        requireVersionForTrading = false;
-                        minRequiredVersionForTrading = Optional.empty();
-                        updateReleaseNotificationState();
-                    }
-                }
-            }
-
-            @Override
-            public void onCleared() {
-                requireVersionForTrading = false;
-                minRequiredVersionForTrading = Optional.empty();
-                updateReleaseNotificationState();
-            }
-        }));
+        pins.add(alertService.getAuthorizedAlertDataSet().addObserver(this::updateVersionForTradingRequirement));
 
         pins.add(settingsService.getCookieChanged().addObserver(e -> {
             boolean notifyForPreRelease = settingsService.getCookie().asBoolean(CookieKey.NOTIFY_FOR_PRE_RELEASE).orElse(false);
@@ -228,6 +196,13 @@ public class UpdaterService implements Service {
     /* --------------------------------------------------------------------- */
     // Private/package static
     /* --------------------------------------------------------------------- */
+
+    private void updateVersionForTradingRequirement() {
+        minRequiredVersionForTrading = AuthorizedAlertDataUtils.findMinRequiredVersionForTrading(
+                alertService.getAuthorizedAlertDataSet().stream(), appType);
+        requireVersionForTrading = minRequiredVersionForTrading.isPresent();
+        updateReleaseNotificationState();
+    }
 
     private void updateReleaseNotificationState() {
         if (releaseNotifications.isEmpty()) {

--- a/trade/src/main/java/bisq/trade/TradeRestrictedException.java
+++ b/trade/src/main/java/bisq/trade/TradeRestrictedException.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade;
+
+import lombok.Getter;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * Thrown when a security-manager emergency alert restricts trading (haltTrading or
+ * requireVersionForTrading). Extends IllegalArgumentException so existing catch sites keep
+ * working, while carrying the restriction type and min. required version so API consumers can
+ * emit a structured error instead of parsing the message text.
+ * <p>
+ * The message texts are a compatibility contract: released mobile clients classify these
+ * failures by matching fragments of them. Do not reword without a migration path.
+ */
+@Getter
+public class TradeRestrictedException extends IllegalArgumentException {
+    public enum Restriction {
+        HALT_TRADING,
+        MIN_VERSION_REQUIRED
+    }
+
+    private final Restriction restriction;
+    @Nullable
+    private final String minRequiredVersion;
+
+    public static TradeRestrictedException haltTrading() {
+        return new TradeRestrictedException(Restriction.HALT_TRADING,
+                null,
+                "Trading is on halt for security reasons. " +
+                        "The Bisq security manager has published an emergency alert with haltTrading set to true");
+    }
+
+    public static TradeRestrictedException minVersionRequired(String minRequiredVersion) {
+        return new TradeRestrictedException(Restriction.MIN_VERSION_REQUIRED,
+                minRequiredVersion,
+                "For trading you need to have version " + minRequiredVersion + " installed. " +
+                        "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+    }
+
+    private TradeRestrictedException(Restriction restriction, @Nullable String minRequiredVersion, String message) {
+        super(message);
+        this.restriction = restriction;
+        this.minRequiredVersion = minRequiredVersion;
+    }
+
+    public Optional<String> findMinRequiredVersion() {
+        return Optional.ofNullable(minRequiredVersion);
+    }
+}

--- a/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
+++ b/trade/src/main/java/bisq/trade/bisq_easy/BisqEasyTradeService.java
@@ -21,13 +21,11 @@ import bisq.account.payment_method.BitcoinPaymentMethodSpec;
 import bisq.account.payment_method.fiat.FiatPaymentMethodSpec;
 import bisq.bonded_roles.release.AppType;
 import bisq.bonded_roles.security_manager.alert.AlertService;
-import bisq.bonded_roles.security_manager.alert.AlertType;
-import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.bonded_roles.security_manager.alert.AuthorizedAlertDataUtils;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.monetary.Monetary;
 import bisq.common.observable.Pin;
-import bisq.common.observable.collection.CollectionObserver;
 import bisq.common.observable.collection.ReadOnlyObservableSet;
 import bisq.common.platform.Version;
 import bisq.common.timer.Scheduler;
@@ -47,6 +45,7 @@ import bisq.persistence.Persistence;
 import bisq.persistence.RateLimitedPersistenceClient;
 import bisq.settings.SettingsService;
 import bisq.trade.ServiceProvider;
+import bisq.trade.TradeRestrictedException;
 import bisq.trade.bisq_easy.protocol.BisqEasyBuyerAsMakerProtocol;
 import bisq.trade.bisq_easy.protocol.BisqEasyBuyerAsTakerProtocol;
 import bisq.trade.bisq_easy.protocol.BisqEasyClosedTrade;
@@ -105,9 +104,9 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
     private final Map<String, BisqEasyProtocol> tradeProtocolById = new ConcurrentHashMap<>();
     private final ContactListService contactListService;
     private final UserProfileService userProfileService;
-    private boolean haltTrading;
-    private boolean requireVersionForTrading;
-    private Optional<String> minRequiredVersionForTrading = Optional.empty();
+    // Written from the alert-set observer thread, read from trade calls on other threads
+    private volatile boolean haltTrading;
+    private volatile Optional<String> minRequiredVersionForTrading = Optional.empty();
     @Nullable
     private Pin authorizedAlertDataSetPin, numDaysAfterRedactingTradeDataPin;
     @Nullable
@@ -142,42 +141,7 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
                 .forEach(this::onMessage);
         networkService.addConfidentialMessageListener(this);
 
-        authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(new CollectionObserver<>() {
-            @Override
-            public void onAdded(AuthorizedAlertData authorizedAlertData) {
-                if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY && authorizedAlertData.getAppType() == appType) {
-                    if (authorizedAlertData.isHaltTrading()) {
-                        haltTrading = true;
-                    }
-                    if (authorizedAlertData.isRequireVersionForTrading()) {
-                        requireVersionForTrading = true;
-                        minRequiredVersionForTrading = authorizedAlertData.getMinVersion();
-                    }
-                }
-            }
-
-            @Override
-            public void onRemoved(Object element) {
-                if (element instanceof AuthorizedAlertData authorizedAlertData) {
-                    if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY && authorizedAlertData.getAppType() == appType) {
-                        if (authorizedAlertData.isHaltTrading()) {
-                            haltTrading = false;
-                        }
-                        if (authorizedAlertData.isRequireVersionForTrading()) {
-                            requireVersionForTrading = false;
-                            minRequiredVersionForTrading = Optional.empty();
-                        }
-                    }
-                }
-            }
-
-            @Override
-            public void onCleared() {
-                haltTrading = false;
-                requireVersionForTrading = false;
-                minRequiredVersionForTrading = Optional.empty();
-            }
-        });
+        authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(this::updateTradeRestrictions);
 
         numDaysAfterRedactingTradeDataScheduler = Scheduler.run(this::maybeRedactDataOfCompletedTrades)
                 .host(this)
@@ -459,16 +423,24 @@ public class BisqEasyTradeService extends RateLimitedPersistenceClient<BisqEasyT
         return tradeProtocol;
     }
 
+    private void updateTradeRestrictions() {
+        haltTrading = AuthorizedAlertDataUtils.isTradingHalted(
+                alertService.getAuthorizedAlertDataSet().stream(), appType);
+        minRequiredVersionForTrading = AuthorizedAlertDataUtils.findMinRequiredVersionForTrading(
+                alertService.getAuthorizedAlertDataSet().stream(), appType);
+    }
+
     private void verifyTradingNotOnHalt() {
-        checkArgument(!haltTrading, "Trading is on halt for security reasons. " +
-                "The Bisq security manager has published an emergency alert with haltTrading set to true");
+        if (haltTrading) {
+            throw TradeRestrictedException.haltTrading();
+        }
     }
 
     private void verifyMinVersionForTrading() {
-        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent()) {
-            checkArgument(ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get())),
-                    "For trading you need to have version " + minRequiredVersionForTrading.get() + " installed. " +
-                            "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+        Optional<String> minRequiredVersion = minRequiredVersionForTrading;
+        if (minRequiredVersion.isPresent()
+                && !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersion.get()))) {
+            throw TradeRestrictedException.minVersionRequired(minRequiredVersion.get());
         }
     }
 

--- a/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/MuSigTradeService.java
@@ -23,15 +23,13 @@ import bisq.account.payment_method.PaymentMethod;
 import bisq.account.payment_method.PaymentMethodSpec;
 import bisq.bonded_roles.release.AppType;
 import bisq.bonded_roles.security_manager.alert.AlertService;
-import bisq.bonded_roles.security_manager.alert.AlertType;
-import bisq.bonded_roles.security_manager.alert.AuthorizedAlertData;
+import bisq.bonded_roles.security_manager.alert.AuthorizedAlertDataUtils;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannel;
 import bisq.chat.mu_sig.open_trades.MuSigOpenTradeChannelService;
 import bisq.common.application.ApplicationVersion;
 import bisq.common.application.Service;
 import bisq.common.monetary.Monetary;
 import bisq.common.observable.Pin;
-import bisq.common.observable.collection.CollectionObserver;
 import bisq.common.observable.map.ObservableHashMap;
 import bisq.common.platform.Version;
 import bisq.common.threading.ExecutorFactory;
@@ -61,6 +59,7 @@ import bisq.support.mediation.mu_sig.MuSigPaymentDetailsRequest;
 import bisq.support.mediation.mu_sig.MuSigPaymentDetailsResponse;
 import bisq.trade.MuSigDisputeState;
 import bisq.trade.ServiceProvider;
+import bisq.trade.TradeRestrictedException;
 import bisq.trade.mu_sig.events.MuSigTradeEvent;
 import bisq.trade.mu_sig.events.blockchain.DepositTxConfirmedEvent;
 import bisq.trade.mu_sig.events.buyer.PaymentInitiatedEvent;
@@ -140,9 +139,9 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
     // We don't persist the protocol, only the model.
     private final Map<String, MuSigProtocol> tradeProtocolById = new ConcurrentHashMap<>();
 
-    private boolean haltTrading;
-    private boolean requireVersionForTrading;
-    private Optional<String> minRequiredVersionForTrading = Optional.empty();
+    // Written from the alert-set observer thread, read from trade calls on other threads
+    private volatile boolean haltTrading;
+    private volatile Optional<String> minRequiredVersionForTrading = Optional.empty();
 
     private Pin authorizedAlertDataSetPin, numDaysAfterRedactingTradeDataPin;
     private Scheduler numDaysAfterRedactingTradeDataScheduler;
@@ -193,42 +192,7 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
                             .filter(MuSigTrade::isDepositTxCreatedButNotConfirmed)
                             .forEach(this::observeDepositTxConfirmationStatus);
 
-                    authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(new CollectionObserver<>() {
-                        @Override
-                        public void onAdded(AuthorizedAlertData authorizedAlertData) {
-                            if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY && authorizedAlertData.getAppType() == appType) {
-                                if (authorizedAlertData.isHaltTrading()) {
-                                    haltTrading = true;
-                                }
-                                if (authorizedAlertData.isRequireVersionForTrading()) {
-                                    requireVersionForTrading = true;
-                                    minRequiredVersionForTrading = authorizedAlertData.getMinVersion();
-                                }
-                            }
-                        }
-
-                        @Override
-                        public void onRemoved(Object element) {
-                            if (element instanceof AuthorizedAlertData authorizedAlertData) {
-                                if (authorizedAlertData.getAlertType() == AlertType.EMERGENCY&& authorizedAlertData.getAppType() == appType ) {
-                                    if (authorizedAlertData.isHaltTrading()) {
-                                        haltTrading = false;
-                                    }
-                                    if (authorizedAlertData.isRequireVersionForTrading()) {
-                                        requireVersionForTrading = false;
-                                        minRequiredVersionForTrading = Optional.empty();
-                                    }
-                                }
-                            }
-                        }
-
-                        @Override
-                        public void onCleared() {
-                            haltTrading = false;
-                            requireVersionForTrading = false;
-                            minRequiredVersionForTrading = Optional.empty();
-                        }
-                    });
+                    authorizedAlertDataSetPin = alertService.getAuthorizedAlertDataSet().addObserver(this::updateTradeRestrictions);
 
                     numDaysAfterRedactingTradeDataScheduler = Scheduler.run(this::maybeRedactDataOfCompletedTrades)
                             .host(this)
@@ -645,16 +609,24 @@ public final class MuSigTradeService extends RateLimitedPersistenceClient<MuSigT
         return tradeProtocol;
     }
 
+    private void updateTradeRestrictions() {
+        haltTrading = AuthorizedAlertDataUtils.isTradingHalted(
+                alertService.getAuthorizedAlertDataSet().stream(), appType);
+        minRequiredVersionForTrading = AuthorizedAlertDataUtils.findMinRequiredVersionForTrading(
+                alertService.getAuthorizedAlertDataSet().stream(), appType);
+    }
+
     private void verifyTradingNotOnHalt() {
-        checkArgument(!haltTrading, "Trading is on halt for security reasons. " +
-                "The Bisq security manager has published an emergency alert with haltTrading set to true");
+        if (haltTrading) {
+            throw TradeRestrictedException.haltTrading();
+        }
     }
 
     private void verifyMinVersionForTrading() {
-        if (requireVersionForTrading && minRequiredVersionForTrading.isPresent()) {
-            checkArgument(ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersionForTrading.get())),
-                    "For trading you need to have version " + minRequiredVersionForTrading.get() + " installed. " +
-                            "The Bisq security manager has published an emergency alert with a min. version required for trading.");
+        Optional<String> minRequiredVersion = minRequiredVersionForTrading;
+        if (minRequiredVersion.isPresent()
+                && !ApplicationVersion.getVersion().aboveOrEqual(new Version(minRequiredVersion.get()))) {
+            throw TradeRestrictedException.minVersionRequired(minRequiredVersion.get());
         }
     }
 

--- a/trade/src/test/java/bisq/trade/TradeRestrictedExceptionTest.java
+++ b/trade/src/test/java/bisq/trade/TradeRestrictedExceptionTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.trade;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TradeRestrictedExceptionTest {
+
+    // The message fragments are a compatibility contract: released mobile clients classify
+    // trade-restriction failures by matching them (see TradeRestrictionError in bisq-mobile).
+
+    @Test
+    void haltTradingKeepsMessageContractAndCarriesRestriction() {
+        TradeRestrictedException exception = TradeRestrictedException.haltTrading();
+
+        assertThat(exception.getMessage()).contains("Trading is on halt");
+        assertThat(exception.getRestriction()).isEqualTo(TradeRestrictedException.Restriction.HALT_TRADING);
+        assertThat(exception.findMinRequiredVersion()).isEmpty();
+    }
+
+    @Test
+    void minVersionRequiredKeepsMessageContractAndCarriesVersion() {
+        TradeRestrictedException exception = TradeRestrictedException.minVersionRequired("2.1.12");
+
+        assertThat(exception.getMessage())
+                .contains("version 2.1.12 installed")
+                .contains("min. version required for trading");
+        assertThat(exception.getRestriction()).isEqualTo(TradeRestrictedException.Restriction.MIN_VERSION_REQUIRED);
+        assertThat(exception.findMinRequiredVersion()).contains("2.1.12");
+    }
+
+    @Test
+    void isCatchableAsIllegalArgumentExceptionForExistingCallSites() {
+        assertThat(TradeRestrictedException.haltTrading()).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
### Problem

When the security manager publishes an EMERGENCY alert with `haltTrading` or `requireVersionForTrading`, the trusted node (api-app registers its trade service as `AppType.DESKTOP`) rejects take-offer with a raw `checkArgument` message written for desktop users ("For trading you need to have version X installed…"). That text travels verbatim over the API, so Connect apps have no reliable way to classify the failure — mobile users got a cryptic error and a blocking dialog, which forced the Bisq Connect 0.8.2 hotfix (client-side string matching on the English backend text).

While fixing this we found the opposite gap: an EMERGENCY alert published with app type `UNSPECIFIED` shows a notification banner (`AlertNotificationsService` treats `UNSPECIFIED` as a wildcard) but does **not** restrict trading - `BisqEasyTradeService`/`MuSigTradeService` matched the app type with strict equality. A network-wide halt would silently fail open in the trade services.

### Dev logs

 - long term fix to avoid https://github.com/bisq-network/bisq-mobile/issues/1775 ocurrence
 - Implemented TradeRestrictedException and usages to handle that case appropriately
 - closed gap with Unespecified restriction to afloat handling
 - handled structured error in Trade take offer
 - harden alerts bookeeping (current toggle impl make alerts overlap one another potentially causing missings)i
 - improved semantics on security alerts checks
 - added AI generated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer handling for trading restrictions caused by trading halts or required minimum versions.
  - Trade APIs now return structured error details, including restriction type and required version when applicable.
  - Alerts applying to all application types are now recognized consistently.
  - Trading version requirements are updated automatically when authorized alerts change.

- **Bug Fixes**
  - Improved detection and enforcement of applicable trading restrictions across desktop and trading services.
  - Preserved existing error messages while providing more precise restriction information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->