### PR TITLE
chore: sync #4961 to main — Authorize WebSocket subscriptions without breaking existing pairings

### DIFF
--- a/api/src/main/java/bisq/api/ApiService.java
+++ b/api/src/main/java/bisq/api/ApiService.java
@@ -24,7 +24,6 @@ import bisq.api.access.pairing.PairingCode;
 import bisq.api.access.pairing.PairingService;
 import bisq.api.access.permissions.Permission;
 import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.access.persistence.ApiAccessStoreService;
 import bisq.api.access.session.SessionService;
 import bisq.api.access.transport.ApiAccessTransportService;
@@ -106,7 +105,7 @@ public class ApiService implements Service {
     @Getter
     private final PairingService pairingService;
     @Getter
-    private final PermissionService<RestPermissionMapping> permissionService;
+    private final PermissionService permissionService;
     @Getter
     private final SessionService sessionService;
     @Getter
@@ -149,7 +148,7 @@ public class ApiService implements Service {
                 apiConfig.getOnionServicePort());
 
         ApiAccessStoreService apiAccessStoreService = new ApiAccessStoreService(persistenceService);
-        permissionService = new PermissionService<>(apiAccessStoreService, new RestPermissionMapping());
+        permissionService = new PermissionService(apiAccessStoreService);
         pairingService = new PairingService(apiConfig, appDataDirPath, apiAccessStoreService, permissionService);
         sessionService = new SessionService(apiConfig.getSessionTtlInMinutes());
         tlsContextService = new TlsContextService(apiConfig, appDataDirPath);
@@ -223,7 +222,8 @@ public class ApiService implements Service {
                     userService,
                     bisqEasyService,
                     networkService,
-                    openTradeItemsService));
+                    openTradeItemsService,
+                    permissionService));
         } else {
             webSocketService = Optional.empty();
         }
@@ -232,7 +232,6 @@ public class ApiService implements Service {
                 resourceConfig,
                 webSocketService,
                 sessionAuthenticationService,
-                permissionService,
                 tlsContextService);
     }
 

--- a/api/src/main/java/bisq/api/HttpServerBootstrapService.java
+++ b/api/src/main/java/bisq/api/HttpServerBootstrapService.java
@@ -19,8 +19,6 @@ package bisq.api;
 
 import bisq.api.access.filter.WebSocketFilterAddOn;
 import bisq.api.access.filter.authn.SessionAuthenticationService;
-import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.access.transport.TlsContext;
 import bisq.api.access.transport.TlsContextService;
 import bisq.api.rest_api.util.StaticFileHandler;
@@ -67,7 +65,6 @@ public class HttpServerBootstrapService implements Service {
     private final ResourceConfig resourceConfig;
     private final Optional<WebSocketService> webSocketService;
     private final SessionAuthenticationService sessionAuthenticationService;
-    private final PermissionService<RestPermissionMapping> permissionService;
     private final TlsContextService tlsContextService;
 
     private Optional<HttpServer> httpServer = Optional.empty();
@@ -78,14 +75,12 @@ public class HttpServerBootstrapService implements Service {
                                       ResourceConfig resourceConfig,
                                       Optional<WebSocketService> webSocketService,
                                       SessionAuthenticationService sessionAuthenticationService,
-                                      PermissionService<RestPermissionMapping> permissionService,
                                       TlsContextService tlsContextService
     ) {
         this.apiConfig = apiConfig;
         this.resourceConfig = resourceConfig;
         this.webSocketService = webSocketService;
         this.sessionAuthenticationService = sessionAuthenticationService;
-        this.permissionService = permissionService;
         this.tlsContextService = tlsContextService;
     }
 

--- a/api/src/main/java/bisq/api/access/ApiAccessService.java
+++ b/api/src/main/java/bisq/api/access/ApiAccessService.java
@@ -54,25 +54,6 @@ public class ApiAccessService {
         return new PairingResponse(clientId, clientSecret, sessionToken.getSessionId(), expiresAt);
     }
 
-    /**
-     * Revokes a paired client by invalidating all its active sessions and removing
-     * its stored profile and permissions. After revocation the client can no longer
-     * authenticate and must go through the pairing flow again.
-     *
-     * @param clientId The client ID to revoke
-     * @return {@code true} if the client was found and revoked; {@code false} if not found
-     */
-    public boolean revokeClient(String clientId) {
-        boolean removed = pairingService.revokeClientProfile(clientId);
-        sessionService.removeSessionByClientId(clientId);
-        if (removed) {
-            log.info("Revoked client {}", clientId);
-        } else {
-            log.warn("Client profile not found for {}, but session was still invalidated", clientId);
-        }
-        return removed;
-    }
-
     public SessionResponse requestSession(String clientId, String clientSecret) throws InvalidSessionRequestException {
         ClientProfile clientProfile = pairingService.findClientProfile(clientId)
                 .orElseThrow(() -> new InvalidSessionRequestException("No client profile found for Client ID"));

--- a/api/src/main/java/bisq/api/access/filter/authz/RestApiAuthorizationFilter.java
+++ b/api/src/main/java/bisq/api/access/filter/authz/RestApiAuthorizationFilter.java
@@ -25,11 +25,16 @@ import java.util.Set;
 @Priority(Priorities.AUTHORIZATION)
 public class RestApiAuthorizationFilter extends RestApiFilter {
     private final UriValidator uriValidator;
-    private final PermissionService<RestPermissionMapping> permissionService;
+    private final PermissionService permissionService;
+    // Owned here rather than reached through PermissionService: the mapping answers what a REST
+    // path requires, which is this filter's question and nobody else's. Built like uriValidator
+    // above, for the same reason.
+    private final RestPermissionMapping permissionMapping;
 
-    public RestApiAuthorizationFilter(PermissionService<RestPermissionMapping> permissionService) {
+    public RestApiAuthorizationFilter(PermissionService permissionService) {
         this.permissionService = permissionService;
         this.uriValidator = new UriValidator();
+        this.permissionMapping = new RestPermissionMapping();
     }
 
     @Override
@@ -47,7 +52,7 @@ public class RestApiAuthorizationFilter extends RestApiFilter {
                 throw new AuthorizationException("No permissions found for client " + clientId);
             }
             Set<Permission> granted = optionalPermissionSet.get();
-            Permission required = permissionService.getPermissionMapping().getRequiredPermission(requestUri.getPath(), context.getMethod());
+            Permission required = permissionMapping.getRequiredPermission(requestUri.getPath(), context.getMethod());
             if (!permissionService.hasPermission(granted, required)) {
                 // Structured body so clients can distinguish "this grant lacks one permission"
                 // (e.g. paired before the node gained a feature — fixable by re-pairing) from a

--- a/api/src/main/java/bisq/api/access/pairing/PairingService.java
+++ b/api/src/main/java/bisq/api/access/pairing/PairingService.java
@@ -22,7 +22,6 @@ import bisq.api.access.identity.ClientProfile;
 import bisq.api.access.pairing.qr.PairingQrCodeGenerator;
 import bisq.api.access.pairing.qr.TextQrCodeRenderer;
 import bisq.api.access.permissions.Permission;
-import bisq.api.access.permissions.PermissionMapping;
 import bisq.api.access.permissions.PermissionService;
 import bisq.api.access.persistence.ApiAccessStoreService;
 import bisq.api.access.transport.TlsContext;
@@ -53,7 +52,7 @@ public class PairingService {
     private final ApiConfig apiConfig;
     private final Path appDataDirPath;
     private final ApiAccessStoreService apiAccessStoreService;
-    private final PermissionService<? extends PermissionMapping> permissionService;
+    private final PermissionService permissionService;
     @Getter
     private final int pairingCodeTtlInSeconds;
     private final Map<String, PairingCode> pairingCodeByIdMap = new ConcurrentHashMap<>();
@@ -65,7 +64,7 @@ public class PairingService {
     public PairingService(ApiConfig apiConfig,
                           Path appDataDirPath,
                           ApiAccessStoreService apiAccessStoreService,
-                          PermissionService<? extends PermissionMapping> permissionService) {
+                          PermissionService permissionService) {
         this.apiConfig = apiConfig;
         this.appDataDirPath = appDataDirPath;
         this.apiAccessStoreService = apiAccessStoreService;

--- a/api/src/main/java/bisq/api/access/permissions/Permission.java
+++ b/api/src/main/java/bisq/api/access/permissions/Permission.java
@@ -52,7 +52,19 @@ public enum Permission implements ProtoEnum {
     TRADES(7, Kind.STANDARD),
     USER_IDENTITIES(8, Kind.STANDARD),
     USER_PROFILES(9, Kind.STANDARD),
-    MOBILE_DEVICES(10, Kind.STANDARD);
+    MOBILE_DEVICES(10, Kind.STANDARD),
+    // Id 11 is reserved for PRIVATE_CHAT_CHANNELS, which is declared on the for-mobile branch.
+    // Ids are wire values, so the gap stays until that work reaches main.
+    //
+    // NETWORK_INFO has no REST route of its own — the network state is served over the
+    // NETWORK_INFO subscription only. It is declared here because the permission names the data,
+    // not the transport: without it that data is the one thing in the API reachable with no grant
+    // at all, and it is not diagnostics — NetworkInfoDto carries the node's own address, its keyId
+    // and the address of every peer it is connected to.
+    //
+    // STANDARD so a grantAll pairing picks it up at read time (see PermissionSet) rather than
+    // losing the network banner until the user pairs again.
+    NETWORK_INFO(12, Kind.STANDARD);
 
     /** Grant classification. Named so a declaration reads as an explicit security decision. */
     public enum Kind {

--- a/api/src/main/java/bisq/api/access/permissions/PermissionService.java
+++ b/api/src/main/java/bisq/api/access/permissions/PermissionService.java
@@ -18,19 +18,23 @@
 package bisq.api.access.permissions;
 
 import bisq.api.access.persistence.ApiAccessStoreService;
-import lombok.Getter;
 
 import java.util.Optional;
 import java.util.Set;
 
-public class PermissionService<T extends PermissionMapping> {
+/**
+ * Reads and writes the permissions granted to a paired client.
+ * <p>
+ * It holds no mapping: which permission a given access requires is the business of the surface
+ * that serves it — REST paths for {@link RestPermissionMapping}, subscription topics for
+ * {@code SubscriptionPermissionMapping} — and those two questions have no common shape. Keeping a
+ * single path-shaped mapping here is what made the subscription surface easy to overlook.
+ */
+public class PermissionService {
     private final ApiAccessStoreService apiAccessStoreService;
-    @Getter
-    private final T permissionMapping;
 
-    public PermissionService(ApiAccessStoreService apiAccessStoreService, T permissionMapping) {
+    public PermissionService(ApiAccessStoreService apiAccessStoreService) {
         this.apiAccessStoreService = apiAccessStoreService;
-        this.permissionMapping = permissionMapping;
     }
 
     public boolean hasPermission(Set<Permission> granted, Permission required) {

--- a/api/src/main/java/bisq/api/access/persistence/ApiAccessStore.java
+++ b/api/src/main/java/bisq/api/access/persistence/ApiAccessStore.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -39,6 +40,53 @@ final class ApiAccessStore implements PersistableStore<ApiAccessStore> {
     // this field, so it cannot survive a downgrade and MUST NOT gate any security decision.
     // Promotion to grantAll is evidence-based instead; see promoteIfFullStandardGrant.
     private static final int PERMISSIONS_SCHEMA_VERSION = 1;
+
+    /**
+     * The full standard sets of released versions, so a store written by one of them is still
+     * recognised as the full grant it was issued as.
+     * <p>
+     * Kept in code and not in the store on purpose: nothing persisted survives a downgrade, which
+     * is the whole reason the promotion below reads the entry's content as evidence. Spelled out
+     * value by value rather than derived from a range or an id bound, because the deliberate hole
+     * at enum id 11 (proto 12) is exactly the shape that makes a derived set quietly stop matching
+     * what shipped.
+     * <p>
+     * One entry per shape that shipped, and these are expected to be enough for good: the first
+     * release carrying grantAll promotes every store it reads and persists the result, and a store
+     * that never meets that release still holds one of these same sets however many versions later
+     * it is opened. Every pairing on those releases granted the full set
+     * ({@code ApiConfig#grantedPermissions} was {@code Set.of(Permission.values())}), all standard,
+     * and a grant is only rewritten at pairing time, so a client that paired on v2.1.9 and never
+     * re-paired still holds the v2.1.9 shape whatever it upgraded to since.
+     * <p>
+     * Every permission listed here must stay standard: promotion replaces the explicit list with
+     * the grantAll expansion, which never covers sensitive permissions, so reclassifying a listed
+     * permission as sensitive requires pruning it from these sets first.
+     */
+    static final Set<Set<Permission>> RELEASED_FULL_STANDARD_SETS = Set.of(
+            // v2.1.9, the first release with this store: 10 permissions, up to USER_PROFILES.
+            Set.of(Permission.TRADE_CHAT_CHANNELS,
+                    Permission.EXPLORER,
+                    Permission.MARKET_PRICE,
+                    Permission.OFFERBOOK,
+                    Permission.PAYMENT_ACCOUNTS,
+                    Permission.REPUTATION,
+                    Permission.SETTINGS,
+                    Permission.TRADES,
+                    Permission.USER_IDENTITIES,
+                    Permission.USER_PROFILES),
+            // v2.1.10 to v2.1.12: the same plus MOBILE_DEVICES.
+            Set.of(Permission.TRADE_CHAT_CHANNELS,
+                    Permission.EXPLORER,
+                    Permission.MARKET_PRICE,
+                    Permission.OFFERBOOK,
+                    Permission.PAYMENT_ACCOUNTS,
+                    Permission.REPUTATION,
+                    Permission.SETTINGS,
+                    Permission.TRADES,
+                    Permission.USER_IDENTITIES,
+                    Permission.USER_PROFILES,
+                    Permission.MOBILE_DEVICES));
 
     private transient boolean promotedEntriesDuringLoad;
 
@@ -105,10 +153,15 @@ final class ApiAccessStore implements PersistableStore<ApiAccessStore> {
 
     /**
      * Evidence-based promotion, applied on every load and deliberately NOT gated on
-     * {@code permissionsSchemaVersion}: no in-store marker survives a downgrade, because a
-     * pre-grantAll node rebuilds the proto from its own domain model on persist and thereby
-     * drops fields it does not know. Trusting a version stamp would let a downgrade/upgrade
-     * cycle silently promote a deliberately restricted entry to full access.
+     * {@code permissionsSchemaVersion} in either direction. Not to promote: no in-store marker
+     * survives a downgrade, because a pre-grantAll node rebuilds the proto from its own domain
+     * model on persist and thereby drops fields it does not know, so trusting a version stamp
+     * would let a downgrade/upgrade cycle silently promote a deliberately restricted entry to
+     * full access. Not to refuse either: the stamp only says "written by a binary that had the
+     * field", and a binary can have the field without knowing the released shapes below — the
+     * builds between grantAll and this rule stamp every persist while leaving a v2.1.9-shaped
+     * entry explicit — so refusing on the stamp would freeze exactly the grants this rule exists
+     * to rescue.
      * <p>
      * Instead the entry's own content is the evidence: only a set EXACTLY equal to the running
      * version's auto-grantable ("standard") set is promoted — at that moment promotion grants
@@ -117,29 +170,46 @@ final class ApiAccessStore implements PersistableStore<ApiAccessStore> {
      * containsAll: a set that additionally holds a sensitive permission must stay explicit,
      * otherwise promotion would silently drop the sensitive grant from the grantAll expansion.
      * <p>
-     * Trade-off: a full grant persisted by an older version and first re-read by a binary that
-     * has since gained permissions is NOT promoted and that client keeps the old set (fails
-     * closed; re-pairing restores full access) — mitigated by the persist-after-promotion in
-     * {@code ApiAccessStoreService#onPersistedApplied}.
+     * A full grant persisted by an older version counts as the same evidence, through
+     * {@link #RELEASED_FULL_STANDARD_SETS}. The two branches differ in how long they match. The
+     * running-set branch is a one-shot as long as the standard set only grows: once the binary has
+     * grown past a set, that set never equals the running standard set again. Ids are append-only,
+     * but that is not what carries it — {@code Permission#autoGrantable} filters on {@code Kind},
+     * so reclassifying a standard permission as sensitive would shrink the set, which is what
+     * {@code PermissionTest#everyCurrentPermissionIsStandard} guards. The released-set branch is
+     * permanent: the released shapes stay in that constant and keep being promoted by every future
+     * version, because a store that skipped the first grantAll release still holds exactly one of
+     * them however much later it is opened. Leaning on the persist-after-promotion in
+     * {@code ApiAccessStoreService#onPersistedApplied} instead would be circular — it writes only
+     * when something was promoted, so it covers the second new permission onward and does nothing
+     * for the first, which is the one arriving in the same release as grantAll itself.
      * <p>
      * KNOWN RESIDUAL (not reachable today — no live path persists a genuinely restricted
      * non-grantAll grant; every pairing grants the full standard set, folded to grantAll at
-     * write time by {@code PermissionService#putPermissions}). The equality is against the
-     * RUNNING binary's autoGrantable set, so a deliberately restricted grant is indistinguishable
-     * from a full grant of an OLDER version whose standard set happened to equal it: read by that
-     * older binary it would be promoted (and persisted) as grantAll, then re-expand on upgrade —
-     * regaining a standard permission it was never granted. This becomes reachable only once a
-     * feature can persist a genuinely restricted grant (granular-permission editor / sensitive-
-     * permission per-device flow); that feature must first introduce a downgrade-durable marker
-     * distinguishing "deliberate restriction" from "legacy full grant", or accept this as a
-     * documented residual. Sensitive permissions are unaffected either way: a set containing one
-     * can never equal any version's autoGrantable set, so it is never promotable.
+     * write time by {@code PermissionService#putPermissions}). A deliberately restricted grant is
+     * indistinguishable from a full grant that happens to equal it, on either branch. Running-set
+     * branch: read by an OLDER binary whose standard set equals the restriction, it is promoted
+     * (and persisted) as grantAll, then re-expands on upgrade — regaining a standard permission it
+     * was never granted. Released-set branch, and this one does not fade with versions: a grant of
+     * exactly one of the released shapes (the v2.1.9 or the v2.1.12 set — a natural "everything
+     * except the newer permissions" choice) is widened to grantAll on the next load by every
+     * binary from here on, and persisted that way.
+     * This becomes reachable only once a feature can persist a genuinely restricted grant
+     * (granular-permission editor / sensitive-permission per-device flow); that feature must first
+     * introduce a downgrade-durable marker distinguishing "deliberate restriction" from "legacy
+     * full grant", and until it does, no code path may issue a released full set as a deliberate
+     * restriction. Sensitive permissions are unaffected on the running-set branch by construction:
+     * a set containing one can never equal any version's autoGrantable set. On the released-set
+     * branch that holds only by convention — the constant is a value list, so a permission listed
+     * there that is later reclassified as sensitive would still match and be dropped from the
+     * grantAll expansion; {@code ApiAccessStoreTest} pins that every listed permission is standard.
      */
     private static PermissionSet promoteIfFullStandardGrant(String clientId, PermissionSet permissionSet) {
         if (permissionSet.isGrantAll()) {
             return permissionSet;
         }
-        if (permissionSet.getPermissions().equals(Permission.autoGrantable())) {
+        Set<Permission> permissions = permissionSet.getPermissions();
+        if (permissions.equals(Permission.autoGrantable()) || RELEASED_FULL_STANDARD_SETS.contains(permissions)) {
             log.info("Promoting full standard permission set of client {} to grantAll", clientId);
             return PermissionSet.grantAll();
         }

--- a/api/src/main/java/bisq/api/rest_api/RestApiBaseResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/RestApiBaseResourceConfig.java
@@ -5,7 +5,6 @@ import bisq.api.access.filter.authn.RestApiSessionAuthenticationFilter;
 import bisq.api.access.filter.authn.SessionAuthenticationService;
 import bisq.api.access.filter.authz.RestApiAuthorizationFilter;
 import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.api.rest_api.util.SwaggerResolution;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
@@ -13,7 +12,7 @@ import org.glassfish.jersey.inject.hk2.AbstractBinder;
 public abstract class RestApiBaseResourceConfig extends PairingApiResourceConfig {
     public RestApiBaseResourceConfig(ApiConfig apiConfig,
                                      AccessApi accessApi,
-                                     PermissionService<RestPermissionMapping> permissionService,
+                                     PermissionService permissionService,
                                      SessionAuthenticationService sessionAuthenticationService) {
         super(accessApi);
 

--- a/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
+++ b/api/src/main/java/bisq/api/rest_api/RestApiResourceConfig.java
@@ -3,7 +3,6 @@ package bisq.api.rest_api;
 import bisq.api.ApiConfig;
 import bisq.api.access.filter.authn.SessionAuthenticationService;
 import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.api.rest_api.endpoints.chat.trade.TradeChatMessagesRestApi;
 import bisq.api.rest_api.endpoints.config.ConfigRestApi;
@@ -28,7 +27,7 @@ import org.glassfish.jersey.inject.hk2.AbstractBinder;
 @ApplicationPath("/api/v1")
 public class RestApiResourceConfig extends RestApiBaseResourceConfig {
     public RestApiResourceConfig(ApiConfig apiConfig,
-                                 PermissionService<RestPermissionMapping> permissionService,
+                                 PermissionService permissionService,
                                  SessionAuthenticationService sessionAuthenticationService,
                                  AccessApi accessApi,
                                  OfferbookRestApi offerbookRestApi,

--- a/api/src/main/java/bisq/api/rest_api/endpoints/access/AccessApi.java
+++ b/api/src/main/java/bisq/api/rest_api/endpoints/access/AccessApi.java
@@ -30,17 +30,14 @@ import bisq.api.dto.access.session.SessionRequestDto;
 import bisq.api.dto.access.session.SessionResponseDto;
 import bisq.api.rest_api.endpoints.RestApiBase;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -192,38 +189,6 @@ public class AccessApi extends RestApiBase {
         } catch (Exception e) {
             log.error("Unexpected error during session request", e);
             return buildErrorResponse("Session request failed");
-        }
-    }
-
-    @DELETE
-    @Path("/clients/{clientId}")
-    @Operation(
-            summary = "Revoke a paired client",
-            description = """
-                    Revokes a previously paired API client.
-
-                    All active sessions for the client are immediately invalidated and
-                    the client profile is removed from persistent storage. The client
-                    can no longer authenticate and must pair again via QR code to regain
-                    access.
-                    """
-    )
-    @ApiResponse(responseCode = "204", description = "Client successfully revoked")
-    @ApiResponse(responseCode = "404", description = "Client not found")
-    @ApiResponse(responseCode = "500", description = "Unexpected internal server error")
-    public Response revokeClient(
-            @Parameter(description = "The client ID to revoke", required = true)
-            @PathParam("clientId") String clientId
-    ) {
-        try {
-            boolean revoked = apiAccessService.revokeClient(clientId);
-            if (!revoked) {
-                return buildNotFoundResponse("Client not found: " + clientId);
-            }
-            return buildNoContentResponse();
-        } catch (Exception e) {
-            log.error("Unexpected error during client revocation for clientId={}", clientId, e);
-            return buildErrorResponse("Client revocation failed");
         }
     }
 }

--- a/api/src/main/java/bisq/api/web_socket/WebSocketService.java
+++ b/api/src/main/java/bisq/api/web_socket/WebSocketService.java
@@ -18,6 +18,7 @@
 package bisq.api.web_socket;
 
 import bisq.api.ApiConfig;
+import bisq.api.access.permissions.PermissionService;
 import bisq.api.access.transport.TlsContextService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.api.web_socket.rest_api_proxy.WebSocketRestApiService;
@@ -68,7 +69,8 @@ public class WebSocketService implements Service {
                             UserService userService,
                             BisqEasyService bisqEasyService,
                             NetworkService networkService,
-                            OpenTradeItemsService openTradeItemsService) {
+                            OpenTradeItemsService openTradeItemsService,
+                            PermissionService permissionService) {
         this.apiConfig = apiConfig;
         subscriptionService = new SubscriptionService(bondedRolesService,
                 alertNotificationsService,
@@ -77,7 +79,9 @@ public class WebSocketService implements Service {
                 userService,
                 bisqEasyService,
                 networkService,
-                openTradeItemsService);
+                openTradeItemsService,
+                permissionService,
+                apiConfig.isAuthorizationRequired());
         webSocketRestApiService = new WebSocketRestApiService(apiConfig, tlsContextService);
         webSocketConnectionHandler = new WebSocketConnectionHandler(subscriptionService, webSocketRestApiService);
     }

--- a/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiService.java
+++ b/api/src/main/java/bisq/api/web_socket/rest_api_proxy/WebSocketRestApiService.java
@@ -23,6 +23,7 @@ import bisq.api.access.filter.authz.AuthorizationException;
 import bisq.api.access.filter.authz.UriValidator;
 import bisq.api.access.transport.TlsContextService;
 import bisq.api.web_socket.util.JsonUtil;
+import bisq.api.web_socket.util.WebSocketIdentity;
 import bisq.common.application.Service;
 import bisq.common.util.StringUtils;
 import bisq.security.tls.TlsException;
@@ -32,7 +33,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.glassfish.grizzly.websockets.DefaultWebSocket;
 import org.glassfish.grizzly.websockets.WebSocket;
 
 import javax.net.ssl.SSLContext;
@@ -214,21 +214,11 @@ public class WebSocketRestApiService implements Service {
      * identity to pass on and the REST API asks for none.
      */
     private static void forwardAuthenticatedIdentity(WebSocket webSocket, HttpRequest.Builder requestBuilder) {
-        HttpServletRequest upgradeRequest = findUpgradeRequest(webSocket)
+        HttpServletRequest upgradeRequest = WebSocketIdentity.findUpgradeRequest(webSocket)
                 .orElseThrow(() -> new IllegalStateException(
                         "Could not resolve the upgrade request of the WebSocket connection"));
         copyHeader(upgradeRequest, requestBuilder, Headers.SESSION_ID);
         copyHeader(upgradeRequest, requestBuilder, Headers.CLIENT_ID);
-    }
-
-    /**
-     * The upgrade request is where the connection's authenticated identity lives, so it is read from
-     * the WebSocket rather than from the message.
-     */
-    private static Optional<HttpServletRequest> findUpgradeRequest(WebSocket webSocket) {
-        return webSocket instanceof DefaultWebSocket defaultWebSocket
-                ? Optional.ofNullable(defaultWebSocket.getUpgradeRequest())
-                : Optional.empty();
     }
 
     private static void copyHeader(HttpServletRequest upgradeRequest,

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionPermissionMapping.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionPermissionMapping.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.subscription;
+
+import bisq.api.access.permissions.Permission;
+
+/**
+ * Maps a subscription topic to the permission a client must hold to receive it.
+ * <p>
+ * Deliberately NOT a {@link bisq.api.access.permissions.PermissionMapping}: that interface answers
+ * for a path and a method, and a topic is neither. Keeping both surfaces behind one path-shaped
+ * interface is what let a WebSocket-only feature ship without ever being asked for a permission.
+ * <p>
+ * The switch is an expression with no {@code default} on purpose: a topic added without declaring
+ * its permission does not compile. That is what makes the omission unrepeatable rather than
+ * something each author has to remember.
+ * <p>
+ * Every row asks for the permission that already guards the same data over REST, so a client cannot
+ * reach through a subscription what a request would refuse it. {@code NETWORK_INFO} is the one row
+ * with no REST route to mirror; see {@link Permission#NETWORK_INFO}.
+ */
+public final class SubscriptionPermissionMapping {
+    public Permission getRequiredPermission(Topic topic) {
+        return switch (topic) {
+            case MARKET_PRICE -> Permission.MARKET_PRICE;
+            case NUM_OFFERS, OFFERS -> Permission.OFFERBOOK;
+            case TRADES, TRADE_PROPERTIES -> Permission.TRADES;
+            case TRADE_CHAT_MESSAGES, CHAT_REACTIONS -> Permission.TRADE_CHAT_CHANNELS;
+            case REPUTATION -> Permission.REPUTATION;
+            case NUM_USER_PROFILES -> Permission.USER_PROFILES;
+            case ALERT_NOTIFICATIONS, TRADE_RESTRICTING_ALERT -> Permission.SETTINGS;
+            case NETWORK_INFO -> Permission.NETWORK_INFO;
+        };
+    }
+}

--- a/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
+++ b/api/src/main/java/bisq/api/web_socket/subscription/SubscriptionService.java
@@ -18,6 +18,8 @@
 package bisq.api.web_socket.subscription;
 
 
+import bisq.api.access.permissions.Permission;
+import bisq.api.access.permissions.PermissionService;
 import bisq.api.web_socket.domain.BaseWebSocketService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.api.web_socket.domain.trade_restricting_alert.TradeRestrictingAlertWebSocketService;
@@ -34,6 +36,7 @@ import bisq.api.web_socket.domain.trades.TradePropertiesWebSocketService;
 import bisq.api.web_socket.domain.trades.TradesWebSocketService;
 import bisq.api.web_socket.domain.user_profile.NumUserProfilesWebSocketService;
 import bisq.api.web_socket.util.JsonUtil;
+import bisq.api.web_socket.util.WebSocketIdentity;
 import bisq.bisq_easy.BisqEasyService;
 import bisq.bonded_roles.BondedRolesService;
 import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
@@ -47,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.glassfish.grizzly.websockets.WebSocket;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -64,6 +68,14 @@ public class SubscriptionService implements Service {
     private final TradeRestrictingAlertWebSocketService tradeRestrictingAlertWebSocketService;
     private final AlertNotificationsWebSocketService alertNotificationsWebSocketService;
     private final NetworkInfoWebSocketService networkInfoWebSocketService;
+    private final PermissionService permissionService;
+    // Built here rather than injected, like RestApiAuthorizationFilter builds its own: which
+    // permission a topic requires is this service's question and nobody else's.
+    private final SubscriptionPermissionMapping permissionMapping = new SubscriptionPermissionMapping();
+    // The same switch that decides whether RestApiBaseResourceConfig registers the REST
+    // authorization filter. A node configured without authorization has no permissions to check
+    // against, so subscriptions must not start demanding them.
+    private final boolean authorizationRequired;
 
     public SubscriptionService(BondedRolesService bondedRolesService,
                                AlertNotificationsService alertNotificationsService,
@@ -72,7 +84,11 @@ public class SubscriptionService implements Service {
                                UserService userService,
                                BisqEasyService bisqEasyService,
                                NetworkService networkService,
-                               OpenTradeItemsService openTradeItemsService) {
+                               OpenTradeItemsService openTradeItemsService,
+                               PermissionService permissionService,
+                               boolean authorizationRequired) {
+        this.permissionService = permissionService;
+        this.authorizationRequired = authorizationRequired;
         subscriberRepository = new SubscriberRepository();
 
         marketPriceWebSocketService = new MarketPriceWebSocketService(subscriberRepository, bondedRolesService);
@@ -142,6 +158,11 @@ public class SubscriptionService implements Service {
 
     private void subscribe(SubscriptionRequest request, WebSocket webSocket) {
         log.info("Received subscription request: {}", request);
+        Optional<String> authorizationError = findAuthorizationError(request.getTopic(), webSocket);
+        if (authorizationError.isPresent()) {
+            refuse(webSocket, request.getRequestId(), authorizationError.get());
+            return;
+        }
         findWebSocketService(request.getTopic())
                 .ifPresent(webSocketService -> {
                     Subscriber subscriber = null;
@@ -149,6 +170,21 @@ public class SubscriptionService implements Service {
                         webSocketService.validate(request);
                         Optional<String> canonicalParameter = webSocketService.canonicalizeParameter(StringUtils.toOptional(request.getParameter()));
                         subscriber = subscriberRepository.add(request, canonicalParameter, webSocket);
+                        // The check above and this add are not one operation. A revocation in between
+                        // removes the grant and closes the socket, but closing only moves a Grizzly
+                        // socket to CLOSING: until the close frame is flushed it still accepts sends
+                        // and the repository has not been swept. Without this re-read the snapshot
+                        // below would go out to a client whose grant is already gone, and the entry
+                        // would stay until the sweep. The re-read sees the grant gone because the
+                        // revocation removes it before it closes the socket. Deliberately not a
+                        // socket-state check: isConnected() is true while CLOSING, and once the
+                        // socket is CLOSED the send throws and the catch below removes the entry.
+                        Optional<String> revokedMeanwhile = findAuthorizationError(request.getTopic(), webSocket);
+                        if (revokedMeanwhile.isPresent()) {
+                            removeSubscriber(subscriber);
+                            refuse(webSocket, request.getRequestId(), revokedMeanwhile.get());
+                            return;
+                        }
                         Optional<String> jsonPayload = webSocketService.getJsonPayload(canonicalParameter);
                         if (jsonPayload.isPresent()) {
                             sendSubscriptionResponse(webSocket, request.getRequestId(), jsonPayload.get(), null);
@@ -171,6 +207,66 @@ public class SubscriptionService implements Service {
                                 String.format("Unexpected error when subscribing to %s", request.getTopic().name()));
                     }
                 });
+    }
+
+    /**
+     * The authorization the REST surface gets from {@code RestApiAuthorizationFilter} and this one
+     * never had: the same connection carries both, but only REST messages are proxied through
+     * JAX-RS, so the filter never sees a subscription and every topic was served to any paired
+     * client regardless of what it was granted.
+     * <p>
+     * Checked before the topic is routed, mirroring a filter running before the resource, and
+     * failing closed at every step. The identity comes from the upgrade request rather than the
+     * message, because the handshake is the only point in the connection's life where anything
+     * could have vouched for it — which is not the same as saying something did; see
+     * {@link WebSocketIdentity}.
+     * <p>
+     * The message repeats the REST vocabulary ({@code permission_not_granted}) so a client can tell
+     * a withheld permission from a transport failure and prompt for re-pairing instead of showing a
+     * connection error. The contract is that prefix, optionally followed by {@code ": "} and the
+     * permission name, so a client has to match on the prefix and never on the whole string. The
+     * name is only there when a known client was refused a specific permission — the two identity
+     * failures give a bare denial, because naming what an unidentified caller would have needed
+     * tells it something it has not earned.
+     *
+     * @return the error to answer with, or empty when the subscription may proceed
+     */
+    private Optional<String> findAuthorizationError(Topic topic, WebSocket webSocket) {
+        if (!authorizationRequired) {
+            return Optional.empty();
+        }
+        Optional<String> clientId = WebSocketIdentity.findClientId(webSocket);
+        if (clientId.isEmpty()) {
+            log.warn("Subscription authz failed: connection carries no clientId. topic={}", topic);
+            return Optional.of("permission_not_granted");
+        }
+        Optional<Set<Permission>> granted = permissionService.findPermissions(clientId.get());
+        if (granted.isEmpty()) {
+            log.warn("Subscription authz failed: no permissions registered for the client. topic={}", topic);
+            return Optional.of("permission_not_granted");
+        }
+        Permission required = permissionMapping.getRequiredPermission(topic);
+        if (!permissionService.hasPermission(granted.get(), required)) {
+            log.warn("Subscription authz failed: required permission {} not granted. topic={}", required.name(), topic);
+            return Optional.of("permission_not_granted: " + required.name());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * A refusal may be answered to a connection that a revocation has just closed: the
+     * subscribe frame was already queued when the grant went, on both the check before the add and
+     * the one after it. Once the socket has reached CLOSED, Grizzly throws on send (while it is
+     * still CLOSING the send goes through and the client simply reads the refusal), and the
+     * executor running {@code onMessage} discards its future, so left alone the throw is neither
+     * handled nor logged. Here it is the expected outcome, not an error to report.
+     */
+    private void refuse(WebSocket webSocket, String requestId, String errorMessage) {
+        try {
+            sendSubscriptionResponse(webSocket, requestId, null, errorMessage);
+        } catch (RuntimeException e) {
+            log.debug("Could not answer refused subscription {}", requestId, e);
+        }
     }
 
     private void removeSubscriber(Subscriber subscriber) {

--- a/api/src/main/java/bisq/api/web_socket/util/WebSocketIdentity.java
+++ b/api/src/main/java/bisq/api/web_socket/util/WebSocketIdentity.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.util;
+
+import bisq.api.access.filter.Headers;
+import bisq.common.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import org.glassfish.grizzly.websockets.DefaultWebSocket;
+import org.glassfish.grizzly.websockets.WebSocket;
+
+import java.util.Optional;
+
+/**
+ * Reads the client identity a WebSocket connection claims.
+ * <p>
+ * It lives on the upgrade request and not on the messages, because the handshake is the one point
+ * where the connection could have been authenticated, and a client can put anything in a frame
+ * afterwards. Shared because two callers need it for opposite reasons: the REST proxy forwards it
+ * to the REST server so its filters can authorise the call, and the subscription service authorises
+ * the topic itself.
+ * <p>
+ * How much this is worth depends on the deployment, and today it is worth less than the name
+ * suggests. {@code WebSocketFilterAddOn} registers the session authentication filter only when
+ * {@code supportSessionHandling} is set, and every shipped app config runs with it off, so in
+ * practice the handshake authenticates nothing and {@code Bisq-Client-Id} is an unvalidated header
+ * that any caller can set. That is not a gap this class introduces — {@code RestApiAuthorizationFilter}
+ * reads the same raw header, and reading the enriched request attribute instead would not help,
+ * since it is filled from that header too. Treat what this returns as a claim that is exactly as
+ * trustworthy as the handshake was, and do not build anything on it that assumes more.
+ */
+public final class WebSocketIdentity {
+    private WebSocketIdentity() {
+    }
+
+    public static Optional<HttpServletRequest> findUpgradeRequest(WebSocket webSocket) {
+        return webSocket instanceof DefaultWebSocket defaultWebSocket
+                ? Optional.ofNullable(defaultWebSocket.getUpgradeRequest())
+                : Optional.empty();
+    }
+
+    public static Optional<String> findClientId(WebSocket webSocket) {
+        return findUpgradeRequest(webSocket)
+                .map(upgradeRequest -> upgradeRequest.getHeader(Headers.CLIENT_ID))
+                .filter(StringUtils::isNotEmpty);
+    }
+}

--- a/api/src/main/proto/api.proto
+++ b/api/src/main/proto/api.proto
@@ -34,6 +34,8 @@ enum Permission {
   PERMISSION_USER_IDENTITIES = 9;
   PERMISSION_USER_PROFILES = 10;
   PERMISSION_MOBILE_DEVICES = 11;
+  // 12 is reserved for PERMISSION_PRIVATE_CHAT_CHANNELS, declared on the for-mobile branch.
+  PERMISSION_NETWORK_INFO = 13;
 }
 
 message PermissionSet {

--- a/api/src/test/java/bisq/api/access/filter/authz/RestApiAuthorizationFilterTest.java
+++ b/api/src/test/java/bisq/api/access/filter/authz/RestApiAuthorizationFilterTest.java
@@ -20,7 +20,6 @@ package bisq.api.access.filter.authz;
 import bisq.api.access.filter.Headers;
 import bisq.api.access.permissions.Permission;
 import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -42,12 +41,10 @@ import static org.mockito.Mockito.when;
 
 class RestApiAuthorizationFilterTest {
 
-    @SuppressWarnings("unchecked")
-    private static PermissionService<RestPermissionMapping> permissionService(Set<Permission> granted) {
-        RestPermissionMapping mapping = mock(RestPermissionMapping.class);
-        when(mapping.getRequiredPermission("/api/v1/offerbook/markets", "GET")).thenReturn(Permission.OFFERBOOK);
-        PermissionService<RestPermissionMapping> permissionService = mock(PermissionService.class);
-        when(permissionService.getPermissionMapping()).thenReturn(mapping);
+    // No mapping stub: the filter owns a real RestPermissionMapping, so the request URI below
+    // resolves through the same rules production uses.
+    private static PermissionService permissionService(Set<Permission> granted) {
+        PermissionService permissionService = mock(PermissionService.class);
         when(permissionService.findPermissions("client-1")).thenReturn(Optional.of(granted));
         when(permissionService.hasPermission(granted, Permission.OFFERBOOK))
                 .thenReturn(granted.contains(Permission.OFFERBOOK));
@@ -96,8 +93,7 @@ class RestApiAuthorizationFilterTest {
     void unknownClientAborts403WithoutTheStructuredBody() {
         // Revoked/unknown clients keep the bare 403: the session-path handling in the client
         // already routes that case to re-pairing, and the body must not aid probing.
-        @SuppressWarnings("unchecked")
-        PermissionService<RestPermissionMapping> permissionService = mock(PermissionService.class, RETURNS_DEEP_STUBS);
+        PermissionService permissionService = mock(PermissionService.class);
         when(permissionService.findPermissions("client-1")).thenReturn(Optional.empty());
         RestApiAuthorizationFilter filter = new RestApiAuthorizationFilter(permissionService);
         ContainerRequestContext context = requestContext();

--- a/api/src/test/java/bisq/api/access/permissions/PermissionServiceTest.java
+++ b/api/src/test/java/bisq/api/access/permissions/PermissionServiceTest.java
@@ -37,12 +37,12 @@ import static org.mockito.Mockito.when;
 
 class PermissionServiceTest {
     private ApiAccessStoreService apiAccessStoreService;
-    private PermissionService<RestPermissionMapping> permissionService;
+    private PermissionService permissionService;
 
     @BeforeEach
     void setUp() {
         apiAccessStoreService = mock(ApiAccessStoreService.class);
-        permissionService = new PermissionService<>(apiAccessStoreService, new RestPermissionMapping());
+        permissionService = new PermissionService(apiAccessStoreService);
     }
 
     @Test

--- a/api/src/test/java/bisq/api/access/permissions/PermissionTest.java
+++ b/api/src/test/java/bisq/api/access/permissions/PermissionTest.java
@@ -30,7 +30,7 @@ class PermissionTest {
 
     @Test
     void everyCurrentPermissionIsStandard() {
-        // The 11 current permissions are all standard. This documents that intent; the security
+        // Every permission declared so far is standard. This documents that intent; the security
         // guarantee itself comes from the SENSITIVE default (an id-only declaration is not
         // auto-grantable), so a forgotten classification fails closed rather than silently
         // joining grantAll. Whoever adds the first sensitive permission updates this test AND
@@ -42,6 +42,29 @@ class PermissionTest {
     @Test
     void autoGrantableEqualsAllValuesWhileNoSensitivePermissionExists() {
         assertEquals(EnumSet.allOf(Permission.class), Permission.autoGrantable());
+    }
+
+    @Test
+    void idsAreUnique() {
+        // fromId returns the first match, so a duplicate id resolves silently to whichever value
+        // was declared first — a permission would then be granted under another one's name. The
+        // deliberate gap at id 11, left for a permission declared in another branch, is exactly the
+        // shape that invites a duplicate the next time someone appends without reading the comment.
+        assertEquals(Permission.values().length,
+                Arrays.stream(Permission.values()).map(Permission::getId).distinct().count(),
+                "two permissions share an id");
+    }
+
+    @Test
+    void everyPermissionHasAProtoEntryOneAheadOfItsId() {
+        // The proto numbers are these ids shifted by one for UNSPECIFIED. Nothing enforces that at
+        // compile time: a value added without its proto entry throws from toProtoEnum at persist
+        // time, which is a store write failing in the field rather than a build failing here.
+        for (Permission permission : Permission.values()) {
+            assertEquals(permission.getId() + 1,
+                    permission.toProtoEnum().getNumber(),
+                    () -> permission.name() + " is out of step with its proto entry");
+        }
     }
 
     @Test

--- a/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreTest.java
+++ b/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreTest.java
@@ -22,13 +22,29 @@ import bisq.api.access.permissions.PermissionSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ApiAccessStoreTest {
+    /** What v2.1.12 wrote for every pairing: all the permissions that binary had. */
+    private static final Set<Permission> AS_SHIPPED_IN_V2_1_12 = Set.of(Permission.TRADE_CHAT_CHANNELS,
+            Permission.EXPLORER,
+            Permission.MARKET_PRICE,
+            Permission.OFFERBOOK,
+            Permission.PAYMENT_ACCOUNTS,
+            Permission.REPUTATION,
+            Permission.SETTINGS,
+            Permission.TRADES,
+            Permission.USER_IDENTITIES,
+            Permission.USER_PROFILES,
+            Permission.MOBILE_DEVICES);
+
     @Test
     void fullPermissionSetIsPromotedToGrantAllOnLoad() {
         // An entry already covering every permission of the running version is promoted to
@@ -47,6 +63,95 @@ class ApiAccessStoreTest {
         PermissionSet migrated = store.getPermissionsByClientId().get("legacy-client");
         assertTrue(migrated.isGrantAll());
         assertEquals(Permission.autoGrantable(), migrated.getPermissions());
+    }
+
+    @Test
+    void releasedFullGrantIsPromotedAfterTheRunningVersionGainedPermissions() {
+        // The case the test above cannot reach: it builds its entry from the RUNNING enum, so it
+        // keeps matching whatever gets added and stays green straight through the regression this
+        // one pins. Here the list is hardcoded to what v2.1.12 actually wrote, which is the shape
+        // every paired client in the field has on disk, and the running binary has gained a
+        // permission since.
+        //
+        // It has to be promoted anyway: the running-set branch of the promotion is a one-shot (ids
+        // are append-only, so a set the binary has grown past never equals the running standard set
+        // again), which is why the released set is spelled out in its own constant. Miss it and
+        // that client keeps a frozen explicit grant for good, losing every standard permission added
+        // from here on.
+        // Keeps the test from going vacuous: it only asserts something while the running standard
+        // set is strictly larger than what that release wrote.
+        assertNotEquals(Permission.autoGrantable(), AS_SHIPPED_IN_V2_1_12);
+
+        bisq.api.protobuf.PermissionSet legacyFullGrant = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addAllPermissions(AS_SHIPPED_IN_V2_1_12.stream().map(Permission::toProtoEnum).toList())
+                .build();
+        bisq.api.protobuf.ApiAccessStore proto = bisq.api.protobuf.ApiAccessStore.newBuilder()
+                .putPermissionsByClientId("legacy-client", legacyFullGrant)
+                .build();
+
+        ApiAccessStore store = ApiAccessStore.fromProto(proto);
+
+        PermissionSet migrated = store.getPermissionsByClientId().get("legacy-client");
+        assertTrue(migrated.isGrantAll());
+        assertEquals(Permission.autoGrantable(), migrated.getPermissions());
+        // The promotion is in memory; this flag is what makes ApiAccessStoreService write it back
+        // on the same boot, so the store on disk stops depending on this rule next time.
+        assertTrue(store.hadPromotedEntriesDuringLoad());
+    }
+
+    @Test
+    void restrictedGrantEqualToAReleasedFullSetIsStillPromoted() {
+        // The released-set branch does not fade with versions, and this pins the cost of that as
+        // current behaviour: a grant of exactly the v2.1.12 set is promoted whatever wrote it,
+        // including this binary stamping the current schema version, which is what a deliberate
+        // "everything except the newer permissions" restriction would look like once something can
+        // issue one. Nothing can today. This test does not catch that feature arriving; it stays
+        // green while the promotion happens. It is here so that the feature has to change this test
+        // on purpose, and the KNOWN RESIDUAL on ApiAccessStore#promoteIfFullStandardGrant says what
+        // it has to add first: a downgrade-durable marker. The stamp is not that marker: builds
+        // between grantAll and the released-set rule stamp every persist while leaving a v2.1.9
+        // entry explicit, so refusing on it would freeze that client (see the test below).
+        assertNotEquals(Permission.autoGrantable(), AS_SHIPPED_IN_V2_1_12);
+        bisq.api.protobuf.PermissionSet restriction = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addAllPermissions(AS_SHIPPED_IN_V2_1_12.stream().map(Permission::toProtoEnum).toList())
+                .build();
+        for (int schemaVersion : new int[]{0, 1}) {
+            bisq.api.protobuf.ApiAccessStore proto = bisq.api.protobuf.ApiAccessStore.newBuilder()
+                    .putPermissionsByClientId("restricted-client", restriction)
+                    .setPermissionsSchemaVersion(schemaVersion)
+                    .build();
+
+            ApiAccessStore store = ApiAccessStore.fromProto(proto);
+
+            PermissionSet loaded = store.getPermissionsByClientId().get("restricted-client");
+            assertTrue(loaded.isGrantAll(), "released full set is promoted at schema version " + schemaVersion);
+            assertTrue(store.hadPromotedEntriesDuringLoad(), "and written back at schema version " + schemaVersion);
+        }
+    }
+
+    @Test
+    void legacyGrantStampedByABuildThatDidNotKnowTheReleasedShapesIsStillPromoted() {
+        // The builds between grantAll and the released-set rule (the base of this change) promote
+        // only their own running set, yet stamp permissionsSchemaVersion on every persist. A client
+        // paired on v2.1.9 whose node ran such a build has its 10-permission entry sitting under
+        // version 1 as soon as anything persisted the store: a new pairing, a revoke, or the
+        // write-back for a promoted sibling. Gating the released-set branch on the stamp would
+        // leave that client frozen for good, so the stamp must not be consulted.
+        Set<Permission> asShippedInV2_1_9 = AS_SHIPPED_IN_V2_1_12.stream()
+                .filter(permission -> permission != Permission.MOBILE_DEVICES)
+                .collect(Collectors.toSet());
+        bisq.api.protobuf.PermissionSet legacyGrant = bisq.api.protobuf.PermissionSet.newBuilder()
+                .addAllPermissions(asShippedInV2_1_9.stream().map(Permission::toProtoEnum).toList())
+                .build();
+        bisq.api.protobuf.ApiAccessStore proto = bisq.api.protobuf.ApiAccessStore.newBuilder()
+                .putPermissionsByClientId("legacy-client", legacyGrant)
+                .setPermissionsSchemaVersion(1)
+                .build();
+
+        ApiAccessStore store = ApiAccessStore.fromProto(proto);
+
+        assertTrue(store.getPermissionsByClientId().get("legacy-client").isGrantAll());
+        assertTrue(store.hadPromotedEntriesDuringLoad());
     }
 
     @Test
@@ -98,6 +203,57 @@ class ApiAccessStoreTest {
         PermissionSet restricted = reloaded.getPermissionsByClientId().get("restricted-client");
         assertFalse(restricted.isGrantAll());
         assertEquals(Set.of(Permission.OFFERBOOK), restricted.getPermissions());
+    }
+
+    @Test
+    void fullGrantRewrittenByAnOlderNodeThatKnowsFewerPermissionsIsStillPromoted() {
+        // The rewrite the test above does not model: an old node drops every enum value it cannot
+        // resolve (ProtobufUtils#fromProtoEnumStream) before rebuilding the list, so what comes
+        // back is that release's own full set, not this version's expansion. The same shape is on
+        // disk for a client that paired on that release and never re-paired, since a grant is only
+        // rewritten at pairing time. Both v2.1.9 (10 permissions) and v2.1.10-v2.1.12 (11) shipped,
+        // so both shapes must be promoted or that client is frozen out of every standard permission
+        // added since.
+        // Keeps the v2.1.12 row from going vacuous through the running-set branch.
+        assertNotEquals(Permission.autoGrantable(), AS_SHIPPED_IN_V2_1_12);
+        ApiAccessStore newStore = new ApiAccessStore();
+        newStore.getPermissionsByClientId().put("full-client", PermissionSet.grantAll());
+        bisq.api.protobuf.ApiAccessStore currentProto = newStore.toProto(false);
+
+        Map<String, Permission> lastPermissionKnownByRelease = Map.of(
+                "v2.1.9", Permission.USER_PROFILES,
+                "v2.1.12", Permission.MOBILE_DEVICES);
+        lastPermissionKnownByRelease.forEach((release, lastKnown) -> {
+            bisq.api.protobuf.ApiAccessStore.Builder oldNodeRewrite = bisq.api.protobuf.ApiAccessStore.newBuilder();
+            currentProto.getPermissionsByClientIdMap().forEach((clientId, entry) ->
+                    oldNodeRewrite.putPermissionsByClientId(clientId,
+                            bisq.api.protobuf.PermissionSet.newBuilder()
+                                    .addAllPermissions(entry.getPermissionsList().stream()
+                                            .filter(p -> p.getNumber() <= lastKnown.toProtoEnum().getNumber())
+                                            .toList())
+                                    .build()));
+
+            ApiAccessStore reloaded = ApiAccessStore.fromProto(oldNodeRewrite.build());
+
+            assertTrue(reloaded.getPermissionsByClientId().get("full-client").isGrantAll(),
+                    "full grant rewritten by " + release + " must be promoted again");
+            assertTrue(reloaded.hadPromotedEntriesDuringLoad(),
+                    "and written back so the store stops depending on the rule");
+        });
+    }
+
+    @Test
+    void everyReleasedFullSetHoldsOnlyStandardPermissions() {
+        // Promotion swaps the explicit list for the grantAll expansion, which never covers a
+        // sensitive permission. The running-set branch cannot meet one by construction; the
+        // released sets are a value list, so a listed permission reclassified as sensitive would
+        // still match and be silently dropped from the grant. Prune it from the sets first.
+        for (Set<Permission> releasedSet : ApiAccessStore.RELEASED_FULL_STANDARD_SETS) {
+            for (Permission permission : releasedSet) {
+                assertTrue(permission.isAutoGrantable(),
+                        permission + " is listed as part of a released full set but is no longer standard");
+            }
+        }
     }
 
     @Test

--- a/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
+++ b/api/src/test/java/bisq/api/rest_api/endpoints/config/ConfigRestApiTest.java
@@ -18,6 +18,7 @@
 package bisq.api.rest_api.endpoints.config;
 
 import bisq.api.access.AllowUnauthenticated;
+import bisq.api.access.permissions.PermissionService;
 import bisq.api.dto.config.ApiCapabilitiesDto;
 import bisq.api.dto.config.TradeAmountLimitsDto;
 import bisq.api.rest_api.endpoints.trades.TradeRestApi;
@@ -167,7 +168,9 @@ class ConfigRestApiTest {
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
                 mock(NetworkService.class, RETURNS_DEEP_STUBS),
-                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS));
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS),
+                mock(PermissionService.class),
+                false);
         try {
             Method method = SubscriptionService.class.getDeclaredMethod("findWebSocketService", Topic.class);
             method.setAccessible(true);

--- a/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionPermissionMappingTest.java
+++ b/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionPermissionMappingTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.web_socket.subscription;
+
+import bisq.api.access.permissions.Permission;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the table itself. The exhaustive switch already guarantees a topic cannot be MISSING a
+ * permission — the class does not compile otherwise — but nothing guarantees a row is not WRONG,
+ * and a wrong row widens access silently: the subscription is served, the client is never told, and
+ * only reading the switch reveals it.
+ * <p>
+ * Every expectation below is the permission that already guards the same data over REST, so a
+ * client cannot reach through a subscription what a request would refuse it. {@code NETWORK_INFO}
+ * is the one row with no REST route to mirror.
+ */
+class SubscriptionPermissionMappingTest {
+    private static final Map<Topic, Permission> EXPECTED = new EnumMap<>(Map.ofEntries(
+            Map.entry(Topic.MARKET_PRICE, Permission.MARKET_PRICE),
+            Map.entry(Topic.NUM_OFFERS, Permission.OFFERBOOK),
+            Map.entry(Topic.OFFERS, Permission.OFFERBOOK),
+            Map.entry(Topic.TRADES, Permission.TRADES),
+            Map.entry(Topic.TRADE_PROPERTIES, Permission.TRADES),
+            Map.entry(Topic.TRADE_CHAT_MESSAGES, Permission.TRADE_CHAT_CHANNELS),
+            Map.entry(Topic.CHAT_REACTIONS, Permission.TRADE_CHAT_CHANNELS),
+            Map.entry(Topic.REPUTATION, Permission.REPUTATION),
+            Map.entry(Topic.NUM_USER_PROFILES, Permission.USER_PROFILES),
+            Map.entry(Topic.ALERT_NOTIFICATIONS, Permission.SETTINGS),
+            Map.entry(Topic.TRADE_RESTRICTING_ALERT, Permission.SETTINGS),
+            Map.entry(Topic.NETWORK_INFO, Permission.NETWORK_INFO)));
+
+    private final SubscriptionPermissionMapping mapping = new SubscriptionPermissionMapping();
+
+    @Test
+    void everyTopicRequiresThePermissionGuardingTheSameDataOverRest() {
+        for (Topic topic : Topic.values()) {
+            assertThat(mapping.getRequiredPermission(topic))
+                    .as("%s", topic)
+                    .isEqualTo(EXPECTED.get(topic));
+        }
+    }
+
+    @Test
+    void everyTopicIsAccountedForHere() {
+        // Without this the loop above would quietly stop covering a topic added later: the switch
+        // would force the author to declare a permission, and this table would not force them to
+        // agree that it is the right one.
+        assertThat(EXPECTED.keySet()).containsExactlyInAnyOrder(Topic.values());
+    }
+}

--- a/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
+++ b/api/src/test/java/bisq/api/web_socket/subscription/SubscriptionServiceTest.java
@@ -17,10 +17,18 @@
 
 package bisq.api.web_socket.subscription;
 
+import bisq.api.access.filter.Headers;
+import bisq.api.access.permissions.Permission;
+import bisq.api.access.permissions.PermissionService;
+import bisq.api.access.permissions.PermissionSet;
+import bisq.api.access.persistence.ApiAccessStoreService;
+import bisq.api.web_socket.domain.BaseWebSocketService;
 import bisq.api.web_socket.domain.OpenTradeItemsService;
 import bisq.api.web_socket.domain.market_price.MarketPriceWebSocketService;
+import bisq.api.web_socket.domain.network.NetworkInfoWebSocketService;
 import bisq.bisq_easy.BisqEasyService;
 import bisq.bonded_roles.BondedRolesService;
+import bisq.bonded_roles.bonded_role.AuthorizedBondedRolesService;
 import bisq.bonded_roles.release.AppType;
 import bisq.bonded_roles.security_manager.alert.AlertNotificationsService;
 import bisq.chat.ChatService;
@@ -32,19 +40,27 @@ import bisq.trade.TradeService;
 import bisq.user.UserService;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.glassfish.grizzly.impl.ReadyFutureImpl;
+import jakarta.servlet.http.HttpServletRequest;
+import org.glassfish.grizzly.websockets.DefaultWebSocket;
 import org.glassfish.grizzly.websockets.WebSocket;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
@@ -70,7 +86,11 @@ class SubscriptionServiceTest {
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
                 mock(NetworkService.class, RETURNS_DEEP_STUBS),
-                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS),
+                mock(PermissionService.class),
+                // Authorization off: these cover routing and subscriber bookkeeping, and the
+                // permission path has its own test.
+                false
         );
 
         WebSocket webSocket = mock(WebSocket.class);
@@ -96,7 +116,11 @@ class SubscriptionServiceTest {
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
                 mock(NetworkService.class, RETURNS_DEEP_STUBS),
-                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS),
+                mock(PermissionService.class),
+                // Authorization off: these cover routing and subscriber bookkeeping, and the
+                // permission path has its own test.
+                false
         );
         SubscriberRepository subscriberRepository = getSubscriberRepository(service);
         replaceWebSocketService(service, "marketPriceWebSocketService", new TestMarketPriceWebSocketService(subscriberRepository));
@@ -138,7 +162,11 @@ class SubscriptionServiceTest {
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
                 mock(NetworkService.class, RETURNS_DEEP_STUBS),
-                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS),
+                mock(PermissionService.class),
+                // Authorization off: these cover routing and subscriber bookkeeping, and the
+                // permission path has its own test.
+                false
         );
 
         service.onMessage(subscriptionJson("r1", "OFFERS", "eur"), mock(WebSocket.class, RETURNS_DEEP_STUBS));
@@ -165,7 +193,11 @@ class SubscriptionServiceTest {
                 mock(UserService.class, RETURNS_DEEP_STUBS),
                 mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
                 mock(NetworkService.class, RETURNS_DEEP_STUBS),
-                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS)
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS),
+                mock(PermissionService.class),
+                // Authorization off: these cover routing and subscriber bookkeeping, and the
+                // permission path has its own test.
+                false
         );
 
         List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
@@ -189,6 +221,295 @@ class SubscriptionServiceTest {
                 .contains("allDataReceived")
                 .contains("connections");
         assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isNotEmpty();
+    }
+
+    /**
+     * The gap this class of test exists for: the same connection carries REST calls and
+     * subscriptions, but only the REST ones are proxied through JAX-RS, so
+     * {@code RestApiAuthorizationFilter} never saw a subscription and every topic was served to any
+     * paired client whatever it had been granted.
+     */
+    @Test
+    void subscriptionIsRefusedWhenTheTopicsPermissionIsNotGranted() throws Exception {
+        SubscriptionService service = authorizingService(EnumSet.of(Permission.TRADES));
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = authenticatedWebSocket(sentMessages);
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.get("errorMessage").asText())
+                .as("the client must be able to tell a withheld permission from a transport failure")
+                .isEqualTo("permission_not_granted: NETWORK_INFO");
+        assertThat(response.hasNonNull("payload"))
+                .as("a refused subscription must not carry the snapshot it was refused")
+                .isFalse();
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO))
+                .as("a refused subscription must not leave a subscriber behind to be pushed to")
+                .isEmpty();
+    }
+
+    @Test
+    void subscriptionProceedsWhenTheTopicsPermissionIsGranted() throws Exception {
+        SubscriptionService service = authorizingService(EnumSet.of(Permission.NETWORK_INFO));
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = authenticatedWebSocket(sentMessages);
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.hasNonNull("errorMessage")).isFalse();
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isNotEmpty();
+    }
+
+    /**
+     * The authorization check and the repository add are two steps. A revocation between them
+     * removes the grant and closes the socket, but closing only moves a Grizzly socket to CLOSING:
+     * until the close frame is flushed it still accepts sends and the repository has not been
+     * swept. Without the re-read after the add, the snapshot would be served to a client whose
+     * grant is already gone and the subscriber would stay. The revocation runs here from the topic
+     * service's {@code validate}, which {@code subscribe} calls after the check and before the add,
+     * and the socket keeps sending, which is the CLOSING window.
+     */
+    @Test
+    void aSubscriptionWhoseClientIsRevokedWhileItIsBeingAddedIsRefusedAndLeavesNoSubscriber() throws Exception {
+        AtomicReference<Map<String, PermissionSet>> store = new AtomicReference<>(
+                Map.of("client-1", new PermissionSet(EnumSet.of(Permission.NETWORK_INFO))));
+        ApiAccessStoreService apiAccessStoreService = mock(ApiAccessStoreService.class);
+        when(apiAccessStoreService.getPermissionsByClientId()).thenAnswer(invocation -> store.get());
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = authenticatedWebSocket(sentMessages);
+        SubscriptionService service = subscriptionService(new PermissionService(apiAccessStoreService), true);
+        replaceWebSocketService(service, "networkInfoWebSocketService",
+                new NetworkInfoWebSocketService(getSubscriberRepository(service),
+                        mock(NetworkService.class, RETURNS_DEEP_STUBS),
+                        mock(AuthorizedBondedRolesService.class, RETURNS_DEEP_STUBS)) {
+                    @Override
+                    public void validate(SubscriptionRequest request) {
+                        store.set(Map.of());
+                    }
+                });
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO))
+                .as("a subscriber whose grant went while it was being added must not stay behind")
+                .isEmpty();
+        assertThat(sentMessages).hasSize(1);
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.get("errorMessage").asText())
+                .as("the still-sending socket gets the refusal, never the snapshot")
+                .isEqualTo("permission_not_granted");
+        assertThat(response.hasNonNull("payload")).isFalse();
+    }
+
+    /**
+     * The other place a refusal meets a closed socket: the subscribe frame was already queued when
+     * the revocation ran, so the first check denies and the answer goes to a connection that no
+     * longer exists. The send throws, and the executor running {@code onMessage} discards its
+     * future, so anything escaping here would be neither handled nor logged.
+     */
+    @Test
+    void aSubscriptionDeniedOnAConnectionAlreadyClosedByTheRevocationEscapesNothing() throws Exception {
+        SubscriptionService service = authorizingService(EnumSet.of(Permission.TRADES));
+        WebSocket webSocket = authenticatedWebSocket(new ArrayList<>());
+        doThrow(new RuntimeException("Socket is not connected.")).when(webSocket).send(anyString());
+
+        assertThatCode(() -> service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket))
+                .doesNotThrowAnyException();
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isEmpty();
+    }
+
+    /**
+     * The other half of the legacy-pairing path. Every client paired before this node existed holds
+     * the full standard set of its release, which the store promotes to grantAll on load (see
+     * {@code ApiAccessStoreTest}). That promotion is worth nothing unless the expansion then covers
+     * this permission, which is what {@code Kind.STANDARD} on {@code NETWORK_INFO} buys: declare it
+     * sensitive and grantAll stops covering it, leaving every existing pairing refused with
+     * re-pairing as the only way back.
+     */
+    @Test
+    void subscriptionProceedsForAClientWhoseLegacyGrantWasPromotedToGrantAll() throws Exception {
+        ApiAccessStoreService apiAccessStoreService = mock(ApiAccessStoreService.class);
+        when(apiAccessStoreService.getPermissionsByClientId())
+                .thenReturn(Map.of("client-1", PermissionSet.grantAll()));
+        SubscriptionService service = subscriptionService(new PermissionService(apiAccessStoreService), true);
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = authenticatedWebSocket(sentMessages);
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.hasNonNull("errorMessage")).isFalse();
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isNotEmpty();
+    }
+
+    /**
+     * The revoked-client path: the pairing is gone from the store while the connection is still
+     * open. Nothing else covers it — every other test here answers for a client the store knows, so
+     * the lookup would keep passing if it stopped failing closed on an unknown one.
+     */
+    @Test
+    void subscriptionIsRefusedWhenTheClientIsNotPaired() throws Exception {
+        SubscriptionService service = authorizingService(EnumSet.allOf(Permission.class));
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = authenticatedWebSocket(sentMessages, "client-2");
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.get("errorMessage").asText())
+                .as("a client the store does not know gets a bare denial, not the missing permission")
+                .isEqualTo("permission_not_granted");
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isEmpty();
+    }
+
+    /**
+     * Fails closed on the step before the permission: the identity is read from the upgrade request,
+     * so a connection that carries none is refused rather than treated as an anonymous client with
+     * nothing to check.
+     * <p>
+     * Both ways of carrying none are covered. A socket that exposes no upgrade request at all never
+     * reaches the header, and a socket that exposes one without a usable {@code Bisq-Client-Id} is
+     * what the emptiness filter in {@code WebSocketIdentity} is for — an absent header and a present
+     * blank one have to land in the same place.
+     */
+    @Test
+    void subscriptionIsRefusedWhenTheConnectionCarriesNoClientId() throws Exception {
+        List<WebSocketFactory> connectionsWithoutAnIdentity = List.of(
+                new WebSocketFactory("no upgrade request", SubscriptionServiceTest::socketWithoutUpgradeRequest),
+                new WebSocketFactory("absent header", sent -> authenticatedWebSocket(sent, null)),
+                new WebSocketFactory("blank header", sent -> authenticatedWebSocket(sent, "")));
+
+        for (WebSocketFactory factory : connectionsWithoutAnIdentity) {
+            SubscriptionService service = authorizingService(EnumSet.allOf(Permission.class));
+            List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+
+            service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), factory.create(sentMessages));
+
+            JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+            assertThat(response.get("errorMessage").asText()).as(factory.name()).isEqualTo("permission_not_granted");
+            assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO))
+                    .as(factory.name())
+                    .isEmpty();
+        }
+    }
+
+    /**
+     * Not a duplicate of the NETWORK_INFO refusal: that one is the topic with no REST route to
+     * mirror, so it could pass while every mirrored row was misrouted. This pins that the mapping is
+     * consulted for an ordinary topic too, and that the refusal names the permission the REST rule
+     * for the same data asks for.
+     */
+    @Test
+    void subscriptionIsRefusedWithThePermissionTheTopicMapsTo() throws Exception {
+        SubscriptionService service = authorizingService(EnumSet.of(Permission.TRADES));
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = authenticatedWebSocket(sentMessages);
+
+        service.onMessage(subscriptionJson("request-1", "OFFERS", "eur"), webSocket);
+
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.get("errorMessage").asText()).isEqualTo("permission_not_granted: OFFERBOOK");
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.OFFERS)).isEmpty();
+    }
+
+    /**
+     * A node configured without authorization registers no REST filter either, so there are no
+     * grants to check against and demanding them would break every such deployment.
+     */
+    @Test
+    void subscriptionProceedsWhenTheNodeRunsWithoutAuthorization() throws Exception {
+        SubscriptionService service = subscriptionService(mock(PermissionService.class), false);
+        List<String> sentMessages = Collections.synchronizedList(new ArrayList<>());
+        WebSocket webSocket = socketWithoutUpgradeRequest(sentMessages);
+
+        service.onMessage(subscriptionJson("request-1", "NETWORK_INFO", null), webSocket);
+
+        JsonNode response = JsonMapperProvider.get().readTree(sentMessages.getFirst());
+        assertThat(response.hasNonNull("errorMessage")).isFalse();
+        assertThat(getSubscriberRepository(service).findSubscribers(Topic.NETWORK_INFO)).isNotEmpty();
+    }
+
+    /**
+     * {@code findWebSocketService} switches over {@link Topic} in arrow form, which the compiler does
+     * not require to be exhaustive. A topic added without its case therefore compiles, and only shows
+     * up as a client whose subscribe never gets answered. This is the check that catches it.
+     */
+    @Test
+    void everyTopicResolvesToAWebSocketService() throws Exception {
+        SubscriptionService service = subscriptionService(mock(PermissionService.class), false);
+
+        Method findWebSocketService = SubscriptionService.class
+                .getDeclaredMethod("findWebSocketService", Topic.class);
+        findWebSocketService.setAccessible(true);
+
+        for (Topic topic : Topic.values()) {
+            @SuppressWarnings("unchecked")
+            Optional<BaseWebSocketService> webSocketService =
+                    (Optional<BaseWebSocketService>) findWebSocketService.invoke(service, topic);
+            assertThat(webSocketService)
+                    .as("Topic %s has no WebSocketService wired in SubscriptionService", topic)
+                    .isPresent();
+        }
+    }
+
+    /** A real PermissionService over a stubbed store, so the grant is read the way production reads it. */
+    private static SubscriptionService authorizingService(Set<Permission> granted) {
+        ApiAccessStoreService apiAccessStoreService = mock(ApiAccessStoreService.class);
+        when(apiAccessStoreService.getPermissionsByClientId())
+                .thenReturn(Map.of("client-1", new PermissionSet(granted)));
+        return subscriptionService(new PermissionService(apiAccessStoreService), true);
+    }
+
+    private static SubscriptionService subscriptionService(PermissionService permissionService,
+                                                           boolean authorizationRequired) {
+        return new SubscriptionService(
+                mock(BondedRolesService.class, RETURNS_DEEP_STUBS),
+                mock(AlertNotificationsService.class, RETURNS_DEEP_STUBS),
+                mock(ChatService.class, RETURNS_DEEP_STUBS),
+                mock(TradeService.class, RETURNS_DEEP_STUBS),
+                mock(UserService.class, RETURNS_DEEP_STUBS),
+                mock(BisqEasyService.class, RETURNS_DEEP_STUBS),
+                mock(NetworkService.class, RETURNS_DEEP_STUBS),
+                mock(OpenTradeItemsService.class, RETURNS_DEEP_STUBS),
+                permissionService,
+                authorizationRequired);
+    }
+
+    /** The identity lives on the upgrade request, which only a DefaultWebSocket exposes. */
+    private static WebSocket authenticatedWebSocket(List<String> sentMessages) {
+        return authenticatedWebSocket(sentMessages, "client-1");
+    }
+
+    private static WebSocket authenticatedWebSocket(List<String> sentMessages, @Nullable String clientId) {
+        HttpServletRequest upgradeRequest = mock(HttpServletRequest.class);
+        when(upgradeRequest.getHeader(Headers.CLIENT_ID)).thenReturn(clientId);
+        DefaultWebSocket webSocket = mock(DefaultWebSocket.class);
+        when(webSocket.getUpgradeRequest()).thenReturn(upgradeRequest);
+        recordSends(webSocket, sentMessages);
+        return webSocket;
+    }
+
+    /** Not a DefaultWebSocket, so there is no upgrade request to read an identity from at all. */
+    private static WebSocket socketWithoutUpgradeRequest(List<String> sentMessages) {
+        WebSocket webSocket = mock(WebSocket.class, RETURNS_DEEP_STUBS);
+        recordSends(webSocket, sentMessages);
+        return webSocket;
+    }
+
+    private static void recordSends(WebSocket webSocket, List<String> sentMessages) {
+        doAnswer(invocation -> {
+            sentMessages.add(invocation.getArgument(0));
+            return ReadyFutureImpl.create(null);
+        }).when(webSocket).send(anyString());
+    }
+
+    /** A named way of building a connection, so a failing row in a loop says which one it was. */
+    private record WebSocketFactory(String name, Function<List<String>, WebSocket> factory) {
+        private WebSocket create(List<String> sentMessages) {
+            return factory.apply(sentMessages);
+        }
     }
 
     private static String subscriptionJson(String requestId, String topic, String parameter) {

--- a/apps/node-monitor-web-app/src/main/java/bisq/node_monitor_app/NodeMonitorApplicationService.java
+++ b/apps/node-monitor-web-app/src/main/java/bisq/node_monitor_app/NodeMonitorApplicationService.java
@@ -24,7 +24,6 @@ import bisq.api.access.ApiAccessService;
 import bisq.api.access.filter.authn.SessionAuthenticationService;
 import bisq.api.access.pairing.PairingService;
 import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.access.persistence.ApiAccessStoreService;
 import bisq.api.access.session.SessionService;
 import bisq.api.access.transport.ApiAccessTransportService;
@@ -180,7 +179,7 @@ public class NodeMonitorApplicationService extends JavaSeApplicationService {
         ApiConfig apiConfig = ApiConfig.from(getConfig("api"));
         if (apiConfig.isRestEnabled()) {
             ApiAccessStoreService apiAccessStoreService = new ApiAccessStoreService(persistenceService);
-            PermissionService<RestPermissionMapping> permissionService = new PermissionService<>(apiAccessStoreService, new RestPermissionMapping());
+            PermissionService permissionService = new PermissionService(apiAccessStoreService);
             PairingService pairingService = new PairingService(apiConfig, config.getAppDataDirPath(), apiAccessStoreService, permissionService);
             SessionService sessionService = new SessionService(apiConfig.getSessionTtlInMinutes());
             TlsContextService tlsContextService = new TlsContextService(apiConfig, config.getAppDataDirPath());
@@ -208,7 +207,6 @@ public class NodeMonitorApplicationService extends JavaSeApplicationService {
                     resourceConfig,
                     Optional.empty(),
                     sessionAuthenticationService,
-                    permissionService,
                     tlsContextService));
         }
     }

--- a/apps/node-monitor-web-app/src/main/java/bisq/node_monitor_app/NodeMonitorRestApiResourceConfig.java
+++ b/apps/node-monitor-web-app/src/main/java/bisq/node_monitor_app/NodeMonitorRestApiResourceConfig.java
@@ -3,7 +3,6 @@ package bisq.node_monitor_app;
 import bisq.api.ApiConfig;
 import bisq.api.access.filter.authn.SessionAuthenticationService;
 import bisq.api.access.permissions.PermissionService;
-import bisq.api.access.permissions.RestPermissionMapping;
 import bisq.api.rest_api.RestApiBaseResourceConfig;
 import bisq.api.rest_api.endpoints.access.AccessApi;
 import bisq.network.NetworkService;
@@ -18,7 +17,7 @@ import org.glassfish.jersey.inject.hk2.AbstractBinder;
 public class NodeMonitorRestApiResourceConfig extends RestApiBaseResourceConfig {
     public NodeMonitorRestApiResourceConfig(ApiConfig apiConfig,
                                             AccessApi accessApi,
-                                            PermissionService<RestPermissionMapping> permissionService,
+                                            PermissionService permissionService,
                                             SessionAuthenticationService sessionAuthenticationService,
                                             NetworkService networkService,
                                             NodeMonitorService nodeMonitorService


### PR DESCRIPTION
Manual sync of #4961 from `for-mobile-based-on-2.1.12` to `main` (with conflict resolution).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-based authorization for WebSocket subscriptions.
  * Added the Network Info permission for supported API and subscription data.
  * Improved recognition of legacy full-access permission grants across released versions.

* **Bug Fixes**
  * Removed the client-revocation API endpoint.
  * Improved WebSocket identity and connection handling.

* **Tests**
  * Added coverage for subscription authorization, permission mappings, and legacy grant migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->