### PR TITLE
Prevent overflow in profile-card offer totals

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 public class BitcoinAmountDisplay extends HBox {
     @Getter
     private final StringProperty btcAmount = new SimpleStringProperty("");
+    private boolean showBtcCode = true;
     private final TextFlow valueTextFlow = new TextFlow();
     @Getter
     private final Text integerPart = new Text();
@@ -55,8 +56,10 @@ public class BitcoinAmountDisplay extends HBox {
 
     public BitcoinAmountDisplay(String amount, boolean showBtcCode) {
         this(amount);
-        btcCode.setVisible(showBtcCode);
-        btcCode.setManaged(showBtcCode);
+        this.showBtcCode = showBtcCode;
+        // Re-apply so btcCode visibility follows the numeric/non-numeric render rather than being
+        // forced on for a non-numeric value (which would show e.g. "N/A BTC").
+        updateDisplay();
     }
 
     public BitcoinAmountDisplay(String amount) {
@@ -145,7 +148,24 @@ public class BitcoinAmountDisplay extends HBox {
         }
 
         valueTextFlow.setVisible(true);
-        formatBtcAmount(amount);
+        try {
+            formatBtcAmount(amount);
+            btcCode.setVisible(showBtcCode);
+            btcCode.setManaged(showBtcCode);
+        } catch (NumberFormatException e) {
+            // A non-numeric value (e.g. a localized "N/A" for a total that cannot be represented)
+            // is rendered verbatim instead of crashing the parse.
+            displayNonNumeric(amount);
+        }
+    }
+
+    private void displayNonNumeric(String amount) {
+        setExclusiveStyle(integerPart, "bitcoin-amount-display-integer-part", "bitcoin-amount-display-integer-part-dimmed");
+        integerPart.setText(amount);
+        leadingZeros.setText("");
+        significantDigits.setText("");
+        btcCode.setVisible(false);
+        btcCode.setManaged(false);
     }
 
     private void setExclusiveStyle(Text textNode, String styleToAdd, String styleToRemove) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
@@ -170,7 +170,7 @@ public class BitcoinAmountDisplay extends HBox {
         boolean seenSeparator = false;
         for (int i = 0; i < amount.length(); i++) {
             char c = amount.charAt(i);
-            if (c == '-' && i == 0) {
+            if ((c == '-' || c == '+') && i == 0) {
                 continue;
             }
             if (c == decimalSeparator) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/components/controls/BitcoinAmountDisplay.java
@@ -148,15 +148,41 @@ public class BitcoinAmountDisplay extends HBox {
         }
 
         valueTextFlow.setVisible(true);
+        // The complete localized amount must be numeric; parsing only the integer part would let
+        // values like "1.N/A" or "1.2.3" through to the numeric formatting.
+        if (!isNumericAmount(amount)) {
+            displayNonNumeric(amount);
+            return;
+        }
         try {
             formatBtcAmount(amount);
             btcCode.setVisible(showBtcCode);
             btcCode.setManaged(showBtcCode);
         } catch (NumberFormatException e) {
-            // A non-numeric value (e.g. a localized "N/A" for a total that cannot be represented)
-            // is rendered verbatim instead of crashing the parse.
             displayNonNumeric(amount);
         }
+    }
+
+    private static boolean isNumericAmount(String amount) {
+        // Digits with at most one localized decimal separator and an optional leading sign; a
+        // bare separator stays accepted as the degenerate zero it always rendered as.
+        char decimalSeparator = StringUtils.getDecimalSeparator();
+        boolean seenSeparator = false;
+        for (int i = 0; i < amount.length(); i++) {
+            char c = amount.charAt(i);
+            if (c == '-' && i == 0) {
+                continue;
+            }
+            if (c == decimalSeparator) {
+                if (seenSeparator) {
+                    return false;
+                }
+                seenSeparator = true;
+            } else if (!Character.isDigit(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void displayNonNumeric(String amount) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewController.java
@@ -35,10 +35,14 @@ import bisq.presentation.formatters.TimeFormatter;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
 import bisq.user.reputation.ReputationService;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ProfileCardOverviewController implements Controller {
@@ -71,14 +75,12 @@ public class ProfileCardOverviewController implements Controller {
 
         String userProfileId = userProfile.getId();
         // TODO Need to add support for swapping base and quote currency when crypto market is used
-        long totalBaseOfferAmountToBuy = getTotalBaseOfferAmount(userProfileId, offer -> offer.getDisplayDirection().isBuy());
-        String formattedTotalBaseOfferAmountToBuy = AmountFormatter.formatBaseAmount(Coin.asBtcFromValue(totalBaseOfferAmountToBuy));
-        model.setTotalBaseOfferAmountToBuy(formattedTotalBaseOfferAmountToBuy);
+        model.setTotalBaseOfferAmountToBuy(formatTotalBaseOfferAmount(
+                getTotalBaseOfferAmount(userProfileId, offer -> offer.getDisplayDirection().isBuy())));
 
         // TODO Need to add support for swapping base and quote currency when crypto market is used
-        long totalBaseOfferAmountToSell = getTotalBaseOfferAmount(userProfileId, offer -> offer.getDisplayDirection().isSell());
-        String formattedTotalBaseOfferAmountToSell = AmountFormatter.formatBaseAmount(Coin.asBtcFromValue(totalBaseOfferAmountToSell));
-        model.setTotalBaseOfferAmountToSell(formattedTotalBaseOfferAmountToSell);
+        model.setTotalBaseOfferAmountToSell(formatTotalBaseOfferAmount(
+                getTotalBaseOfferAmount(userProfileId, offer -> offer.getDisplayDirection().isSell())));
 
         model.setSellingLimit(String.valueOf(AmountFormatter.formatQuoteAmount(getSellingAmountLimitInUsd(userProfileId))));
 
@@ -120,13 +122,40 @@ public class ProfileCardOverviewController implements Controller {
         }
     }
 
-    private long getTotalBaseOfferAmount(String userProfileId, Predicate<BisqEasyOffer> predicate) {
-        return getOffers(userProfileId)
+    private Optional<Long> getTotalBaseOfferAmount(String userProfileId, Predicate<BisqEasyOffer> predicate) {
+        List<Monetary> baseAmounts = getOffers(userProfileId)
                 .map(message -> message.getBisqEasyOffer().orElseThrow())
                 .filter(predicate)
                 .flatMap(offer -> OfferAmountUtil.findBaseSideMaxOrFixedAmount(marketPriceService, offer).stream())
-                .mapToLong(Monetary::getValue)
-                .sum();
+                .collect(Collectors.toList());
+        return checkedBaseAmountSum(baseAmounts);
+    }
+
+    // Individually valid base amounts can still overflow a long in aggregate. Sum with
+    // Math.addExact and treat an overflow as a value that cannot be represented.
+    @VisibleForTesting
+    static Optional<Long> checkedBaseAmountSum(List<Monetary> baseAmounts) {
+        try {
+            long total = 0L;
+            for (Monetary baseAmount : baseAmounts) {
+                long value = baseAmount.getValue();
+                // Drop malformed non-positive per-offer amounts (e.g. a negative from a wrapped
+                // conversion) so they cannot corrupt the total.
+                if (value <= 0) {
+                    continue;
+                }
+                total = Math.addExact(total, value);
+            }
+            return Optional.of(total);
+        } catch (ArithmeticException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static String formatTotalBaseOfferAmount(Optional<Long> totalBaseOfferAmount) {
+        return totalBaseOfferAmount
+                .map(value -> AmountFormatter.formatBaseAmount(Coin.asBtcFromValue(value)))
+                .orElseGet(() -> Res.get("data.na"));
     }
 
     private Stream<BisqEasyOfferbookMessage> getOffers(String userProfileId) {

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/components/controls/BitcoinAmountDisplayTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/components/controls/BitcoinAmountDisplayTest.java
@@ -388,6 +388,13 @@ class BitcoinAmountDisplayTest {
     }
 
     @Test
+    void testPositiveSignedAmountIsFormattedNumerically() {
+        bitcoinAmountDisplay.setBtcAmount("+1.2");
+        assertEquals("+1.", bitcoinAmountDisplay.getIntegerPart().getText());
+        assertTrue(bitcoinAmountDisplay.getBtcCode().isVisible());
+    }
+
+    @Test
     void testMultipleDecimalSeparatorsAreRenderedVerbatim() {
         bitcoinAmountDisplay.setBtcAmount("1.2.3");
         assertEquals("1.2.3", bitcoinAmountDisplay.getIntegerPart().getText());

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/components/controls/BitcoinAmountDisplayTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/components/controls/BitcoinAmountDisplayTest.java
@@ -352,4 +352,29 @@ class BitcoinAmountDisplayTest {
             LocaleRepository.setDefaultLocale(originalLocale);
         }
     }
+
+    @Test
+    void testNonNumericAmountIsRenderedVerbatimWithoutCrashing() {
+        bitcoinAmountDisplay.setBtcAmount("N/A");
+        assertEquals("N/A", bitcoinAmountDisplay.getIntegerPart().getText());
+        assertEquals("", bitcoinAmountDisplay.getLeadingZeros().getText());
+        assertEquals("", bitcoinAmountDisplay.getSignificantDigits().getText());
+        assertFalse(bitcoinAmountDisplay.getBtcCode().isVisible());
+    }
+
+    @Test
+    void testNonNumericHidesBtcCodeEvenWhenConstructedWithBtcCode() {
+        BitcoinAmountDisplay display = new BitcoinAmountDisplay("N/A", true);
+        assertEquals("N/A", display.getIntegerPart().getText());
+        assertFalse(display.getBtcCode().isVisible());
+    }
+
+    @Test
+    void testNonNumericResetsDimmedIntegerStyleFromPreviousRender() {
+        bitcoinAmountDisplay.setBtcAmount("0.0");
+        assertTrue(bitcoinAmountDisplay.getIntegerPart().getStyleClass().contains("bitcoin-amount-display-integer-part-dimmed"));
+        bitcoinAmountDisplay.setBtcAmount("N/A");
+        assertFalse(bitcoinAmountDisplay.getIntegerPart().getStyleClass().contains("bitcoin-amount-display-integer-part-dimmed"));
+        assertTrue(bitcoinAmountDisplay.getIntegerPart().getStyleClass().contains("bitcoin-amount-display-integer-part"));
+    }
 }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/components/controls/BitcoinAmountDisplayTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/components/controls/BitcoinAmountDisplayTest.java
@@ -377,4 +377,20 @@ class BitcoinAmountDisplayTest {
         assertFalse(bitcoinAmountDisplay.getIntegerPart().getStyleClass().contains("bitcoin-amount-display-integer-part-dimmed"));
         assertTrue(bitcoinAmountDisplay.getIntegerPart().getStyleClass().contains("bitcoin-amount-display-integer-part"));
     }
+
+    @Test
+    void testNonNumericFractionalPartIsRenderedVerbatim() {
+        bitcoinAmountDisplay.setBtcAmount("1.N/A");
+        assertEquals("1.N/A", bitcoinAmountDisplay.getIntegerPart().getText());
+        assertEquals("", bitcoinAmountDisplay.getLeadingZeros().getText());
+        assertEquals("", bitcoinAmountDisplay.getSignificantDigits().getText());
+        assertFalse(bitcoinAmountDisplay.getBtcCode().isVisible());
+    }
+
+    @Test
+    void testMultipleDecimalSeparatorsAreRenderedVerbatim() {
+        bitcoinAmountDisplay.setBtcAmount("1.2.3");
+        assertEquals("1.2.3", bitcoinAmountDisplay.getIntegerPart().getText());
+        assertFalse(bitcoinAmountDisplay.getBtcCode().isVisible());
+    }
 }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/user/profile_card/overview/ProfileCardOverviewControllerTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.user.profile_card.overview;
+
+import bisq.common.monetary.Coin;
+import bisq.common.monetary.Monetary;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProfileCardOverviewControllerTest {
+    @Test
+    void sumsIndividuallyValidBaseAmounts() {
+        List<Monetary> baseAmounts = List.of(Coin.asBtcFromValue(100), Coin.asBtcFromValue(200));
+        assertEquals(Optional.of(300L), ProfileCardOverviewController.checkedBaseAmountSum(baseAmounts));
+    }
+
+    @Test
+    void emptyListSumsToZero() {
+        assertEquals(Optional.of(0L), ProfileCardOverviewController.checkedBaseAmountSum(List.of()));
+    }
+
+    @Test
+    void aggregateOverflowIsNotRepresentable() {
+        // Each amount is individually valid but the sum exceeds Long.MAX_VALUE.
+        List<Monetary> baseAmounts = List.of(Coin.asBtcFromValue(Long.MAX_VALUE), Coin.asBtcFromValue(1));
+        assertEquals(Optional.empty(), ProfileCardOverviewController.checkedBaseAmountSum(baseAmounts));
+    }
+
+    @Test
+    void nonPositiveBaseAmountsAreDropped() {
+        List<Monetary> baseAmounts = List.of(Coin.asBtcFromValue(100), Coin.asBtcFromValue(-50), Coin.asBtcFromValue(0));
+        assertEquals(Optional.of(100L), ProfileCardOverviewController.checkedBaseAmountSum(baseAmounts));
+    }
+}


### PR DESCRIPTION
Fixes #4943

## Problem
`ProfileCardOverviewController#getTotalBaseOfferAmount` summed per-offer base amounts with a plain `long` sum, which can wrap to an incorrect or negative total even when each offer is individually valid.

## Fix
- Accumulate the total with `Math.addExact` in a checked helper (`checkedBaseAmountSum`); on overflow it returns empty and the card shows a localized `N/A`.
- Drop non-positive per-offer amounts so a single malformed value can't corrupt the total.
- `BitcoinAmountDisplay` parsed its input numerically and threw `NumberFormatException` on any non-numeric value (which would have crashed the whole card on the new `N/A`). It now renders a non-numeric value verbatim, hiding the BTC code, instead of crashing.

## Tests
`ProfileCardOverviewControllerTest` (normal sum, empty, aggregate overflow → empty, non-positive dropped) and `BitcoinAmountDisplayTest` (non-numeric rendered verbatim without crashing, incl. the two-arg constructor and dimmed-style reset).

## Remarks
A *positive* per-offer conversion wrap (a quote whose `PriceQuote` conversion overflows via `BigDecimal.longValue()`) is the separate #4910, addressed by #4922, and is out of scope here — this PR fixes the aggregate total. The overflow/`N/A` path is only reachable with malformed peer offers, so it isn't reliably reproducible in a running client; it is covered by unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bitcoin amounts that cannot be parsed numerically are now displayed as provided without errors, with clearer formatting and styling.
  * Profile offer totals now ignore invalid or non-positive amounts and safely indicate when a total cannot be calculated.
  * Buy and sell totals consistently display an unavailable value when no valid total exists.

* **Tests**
  * Added coverage for nonnumeric amounts, valid totals, empty data, invalid values, and overflow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->