### PR TITLE
chore: sync #4957 to main — chore/4914_followups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,8 @@ docker/data_dirs
 /tx
 /.java-version
 
-# sym link to bisq2-* repos
-bisq2-umbrel
-bisq2-startos
+# sym links to bisq2-* sub repos (e.g. bisq2-umbrel)
+/bisq2-*
 
 # Directory for temp files
 /temp

--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,9 @@ docker/data_dirs
 /tx
 /.java-version
 
-# sym links to bisq2-* sub repos (e.g. bisq2-umbrel)
-/bisq2-*
+# sym links to bisq2-* sub repos (please list each one, e.g. bisq2-umbrel)
+/bisq2-umbrel
+/bisq2-startos
 
 # Directory for temp files
 /temp

--- a/api/src/main/java/bisq/api/access/permissions/Permission.java
+++ b/api/src/main/java/bisq/api/access/permissions/Permission.java
@@ -21,9 +21,6 @@ import bisq.common.proto.ProtoEnum;
 import lombok.Getter;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,7 +29,7 @@ import java.util.stream.Collectors;
  * <p>
  * {@code autoGrantable} encodes the standard-vs-sensitive distinction: a grantAll grant expands
  * only to auto-grantable permissions (see {@link PermissionSet}), so already-paired clients gain
- * future NORMAL features automatically but can never silently acquire a security-sensitive
+ * future STANDARD features automatically but can never silently acquire a security-sensitive
  * capability.
  * <p>
  * SECURE BY DEFAULT: the single-argument constructor marks a permission SENSITIVE
@@ -95,22 +92,15 @@ public enum Permission implements ProtoEnum {
      * All permissions a grantAll grant expands to — the "standard" set. Sensitive permissions
      * (autoGrantable = false) are excluded by construction and must be granted explicitly.
      * <p>
-     * Ordered by {@code id} into an insertion-ordered set: this feeds the grantAll expansion
-     * serialized by {@code PermissionSet.getBuilder}, and an unspecified iteration order (as a
-     * plain immutable Set has) would make the proto's repeated field non-deterministic across
-     * runs, breaking serializeForHash stability. Set semantics are unchanged — equality stays
-     * order-independent, so promotion/folding comparisons are unaffected.
+     * Iteration order is unspecified; serialization sites sort by {@code id} themselves.
      */
     public static Set<Permission> autoGrantable() {
-        // Unmodifiable AND insertion-ordered: PermissionSet caches this in a static field and
-        // returns it directly from getPermissions(), so a mutable set would let any caller alter
-        // the grantAll expansion for every client (and, once sensitive permissions exist, add
-        // one). LinkedHashSet keeps the id order needed for serializeForHash determinism.
-        LinkedHashSet<Permission> ordered = Arrays.stream(values())
+        // Unmodifiable: PermissionSet caches this in a static field and returns it directly from
+        // getPermissions(), so a mutable set would let any caller alter the grantAll expansion
+        // for every client (and, once sensitive permissions exist, add one).
+        return Arrays.stream(values())
                 .filter(Permission::isAutoGrantable)
-                .sorted(Comparator.comparingInt(Permission::getId))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        return Collections.unmodifiableSet(ordered);
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/api/src/main/java/bisq/api/access/permissions/PermissionSet.java
+++ b/api/src/main/java/bisq/api/access/permissions/PermissionSet.java
@@ -21,6 +21,7 @@ import bisq.common.proto.PersistableProto;
 import bisq.common.proto.ProtobufUtils;
 import lombok.Getter;
 
+import java.util.Comparator;
 import java.util.Set;
 
 /**
@@ -70,8 +71,13 @@ public final class PermissionSet implements PersistableProto {
     public bisq.api.protobuf.PermissionSet.Builder getBuilder(boolean serializeForHash) {
         // For grantAll we serialize the current expansion as well, so a node downgraded to a
         // version without the grantAll field still reads a full grant from the explicit list.
+        // Sorted by id: set iteration order is unspecified, and an order-unstable repeated
+        // field would break serializeForHash determinism.
         return bisq.api.protobuf.PermissionSet.newBuilder()
-                .addAllPermissions(getPermissions().stream().map(Permission::toProtoEnum).toList())
+                .addAllPermissions(getPermissions().stream()
+                        .sorted(Comparator.comparingInt(Permission::getId))
+                        .map(Permission::toProtoEnum)
+                        .toList())
                 .setGrantAll(grantAll);
     }
 

--- a/api/src/test/java/bisq/api/access/permissions/PermissionSetTest.java
+++ b/api/src/test/java/bisq/api/access/permissions/PermissionSetTest.java
@@ -19,7 +19,10 @@ package bisq.api.access.permissions;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,6 +98,26 @@ class PermissionSetTest {
 
         assertFalse(fromProto.isGrantAll());
         assertEquals(explicit, fromProto.getPermissions());
+    }
+
+    @Test
+    void protoPermissionListIsSortedById() {
+        // Set iteration order is unspecified (Set.copyOf salts it per JVM run), so an unsorted
+        // repeated field would make serializeForHash non-deterministic across runs. Using all
+        // permissions makes an accidentally id-ordered iteration practically impossible.
+        List<bisq.api.protobuf.Permission> expectedIdOrder = Arrays.stream(Permission.values())
+                .sorted(Comparator.comparingInt(Permission::getId))
+                .map(Permission::toProtoEnum)
+                .toList();
+
+        PermissionSet explicit = new PermissionSet(EnumSet.allOf(Permission.class));
+        assertEquals(expectedIdOrder, explicit.toProto(true).getPermissionsList());
+
+        List<bisq.api.protobuf.Permission> expectedGrantAllOrder = Permission.autoGrantable().stream()
+                .sorted(Comparator.comparingInt(Permission::getId))
+                .map(Permission::toProtoEnum)
+                .toList();
+        assertEquals(expectedGrantAllOrder, PermissionSet.grantAll().toProto(true).getPermissionsList());
     }
 
     @Test

--- a/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreTest.java
+++ b/api/src/test/java/bisq/api/access/persistence/ApiAccessStoreTest.java
@@ -21,7 +21,6 @@ import bisq.api.access.permissions.Permission;
 import bisq.api.access.permissions.PermissionSet;
 import org.junit.jupiter.api.Test;
 
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +51,7 @@ class ApiAccessStoreTest {
         // covering permissions added later — which is what every full grant was issued to mean.
         // This is how pre-grantAll stores (always full grants) gain forward coverage.
         bisq.api.protobuf.PermissionSet fullEntry = bisq.api.protobuf.PermissionSet.newBuilder()
-                .addAllPermissions(EnumSet.allOf(Permission.class).stream().map(Permission::toProtoEnum).toList())
+                .addAllPermissions(Permission.autoGrantable().stream().map(Permission::toProtoEnum).toList())
                 .build();
         bisq.api.protobuf.ApiAccessStore proto = bisq.api.protobuf.ApiAccessStore.newBuilder()
                 .putPermissionsByClientId("legacy-client", fullEntry)


### PR DESCRIPTION
Automated sync of #4957 from `for-mobile-based-on-2.1.12` to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Permission lists are now consistently serialized in numeric ID order, providing stable and predictable API output.
  - Full permission sets now correctly recognize standard permissions eligible for automatic granting, avoiding unintended inclusion of special permissions.

- **Refactor**
  - Permission handling has been streamlined while preserving existing access behavior.
  - Ignored Bisq2 symlinks are now limited to the explicitly supported entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->