### PR TITLE
Make published jars reproducible across build machines

### DIFF
--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -28,6 +28,10 @@ tasks {
     withType<Jar> {
         isPreserveFileTimestamps = false
         isReproducibleFileOrder = true
+        // Pinned so the entry modes don't follow the umask of the machine that compiled the classes
+        // and checked out the resources.
+        dirPermissions { unix("0755") }
+        filePermissions { unix("0644") }
     }
 }
 

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
@@ -80,6 +80,10 @@ class TorBinaryPackager(private val project: Project, private val torBinaryDownl
                 archiveFileName.set("tor.zip")
                 destinationDirectory.set(project.layout.buildDirectory.dir("generated/src/main/resources"))
                 from(project.layout.buildDirectory.dir(PROCESSED_DIR))
+
+                // This archive ends up as a resource inside tor.jar, so it has to be reproducible too.
+                isPreserveFileTimestamps = false
+                isReproducibleFileOrder = true
             }
 
         if (getOS() == OS.LINUX) {


### PR DESCRIPTION
Gradle copies file modes from disk into jar entries, so the umask of the machine that compiled the classes and checked out the resources ends up in every published jar. Entry order and timestamps were already pinned, but building the same commit under umask 022 and then 002 still produced 27 differing jars out of 27.

Pin the entry modes to 0644/0755 in `bisq.java-conventions`. The 204 tracked resources carrying an exec bit are images, fonts and text, so normalising them loses nothing.

Separately, give the bundled `tor.zip` the fixed entry order and timestamps the jar tasks already have. It ships as a resource inside `tor.jar` on macOS and Windows, and its permissions stay as extracted so the Tor binaries remain executable, which
is why it is handled apart from the jar convention.

Verified with four clean builds, `--no-build-cache`, fresh daemon per umask: 27/27 jars differ before the change, 0/27 after.

Needs Gradle 8.3 or newer for `dirPermissions`/`filePermissions`; the pinned 8.9
satisfies it.

This is done as part of preparations for f-droid release of android apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Built JAR and Tor binary archives now use consistent file permissions.
  * Archive contents are packaged in a stable order without preserving build-machine timestamps, improving reproducibility across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->