### PR TITLE
Pin zip entry permissions of the bundled shadow jars

### DIFF
--- a/build-logic/bi2p/src/main/kotlin/bisq/gradle/bi2p/Bi2pAppPlugin.kt
+++ b/build-logic/bi2p/src/main/kotlin/bisq/gradle/bi2p/Bi2pAppPlugin.kt
@@ -31,6 +31,8 @@ class Bi2pAppPlugin : Plugin<Project> {
             from(project.layout.buildDirectory.dir("libs"))
             isPreserveFileTimestamps = false
             isReproducibleFileOrder = true
+            // The single entry is the shadow jar, whose on-disk mode follows the umask of the building machine.
+            filePermissions { unix("0644") }
         }
 
         val copyBi2pAppVersionToResources = project.tasks.register<Copy>("copyBi2pAppVersionToResources") {

--- a/build-logic/webcam-app/src/main/kotlin/bisq/gradle/webcam_app/WebcamAppPlugin.kt
+++ b/build-logic/webcam-app/src/main/kotlin/bisq/gradle/webcam_app/WebcamAppPlugin.kt
@@ -30,6 +30,8 @@ class WebcamAppPlugin : Plugin<Project> {
             from(project.layout.buildDirectory.dir("libs"))
             isPreserveFileTimestamps = false
             isReproducibleFileOrder = true
+            // The single entry is the shadow jar, whose on-disk mode follows the umask of the building machine.
+            filePermissions { unix("0644") }
         }
 
         val copyWebcamAppVersionToResources = project.tasks.register<Copy>("copyWebcamAppVersionToResources") {


### PR DESCRIPTION
zipBi2pAppShadowJar and zipWebcamAppShadowJar wrap the shadow jar into a Zip that ends up as a resource inside the desktop jar. The shadow jar entries are already pinned by the jar convention, but the Zip copies the on-disk mode of the shadow jar file itself, which follows the umask of the building machine. Building under umask 022 and then 002 produced identical shadow jars but different zips (0644 versus 0664 entry), and so a different desktop jar.

Pinning the entry mode makes both zips identical across umasks. Note the Gradle daemon keeps the umask it was started with, so comparing umasks needs a daemon restart between builds.

suggested by @KimStrand at https://github.com/bisq-network/bisq2/pull/4990#discussion_r3971538637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Standardized file permissions to `0644` for entries in generated application archives, ensuring consistent archive permissions across build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->