### PR TITLE
Sync reproducible jar changes from main to for-mobile-based-on-2.1.12

### DIFF
--- a/apps/desktop/bi2p/build.gradle.kts
+++ b/apps/desktop/bi2p/build.gradle.kts
@@ -58,6 +58,8 @@ tasks {
         val version = VersionUtil.getVersionFromFile(project)
         archiveClassifier.set("$version-all")
         mergeServiceFiles()
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
     }
 
     distZip {

--- a/build-logic/bi2p/src/main/kotlin/bisq/gradle/bi2p/Bi2pAppPlugin.kt
+++ b/build-logic/bi2p/src/main/kotlin/bisq/gradle/bi2p/Bi2pAppPlugin.kt
@@ -29,6 +29,8 @@ class Bi2pAppPlugin : Plugin<Project> {
             destinationDirectory.set(project.layout.buildDirectory.dir("generated"))
             include("bi2p-$version-all.jar")
             from(project.layout.buildDirectory.dir("libs"))
+            isPreserveFileTimestamps = false
+            isReproducibleFileOrder = true
         }
 
         val copyBi2pAppVersionToResources = project.tasks.register<Copy>("copyBi2pAppVersionToResources") {

--- a/build-logic/bi2p/src/main/kotlin/bisq/gradle/bi2p/Bi2pAppPlugin.kt
+++ b/build-logic/bi2p/src/main/kotlin/bisq/gradle/bi2p/Bi2pAppPlugin.kt
@@ -31,6 +31,8 @@ class Bi2pAppPlugin : Plugin<Project> {
             from(project.layout.buildDirectory.dir("libs"))
             isPreserveFileTimestamps = false
             isReproducibleFileOrder = true
+            // The single entry is the shadow jar, whose on-disk mode follows the umask of the building machine.
+            filePermissions { unix("0644") }
         }
 
         val copyBi2pAppVersionToResources = project.tasks.register<Copy>("copyBi2pAppVersionToResources") {

--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -28,6 +28,10 @@ tasks {
     withType<Jar> {
         isPreserveFileTimestamps = false
         isReproducibleFileOrder = true
+        // Pinned so the entry modes don't follow the umask of the machine that compiled the classes
+        // and checked out the resources.
+        dirPermissions { unix("0755") }
+        filePermissions { unix("0644") }
     }
 }
 

--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -24,6 +24,11 @@ tasks {
     test {
         useJUnitPlatform()
     }
+
+    withType<Jar> {
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+    }
 }
 
 val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
+++ b/build-logic/tor-binary/src/main/kotlin/bisq/gradle/tor_binary/TorBinaryPackager.kt
@@ -80,6 +80,10 @@ class TorBinaryPackager(private val project: Project, private val torBinaryDownl
                 archiveFileName.set("tor.zip")
                 destinationDirectory.set(project.layout.buildDirectory.dir("generated/src/main/resources"))
                 from(project.layout.buildDirectory.dir(PROCESSED_DIR))
+
+                // This archive ends up as a resource inside tor.jar, so it has to be reproducible too.
+                isPreserveFileTimestamps = false
+                isReproducibleFileOrder = true
             }
 
         if (getOS() == OS.LINUX) {

--- a/build-logic/webcam-app/src/main/kotlin/bisq/gradle/webcam_app/WebcamAppPlugin.kt
+++ b/build-logic/webcam-app/src/main/kotlin/bisq/gradle/webcam_app/WebcamAppPlugin.kt
@@ -28,6 +28,8 @@ class WebcamAppPlugin : Plugin<Project> {
             destinationDirectory.set(project.layout.buildDirectory.dir("generated"))
             include("webcam-app-$version-all.jar")
             from(project.layout.buildDirectory.dir("libs"))
+            isPreserveFileTimestamps = false
+            isReproducibleFileOrder = true
         }
 
         val copyWebcamAppVersionToResources = project.tasks.register<Copy>("copyWebcamAppVersionToResources") {

--- a/build-logic/webcam-app/src/main/kotlin/bisq/gradle/webcam_app/WebcamAppPlugin.kt
+++ b/build-logic/webcam-app/src/main/kotlin/bisq/gradle/webcam_app/WebcamAppPlugin.kt
@@ -30,6 +30,8 @@ class WebcamAppPlugin : Plugin<Project> {
             from(project.layout.buildDirectory.dir("libs"))
             isPreserveFileTimestamps = false
             isReproducibleFileOrder = true
+            // The single entry is the shadow jar, whose on-disk mode follows the umask of the building machine.
+            filePermissions { unix("0644") }
         }
 
         val copyWebcamAppVersionToResources = project.tasks.register<Copy>("copyWebcamAppVersionToResources") {


### PR DESCRIPTION
Brings the reproducible jar work from main (#4986) to the mobile branch to prepare for f-droid release

The mobile branch never received the `withType<Jar>` block from "fix reproducible build issues" (5f0ad3c393), which #4986 builds on, so that commit is cherry-picked first. All three commits are cherry-picked with `-x`:

- 5f0ad3c393 fix reproducible build issues
  Only conflict was `gradle.properties`; resolved by keeping the mobile version, which already has `org.gradle.java.installations.auto-detect=false` and its own `tor.version`.
- 4c53a4a894 Pin jar entry permissions to make jars reproducible
- e23c12da04 Make the bundled Tor archive reproducible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Archives and application packages are now generated reproducibly, with consistent file ordering and timestamps.
  * Packaged files use standardized permissions, reducing differences between builds on different machines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->