### PR TITLE
chore: sync #4973 to main — chore/4965_review_followups

### DIFF
--- a/api/src/main/java/bisq/api/dto/settings/SettingsApiVersionDto.java
+++ b/api/src/main/java/bisq/api/dto/settings/SettingsApiVersionDto.java
@@ -19,7 +19,9 @@ package bisq.api.dto.settings;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import javax.annotation.Nullable;
+
 // imageVersion is only present on containerised distributions (see SettingsRestApi.resolveImageVersion)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record SettingsApiVersionDto(String version, String imageVersion) {
+public record SettingsApiVersionDto(String version, @Nullable String imageVersion) {
 }

--- a/apps/api-app/docker/README.md
+++ b/apps/api-app/docker/README.md
@@ -120,7 +120,8 @@ scope, then:
 echo "$GITHUB_PAT" | docker login ghcr.io -u <you> --password-stdin
 
 VERSION=2.1.11.1
-docker build -f apps/api-app/docker/Dockerfile -t ghcr.io/<you>/bisq2-api:$VERSION .
+docker build -f apps/api-app/docker/Dockerfile --build-arg IMAGE_VERSION=$VERSION \
+  -t ghcr.io/<you>/bisq2-api:$VERSION .
 docker build -f apps/api-app/docker/qr-ui/Dockerfile --build-arg APP_VERSION=$VERSION \
   -t ghcr.io/<you>/bisq2-api-web-ui:$VERSION apps/api-app/docker/qr-ui
 docker push ghcr.io/<you>/bisq2-api:$VERSION


### PR DESCRIPTION
Automated sync of #4973 from `for-mobile-based-on-2.1.12` to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API compatibility when an image version is unavailable by allowing it to be omitted from responses.

* **Documentation**
  * Updated the manual API image publishing instructions to include the image version during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->