### PR TITLE
Judge the MuSig minimum on the fiat obligation

### DIFF
--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -344,28 +344,30 @@ public final class MuSigTakeOfferRequestValidator {
             // the absolute and rail limits, so require a fresh one before enforcing them.
             throw reject("No fresh BTC/USD price is available to validate the absolute trade limits");
         }
-        // Exact BigDecimal (PriceQuote's longValue would wrap at an extreme price); the result is
-        // a USD Fiat atomic value comparable to the policy limits.
-        BigDecimal usdAtomic = BigDecimal.valueOf(btcAmount.getValue())
+        // Exact BigDecimal; the result is a USD Fiat atomic value comparable to the policy limits.
+        BigDecimal btcValueUsd = BigDecimal.valueOf(btcAmount.getValue())
                 .multiply(BigDecimal.valueOf(btcUsdMarketPrice.get().getPriceQuote().getValue()))
                 .movePointLeft(btcAmount.getPrecision());
-        if (usdAtomic.compareTo(BigDecimal.valueOf(MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT.getValue())) < 0) {
-            throw reject("The trade amount lies below the absolute minimum. usd=" + usdAtomic.toPlainString());
+        // The limits bound the fiat obligation. For a USD quote that is the quote amount itself;
+        // the Bitcoin-side value only stands in for it otherwise (non-USD fiat needs a fiat/USD
+        // conversion - a disclosed follow-up). Judging the minimum on the Bitcoin side rejects a
+        // take at exactly the minimum, whose satoshi rounding lands a fraction below it; that
+        // remains the case for non-USD fiat until the conversion exists.
+        BigDecimal obligationUsd = market.isBaseCurrencyBitcoin() && "USD".equals(market.getQuoteCurrencyCode())
+                ? BigDecimal.valueOf(quoteSideAmount)
+                : btcValueUsd;
+        if (obligationUsd.compareTo(BigDecimal.valueOf(MuSigTradeAmountLimitsPolicy.MIN_USD_TRADE_AMOUNT.getValue())) < 0) {
+            throw reject("The trade amount lies below the absolute minimum. usd=" + obligationUsd.toPlainString());
         }
-        // The rail cap must bound the actual fiat obligation, which the tolerance lets sit above
-        // the Bitcoin value. For a USD quote that obligation is directly comparable, so cap on the
-        // larger of the two. (Non-USD fiat needs a fiat/USD conversion - a disclosed follow-up.)
-        BigDecimal obligationUsd = usdAtomic;
-        if (market.isBaseCurrencyBitcoin() && "USD".equals(market.getQuoteCurrencyCode())) {
-            obligationUsd = obligationUsd.max(BigDecimal.valueOf(quoteSideAmount));
-        }
+        // The tolerance lets the Bitcoin value sit above the obligation, so cap on the larger of the two.
+        BigDecimal cappedUsd = obligationUsd.max(btcValueUsd);
         PaymentMethodSpec<?> nonBtcSideSpec = market.isBaseCurrencyBitcoin()
                 ? contract.getQuoteSidePaymentMethodSpec()
                 : contract.getBaseSidePaymentMethodSpec();
         Fiat railLimit = MuSigTradeAmountLimitsPolicy.getMaxTradeLimitInUsd(
                 nonBtcSideSpec.getPaymentMethod().getPaymentRail());
-        if (obligationUsd.compareTo(BigDecimal.valueOf(railLimit.getValue())) > 0) {
-            throw reject("The trade amount exceeds the payment rail's limit. usd=" + obligationUsd.toPlainString()
+        if (cappedUsd.compareTo(BigDecimal.valueOf(railLimit.getValue())) > 0) {
+            throw reject("The trade amount exceeds the payment rail's limit. usd=" + cappedUsd.toPlainString()
                     + ", limit=" + railLimit.getValue());
         }
     }

--- a/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
+++ b/trade/src/main/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidator.java
@@ -344,9 +344,15 @@ public final class MuSigTakeOfferRequestValidator {
             // the absolute and rail limits, so require a fresh one before enforcing them.
             throw reject("No fresh BTC/USD price is available to validate the absolute trade limits");
         }
+        PriceQuote btcUsdQuote = btcUsdMarketPrice.get().getPriceQuote();
+        if (btcUsdQuote.getValue() <= 0) {
+            // MarketPrice validates only the timestamp. A non-positive rate would value the
+            // Bitcoin side at zero and leave the fiat obligation alone to decide the limits.
+            throw reject("No positive BTC/USD price is available to validate the absolute trade limits");
+        }
         // Exact BigDecimal; the result is a USD Fiat atomic value comparable to the policy limits.
         BigDecimal btcValueUsd = BigDecimal.valueOf(btcAmount.getValue())
-                .multiply(BigDecimal.valueOf(btcUsdMarketPrice.get().getPriceQuote().getValue()))
+                .multiply(BigDecimal.valueOf(btcUsdQuote.getValue()))
                 .movePointLeft(btcAmount.getPrecision());
         // The limits bound the fiat obligation. For a USD quote that is the quote amount itself;
         // the Bitcoin-side value only stands in for it otherwise (non-USD fiat needs a fiat/USD

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -705,9 +705,46 @@ class MuSigTakeOfferRequestValidatorTest {
 
     @Test
     void amountBelowTheAbsoluteMinimumIsRejected() {
-        // 0.0001 BTC at $50,000 is $5, below the $10 absolute minimum.
+        // $5 on the quote side (and 0.0001 BTC at $50,000 is $5 as well), below the $10 absolute minimum.
         assertEconomicsRejected(fiatContract(10_000L, 50_000L, new BaseSideFixedAmountSpec(10_000L)),
                 TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    @Test
+    void usdAmountAtTheAbsoluteMinimumIsAcceptedDespiteBitcoinSideRounding() {
+        // 10 USD at 111,393.92375 USD/BTC is 8,977.16 sats; the taker rounds to 8,977 sats, which
+        // converts back to 9.9998 USD. The 10 USD obligation is what the minimum bounds.
+        PriceQuote price = PriceQuote.fromFiatPrice(111_393.92375, "USD");
+        stubFreshBtcUsdPrice(price);
+        MuSigOffer offer = createOffer(new bisq.offer.amount.spec.QuoteSideFixedAmountSpec(100_000L), price);
+        long derivedBase = price.toBaseSideMonetary(Fiat.fromValue(100_000L, "USD")).getValue();
+
+        assertThat(derivedBase).isEqualTo(8_977L);
+        assertThat(price.toQuoteSideMonetary(Coin.asBtcFromValue(derivedBase)).getValue()).isLessThan(100_000L);
+        assertEconomicsAccepted(createContract(offer, derivedBase, 100_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile)));
+    }
+
+    @Test
+    void usdObligationBelowTheAbsoluteMinimumIsRejected() {
+        // 9.99 USD is below the minimum on the quote side. The Bitcoin side is 9,000 sats, worth
+        // 10.03 USD and within the price tolerance, so a Bitcoin-side basis would have accepted it.
+        PriceQuote price = PriceQuote.fromFiatPrice(111_393.92375, "USD");
+        stubFreshBtcUsdPrice(price);
+        MuSigOffer offer = createOffer(new bisq.offer.amount.spec.QuoteSideFixedAmountSpec(99_900L), price);
+
+        assertThat(price.toQuoteSideMonetary(Coin.asBtcFromValue(9_000L)).getValue()).isGreaterThan(100_000L);
+        assertEconomicsRejected(createContract(offer, 9_000L, 99_900L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile)), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
+    private void stubFreshBtcUsdPrice(PriceQuote price) {
+        bisq.bonded_roles.market_price.MarketPrice freshPrice =
+                org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);
+        org.mockito.Mockito.when(freshPrice.isValidDate()).thenReturn(true);
+        org.mockito.Mockito.when(freshPrice.getPriceQuote()).thenReturn(price);
+        org.mockito.Mockito.when(marketPriceService.findMarketPrice(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Optional.of(freshPrice));
     }
 
     @Test

--- a/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
+++ b/trade/src/test/java/bisq/trade/mu_sig/messages/network/handler/maker/MuSigTakeOfferRequestValidatorTest.java
@@ -738,6 +738,19 @@ class MuSigTakeOfferRequestValidatorTest {
                 Optional.of(mediatorProfile), Optional.of(arbitratorProfile)), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
     }
 
+    @Test
+    void nonPositiveBtcUsdPriceIsRejectedInsteadOfDisablingTheBitcoinSideCap() {
+        // A fresh BTC/USD quote of zero values the Bitcoin side at 0 USD. The rail cap must not
+        // then fall back to the fiat obligation alone: 10 BTC against a 5,000 USD ACH obligation
+        // would pass. Such a quote is not a usable rate and is rejected outright.
+        PriceQuote offerPrice = PriceQuote.fromFiatPrice(500, "USD");
+        stubFreshBtcUsdPrice(PriceQuote.fromFiatPrice(0, "USD"));
+        MuSigOffer offer = createOffer(new BaseSideFixedAmountSpec(1_000_000_000L), offerPrice);
+
+        assertEconomicsRejected(createContract(offer, 1_000_000_000L, 50_000_000L, offer.getPriceSpec(),
+                Optional.of(mediatorProfile), Optional.of(arbitratorProfile)), TradeProtocolFailure.OFFER_NOT_AVAILABLE);
+    }
+
     private void stubFreshBtcUsdPrice(PriceQuote price) {
         bisq.bonded_roles.market_price.MarketPrice freshPrice =
                 org.mockito.Mockito.mock(bisq.bonded_roles.market_price.MarketPrice.class);


### PR DESCRIPTION
Taking a MuSig offer at its 10 USD minimum fails at the maker with "The maker has rejected the take offer request because the offer is not available anymore." The maker log shows the real reason: `The trade amount lies below the absolute minimum. usd=99998.3253`.

The taker's 10 USD converts to 8,977 sats at the current price, and the maker's validation converts those sats back to 9.9998 USD and compares that with the 10 USD minimum. The check judged the Bitcoin-side value with no tolerance, while the rail cap check next to it already takes the fiat obligation into account. Introduced with #4938.

### Fix

For a USD quote the absolute minimum now bounds the quote amount itself, which is the obligation the policy limits express. The rail cap keeps bounding the larger of the quote amount and the Bitcoin-side value, as before. For non-USD fiat quotes the Bitcoin-side value still stands in for the obligation, since that needs a fiat/USD conversion (the follow-up already noted in the code). Applying the price tolerance to the minimum instead would also have worked; I went with the obligation because it mirrors the cap and needs no threshold.

One consequence worth stating: within the maker's price tolerance the Bitcoin side of a 10 USD take can now sit a few percent under 10 USD, where before it was the quote side that could. The two sides are bound to each other by the tolerance check either way, so this is a side swap rather than a loosening. If you'd rather have the minimum hold on both sides, the strict form is the smaller of the two values with a one-satoshi allowance; say so and I'll switch.

### Testing

Two validator tests: a 10 USD take at 111,393.92375 USD/BTC (8,977 sats, worth 9.9998 USD on the way back) is accepted, and a 9.99 USD take whose Bitcoin side is worth 10.03 USD is rejected. Both fail on the unfixed validator. `:trade:test` is green.

Found while manually testing #4992 with two local clients: the first take at the offer minimum was rejected, a take at 50 USD went through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Corrected minimum trade amount validation for USD-quoted Bitcoin markets to use the quote-side obligation, preventing rounding from incorrectly accepting or rejecting offers.
- Improved rail-limit validation by considering the greater of the trade obligation and Bitcoin-side value.
- Rejects offers when the BTC/USD price is zero or otherwise non-positive, instead of bypassing Bitcoin-side limit checks.
- Added coverage for edge cases involving minimum USD obligations and Bitcoin value rounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->