### PR TITLE
Make chat mention tagging follow the caret

### DIFF
--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -46,8 +46,10 @@ import bisq.settings.SettingsService;
 import bisq.user.banned.BannedUserService;
 import bisq.user.identity.UserIdentity;
 import bisq.user.identity.UserIdentityService;
+import bisq.desktop.main.content.chat.message_container.components.ChatMentionParser;
 import bisq.user.profile.UserProfile;
 import bisq.user.profile.UserProfileService;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -211,10 +213,37 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
         return chatMessagesListController.scrollPageDown();
     }
 
-    void onUserProfileSelected(UserProfile user) {
-        String content = model.getTextInput().get().replaceAll("@[a-zA-Z\\d]*$", "@" + user.getUserName() + " ");
-        model.getTextInput().set(content);
-        model.getCaretPosition().set(content.length());
+    @VisibleForTesting
+    ChatMessageContainerModel getModel() {
+        return model;
+    }
+
+    void onUserProfileSelected(UserProfile user, ChatMentionParser.MentionMatch match) {
+        String text = model.getTextInput().get();
+        if (text == null
+                || match.indicatorIndex() < 0
+                || match.caretPosition() > text.length()
+                || match.indicatorIndex() >= match.caretPosition()) {
+            // The text changed between parsing and selection; dropping the completion is safer
+            // than replacing an arbitrary range.
+            return;
+        }
+        String prefix = text.substring(0, match.indicatorIndex());
+        String suffix = text.substring(match.caretPosition());
+        String mention = "@" + user.getUserName();
+        int caretPosition = prefix.length() + mention.length();
+        String separator = "";
+        if (suffix.startsWith(" ")) {
+            // Reuse the existing space and continue typing after it.
+            caretPosition++;
+        } else if (suffix.isEmpty() || Character.isLetterOrDigit(suffix.charAt(0))) {
+            // A separating space is only needed before a word; punctuation and line breaks
+            // must stay attached to the mention.
+            separator = " ";
+            caretPosition++;
+        }
+        model.getTextInput().set(prefix + mention + separator + suffix);
+        model.getCaretPosition().set(caretPosition);
     }
 
     void onOpenProfileCard(UserProfile userProfile) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerController.java
@@ -243,7 +243,7 @@ public class ChatMessageContainerController implements bisq.desktop.common.view.
             caretPosition++;
         }
         model.getTextInput().set(prefix + mention + separator + suffix);
-        model.getCaretPosition().set(caretPosition);
+        model.getCaretPositionRequest().set(ChatMessageContainerModel.CaretPositionRequest.of(caretPosition));
     }
 
     void onOpenProfileCard(UserProfile userProfile) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerModel.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerModel.java
@@ -26,6 +26,8 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import lombok.Getter;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 @Getter
 public class ChatMessageContainerModel implements bisq.desktop.common.view.Model {
     private final ChatChannelDomain chatChannelDomain;
@@ -37,9 +39,20 @@ public class ChatMessageContainerModel implements bisq.desktop.common.view.Model
     private final ObjectProperty<Boolean> focusInputTextField = new SimpleObjectProperty<>();
     private final ObservableList<UserProfile> mentionableUsers = FXCollections.observableArrayList();
     private final BooleanProperty chatDialogEnabled = new SimpleBooleanProperty(true);
-    private final IntegerProperty caretPosition = new SimpleIntegerProperty();
+    private final ObjectProperty<CaretPositionRequest> caretPositionRequest = new SimpleObjectProperty<>();
 
     public ChatMessageContainerModel(ChatChannelDomain chatChannelDomain) {
         this.chatChannelDomain = chatChannelDomain;
+    }
+
+    // Positioning the caret is a request, not a state: consecutive requests for the same
+    // position must each reach the view, so every request carries a fresh sequence number
+    // to defeat the change listener's equality check.
+    public record CaretPositionRequest(int position, long sequence) {
+        private static final AtomicLong SEQUENCES = new AtomicLong();
+
+        public static CaretPositionRequest of(int position) {
+            return new CaretPositionRequest(position, SEQUENCES.incrementAndGet());
+        }
     }
 }

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -27,6 +27,7 @@ import bisq.desktop.main.content.chat.ChatUtil;
 import bisq.desktop.main.content.chat.message_container.components.ChatMentionPopupMenu;
 import bisq.desktop.main.content.components.UserProfileSelection;
 import bisq.i18n.Res;
+import com.google.common.annotations.VisibleForTesting;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -241,6 +242,11 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
         messagesListView.visibleProperty().unbind();
         messagesListView.managedProperty().unbind();
         userProfileSelectionRoot.disableProperty().unbind();
+    }
+
+    @VisibleForTesting
+    ChatMentionPopupMenu userMentionPopup() {
+        return userMentionPopup;
     }
 
     private void processKeyPressed(KeyEvent keyEvent) {

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerView.java
@@ -103,9 +103,9 @@ public class ChatMessageContainerView extends bisq.desktop.common.view.View<VBox
 
         inputField.textProperty().bindBidirectional(model.getTextInput());
 
-        caretPositionPin = EasyBind.subscribe(model.getCaretPosition(), position -> {
-            if (position != null) {
-                inputField.positionCaret(position.intValue());
+        caretPositionPin = EasyBind.subscribe(model.getCaretPositionRequest(), request -> {
+            if (request != null) {
+                inputField.positionCaret(request.position());
             }
         });
 

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionParser.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionParser.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.components;
+
+import java.util.Optional;
+
+/**
+ * Finds the mention token the caret is currently inside. The single parsed match is shared by
+ * the popup filter and the completion so both always agree on the replaced range.
+ */
+public final class ChatMentionParser {
+    private static final char INDICATOR = '@';
+
+    public record MentionMatch(String query, int indicatorIndex, int caretPosition) {
+    }
+
+    public static Optional<MentionMatch> findMentionAtCaret(String text, int caretPosition) {
+        if (text == null || caretPosition < 1 || caretPosition > text.length()) {
+            return Optional.empty();
+        }
+        int indicatorIndex = -1;
+        for (int i = caretPosition - 1; i >= 0; i--) {
+            char c = text.charAt(i);
+            if (c == INDICATOR) {
+                indicatorIndex = i;
+                break;
+            }
+            if (!isTokenCharacter(c)) {
+                return Optional.empty();
+            }
+        }
+        if (indicatorIndex < 0) {
+            return Optional.empty();
+        }
+        if (indicatorIndex > 0 && !Character.isWhitespace(text.charAt(indicatorIndex - 1))) {
+            return Optional.empty();
+        }
+        // The completion never replaces past the caret: text right after the caret can be a
+        // pre-existing word the user typed the mention in front of, and deleting it silently
+        // would be worse than leaving a token remainder behind (the editor-standard behavior).
+        return Optional.of(new MentionMatch(text.substring(indicatorIndex + 1, caretPosition), indicatorIndex, caretPosition));
+    }
+
+    private static boolean isTokenCharacter(char c) {
+        return Character.isLetterOrDigit(c) && c < 128;
+    }
+
+    private ChatMentionParser() {
+    }
+}

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionPopupMenu.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionPopupMenu.java
@@ -22,10 +22,11 @@ import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.controls.BisqPopup;
 import bisq.desktop.components.controls.BisqTextArea;
 import bisq.i18n.Res;
+import bisq.desktop.main.content.chat.message_container.components.ChatMentionParser.MentionMatch;
 import bisq.user.profile.UserProfile;
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -37,27 +38,35 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.control.IndexedCell;
+import javafx.scene.control.skin.VirtualFlow;
+import javafx.scene.input.KeyEvent;
 import javafx.util.Callback;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 @Slf4j
 public class ChatMentionPopupMenu extends BisqPopup {
     private final BisqTextArea inputField;
-    private final Consumer<UserProfile> userProfileSelectedHandler;
-    private final StringProperty filter = new SimpleStringProperty();
+    private final BiConsumer<UserProfile, MentionMatch> userProfileSelectedHandler;
+    private final ObjectProperty<MentionMatch> mentionMatch = new SimpleObjectProperty<>();
+    // Escape dismisses the popup for the current mention token; leaving the token re-arms it.
+    private boolean dismissed;
+    // Last non-torn parse result; JavaFX updates the text before clamping the caret, and the
+    // torn intermediate state must not produce a transient null that wipes the dismissal.
+    private MentionMatch lastStableMatch;
     @Getter
     private final ObservableList<ListItem> observableList = FXCollections.observableArrayList();
     private final FilteredList<ListItem> filteredList = new FilteredList<>(observableList);
     private final SortedList<ListItem> sortedList = new SortedList<>(filteredList);
     private final ListView<ListItem> listView = new ListView<>(sortedList);
-    private final ChangeListener<String> filterChangeListener;
+    private final ChangeListener<MentionMatch> mentionMatchChangeListener;
 
-    public ChatMentionPopupMenu(BisqTextArea inputField, Consumer<UserProfile> userProfileSelectedHandler) {
+    public ChatMentionPopupMenu(BisqTextArea inputField, BiConsumer<UserProfile, MentionMatch> userProfileSelectedHandler) {
         super();
         this.inputField = inputField;
         this.userProfileSelectedHandler = userProfileSelectedHandler;
@@ -77,30 +86,149 @@ public class ChatMentionPopupMenu extends BisqPopup {
         setContentNode(listView);
         getStyleClass().add("chat-mention-popup");
 
-        filterChangeListener = (observableValue, oldValue, newValue) -> {
+        // While a popup is showing, JavaFX redirects the owner window's key events to the popup
+        // window first, so the navigation keys must be handled here - a filter on the input
+        // field never sees them. Unhandled keys (typed characters, Enter without a candidate)
+        // continue to the input field through the same redirection.
+        addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyPressed);
+
+        mentionMatchChangeListener = (observableValue, oldValue, newValue) -> {
             if (newValue != null) {
-                filteredList.setPredicate(item -> item.matchUserName(newValue));
-                sortedList.setComparator(sortByPrefixMatchingQuery(newValue));
+                // The caret can jump from one mention token straight into another; the token
+                // identity, not a null transition, decides when the dismissal is re-armed.
+                boolean isNewToken = oldValue == null || oldValue.indicatorIndex() != newValue.indicatorIndex();
+                if (isNewToken) {
+                    dismissed = false;
+                }
+                String query = newValue.query();
+                filteredList.setPredicate(item -> item.matchUserName(query));
+                sortedList.setComparator(sortByPrefixMatchingQuery(query));
                 listView.setPrefHeight(Math.min(ListItem.CELL_HEIGHT * 10, filteredList.size() * ListItem.CELL_HEIGHT));
-                if (oldValue == null) {
+                listView.getSelectionModel().clearSelection();
+                if (!dismissed && !isShowing()) {
                     show(inputField);
                 }
             } else {
+                dismissed = false;
                 hide();
             }
         };
     }
 
     public void init() {
-        filter.addListener(filterChangeListener);
-        filter.bind(Bindings.createStringBinding(
-                () -> StringUtils.deriveWordStartingWith(inputField.getText(), '@'),
-                inputField.textProperty()));
+        mentionMatch.addListener(mentionMatchChangeListener);
+        mentionMatch.bind(Bindings.createObjectBinding(
+                () -> {
+                    String text = inputField.getText();
+                    int caretPosition = inputField.getCaretPosition();
+                    if (text != null && caretPosition > text.length()) {
+                        // Torn text/caret intermediate state: keep the previous result until
+                        // the caret is clamped.
+                        return lastStableMatch;
+                    }
+                    lastStableMatch = ChatMentionParser.findMentionAtCaret(text, caretPosition).orElse(null);
+                    return lastStableMatch;
+                },
+                inputField.textProperty(),
+                inputField.caretPositionProperty()));
     }
 
     public void cleanup() {
-        filter.removeListener(filterChangeListener);
-        filter.unbind();
+        hide();
+        mentionMatch.removeListener(mentionMatchChangeListener);
+        mentionMatch.unbind();
+        mentionMatch.set(null);
+        listView.getSelectionModel().clearSelection();
+        dismissed = false;
+        lastStableMatch = null;
+    }
+
+    public boolean moveSelectionDown() {
+        if (sortedList.isEmpty()) {
+            return false;
+        }
+        int index = listView.getSelectionModel().getSelectedIndex();
+        int next = Math.min(index + 1, sortedList.size() - 1);
+        listView.getSelectionModel().select(next);
+        scrollToIfNotVisible(next);
+        return true;
+    }
+
+    public boolean moveSelectionUp() {
+        if (sortedList.isEmpty()) {
+            return false;
+        }
+        int index = listView.getSelectionModel().getSelectedIndex();
+        int previous = Math.max(index - 1, 0);
+        listView.getSelectionModel().select(previous);
+        scrollToIfNotVisible(previous);
+        return true;
+    }
+
+    private void scrollToIfNotVisible(int index) {
+        // scrollTo anchors the row to the top, so calling it unconditionally makes the whole
+        // list jump on every arrow press; only scroll when the selection leaves the viewport.
+        if (listView.lookup(".virtual-flow") instanceof VirtualFlow<?> virtualFlow) {
+            IndexedCell<?> firstVisibleCell = virtualFlow.getFirstVisibleCell();
+            IndexedCell<?> lastVisibleCell = virtualFlow.getLastVisibleCell();
+            if (firstVisibleCell != null && lastVisibleCell != null
+                    && index >= firstVisibleCell.getIndex() && index <= lastVisibleCell.getIndex()) {
+                return;
+            }
+        }
+        listView.scrollTo(index);
+    }
+
+    public boolean completeSelection() {
+        MentionMatch match = mentionMatch.get();
+        if (match == null || sortedList.isEmpty()) {
+            return false;
+        }
+        ListItem item = listView.getSelectionModel().getSelectedItem();
+        if (item == null) {
+            item = sortedList.get(0);
+        }
+        userProfileSelectedHandler.accept(item.getUserProfile(), match);
+        // Completion dismisses like Escape: when the caret lands inside the completed token
+        // (e.g. before punctuation) the popup must not immediately re-open.
+        dismiss();
+        return true;
+    }
+
+    public void dismiss() {
+        dismissed = true;
+        hide();
+    }
+
+    private void handleKeyPressed(KeyEvent keyEvent) {
+        boolean noModifiers = !keyEvent.isShiftDown() && !keyEvent.isControlDown()
+                && !keyEvent.isAltDown() && !keyEvent.isMetaDown();
+        switch (keyEvent.getCode()) {
+            case DOWN -> {
+                // With an empty result list the arrows keep their text-area meaning.
+                if (noModifiers && moveSelectionDown()) {
+                    keyEvent.consume();
+                }
+            }
+            case UP -> {
+                if (noModifiers && moveSelectionUp()) {
+                    keyEvent.consume();
+                }
+            }
+            case ENTER, TAB -> {
+                // Without a completable candidate the event continues to the input field, so
+                // Enter still sends the message.
+                if (noModifiers && completeSelection()) {
+                    keyEvent.consume();
+                }
+            }
+            case ESCAPE -> {
+                dismiss();
+                keyEvent.consume();
+            }
+            default -> {
+            }
+        }
     }
 
     @Override
@@ -144,8 +272,11 @@ public class ChatMentionPopupMenu extends BisqPopup {
                         if (item != null && !empty) {
                             button.setText(item.getUserName());
                             button.setOnAction(e -> {
-                                userProfileSelectedHandler.accept(item.getUserProfile());
-                                hide();
+                                MentionMatch match = mentionMatch.get();
+                                if (match != null) {
+                                    userProfileSelectedHandler.accept(item.getUserProfile(), match);
+                                }
+                                dismiss();
                             });
 
                             setGraphic(button);

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionPopupMenu.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionPopupMenu.java
@@ -72,6 +72,10 @@ public class ChatMentionPopupMenu extends BisqPopup {
         this.userProfileSelectedHandler = userProfileSelectedHandler;
 
         sortedList.setComparator(ListItem::compareTo);
+        // The key filter below owns the keyboard; if the list ever became the popup's focus
+        // owner, its own key handling would swallow redirected keys (e.g. Enter) that must
+        // fall through to the input field.
+        listView.setFocusTraversable(false);
         listView.getStyleClass().add("chat-mention-list-view");
         listView.setPrefWidth(450);
         listView.setCellFactory(getCellFactory());
@@ -96,7 +100,11 @@ public class ChatMentionPopupMenu extends BisqPopup {
             if (newValue != null) {
                 // The caret can jump from one mention token straight into another; the token
                 // identity, not a null transition, decides when the dismissal is re-armed.
-                boolean isNewToken = oldValue == null || oldValue.indicatorIndex() != newValue.indicatorIndex();
+                // The indicator offset alone is not identity: replacing a dismissed token with
+                // a fresh one at the same offset must re-arm too.
+                boolean isNewToken = oldValue == null
+                        || oldValue.indicatorIndex() != newValue.indicatorIndex()
+                        || !isWithinTokenEdit(oldValue.query(), newValue.query());
                 if (isNewToken) {
                     dismissed = false;
                 }
@@ -200,6 +208,15 @@ public class ChatMentionPopupMenu extends BisqPopup {
         hide();
     }
 
+    private static boolean isWithinTokenEdit(String oldQuery, String newQuery) {
+        if (newQuery.isEmpty()) {
+            // The token content was cleared; whatever comes next is a fresh mention attempt.
+            return oldQuery.isEmpty();
+        }
+        // Typing extends the query and Backspace truncates it; anything else replaced it.
+        return oldQuery.startsWith(newQuery) || newQuery.startsWith(oldQuery);
+    }
+
     private void handleKeyPressed(KeyEvent keyEvent) {
         boolean noModifiers = !keyEvent.isShiftDown() && !keyEvent.isControlDown()
                 && !keyEvent.isAltDown() && !keyEvent.isMetaDown();
@@ -263,6 +280,7 @@ public class ChatMentionPopupMenu extends BisqPopup {
                     {
                         button.getStyleClass().add("chat-mention-list-button");
                         button.setMaxWidth(Double.MAX_VALUE);
+                        button.setFocusTraversable(false);
                     }
 
                     @Override

--- a/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionPopupMenu.java
+++ b/apps/desktop/desktop/src/main/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionPopupMenu.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.content.chat.message_container.components;
 
 import bisq.common.util.StringUtils;
+import bisq.desktop.common.threading.UIThread;
 import bisq.desktop.common.utils.ImageUtil;
 import bisq.desktop.components.controls.BisqPopup;
 import bisq.desktop.components.controls.BisqTextArea;
@@ -38,6 +39,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.input.KeyEvent;
@@ -56,6 +58,21 @@ public class ChatMentionPopupMenu extends BisqPopup {
     private final ObjectProperty<MentionMatch> mentionMatch = new SimpleObjectProperty<>();
     // Escape dismisses the popup for the current mention token; leaving the token re-arms it.
     private boolean dismissed;
+    // Indicator offset of the dismissed token. An edit that overwrites this character ends
+    // the token, and with it the dismissal; the tracker below watches for that.
+    private int dismissedIndicatorIndex = -1;
+    private final TextFormatter<String> tokenEditTracker = new TextFormatter<>(change -> {
+        if (dismissed
+                && change.isContentChange()
+                && change.getRangeStart() <= dismissedIndicatorIndex
+                && dismissedIndicatorIndex < change.getRangeEnd()) {
+            // The edit removed or replaced the dismissed token's indicator character, so
+            // whatever the edit produced at this offset is a fresh mention attempt.
+            dismissed = false;
+            reevaluateAfterEdit();
+        }
+        return change;
+    });
     // Last non-torn parse result; JavaFX updates the text before clamping the caret, and the
     // torn intermediate state must not produce a transient null that wipes the dismissal.
     private MentionMatch lastStableMatch;
@@ -100,11 +117,9 @@ public class ChatMentionPopupMenu extends BisqPopup {
             if (newValue != null) {
                 // The caret can jump from one mention token straight into another; the token
                 // identity, not a null transition, decides when the dismissal is re-armed.
-                // The indicator offset alone is not identity: replacing a dismissed token with
-                // a fresh one at the same offset must re-arm too.
-                boolean isNewToken = oldValue == null
-                        || oldValue.indicatorIndex() != newValue.indicatorIndex()
-                        || !isWithinTokenEdit(oldValue.query(), newValue.query());
+                // A same-offset replacement is caught by the edit tracker, which drops the
+                // dismissal when an edit overwrites the dismissed token's indicator.
+                boolean isNewToken = oldValue == null || oldValue.indicatorIndex() != newValue.indicatorIndex();
                 if (isNewToken) {
                     dismissed = false;
                 }
@@ -124,6 +139,7 @@ public class ChatMentionPopupMenu extends BisqPopup {
     }
 
     public void init() {
+        inputField.setTextFormatter(tokenEditTracker);
         mentionMatch.addListener(mentionMatchChangeListener);
         mentionMatch.bind(Bindings.createObjectBinding(
                 () -> {
@@ -143,11 +159,13 @@ public class ChatMentionPopupMenu extends BisqPopup {
 
     public void cleanup() {
         hide();
+        inputField.setTextFormatter(null);
         mentionMatch.removeListener(mentionMatchChangeListener);
         mentionMatch.unbind();
         mentionMatch.set(null);
         listView.getSelectionModel().clearSelection();
         dismissed = false;
+        dismissedIndicatorIndex = -1;
         lastStableMatch = null;
     }
 
@@ -204,17 +222,25 @@ public class ChatMentionPopupMenu extends BisqPopup {
     }
 
     public void dismiss() {
+        MentionMatch match = mentionMatch.get();
+        dismissedIndicatorIndex = match != null ? match.indicatorIndex() : -1;
         dismissed = true;
         hide();
     }
 
-    private static boolean isWithinTokenEdit(String oldQuery, String newQuery) {
-        if (newQuery.isEmpty()) {
-            // The token content was cleared; whatever comes next is a fresh mention attempt.
-            return oldQuery.isEmpty();
-        }
-        // Typing extends the query and Backspace truncates it; anything else replaced it.
-        return oldQuery.startsWith(newQuery) || newQuery.startsWith(oldQuery);
+    private void reevaluateAfterEdit() {
+        // A byte-identical replacement changes neither the text nor the match, so the match
+        // listener never runs; re-evaluate once the edit has been applied. The formatter
+        // check keeps a queued callback from acting after cleanup().
+        UIThread.runOnNextRenderFrame(() -> {
+            if (inputField.getTextFormatter() != tokenEditTracker) {
+                return;
+            }
+            MentionMatch match = mentionMatch.get();
+            if (match != null && !dismissed && !isShowing()) {
+                show(inputField);
+            }
+        });
     }
 
     private void handleKeyPressed(KeyEvent keyEvent) {

--- a/apps/desktop/desktop/src/main/resources/css/chat.css
+++ b/apps/desktop/desktop/src/main/resources/css/chat.css
@@ -386,6 +386,12 @@
     -fx-background-radius: 8;
 }
 
+/* The opaque button covers the cell, so the keyboard selection highlight must target it. */
+.chat-mention-list-view .list-cell:selected .chat-mention-list-button {
+    -fx-background-color: -bisq-dark-grey-50;
+    -fx-text-fill: -bisq2-green;
+}
+
 .chat-mention-placeholder-label {
     -fx-padding: 5 0;
 }

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerControllerTest.java
@@ -112,7 +112,7 @@ class ChatMessageContainerControllerTest extends TestFxHeadlessSupport {
 
         // The existing space after the token is reused, not duplicated.
         assertThat(controller.getModel().getTextInput().get()).isEqualTo("Hi @john there");
-        assertThat(controller.getModel().getCaretPosition().get()).isEqualTo(9);
+        assertThat(controller.getModel().getCaretPositionRequest().get().position()).isEqualTo(9);
     }
 
     @Test
@@ -134,7 +134,7 @@ class ChatMessageContainerControllerTest extends TestFxHeadlessSupport {
         });
 
         assertThat(controller.getModel().getTextInput().get()).isEqualTo("@alice world");
-        assertThat(controller.getModel().getCaretPosition().get()).isEqualTo(7);
+        assertThat(controller.getModel().getCaretPositionRequest().get().position()).isEqualTo(7);
     }
 
     @Test
@@ -155,7 +155,7 @@ class ChatMessageContainerControllerTest extends TestFxHeadlessSupport {
         });
 
         assertThat(controller.getModel().getTextInput().get()).isEqualTo("Hi @alice, there");
-        assertThat(controller.getModel().getCaretPosition().get()).isEqualTo(9);
+        assertThat(controller.getModel().getCaretPositionRequest().get().position()).isEqualTo(9);
     }
 
     @Test

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerControllerTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerControllerTest.java
@@ -25,6 +25,7 @@ import bisq.common.observable.Observable;
 import bisq.common.observable.collection.ObservableSet;
 import bisq.desktop.common.Transitions;
 import bisq.desktop.ServiceProvider;
+import bisq.desktop.main.content.chat.message_container.components.ChatMentionParser;
 import bisq.desktop.testutil.TestFxHeadlessSupport;
 import bisq.settings.SettingsService;
 import bisq.user.identity.UserIdentity;
@@ -90,6 +91,90 @@ class ChatMessageContainerControllerTest extends TestFxHeadlessSupport {
         assertThat(controller.publishedCitation).isEqualTo(Optional.empty());
         assertThat(controller.publishedChannel).isEqualTo(channel);
         assertThat(controller.publishedUserIdentity).isSameAs(selectedUserIdentity);
+    }
+
+    @Test
+    void mentionCompletionReplacesTheTokenAtTheCaretAndPreservesTheSuffix(FxRobot robot) {
+        closeable = MockitoAnnotations.openMocks(this);
+        Transitions.setSettingsService(settingsService);
+        when(settingsService.getUseAnimations()).thenReturn(new Observable<>(false));
+        when(serviceProvider.getUserService().getUserIdentityService().getUserIdentities())
+                .thenReturn(new ObservableSet<>());
+        TestableController controller = new TestableController(serviceProvider, ChatChannelDomain.SUPPORT);
+        UserProfile mentioned = mock(UserProfile.class);
+        when(mentioned.getUserName()).thenReturn("john");
+
+        robot.interact(() -> {
+            controller.getModel().getTextInput().set("Hi @jo there");
+            controller.onUserProfileSelected(mentioned,
+                    new ChatMentionParser.MentionMatch("jo", 3, 6));
+        });
+
+        // The existing space after the token is reused, not duplicated.
+        assertThat(controller.getModel().getTextInput().get()).isEqualTo("Hi @john there");
+        assertThat(controller.getModel().getCaretPosition().get()).isEqualTo(9);
+    }
+
+    @Test
+    void mentionCompletionDoesNotDeleteTheWordAfterTheCaret(FxRobot robot) {
+        closeable = MockitoAnnotations.openMocks(this);
+        Transitions.setSettingsService(settingsService);
+        when(settingsService.getUseAnimations()).thenReturn(new Observable<>(false));
+        when(serviceProvider.getUserService().getUserIdentityService().getUserIdentities())
+                .thenReturn(new ObservableSet<>());
+        TestableController controller = new TestableController(serviceProvider, ChatChannelDomain.SUPPORT);
+        UserProfile mentioned = mock(UserProfile.class);
+        when(mentioned.getUserName()).thenReturn("alice");
+
+        robot.interact(() -> {
+            // "@al" typed directly in front of the pre-existing word "world".
+            controller.getModel().getTextInput().set("@alworld");
+            controller.onUserProfileSelected(mentioned,
+                    new ChatMentionParser.MentionMatch("al", 0, 3));
+        });
+
+        assertThat(controller.getModel().getTextInput().get()).isEqualTo("@alice world");
+        assertThat(controller.getModel().getCaretPosition().get()).isEqualTo(7);
+    }
+
+    @Test
+    void mentionCompletionBeforePunctuationDoesNotInsertASpace(FxRobot robot) {
+        closeable = MockitoAnnotations.openMocks(this);
+        Transitions.setSettingsService(settingsService);
+        when(settingsService.getUseAnimations()).thenReturn(new Observable<>(false));
+        when(serviceProvider.getUserService().getUserIdentityService().getUserIdentities())
+                .thenReturn(new ObservableSet<>());
+        TestableController controller = new TestableController(serviceProvider, ChatChannelDomain.SUPPORT);
+        UserProfile mentioned = mock(UserProfile.class);
+        when(mentioned.getUserName()).thenReturn("alice");
+
+        robot.interact(() -> {
+            controller.getModel().getTextInput().set("Hi @al, there");
+            controller.onUserProfileSelected(mentioned,
+                    new ChatMentionParser.MentionMatch("al", 3, 6));
+        });
+
+        assertThat(controller.getModel().getTextInput().get()).isEqualTo("Hi @alice, there");
+        assertThat(controller.getModel().getCaretPosition().get()).isEqualTo(9);
+    }
+
+    @Test
+    void mentionCompletionWithAStaleMatchIsDropped(FxRobot robot) {
+        closeable = MockitoAnnotations.openMocks(this);
+        Transitions.setSettingsService(settingsService);
+        when(settingsService.getUseAnimations()).thenReturn(new Observable<>(false));
+        when(serviceProvider.getUserService().getUserIdentityService().getUserIdentities())
+                .thenReturn(new ObservableSet<>());
+        TestableController controller = new TestableController(serviceProvider, ChatChannelDomain.SUPPORT);
+        UserProfile mentioned = mock(UserProfile.class);
+
+        robot.interact(() -> {
+            controller.getModel().getTextInput().set("x");
+            controller.onUserProfileSelected(mentioned,
+                    new ChatMentionParser.MentionMatch("jo", 0, 5));
+        });
+
+        assertThat(controller.getModel().getTextInput().get()).isEqualTo("x");
     }
 
     private static final class TestableController extends ChatMessageContainerController {

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerViewTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerViewTest.java
@@ -385,7 +385,7 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
     }
 
     @Test
-    void atomicallyExtendingADismissedTokenStaysDismissed(FxRobot robot) {
+    void atomicallyReplacingADismissedTokenReArmsThePopup(FxRobot robot) {
         TextInputControl input = view.messageInput();
         UserProfile alice = mock(UserProfile.class);
         when(alice.getUserName()).thenReturn("alice");
@@ -404,20 +404,20 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(view.userMentionPopup().isShowing()).isFalse();
 
-        // Extending the query in one edit is the same intent as typing the rest of the name
-        // after Escape; the dismissal must hold.
+        // The edit replaces the dismissed token's indicator, so the dismissed token no
+        // longer exists; the fresh one at the same offset re-arms the popup.
         robot.interact(() -> {
             input.selectAll();
             input.replaceSelection("@alice");
         });
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(view.userMentionPopup().isShowing())
-                .as("extending a dismissed token must not reopen the popup")
-                .isFalse();
+                .as("replacing the dismissed token wholesale must reopen the popup")
+                .isTrue();
     }
 
     @Test
-    void backspacingToTheBareIndicatorStartsAFreshAttempt(FxRobot robot) {
+    void backspacingToTheBareIndicatorKeepsThePopupHidden(FxRobot robot) {
         TextInputControl input = view.messageInput();
         UserProfile alice = mock(UserProfile.class);
         when(alice.getUserName()).thenReturn("alice");
@@ -436,12 +436,43 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(view.userMentionPopup().isShowing()).isFalse();
 
-        // Clearing the token content ends the dismissed attempt: a retype at the bare
-        // indicator is indistinguishable from this transition, so both re-arm.
+        // The indicator survives the edit, so this is still the dismissed token.
         robot.interact(() -> input.deleteText(1, 2));
         WaitForAsyncUtils.waitForFxEvents();
         assertThat(view.userMentionPopup().isShowing())
-                .as("an emptied token is a fresh mention attempt")
+                .as("backspacing within the dismissed token must not reopen the popup")
+                .isFalse();
+    }
+
+    @Test
+    void replacingADismissedTokenWithIdenticalTextReArmsThePopup(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        // A byte-identical replacement changes neither the text nor the match, so only the
+        // edit itself can re-arm and re-show the popup.
+        robot.interact(() -> {
+            input.selectAll();
+            input.replaceSelection("@al");
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("replacing the dismissed token with identical text must reopen the popup")
                 .isTrue();
     }
 

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerViewTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerViewTest.java
@@ -59,6 +59,7 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
 
     private AutoCloseable closeable;
     private Stage stage;
+    private ChatMessageContainerModel model;
     private ChatMessageContainerView view;
 
     @Start
@@ -68,7 +69,7 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
 
         when(userProfileSelection.getRoot()).thenReturn(new Pane());
 
-        ChatMessageContainerModel model = new ChatMessageContainerModel(ChatChannelDomain.SUPPORT);
+        model = new ChatMessageContainerModel(ChatChannelDomain.SUPPORT);
         view = new ChatMessageContainerView(model,
                 controller,
                 new VBox(),
@@ -232,6 +233,243 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
         assertThat(view.userMentionPopup().isShowing())
                 .as("a fresh mention token after leaving the dismissed one must open the popup")
                 .isTrue();
+    }
+
+    @Test
+    void arrowDownMovesTheSelectionAndTabCompletesIt(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile albert = mock(UserProfile.class);
+        when(albert.getUserName()).thenReturn("albert");
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(albert), new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isTrue();
+
+        // Both candidates match; they sort alphabetically, so the second ArrowDown lands on alice.
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DOWN, false, false, false, false)));
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DOWN, false, false, false, false)));
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.TAB, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verify(controller).onUserProfileSelected(eq(alice), any());
+        verify(controller, never()).onSendMessage(any());
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+    }
+
+    @Test
+    void arrowUpMovesTheSelectionBack(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile albert = mock(UserProfile.class);
+        when(albert.getUserName()).thenReturn("albert");
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(albert), new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DOWN, false, false, false, false)));
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DOWN, false, false, false, false)));
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.UP, false, false, false, false)));
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ENTER, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verify(controller).onUserProfileSelected(eq(albert), any());
+        verify(controller, never()).onSendMessage(any());
+    }
+
+    @Test
+    void shiftEnterInsertsANewLineWhileThePopupShows(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isTrue();
+
+        // The popup only claims unmodified keys; Shift+Enter keeps its line-break meaning.
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ENTER, true, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(input.getText()).isEqualTo("@al" + System.lineSeparator());
+        verify(controller, never()).onUserProfileSelected(any(), any());
+        verify(controller, never()).onSendMessage(any());
+    }
+
+    @Test
+    void enterWithoutAMatchingCandidateSendsTheMessage(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@zz");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isTrue();
+
+        // With an empty candidate list the popup lets Enter through to the input field.
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ENTER, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verify(controller).onSendMessage("@zz");
+        verify(controller, never()).onUserProfileSelected(any(), any());
+    }
+
+    @Test
+    void replacingADismissedTokenAtTheSameOffsetReArmsThePopup(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        // Select-all and retype puts a fresh token at the same offset in one text change.
+        robot.interact(() -> {
+            input.selectAll();
+            input.replaceSelection("@bo");
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("a dismissal must not suppress a fresh token at the same offset")
+                .isTrue();
+    }
+
+    @Test
+    void atomicallyExtendingADismissedTokenStaysDismissed(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        // Extending the query in one edit is the same intent as typing the rest of the name
+        // after Escape; the dismissal must hold.
+        robot.interact(() -> {
+            input.selectAll();
+            input.replaceSelection("@alice");
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("extending a dismissed token must not reopen the popup")
+                .isFalse();
+    }
+
+    @Test
+    void backspacingToTheBareIndicatorStartsAFreshAttempt(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@a");
+            input.positionCaret(2);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        // Clearing the token content ends the dismissed attempt: a retype at the bare
+        // indicator is indistinguishable from this transition, so both re-arm.
+        robot.interact(() -> input.deleteText(1, 2));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("an emptied token is a fresh mention attempt")
+                .isTrue();
+    }
+
+    @Test
+    void repeatedMentionCompletionsKeepMovingTheCaret(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        // First completion: the controller publishes the completed text and the caret target.
+        robot.interact(() -> {
+            model.getTextInput().set("@alice ");
+            model.getCaretPositionRequest().set(ChatMessageContainerModel.CaretPositionRequest.of(7));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(input.getCaretPosition()).isEqualTo(7);
+
+        // Sending clears the input; the next completion computes the same caret position.
+        robot.interact(() -> model.getTextInput().set(""));
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() -> {
+            model.getTextInput().set("@alice ");
+            model.getCaretPositionRequest().set(ChatMessageContainerModel.CaretPositionRequest.of(7));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(input.getCaretPosition())
+                .as("an equal caret target after a text update must still position the caret")
+                .isEqualTo(7);
     }
 
     @Test

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerViewTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/ChatMessageContainerViewTest.java
@@ -18,8 +18,10 @@
 package bisq.desktop.main.content.chat.message_container;
 
 import bisq.chat.ChatChannelDomain;
+import bisq.desktop.main.content.chat.message_container.components.ChatMentionPopupMenu;
 import bisq.desktop.main.content.components.UserProfileSelection;
 import bisq.desktop.testutil.TestFxHeadlessSupport;
+import bisq.user.profile.UserProfile;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextInputControl;
@@ -39,6 +41,10 @@ import javafx.scene.input.KeyEvent;
 import org.testfx.util.WaitForAsyncUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +84,154 @@ class ChatMessageContainerViewTest extends TestFxHeadlessSupport {
     @AfterEach
     void tearDown() throws Exception {
         closeable.close();
+    }
+
+    @Test
+    void mentionPopupFollowsTheCaretNotTheEndOfTheText(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al hello");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("the popup must open for a mention token in front of existing text")
+                .isTrue();
+
+        robot.interact(() -> input.positionCaret(input.getText().length()));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("moving the caret out of the token must hide the popup")
+                .isFalse();
+    }
+
+    @Test
+    void enterCompletesTheMentionInsteadOfSending(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al hello");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ENTER, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verify(controller).onUserProfileSelected(eq(alice), any());
+        verify(controller, never()).onSendMessage(any());
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+    }
+
+    @Test
+    void escapeDismissesThePopupAndEnterSendsAgain(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ENTER, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        verify(controller).onSendMessage("@al");
+        verify(controller, never()).onUserProfileSelected(any(), any());
+    }
+
+    @Test
+    void movingTheCaretIntoAnotherTokenReArmsADismissedPopup(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al x @bo");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        // The caret jumps straight from the dismissed token into another one.
+        robot.interact(() -> input.positionCaret(9));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("a dismissal must not leak into another mention token")
+                .isTrue();
+    }
+
+    @Test
+    void backspaceWithinTheDismissedTokenKeepsThePopupHidden(FxRobot robot) {
+        TextInputControl input = view.messageInput();
+        UserProfile alice = mock(UserProfile.class);
+        when(alice.getUserName()).thenReturn("alice");
+        robot.interact(() -> view.userMentionPopup().getObservableList()
+                .setAll(new ChatMentionPopupMenu.ListItem(alice)));
+
+        robot.targetWindow(stage);
+        robot.clickOn(input);
+        robot.interact(() -> {
+            input.setText("@al");
+            input.positionCaret(3);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() ->
+                input.fireEvent(new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false)));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing()).isFalse();
+
+        // Backspace produces a torn text/caret intermediate state; the dismissal must survive.
+        robot.interact(() -> input.deleteText(2, 3));
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("editing the dismissed token must not reopen the popup")
+                .isFalse();
+
+        // A genuinely fresh token re-arms it.
+        robot.interact(() -> {
+            input.setText("");
+            input.positionCaret(0);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        robot.interact(() -> {
+            input.setText("@a");
+            input.positionCaret(2);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+        assertThat(view.userMentionPopup().isShowing())
+                .as("a fresh mention token after leaving the dismissed one must open the popup")
+                .isTrue();
     }
 
     @Test

--- a/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionParserTest.java
+++ b/apps/desktop/desktop/src/test/java/bisq/desktop/main/content/chat/message_container/components/ChatMentionParserTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.content.chat.message_container.components;
+
+import bisq.desktop.main.content.chat.message_container.components.ChatMentionParser.MentionMatch;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ChatMentionParserTest {
+    @Test
+    void mentionAtTheEndOfTheText() {
+        assertEquals(Optional.of(new MentionMatch("jo", 0, 3)),
+                ChatMentionParser.findMentionAtCaret("@jo", 3));
+    }
+
+    @Test
+    void mentionBeforeExistingTextIsFound() {
+        // The reported bug: the caret sits right after "@jo" while more text follows.
+        assertEquals(Optional.of(new MentionMatch("jo", 0, 3)),
+                ChatMentionParser.findMentionAtCaret("@jo hello", 3));
+    }
+
+    @Test
+    void mentionInTheMiddleOfASentence() {
+        assertEquals(Optional.of(new MentionMatch("jo", 6, 9)),
+                ChatMentionParser.findMentionAtCaret("hello @jo world", 9));
+    }
+
+    @Test
+    void matchNeverExtendsPastTheCaret() {
+        // "@al" typed directly in front of an existing word: the word must not become part of
+        // the replaced range, or completion would silently delete it.
+        assertEquals(Optional.of(new MentionMatch("al", 0, 3)),
+                ChatMentionParser.findMentionAtCaret("@alworld", 3));
+        // Caret inside a token: only the part before the caret is replaced.
+        assertEquals(Optional.of(new MentionMatch("j", 0, 2)),
+                ChatMentionParser.findMentionAtCaret("@joe", 2));
+    }
+
+    @Test
+    void indicatorAfterNewLine() {
+        assertEquals(Optional.of(new MentionMatch("jo", 3, 6)),
+                ChatMentionParser.findMentionAtCaret("hi\n@jo", 6));
+    }
+
+    @Test
+    void bareIndicatorMatchesWithEmptyQuery() {
+        assertEquals(Optional.of(new MentionMatch("", 0, 1)),
+                ChatMentionParser.findMentionAtCaret("@", 1));
+    }
+
+    @Test
+    void indicatorNotPrecededByWhitespaceDoesNotMatch() {
+        assertTrue(ChatMentionParser.findMentionAtCaret("x@jo", 4).isEmpty());
+        assertTrue(ChatMentionParser.findMentionAtCaret("a@jo", 4).isEmpty());
+        assertTrue(ChatMentionParser.findMentionAtCaret("@a@b", 4).isEmpty());
+    }
+
+    @Test
+    void caretBeforeTheIndicatorDoesNotMatch() {
+        assertTrue(ChatMentionParser.findMentionAtCaret("@jo", 0).isEmpty());
+    }
+
+    @Test
+    void nonWordCharacterBetweenIndicatorAndCaretDoesNotMatch() {
+        assertTrue(ChatMentionParser.findMentionAtCaret("@j-o", 4).isEmpty());
+    }
+
+    @Test
+    void transientCaretPositionsAreTolerated() {
+        // JavaFX can notify the text before the caret is clamped to the new length.
+        assertTrue(ChatMentionParser.findMentionAtCaret("@jo", 5).isEmpty());
+        assertTrue(ChatMentionParser.findMentionAtCaret("@jo", -1).isEmpty());
+        assertTrue(ChatMentionParser.findMentionAtCaret("", 0).isEmpty());
+        assertTrue(ChatMentionParser.findMentionAtCaret(null, 0).isEmpty());
+    }
+}

--- a/common/src/main/java/bisq/common/util/StringUtils.java
+++ b/common/src/main/java/bisq/common/util/StringUtils.java
@@ -114,20 +114,6 @@ public class StringUtils {
         return string.toLowerCase().contains(searchString.toLowerCase());
     }
 
-    /*
-     * Method used in chat message to check if we should show mention user/channel popup
-     */
-    public static String deriveWordStartingWith(String text, char indicatorSign) {
-        int index = text.lastIndexOf(indicatorSign);
-        if (index < 0 || (index > 1 && text.charAt(index - 1) != ' ')) return null;
-
-        String result = text.substring(index + 1);
-        if (result.matches("[a-zA-Z\\d]*$")) {
-            return result;
-        }
-        return null;
-    }
-
     public static String capitalize(String value, Locale locale) {
         if (value == null || value.isEmpty()) {
             return value;

--- a/common/src/test/java/bisq/common/util/StringUtilsTest.java
+++ b/common/src/test/java/bisq/common/util/StringUtilsTest.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -44,20 +43,6 @@ public class StringUtilsTest {
         assertEquals("SEPA INSTANT", textWithStyleAndRest.get(5).getFirst());
         assertEquals("text-color-mid", textWithStyleAndRest.get(5).getSecond().get(0));
         assertEquals("text-underline", textWithStyleAndRest.get(5).getSecond().get(1));
-    }
-
-    @Test
-    public void deriveWordStartingWith() {
-        assert Objects.equals(StringUtils.deriveWordStartingWith("Hello jo", '@'), null);
-        assert Objects.equals(StringUtils.deriveWordStartingWith("@jo x", '@'), null);
-        assert Objects.equals(StringUtils.deriveWordStartingWith("Hello@jo", '@'), null);
-        assert Objects.equals(StringUtils.deriveWordStartingWith("Hello @jo!", '@'), null);
-        assert Objects.equals(StringUtils.deriveWordStartingWith("Go to#chan", '@'), null);
-
-        assert Objects.equals(StringUtils.deriveWordStartingWith("Hello @jo", '@'), "jo");
-        assert Objects.equals(StringUtils.deriveWordStartingWith("@john", '@'), "john");
-        assert Objects.equals(StringUtils.deriveWordStartingWith("Go to #chann", '#'), "chann");
-        assert Objects.equals(StringUtils.deriveWordStartingWith("#chann", '#'), "chann");
     }
 
     @Test


### PR DESCRIPTION
Fixes #4942

The mention popup and the completion were both anchored to the end of the input text: `StringUtils.deriveWordStartingWith` searched from the last `@` and required the word to end the string, and completing a suggestion replaced an end-anchored regex match with the caret forced to the end. So a mention typed in front of existing text never showed suggestions, and completing one would have replaced the wrong range.

### What changed

- The mention token is now parsed at the caret (new `ChatMentionParser`): the word between the nearest `@` before the caret and the caret itself. The popup filter observes both the text and the caret position, so clicking into the middle of a token re-opens the suggestions for it.
- Completion replaces exactly the parsed range — never text past the caret (IntelliJ-style), and the trailing space is only inserted in front of letters or digits, so punctuation stays attached to the mention.
- Keyboard navigation on the popup: ArrowUp/ArrowDown move the selection, Enter or Tab complete it, Shift+Enter still inserts a newline, and Enter with no match sends the message as usual. The keys are handled on the popup window itself because JavaFX redirects the owner window's key events there while the popup is showing — an input-field handler never sees them.
- Escape dismisses the popup for the current mention token; editing the same token keeps it dismissed, a fresh `@` re-arms it. Completing behaves like Escape for that token.
- The selected row is highlighted and kept in view without re-anchoring the list to the top on every key press.
- `StringUtils.deriveWordStartingWith` had a single caller and is replaced by the caret-aware parser, so it is removed.

### Tests

- `ChatMentionParserTest` covers the token parsing (mid-text, caret bounds, adjacent words, punctuation).
- Controller tests cover the caret-aware insertion and dismissal state.
- View tests drive the real popup event path (arrow selection, Enter/Tab completion, Escape, empty-list passthrough) — they go through the popup window's key handling, which is the load-bearing piece.

### Manual testing

Two clients (Alice + Bob) on a local CLEAR network, both in the same public discussion channel. All steps on Alice unless noted. Client logs were checked afterwards — no exceptions.

**The reported bug — mention in front of existing text**
1. Type `hello world`, press Home, then type `@` and the first letters of Bob's nickname → the suggestion popup opens and filters while typing (it never opened mid-text before).
2. Click Bob's name → the input becomes `@Bob hello world`: single space after the mention, the existing text untouched, caret right after the inserted space.

<img width="1398" height="648" alt="image" src="https://github.com/user-attachments/assets/ad194c9d-9c04-41d7-be2f-4300b2597a1e" />

**Caret-bounded completion**
1. Type `hi @jjj there`, click between the `j`s → the popup opens, filtering on the part before the caret. Completing replaces only the part before the caret; the remaining `j`s and ` there` stay.
2. Type `Hi @xx, more` with the caret right after `xx`, complete → `Hi @Name, more`, no extra space in front of the comma.

**Keyboard navigation**
1. Type `@` alone → popup with the full user list.
2. ArrowDown twice, ArrowUp once → the selection highlight moves accordingly; typing focus stays in the input.
3. Enter → the highlighted name completes into the input, the message is not sent.
4. `@` + letters, Tab → same completion.
5. `@zzzz` (no match) → arrows move the caret in the text as usual, Enter sends the message with the literal `@zzzz`.
6. `@` + letters, Shift+Enter → a newline is inserted, the popup is unaffected.

<img width="1408" height="752" alt="image" src="https://github.com/user-attachments/assets/62780e5b-5862-4c98-8fa5-a834a45d97b1" />

**Escape — dismissal is per token**
1. `@` + letters, Escape → popup closes; typing more letters of the same token or backspacing keeps it closed.
2. A space and a fresh `@` re-open it.
3. Compose `@aa bbb @cc`, Escape on the last token, click into the middle of `@aa` → the popup opens for `@aa` (the dismissal does not leak between tokens).

**Regressions**
1. Plain text + Enter → sends.
2. Empty input + ArrowUp → edit-last-message behavior unchanged.
3. Reply flow that inserts `@Bob` from a message's context menu → still works.
4. `x@name` (no space before the `@`) → no popup, as before.
5. Popup open, switch channel → popup closes.
6. On Bob: a received message containing `@Bob` highlights as before.

<img width="1406" height="959" alt="Screenshot from 2026-08-31 12-09-58" src="https://github.com/user-attachments/assets/0f4e0749-fc92-40ca-ba3a-8690ad6d0b65" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved chat mention completion with accurate caret-based matching.
  - Added keyboard navigation and completion using Arrow keys, Tab, and Enter.
  - Added Escape dismissal and reliable popup reopening for new mention searches.
  - Mention completion now preserves surrounding text and places the caret correctly.

- **Bug Fixes**
  - Prevented accidental deletion of text following a mention.
  - Improved handling near punctuation, newlines, and partially edited mentions.
  - Added clearer visual highlighting for the selected mention result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->