### PR TITLE
Keep proto content out of exception messages and logs

### DIFF
--- a/common/src/main/java/bisq/common/proto/ProtoResolverMap.java
+++ b/common/src/main/java/bisq/common/proto/ProtoResolverMap.java
@@ -46,7 +46,9 @@ public abstract class ProtoResolverMap<T extends Proto> {
         try {
             return resolver.fromAny(anyProto);
         } catch (Exception e) {
-            log.error("Could not resolve proto {}. protoTypeName={}", anyProto, protoTypeName, e);
+            // Never log the Any itself, it can hold private keys or payment account data.
+            log.error("Could not resolve proto. protoTypeName={}, {} bytes",
+                    protoTypeName, anyProto.getValue().size(), e);
             throw new UnresolvableProtobufMessageException(anyProto, e);
         }
     }

--- a/common/src/main/java/bisq/common/proto/UnresolvableProtobufMessageException.java
+++ b/common/src/main/java/bisq/common/proto/UnresolvableProtobufMessageException.java
@@ -20,12 +20,10 @@ package bisq.common.proto;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public class UnresolvableProtobufMessageException extends RuntimeException {
     public UnresolvableProtobufMessageException(String message, Message proto) {
-        super(message + ". Message case not found for proto message: \n" + proto.toString());
+        super(message + ". Message case not found for proto message: " + describe(proto));
     }
 
     public UnresolvableProtobufMessageException(Throwable cause) {
@@ -37,18 +35,31 @@ public class UnresolvableProtobufMessageException extends RuntimeException {
     }
 
     public UnresolvableProtobufMessageException(Message proto) {
-        super("Message case not found for proto message: \n" + proto.toString());
+        super("Message case not found for proto message: " + describe(proto));
     }
 
     public UnresolvableProtobufMessageException(Any proto, Throwable cause) {
-        super("Message case not found for proto message: \n" + proto.toString(), cause);
+        super("Message case not found for proto message: " + describe(proto), cause);
     }
 
     public UnresolvableProtobufMessageException(Any any) {
-        super("No class found for resolving proto Any message.\n" + any.toString());
+        super("No class found for resolving proto Any message. " + describe(any));
     }
 
     public UnresolvableProtobufMessageException(InvalidProtocolBufferException e) {
         super("Could not resolve proto Any message", e);
+    }
+
+    /**
+     * Protos reaching here can hold private keys, payment account details or trade data, and exception messages end up
+     * in the log file, which users share. Only the type and the size may be included, and they are what identifies the
+     * problem anyway.
+     */
+    private static String describe(Message proto) {
+        return proto.getDescriptorForType().getFullName() + ", " + proto.getSerializedSize() + " bytes";
+    }
+
+    private static String describe(Any any) {
+        return "typeUrl=" + any.getTypeUrl() + ", " + any.getValue().size() + " bytes";
     }
 }

--- a/common/src/test/java/bisq/common/proto/UnresolvableProtobufMessageExceptionTest.java
+++ b/common/src/test/java/bisq/common/proto/UnresolvableProtobufMessageExceptionTest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.proto;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.StringValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UnresolvableProtobufMessageExceptionTest {
+    private static final String SECRET = "privateKeyBytesWhichMustNotBeLogged";
+    private static final StringValue PROTO = StringValue.newBuilder().setValue(SECRET).build();
+    private static final Any ANY = Any.pack(PROTO);
+
+    @Test
+    void noConstructorPutsTheProtoContentIntoTheMessage() {
+        List<UnresolvableProtobufMessageException> exceptions = List.of(
+                new UnresolvableProtobufMessageException(PROTO),
+                new UnresolvableProtobufMessageException("MESSAGE_NOT_SET", PROTO),
+                new UnresolvableProtobufMessageException(ANY),
+                new UnresolvableProtobufMessageException(ANY, new RuntimeException("cause")));
+
+        exceptions.forEach(exception ->
+                assertFalse(exception.getMessage().contains(SECRET), exception.getMessage()));
+    }
+
+    @Test
+    void theMessageStillIdentifiesTheProtoType() {
+        assertTrue(new UnresolvableProtobufMessageException(PROTO).getMessage()
+                .contains("google.protobuf.StringValue"));
+        assertTrue(new UnresolvableProtobufMessageException(ANY).getMessage()
+                .contains("type.googleapis.com/google.protobuf.StringValue"));
+    }
+}


### PR DESCRIPTION
## Why this is needed

A protobuf message prints all of its fields when you call `toString()`, `bytes` fields included. Two places put that output where users can see it: `UnresolvableProtobufMessageException` embedded it in the exception message, and `ProtoResolverMap` logged the whole `Any` at error level. `PersistableStoreReaderWriter:111` then logs that exception when a store fails to read.

`security.proto:42` and `:47` declare `KeyPair.privateKey` and `TorKeyPair.privateKey` as plain `bytes`, and `KeyBundleStore` (line 61) holds a map of `KeyBundle`, each carrying both. So a store file that fails to resolve writes identity and Tor onion private keys into `bisq.log` as escaped text: once from the log call, once from the exception message, and again for every backup the reader falls back to.

The keys already sit unencrypted in the app data directory, so this is a second exposure channel rather than a new secret. It is a worse channel though. People attach log files to support tickets, paste them into chat and upload them to issue trackers. Nobody does that with their data directory.

The trigger needs no attacker. A truncated store file after a bad shutdown is enough.

---

## What changes

Both sites now emit only what identifies the problem. For an `Any` that is the type URL and the payload size, for any other message the proto full name from its descriptor and the serialized size. Those are the only parts that help diagnose an unresolved type; the field values never did.

```java
private static String describe(Message proto) {
    return proto.getDescriptorForType().getFullName() + ", " + proto.getSerializedSize() + " bytes";
}

private static String describe(Any any) {
    return "typeUrl=" + any.getTypeUrl() + ", " + any.getValue().size() + " bytes";
}
```

---

## Decisions, and why

### Fix all four constructors, not the two the failure path goes through

Only the two `Any` constructors are reachable from the store read path that motivated this. The two taking a `Message` have exactly the same bug, and they are the more used pair: 54 call sites, nearly all `MESSAGE_NOT_SET` branches in `fromProto` methods. Those cover `AccountPayload`, `Contract` and `TradeParty`, which carry payment account details rather than keys. Not as bad as a private key, still not something to write into a file people share.

Leaving a class half safe invites the next person to assume the constructor they reach for is the safe one. All four now go through `describe`.

### Redact inside the constructors rather than at the call sites

There are 54 call sites for the `Message` constructors alone and 2 for the `Any` ones. Fixing them individually would mean every future call site is a fresh chance to get it wrong. Doing it inside the exception type makes it structural: there is no way to construct this exception with proto content in its message. Every existing call site keeps compiling, because only the message construction inside the constructors changed.

### Keep the type and the size rather than dropping the argument

The argument could have been dropped entirely, but then a report of an unresolvable proto would say nothing about which proto. The type is the whole diagnostic value, and it is not sensitive: it is already visible on the wire in the `Any` type URL. The byte count is useful for spotting a truncated file, which is the most common way this fires, and it reveals nothing.

### Comment the reason on the helper

`describe` carries a short javadoc saying that these protos can hold private keys and payment data and that only the type and size may be included. Without it the method looks like an arbitrary formatting choice, and the next person to want better diagnostics puts the content back.

### Drop `@Slf4j` from the exception class

It was unused. An exception type should not be logging, and leaving a logger on it invites exactly the thing this PR removes.

---

## What was checked and deliberately left alone

`PersistableStoreReaderWriter:74` logs `persistableStore` itself when serialization fails, which looks like the same bug from the write side. It is not. `KeyBundleStore` has no `@ToString`, so it prints an identity hash, and `KeyBundle` and `TorKeyPair` already mark their secret fields `@ToString.Exclude`. The only `PersistableStore` implementation with `@ToString` is `DataStore`, which holds public P2P data.

`ProtobufUtils:93` and `Capability:129` log proto *enum* values, not messages, so there are no field values to leak.

`ProtoResolverMap:42`, `log.error("resolver is null. protoTypeName={}", protoTypeName)`, was already safe and is unchanged.

---

## Testing

`UnresolvableProtobufMessageExceptionTest` packs a recognisable secret string into a proto, builds all four affected constructors, and asserts that none of them reproduces it while all of them still name the type. It uses `com.google.protobuf.StringValue` rather than a bisq proto, so the test does not couple to a domain type that might change.

Checked by mutation rather than only by passing: restoring the old `proto.toString()` in one constructor fails both tests.

---

## Scope

This was found while working on #4984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages to avoid exposing sensitive protobuf contents, including private keys, payment details, and trade data.
  * Error logs and exceptions now identify message types and payload sizes without including full payload values.

* **Tests**
  * Added coverage confirming sensitive payload content is omitted while relevant type information remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->